### PR TITLE
Index meeting summaries in MCP search

### DIFF
--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-/// Structured meeting-summary fields extracted from a saved capture. Carries the
-/// rollup-friendly subset the index needs (decisions, action items, open
-/// questions); each item is one bullet so cross-meeting tools can aggregate.
+/// Structured meeting-summary fields extracted from a saved capture.
 public struct ParsedMeetingSummary: Equatable {
     public struct ActionItem: Equatable {
         /// Named owner if the bullet led with one (`Owner: do thing`); nil means
@@ -18,24 +16,32 @@ public struct ParsedMeetingSummary: Equatable {
     }
 
     public let title: String?
+    public let attendees: [String]
     public let decisions: [String]
     public let actionItems: [ActionItem]
     public let openQuestions: [String]
 
     public init(
         title: String?,
+        attendees: [String] = [],
         decisions: [String],
         actionItems: [ActionItem],
         openQuestions: [String]
     ) {
         self.title = title
+        self.attendees = attendees
         self.decisions = decisions
         self.actionItems = actionItems
         self.openQuestions = openQuestions
     }
 
     public var isEmpty: Bool {
-        decisions.isEmpty && actionItems.isEmpty && openQuestions.isEmpty
+        let cleanTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (cleanTitle?.isEmpty ?? true)
+            && attendees.isEmpty
+            && decisions.isEmpty
+            && actionItems.isEmpty
+            && openQuestions.isEmpty
     }
 }
 
@@ -69,6 +75,8 @@ public enum CaptureSummaryParser {
         if values["capture_type"] == "meeting_summary" {
             return assemble(
                 title: cleanTitle(values["summary_title"]),
+                attendees: bulletItems(section("# Attendees", in: body, headingLevel: "#"))
+                    + bulletItems(section("# Participants", in: body, headingLevel: "#")),
                 decisions: bulletItems(section("# Decisions", in: body, headingLevel: "#")),
                 actions: bulletItems(section("# Action Items", in: body, headingLevel: "#")),
                 questions: bulletItems(section("# Open Questions", in: body, headingLevel: "#"))
@@ -79,6 +87,8 @@ public enum CaptureSummaryParser {
             let block = localSummaryBlock(in: body) ?? body
             if let localSummary = assemble(
                 title: cleanTitle(values["local_summary_title"]),
+                attendees: inlineItems("### Attendees", in: block, fallback: nil)
+                    + inlineItems("### Participants", in: block, fallback: values["local_summary_participants"]),
                 decisions: inlineItems("### Decisions", in: block, fallback: values["local_summary_decisions"]),
                 actions: inlineItems("### Action Items", in: block, fallback: values["local_summary_action_items"]),
                 questions: inlineItems("### Open Questions", in: block, fallback: values["local_summary_open_questions"])
@@ -90,6 +100,7 @@ public enum CaptureSummaryParser {
         if values["auto_summary_version"] != nil {
             return assemble(
                 title: nil,
+                attendees: [],
                 decisions: frontmatterItems(values["auto_summary_decisions"]),
                 actions: frontmatterItems(values["auto_summary_action_items"]),
                 questions: frontmatterItems(values["auto_summary_open_questions"])
@@ -103,12 +114,14 @@ public enum CaptureSummaryParser {
 
     private static func assemble(
         title: String?,
+        attendees: [String],
         decisions: [String],
         actions: [String],
         questions: [String]
     ) -> ParsedMeetingSummary? {
         let summary = ParsedMeetingSummary(
             title: title,
+            attendees: unique(attendees),
             decisions: decisions,
             actionItems: actions.map(actionItem(from:)),
             openQuestions: questions
@@ -223,6 +236,17 @@ public enum CaptureSummaryParser {
         let title = cleanMarkdown(raw)
         guard !title.isEmpty, title != placeholder else { return nil }
         return String(title.prefix(96))
+    }
+
+    private static func unique(_ values: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for value in values {
+            let normalized = value.lowercased()
+            guard seen.insert(normalized).inserted else { continue }
+            result.append(value)
+        }
+        return result
     }
 
     private static func cleanMarkdown(_ raw: String?) -> String {

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureSummaryParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureSummaryParserTests.swift
@@ -61,6 +61,7 @@ final class CaptureSummaryParserTests: XCTestCase {
     func testParsesInlineBodyBlockSections() throws {
         let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: inlineMeeting()))
         XCTAssertEqual(summary.title, "Beta launch sync")
+        XCTAssertEqual(summary.attendees, ["Jenny"])
         XCTAssertEqual(summary.decisions, ["Ship the beta on Friday", "Cut the legacy import path"])
         XCTAssertEqual(summary.openQuestions, ["Do we need a migration window?"])
         XCTAssertEqual(summary.actionItems.count, 2)
@@ -100,6 +101,21 @@ final class CaptureSummaryParserTests: XCTestCase {
         XCTAssertTrue(summary.decisions.isEmpty)
         XCTAssertTrue(summary.openQuestions.isEmpty)
         XCTAssertEqual(summary.actionItems.count, 2)
+    }
+
+    func testParsesTitleAndParticipantsWhenFactSectionsAreEmpty() throws {
+        let markdown = inlineMeeting(
+            decisions: "### Decisions\n- None found.",
+            actionItems: "### Action Items\n- None found.",
+            openQuestions: "### Open Questions\n- None found."
+        )
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: markdown))
+
+        XCTAssertEqual(summary.title, "Beta launch sync")
+        XCTAssertEqual(summary.attendees, ["Jenny"])
+        XCTAssertTrue(summary.decisions.isEmpty)
+        XCTAssertTrue(summary.actionItems.isEmpty)
+        XCTAssertTrue(summary.openQuestions.isEmpty)
     }
 
     func testFallsBackToFrontmatterWhenBodyBlockMissing() throws {
@@ -210,6 +226,7 @@ final class CaptureSummaryParserTests: XCTestCase {
         """
         let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: sidecar))
         XCTAssertEqual(summary.title, "Beta launch sync")
+        XCTAssertTrue(summary.attendees.isEmpty)
         XCTAssertEqual(summary.decisions, ["Ship the beta on Friday"])
         XCTAssertEqual(summary.actionItems.first?.owner, "Jenny")
         XCTAssertEqual(summary.openQuestions, ["Do we need a migration window?"])
@@ -233,11 +250,34 @@ final class CaptureSummaryParserTests: XCTestCase {
     }
 
     func testReturnsNilWhenEverySectionEmpty() {
-        let markdown = inlineMeeting(
-            decisions: "### Decisions\n- None found.",
-            actionItems: "### Action Items\n- None found.",
-            openQuestions: "### Open Questions\n- None found."
-        )
+        let markdown = """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        local_summary_version: "1"
+        local_summary_decisions: "None found."
+        local_summary_action_items: "None found."
+        local_summary_open_questions: "None found."
+        ---
+
+        # Meeting
+
+        ## Full Transcript
+
+        [00:00] [System/Jenny] Nothing to summarize.
+
+        ## Local Summary
+
+        ### Decisions
+        - None found.
+
+        ### Action Items
+        - None found.
+
+        ### Open Questions
+        - None found.
+        """
         XCTAssertNil(CaptureSummaryParser.parse(from: markdown))
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SQLite3
+import TranscriptedCaptureKit
 
 final class TranscriptIndex: @unchecked Sendable {
     private var db: OpaquePointer?
@@ -52,8 +53,9 @@ final class TranscriptIndex: @unchecked Sendable {
     }
 
     /// Bump when the derived index shape changes so existing on-disk indexes are
-    /// rebuilt from disk on next open. v2 added `meeting_summary_items`.
-    private static let schemaVersion: Int32 = 2
+    /// rebuilt from disk on next open. v2 added `meeting_summary_items`; v3 adds
+    /// the meeting-summary FTS document used by general search.
+    private static let schemaVersion: Int32 = 3
 
     /// An already-indexed meeting whose transcript mtime is unchanged is skipped
     /// by `reconcile`, so a schema addition (new table/column) would never
@@ -237,6 +239,40 @@ final class TranscriptIndex: @unchecked Sendable {
             END
         """)
 
+        exec("""
+            CREATE TABLE IF NOT EXISTS meeting_summary_documents (
+                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL UNIQUE,
+                title TEXT NOT NULL DEFAULT '',
+                attendees TEXT NOT NULL DEFAULT '',
+                decisions TEXT NOT NULL DEFAULT '',
+                action_items TEXT NOT NULL DEFAULT '',
+                open_questions TEXT NOT NULL DEFAULT ''
+            )
+        """)
+
+        exec("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS meeting_summary_documents_fts USING fts5(
+                title, attendees, decisions, action_items, open_questions,
+                content='meeting_summary_documents', content_rowid='rowid',
+                tokenize='porter unicode61'
+            )
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS meeting_summary_documents_ai AFTER INSERT ON meeting_summary_documents BEGIN
+                INSERT INTO meeting_summary_documents_fts(rowid, title, attendees, decisions, action_items, open_questions)
+                VALUES (new.rowid, new.title, new.attendees, new.decisions, new.action_items, new.open_questions);
+            END
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS meeting_summary_documents_ad AFTER DELETE ON meeting_summary_documents BEGIN
+                INSERT INTO meeting_summary_documents_fts(meeting_summary_documents_fts, rowid, title, attendees, decisions, action_items, open_questions)
+                VALUES ('delete', old.rowid, old.title, old.attendees, old.decisions, old.action_items, old.open_questions);
+            END
+        """)
+
         exec("CREATE INDEX IF NOT EXISTS idx_meetings_date ON meetings(date)")
         exec("CREATE INDEX IF NOT EXISTS idx_meeting_speakers_name ON meeting_speakers(speaker_name COLLATE NOCASE)")
         exec("CREATE INDEX IF NOT EXISTS idx_meeting_speakers_persistent_id ON meeting_speakers(persistent_speaker_id)")
@@ -247,6 +283,7 @@ final class TranscriptIndex: @unchecked Sendable {
         exec("CREATE INDEX IF NOT EXISTS idx_summary_items_filename ON meeting_summary_items(filename)")
         exec("CREATE INDEX IF NOT EXISTS idx_summary_items_kind ON meeting_summary_items(kind)")
         exec("CREATE INDEX IF NOT EXISTS idx_summary_items_owner ON meeting_summary_items(owner COLLATE NOCASE)")
+        exec("CREATE INDEX IF NOT EXISTS idx_summary_documents_filename ON meeting_summary_documents(filename)")
     }
 
     // MARK: - Reconciliation
@@ -398,7 +435,10 @@ final class TranscriptIndex: @unchecked Sendable {
             )
         }
 
-        try insertSummaryItems(forMeeting: url, filename: filename)
+        if let summary = TranscriptLoader.loadMeetingSummary(forTranscript: url) {
+            try insertSummaryItems(summary, filename: filename)
+            try insertSummarySearchDocument(summary, filename: filename)
+        }
 
         try execOrThrow("COMMIT")
         committed = true
@@ -409,9 +449,7 @@ final class TranscriptIndex: @unchecked Sendable {
     /// generated sidecar) and write one row per Decision / Action Item / Open
     /// Question. Called inside the meeting index transaction. A meeting with no
     /// summary inserts nothing.
-    private func insertSummaryItems(forMeeting url: URL, filename: String) throws {
-        guard let summary = TranscriptLoader.loadMeetingSummary(forTranscript: url) else { return }
-
+    private func insertSummaryItems(_ summary: ParsedMeetingSummary, filename: String) throws {
         for (position, text) in summary.decisions.enumerated() {
             try bindExec(
                 "INSERT INTO meeting_summary_items (filename, kind, position, owner, text) VALUES (?,?,?,?,?)",
@@ -433,6 +471,24 @@ final class TranscriptIndex: @unchecked Sendable {
                 bindings: [.text(filename), .text(SummaryItemKind.openQuestion), .int(position), .null, .text(text)]
             )
         }
+    }
+
+    private func insertSummarySearchDocument(_ summary: ParsedMeetingSummary, filename: String) throws {
+        try bindExec(
+            """
+            INSERT INTO meeting_summary_documents
+                (filename, title, attendees, decisions, action_items, open_questions)
+            VALUES (?,?,?,?,?,?)
+            """,
+            bindings: [
+                .text(filename),
+                .text(summary.title ?? ""),
+                .text(summary.attendees.joined(separator: "\n")),
+                .text(summary.decisions.joined(separator: "\n")),
+                .text(summary.actionItems.map(\.text).joined(separator: "\n")),
+                .text(summary.openQuestions.joined(separator: "\n"))
+            ]
+        )
     }
 
     private func indexDictationDay(file url: URL, filename: String, modDate: TimeInterval) throws {
@@ -493,6 +549,7 @@ final class TranscriptIndex: @unchecked Sendable {
         defer { if !committed { exec("ROLLBACK") } }
         try bindExec("DELETE FROM utterances WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM meeting_summary_items WHERE filename = ?", bindings: [.text(filename)])
+        try bindExec("DELETE FROM meeting_summary_documents WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM meeting_speakers WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM meetings WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM dictation_entries WHERE filename = ?", bindings: [.text(filename)])
@@ -599,8 +656,63 @@ final class TranscriptIndex: @unchecked Sendable {
 
     func searchUtterances(query: String, speaker: String?, dateFrom: String?, dateTo: String?, maxMeetings: Int = 10, snippetsPerMeeting: Int = 3) throws -> GroupedSearchResult {
         return try queue.sync {
-            let tokens = query.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-            let ftsQuery = tokens.map { "\"\($0.replacingOccurrences(of: "\"", with: ""))\"" }.joined(separator: " ")
+            guard let ftsQuery = ftsQuery(from: query) else {
+                return GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false)
+            }
+
+            var summaryGroups: [MeetingSearchGroup] = []
+            var summaryFilenames: Set<String> = []
+
+            if speaker == nil {
+                var summarySQL = """
+                    SELECT d.filename, d.title, d.attendees, d.decisions, d.action_items, d.open_questions,
+                           m.date, m.datetime, m.duration_seconds,
+                           bm25(meeting_summary_documents_fts, 8.0, 4.0, 6.0, 6.0, 6.0) AS score
+                    FROM meeting_summary_documents_fts
+                    JOIN meeting_summary_documents d ON d.rowid = meeting_summary_documents_fts.rowid
+                    JOIN meetings m ON m.filename = d.filename
+                    WHERE meeting_summary_documents_fts MATCH ?
+                """
+                var summaryBindings: [SQLBinding] = [.text(ftsQuery)]
+                if let dateFrom = dateFrom {
+                    summarySQL += " AND m.date >= ?"
+                    summaryBindings.append(.text(dateFrom))
+                }
+                if let dateTo = dateTo {
+                    summarySQL += " AND m.date <= ?"
+                    summaryBindings.append(.text(dateTo))
+                }
+                summarySQL += " ORDER BY score LIMIT 200"
+
+                var summaryStmt: OpaquePointer?
+                guard sqlite3_prepare_v2(db, summarySQL, -1, &summaryStmt, nil) == SQLITE_OK else {
+                    throw MCPIndexError.queryFailed(dbError())
+                }
+                defer { sqlite3_finalize(summaryStmt) }
+                for (i, binding) in summaryBindings.enumerated() {
+                    bind(stmt: summaryStmt, index: Int32(i + 1), value: binding)
+                }
+
+                while sqlite3_step(summaryStmt) == SQLITE_ROW {
+                    let filename = colText(summaryStmt, 0)
+                    summaryFilenames.insert(filename)
+                    summaryGroups.append(MeetingSearchGroup(
+                        meetingTitle: summarySearchTitle(summaryTitle: colText(summaryStmt, 1), filename: filename),
+                        meetingDate: colText(summaryStmt, 6),
+                        meetingDateTime: colText(summaryStmt, 7),
+                        filename: filename,
+                        snippets: summarySearchSnippets(
+                            query: query,
+                            title: colText(summaryStmt, 1),
+                            attendees: colText(summaryStmt, 2),
+                            decisions: colText(summaryStmt, 3),
+                            actionItems: colText(summaryStmt, 4),
+                            openQuestions: colText(summaryStmt, 5),
+                            limit: snippetsPerMeeting
+                        )
+                    ))
+                }
+            }
 
             var sql = """
                 SELECT u.filename, u.speaker_name, u.utterance_start, u.text,
@@ -677,8 +789,7 @@ final class TranscriptIndex: @unchecked Sendable {
                 }
             }
 
-            let totalMeetings = meetingOrder.count
-            let results = meetingOrder.prefix(maxMeetings).compactMap { filename -> MeetingSearchGroup? in
+            var rawSearchGroups = meetingOrder.compactMap { filename -> MeetingSearchGroup? in
                 guard let g = grouped[filename] else { return nil }
                 let title = filename
                     .replacingOccurrences(of: "Call_", with: "")
@@ -692,13 +803,101 @@ final class TranscriptIndex: @unchecked Sendable {
                     snippets: g.snippets
                 )
             }
+            let rawGroupsByFilename = Dictionary(uniqueKeysWithValues: rawSearchGroups.map { ($0.filename, $0) })
+            let mergedSummaryGroups = summaryGroups.map { summaryGroup -> MeetingSearchGroup in
+                guard let rawGroup = rawGroupsByFilename[summaryGroup.filename] else { return summaryGroup }
+                let cappedSnippets: [SearchSnippet]
+                if snippetsPerMeeting > 1, !rawGroup.snippets.isEmpty {
+                    let summarySlots = max(1, snippetsPerMeeting - 1)
+                    var snippets = Array(summaryGroup.snippets.prefix(summarySlots))
+                    snippets.append(contentsOf: rawGroup.snippets.prefix(snippetsPerMeeting - snippets.count))
+                    cappedSnippets = snippets
+                } else {
+                    cappedSnippets = Array(summaryGroup.snippets.prefix(max(1, snippetsPerMeeting)))
+                }
+                return MeetingSearchGroup(
+                    meetingTitle: summaryGroup.meetingTitle,
+                    meetingDate: summaryGroup.meetingDate,
+                    meetingDateTime: summaryGroup.meetingDateTime,
+                    filename: summaryGroup.filename,
+                    snippets: cappedSnippets
+                )
+            }
+            rawSearchGroups.removeAll { summaryFilenames.contains($0.filename) }
+
+            let combined = mergedSummaryGroups + rawSearchGroups
+            let uniqueTotal = summaryFilenames.union(Set(meetingOrder)).count
 
             return GroupedSearchResult(
-                results: Array(results),
-                totalMeetingsMatched: totalMeetings,
-                truncated: totalMeetings > maxMeetings
+                results: Array(combined.prefix(maxMeetings)),
+                totalMeetingsMatched: uniqueTotal,
+                truncated: uniqueTotal > maxMeetings
             )
         }
+    }
+
+    private func summarySearchTitle(summaryTitle: String, filename: String) -> String {
+        let trimmed = summaryTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return filename
+            .replacingOccurrences(of: "Call_", with: "")
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: ":")
+    }
+
+    private func summarySearchSnippets(
+        query: String,
+        title: String,
+        attendees: String,
+        decisions: String,
+        actionItems: String,
+        openQuestions: String,
+        limit: Int
+    ) -> [SearchSnippet] {
+        let fields: [(label: String, text: String)] = [
+            ("Title", title),
+            ("Decisions", decisions),
+            ("Action Items", actionItems),
+            ("Open Questions", openQuestions),
+            ("Attendees", attendees)
+        ]
+
+        let queryTokens = query
+            .components(separatedBy: .whitespacesAndNewlines)
+            .map { $0.trimmingCharacters(in: CharacterSet.alphanumerics.inverted).lowercased() }
+            .filter { !$0.isEmpty }
+        let orderedFields = fields.sorted { lhs, rhs in
+            let lhsMatches = summaryField(lhs.text, matchesAny: queryTokens)
+            let rhsMatches = summaryField(rhs.text, matchesAny: queryTokens)
+            return lhsMatches == rhsMatches ? false : lhsMatches
+        }
+
+        let snippets = orderedFields.compactMap { field -> SearchSnippet? in
+            let trimmed = field.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            return SearchSnippet(
+                speaker: "Summary",
+                speakerId: nil,
+                timestamp: field.label,
+                text: "\(field.label): \(singleLineSummarySnippet(trimmed))"
+            )
+        }
+        return Array(snippets.prefix(max(1, limit)))
+    }
+
+    private func summaryField(_ text: String, matchesAny queryTokens: [String]) -> Bool {
+        guard !queryTokens.isEmpty else { return false }
+        let normalized = text.lowercased()
+        return queryTokens.contains { normalized.contains($0) }
+    }
+
+    private func singleLineSummarySnippet(_ text: String) -> String {
+        let singleLine = text
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " | ")
+        return String(singleLine.prefix(320))
     }
 
     func listDictationDays(count: Int, dateFrom: String? = nil, dateTo: String? = nil) throws -> [DictationDaySummary] {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryItemIndexTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryItemIndexTests.swift
@@ -33,6 +33,91 @@ final class SummaryItemIndexTests: XCTestCase {
         XCTAssertEqual(questions.map(\.text), ["Do we need a migration window?"])
     }
 
+    func testSearchIndexesSummaryTitleAttendeesAndSections() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                attendees: ["Jenny", "Priya"],
+                decisions: ["Adopt pricing decision memo"],
+                actionItems: ["Priya: send launch checklist"],
+                openQuestions: ["Should enterprise pricing wait?"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let decision = try index.searchUtterances(query: "pricing decision", speaker: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(decision.results.first?.filename, "Call_2026-04-18_09-15-00")
+        XCTAssertEqual(decision.results.first?.snippets.first?.speaker, "Summary")
+        XCTAssertTrue(decision.results.first?.snippets.first?.text.contains("Decisions") == true)
+
+        let attendee = try index.searchUtterances(query: "Priya", speaker: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(attendee.results.first?.filename, "Call_2026-04-18_09-15-00")
+        XCTAssertTrue(attendee.results.first?.snippets.contains(where: { $0.timestamp == "Attendees" }) == true)
+
+        let title = try index.searchUtterances(query: "Beta launch", speaker: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(title.results.first?.meetingTitle, "Beta launch sync")
+    }
+
+    func testSearchIndexesTitleAndAttendeesWhenFactSectionsAreEmpty() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                attendees: ["Priya"],
+                decisions: [],
+                actionItems: [],
+                openQuestions: []
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        XCTAssertTrue(try index.listSummaryItems().isEmpty)
+
+        let attendee = try index.searchUtterances(query: "Priya", speaker: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(attendee.results.first?.filename, "Call_2026-04-18_09-15-00")
+        XCTAssertEqual(attendee.results.first?.snippets.first?.speaker, "Summary")
+
+        let title = try index.searchUtterances(query: "Beta launch", speaker: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(title.results.first?.meetingTitle, "Beta launch sync")
+    }
+
+    func testSummarySearchRanksAboveRawUtteranceHits() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                date: "2026-04-18",
+                decisions: ["Pricing decision is to keep the beta free"],
+                actionItems: [],
+                openQuestions: []
+            ).replacingOccurrences(
+                of: "[00:00] [System/Jenny] Let's lock the launch.",
+                with: "[00:00] [System/Jenny] Raw pricing decision transcript evidence"
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try writeFixture(
+            makeFixtureJSON(
+                date: "2026-04-19T09:15:00-0500",
+                utterances: [("system_0", 0.0, 5.0, "Raw pricing decision chatter")]
+            ),
+            filename: "Call_2026-04-19_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let results = try index.searchUtterances(query: "pricing decision", speaker: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(results.results.map(\.filename), [
+            "Call_2026-04-18_09-15-00",
+            "Call_2026-04-19_09-15-00"
+        ])
+        XCTAssertEqual(results.results.first?.snippets.first?.speaker, "Summary")
+        XCTAssertEqual(results.results.first?.snippets.count, 3)
+        XCTAssertTrue(results.results.first?.snippets.contains(where: {
+            $0.speaker == "Jenny" && $0.timestamp == "0:00" && $0.text.contains("transcript evidence")
+        }) == true)
+    }
+
     func testIndexesActionItemOwnerAndUnassigned() throws {
         try writeFixture(makeMeetingWithInlineSummary(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
         try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
@@ -134,6 +219,54 @@ final class SummaryItemIndexTests: XCTestCase {
         try reopened.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
         XCTAssertEqual(try reopened.listRecentMeetings(count: 10).count, 1)
         XCTAssertEqual(try reopened.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.decision).count, 2)
+    }
+
+    func testVersionTwoIndexBackfillsSummarySearchDocuments() throws {
+        try writeFixture(makeMeetingWithInlineSummary(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        index = nil
+
+        let dbPath = tempDir.appendingPathComponent("mcp_index.sqlite").path
+        var raw: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(dbPath, &raw), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(raw, "PRAGMA user_version=2", nil, nil, nil), SQLITE_OK)
+        sqlite3_close(raw)
+
+        let reopened = try TranscriptIndex(indexDir: tempDir)
+        XCTAssertTrue(try reopened.searchUtterances(query: "beta", speaker: nil, dateFrom: nil, dateTo: nil).results.isEmpty)
+
+        try reopened.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertEqual(
+            try reopened.searchUtterances(query: "Beta launch", speaker: nil, dateFrom: nil, dateTo: nil).results.first?.filename,
+            "Call_2026-04-18_09-15-00"
+        )
+    }
+
+    func testFiveHundredMeetingSummaryBackfillBudget() throws {
+        for index in 0..<500 {
+            try writeFixture(
+                makeMeetingWithInlineSummary(
+                    decisions: ["Synthetic pricing decision \(index)"],
+                    actionItems: ["Jenny: follow up on synthetic task \(index)"],
+                    openQuestions: ["Should synthetic question \(index) stay open?"]
+                ),
+                filename: String(format: "Call_2026-04-18_09-15-%03d", index),
+                to: tempDir
+            )
+        }
+
+        let started = Date()
+        try withLogsSuppressed {
+            try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        }
+        let elapsed = Date().timeIntervalSince(started)
+
+        XCTAssertLessThan(elapsed, 60, "500-meeting summary backfill should stay under the PRD budget")
+        XCTAssertEqual(try index.listRecentMeetings(count: 50).count, 50)
+        XCTAssertEqual(
+            try index.searchUtterances(query: "Synthetic pricing decision 499", speaker: nil, dateFrom: nil, dateTo: nil).results.first?.snippets.first?.speaker,
+            "Summary"
+        )
     }
 
     func testGeneratedSidecarIsNotIndexedAsMeetingButFeedsSummary() throws {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
@@ -143,6 +143,7 @@ func writeFixture(_ content: String, filename: String, to directory: URL) throws
 func makeMeetingWithInlineSummary(
     date: String = "2026-04-18",
     time: String = "09:15:00",
+    attendees: [String] = ["Jenny", "Sam"],
     decisions: [String] = ["Ship the beta on Friday", "Cut the legacy import path"],
     actionItems: [String] = ["Jenny: send the revised spec", "Follow up with legal"],
     openQuestions: [String] = ["Do we need a migration window?"]
@@ -184,6 +185,8 @@ func makeMeetingWithInlineSummary(
     \(block("### Decisions", decisions))
 
     \(block("### Open Questions", openQuestions))
+
+    \(block("### Participants", attendees))
 
     \(block("### Action Items", actionItems))
     <!-- transcripted:local-summary:end -->


### PR DESCRIPTION
## Summary
- Add a v3 MCP index schema with meeting summary search documents backed by FTS5.
- Index summary title, attendees, decisions, action items, and open questions from the shared CaptureSummaryParser.
- Rank summary matches ahead of raw utterance-only matches while preserving capped raw snippets when a meeting matches both.
- Force v2/v1 index rebuild/backfill on next reconcile.

## Tests / checks
- swift test --package-path Tools/TranscriptedCaptureKit
- swift test --package-path Tools/TranscriptedMCP
- swift test --package-path Tools/TranscriptedCLI
- bash run-e2e-smoke.sh
- git diff --check
- codex review --base origin/main: clean, no discrete correctness issues

## Maestro lanes
- Codex: implementation, tests, review fixes, commit/push/PR
- Local: cheap triage attempted; proof /Users/redbars/.codex/maestro/runs/20260703T001539Z-ws21-index-triage-local
- Claude: schema risk review attempted, no useful output; proof /Users/redbars/.codex/maestro/runs/20260703T002030Z-ws21-schema-risk-review-claude
- Windows: skipped; local-only/privacy-sensitive repo work did not need it

## Risks / unknowns
- Adjacent open PRs touching TranscriptIndex may conflict (#1365, #1352 observed during preflight).
- Product runtime remains local-only; no cloud calls were added.