### PR TITLE
Docs: disclose the MCP helper's anonymous usage ping

### DIFF
--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -49,3 +49,21 @@ If `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 `dictations/` subfolders, `transcripted-mcp` uses those subfolders
 automatically and stores its SQLite index in that shared root unless
 `TRANSCRIPTED_INDEX_DIR` is also set.
+
+## Telemetry
+
+The server can emit one anonymous PostHog event per successful tool call
+(`agent_capture_query_observed`, see `AgentCaptureQueryTelemetry.swift`). The
+payload is bucketed metadata only — query kind, artifact kind, capture-age
+bucket, source-count bucket — validated against an allow-list; transcript
+text, query strings, titles, speaker names, and file paths are never sent.
+
+It is gated twice:
+
+- it honors the app's anonymous-analytics toggle
+  (`observability-anonymous-analytics-enabled`; off means nothing is sent)
+- it no-ops entirely unless a PostHog API key and HTTPS host are configured
+  via `POSTHOG_API_KEY`/`POSTHOG_HOST`, a local override, or the bundle's
+  `TranscriptedPostHogAPIKey` — source builds have none by default
+
+Transcripts and audio never leave the Mac in any mode.

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -74,6 +74,19 @@ Current `transcripted-mcp` capabilities:
 These tools are read-only, but they are not redacted. `read_meeting` and
 `read_dictation` can return local transcript text to the agent you connected.
 
+### Anonymous usage ping
+
+Like the app, the MCP helper can send one anonymous analytics event per
+successful tool call (`agent_capture_query_observed`) so we can tell whether
+the agent connection gets used. It carries only bucketed metadata — which kind
+of tool ran, meeting vs dictation, rough capture age, rough source count.
+It never includes transcript text, queries, titles, speaker names, or file
+paths, and your captures still never leave your Mac.
+
+It follows the same anonymous-analytics switch as the app: turn off analytics
+in Settings → Privacy and the helper sends nothing. Source builds send nothing
+by default because they ship without an analytics key.
+
 ## Local Coding Agents
 
 Claude Code, Codex, and Cursor get the same one-click `Connect` as Claude


### PR DESCRIPTION
## Why

PR #1357 had the right docs disclosure, but it was stacked on #1356 and carried a large unrelated diff when compared with `main`. This rebuild preserves only the MCP helper anonymous usage-ping disclosure on fresh `origin/main`.

## What changed

- `docs/agent-connect.md`: discloses the anonymous `agent_capture_query_observed` ping in the agent connection docs.
- `Tools/TranscriptedMCP/README.md`: documents the PostHog event, bucketed allow-listed payload, opt-out gate, API-key/HTTPS-host gate, and source-build default.

No #1356 docs sync changes were brought over.

## Checks

- `git diff --check`
- `bash scripts/dev/agent-preflight.sh`
- `swift test --package-path Tools/TranscriptedMCP`
- `bash run-e2e-smoke.sh`

## Supersedes

Supersedes #1357 as the minimal `main`-based replacement.