### PR TITLE
Rebuild MCP search and receipt tools

### DIFF
--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -100,6 +100,10 @@ enum AgentConnectionGuide {
         "search",
         "who_is",
         "recap",
+        "decisions",
+        "commitments",
+        "open_questions",
+        "search_meetings",
     ]
 
     static func skillFileURL(for skill: AgentConnectionStarterSkill) -> URL {

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -27,7 +27,7 @@ func testAgentConnectionGuide() {
             "prompt should tell local agents to use direct tools when available"
         )
         assertTrue(
-            AgentConnectionGuide.directToolNames.count == 9,
+            AgentConnectionGuide.directToolNames.count == 13,
             "prompt should track the full Transcripted MCP direct tool set"
         )
         for toolName in AgentConnectionGuide.directToolNames {
@@ -48,6 +48,10 @@ func testAgentConnectionGuide() {
                 "search",
                 "who_is",
                 "recap",
+                "decisions",
+                "commitments",
+                "open_questions",
+                "search_meetings",
             ]),
             "direct tool list should mirror Tools/TranscriptedMCP tool registration"
         )

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -35,20 +35,23 @@ When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 that mode the SQLite index also defaults to the shared root unless
 `TRANSCRIPTED_INDEX_DIR` is set.
 
-## Package Layout (20 Swift files)
+## Package Layout (24 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
-- `Sources/TranscriptedMCP/` — 10 source files for server startup, directory resolution, path validation, indexing, telemetry, and tool handlers
-- `Tests/TranscriptedMCPTests/` — 10 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, tool handlers, markdown loading, logging, telemetry, name variants, and shared fixtures
+- `Sources/TranscriptedMCP/` — 13 source files for server startup, directory resolution, path validation, indexing, telemetry, semantic search, and tool handlers
+- `Tests/TranscriptedMCPTests/` — 11 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, tool handlers, markdown loading, logging, telemetry, name variants, semantic search, and shared fixtures
 
 ## File Index
 
 | File | Purpose |
 |------|---------|
-| `Main.swift` | `@main` entry point; resolves directories, builds the index, starts file watchers, then starts the MCP stdio server |
+| `Main.swift` | `@main` entry point; resolves directories, builds the index (with an `NLEmbeddingProvider` for semantic search), starts file watchers, then starts the MCP stdio server |
 | `DataDirectories.swift` | Index-dir resolution plus a thin wrapper over `TranscriptedCaptureKit`'s shared capture-library resolver |
 | `ToolHandlers.swift` | Registers every MCP tool and routes requests to the correct loader or index method |
-| `TranscriptIndex.swift` | SQLite-backed index, incremental updates, and query methods across meetings and dictations |
+| `TranscriptIndex.swift` | SQLite-backed index, incremental updates, and query methods across meetings and dictations; routes `lexical`/`semantic`/`hybrid` search modes |
+| `EmbeddingProvider.swift` | `EmbeddingProvider` protocol, the default `NLEmbeddingProvider` (Apple NaturalLanguage, zero-bundle on-device), `SearchMode`, and `VectorMath` helpers |
+| `EmbeddingStore.swift` | Vector store on its own SQLite connection; embeds rows, stores Float32 vectors, and runs cosine semantic search over utterances and dictation entries |
+| `SemanticSearchFusion.swift` | Reciprocal-rank fusion that merges lexical (FTS) and semantic result lists for hybrid search |
 | `TranscriptLoader.swift` | Loads markdown meeting transcripts and dictation day files from disk; parsing delegates to `TranscriptedCaptureKit` |
 | `Models.swift` | Codable input/output models and `MCPIndexError` |
 | `NameVariants.swift` | Speaker-name fuzzy matching for speaker-aware queries |
@@ -69,6 +72,7 @@ that mode the SQLite index also defaults to the shared root unless
 | `SummaryRollupTests.swift` | Cross-meeting rollups: action items by owner/status/date, decisions, digest, write-seam idempotency |
 | `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error, read pagination windows and size guard |
 | `AgentCaptureQueryTelemetryTests.swift` | Bucketing and payload coverage for agent capture-query telemetry |
+| `SemanticSearchTests.swift` | Semantic + hybrid search via a deterministic stub provider, graceful fallback, model-change re-embed, vector-math, and RRF fusion |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |
 
 ## MCP Tools
@@ -81,8 +85,8 @@ All tools are read-only.
 | `read_meeting` | Read one meeting transcript by filename; `section` (`full`/`transcript`/`speakers`) plus optional `offset`/`limit` utterance paging |
 | `list_dictations` | List saved dictation day files with counts, source apps, and titles |
 | `read_dictation` | Read one dictation day, one specific entry by `entry_id`, or a paged window of entries via `offset`/`limit` |
-| `search` | Search meeting transcript content |
-| `search_context` | Search across meetings, dictations, or both |
+| `search` | Search meeting transcript content (lexical / semantic / hybrid via `mode`, default hybrid) |
+| `search_context` | Search across meetings, dictations, or both (same `mode` options) |
 | `recent_context` | Get a mixed recent feed of meetings and dictations |
 | `who_is` | Look up a speaker profile across saved meetings |
 | `recap` | Build a structured digest for a date range |
@@ -132,6 +136,18 @@ The SQLite index keeps separate records for:
 Structured summary items are parsed via `TranscriptedCaptureKit.CaptureSummaryParser` from each meeting's inline local summary (or a `<stem>.summary.md` sidecar fallback) during `indexMeeting`. `TranscriptIndex.listSummaryItems(kind:owner:dateFrom:dateTo:)` is the cross-meeting query foundation behind `list_action_items`, `list_decisions`, and `digest`.
 
 This lets the server answer both meeting-specific queries (`who_is`, `read_meeting`) and mixed-context queries (`search_context`, `recent_context`) without touching app-owned runtime state.
+
+The semantic layer adds three additive tables on a separate connection: `embedding_meta` (model id + dimension), `utterance_vectors`, and `dictation_entry_vectors` (Float32 BLOBs keyed by the lexical rows' `rowid`). They never alter the lexical write path.
+
+## Semantic Search
+
+Local, on-device semantic search complements FTS so paraphrase queries hit (e.g. "pricing pushback" finds "they balked at the cost").
+
+- Embeddings come from Apple's `NaturalLanguage` `NLEmbedding.sentenceEmbedding` — **no bundled model, no download, negligible app-size impact**. Backend is pluggable via `EmbeddingProvider`, so a bundled CoreML model can replace it later without touching the store or search path.
+- `EmbeddingStore` embeds new/changed rows after each reconcile (lazily, keyed by `rowid`), re-embeds everything on a model-id/dimension change, and runs a streaming cosine scan with the same speaker/date filters as FTS.
+- `search` / `search_context` accept `mode`: `hybrid` (default — FTS + semantic fused with reciprocal-rank fusion, a strict superset of FTS recall), `lexical`, or `semantic`.
+- All modes degrade gracefully: if the embedding backend is unavailable (e.g. missing OS language assets), the store is never created and every mode runs lexical-only.
+- NLEmbedding's similarity floor is high, so `semantic` alone is best-effort; `hybrid` is rank-based and stays robust because exact FTS hits anchor precision.
 
 ## Build And Test
 

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -89,11 +89,16 @@ All tools are read-only.
 | `list_action_items` | Roll up action items across meetings; filter by owner / status (`open`/`all`; `done` is rejected with an explicit error) / query / date |
 | `list_decisions` | Roll up decisions across meetings; filter by query / date |
 | `digest` | Cross-meeting summary (decisions + action items + open questions) for a window |
+| `decisions` | WS2.3 receipt API for local decision lookup by topic/range |
+| `commitments` | WS2.3 receipt API for local action-item lookup by person/range |
+| `open_questions` | WS2.3 receipt API for local open-question lookup by project/range |
+| `search_meetings` | WS2.3 receipt API for local keyword search over meeting utterances |
 | `status` | Server version, resolved capture directories and which resolution rule selected them, index location, and indexed counts |
 
-The last three are cross-meeting rollups over the structured summary fields and
-query the same `meeting_summary_items` index populated from saved meeting
-Markdown during reconcile.
+The rollup and WS2.3 tools are cross-meeting reads over local structured summary
+fields and raw utterance FTS. They query the same `meeting_summary_items` index
+populated from saved meeting Markdown during reconcile. They do not use
+embeddings, cloud calls, or LLM synthesis.
 
 ## Common Agent Retrieval Shapes
 

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -67,7 +67,7 @@ that mode the SQLite index also defaults to the shared root unless
 | `LoggingTests.swift` | JSON log emission coverage for MCP startup and indexing diagnostics |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
 | `SummaryRollupTests.swift` | Cross-meeting rollups: action items by owner/status/date, decisions, digest, write-seam idempotency |
-| `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error |
+| `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error, read pagination windows and size guard |
 | `AgentCaptureQueryTelemetryTests.swift` | Bucketing and payload coverage for agent capture-query telemetry |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |
 
@@ -78,9 +78,9 @@ All tools are read-only.
 | Tool | Description |
 |------|-------------|
 | `list_meetings` | List saved meetings with metadata and optional date filters |
-| `read_meeting` | Read one meeting transcript by filename |
+| `read_meeting` | Read one meeting transcript by filename; `section` (`full`/`transcript`/`speakers`) plus optional `offset`/`limit` utterance paging |
 | `list_dictations` | List saved dictation day files with counts, source apps, and titles |
-| `read_dictation` | Read one dictation day or one specific dictation entry |
+| `read_dictation` | Read one dictation day, one specific entry by `entry_id`, or a paged window of entries via `offset`/`limit` |
 | `search` | Search meeting transcript content |
 | `search_context` | Search across meetings, dictations, or both |
 | `recent_context` | Get a mixed recent feed of meetings and dictations |
@@ -188,4 +188,5 @@ The in-app Claude Desktop installer copies that helper into:
 - `recent_context` is intentionally mixed; for the latest meeting specifically, prefer `list_meetings` or `recent_context` with `kind: "meeting"`
 - zero-result queries return a self-describing JSON payload (`searched_directories`, indexed counts, `hint`) instead of a bare "not found" string; call `status` to see the full resolution + index picture
 - `read_meeting` and `read_dictation` read markdown directly from disk, not from the SQLite index
+- both read tools carry a size guard: raw dumps larger than `maxUnpaginatedReadCharacters` (~30k chars) — or any call passing `offset`/`limit` — come back as a paginated JSON window (`total_utterances`/`total_entries`, `offset`, `returned`, `truncated`, `next_offset`, `hint`) instead of the full markdown; small unpaginated reads stay byte-identical raw markdown, and `entry_id` reads are unaffected
 - source builds can run the server standalone, but shipped app builds bundle the helper for the one-click Claude Desktop installer

--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -49,3 +49,17 @@ If `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 `dictations/` subfolders, `transcripted-mcp` uses those subfolders
 automatically and stores its SQLite index in that shared root unless
 `TRANSCRIPTED_INDEX_DIR` is also set.
+
+## Cross-Meeting Receipt Tools
+
+WS2.3 adds local structured retrieval tools for agents:
+
+- `decisions(topic, range)`
+- `commitments(person, range)`
+- `open_questions(project, range)`
+- `search_meetings(query, range)`
+
+Each returns JSON receipts shaped around `meetingId`, `timestamp`, and `quote`.
+Summary-derived receipts have `timestamp: null` until exact audio anchors are
+available; raw utterance search includes the transcript timestamp. These tools
+use only the local SQLite index and saved summary/parser output.

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingProvider.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingProvider.swift
@@ -1,0 +1,115 @@
+import Foundation
+import NaturalLanguage
+
+/// Which retrieval strategy a search runs.
+///
+/// - `lexical`  — the original SQLite FTS5 path (exact/stemmed token match).
+/// - `semantic` — vector cosine match only (paraphrase recall).
+/// - `hybrid`   — both, fused with reciprocal-rank fusion. Strict superset of
+///                lexical recall, so it never drops an FTS hit.
+enum SearchMode: String, Codable, Sendable {
+    case lexical
+    case semantic
+    case hybrid
+}
+
+/// Produces dense vector embeddings for short text spans (meeting utterances,
+/// dictation entries).
+///
+/// Pluggable on purpose: today the shipping backend is Apple's built-in
+/// `NaturalLanguage` sentence embedding — zero bundle size, no model download,
+/// fully on-device. A bundled CoreML model (e.g. a quantized MiniLM) can replace
+/// it later without touching the vector store or the search path, by conforming
+/// a new type to this protocol and wiring it in `Main.swift`.
+protocol EmbeddingProvider: Sendable {
+    /// Stable identifier for the embedding space. Changing it invalidates every
+    /// stored vector so they get re-embedded against the new model.
+    var modelID: String { get }
+
+    /// Vector dimensionality, or 0 when the backend is unavailable on this host.
+    var dimension: Int { get }
+
+    /// Whether the backend can actually produce vectors right now.
+    var isAvailable: Bool { get }
+
+    /// Embed one text span. Returns nil for empty/unembeddable input or when the
+    /// backend is unavailable. Returned vectors are L2-normalized so a dot
+    /// product equals cosine similarity.
+    func embed(_ text: String) -> [Float]?
+}
+
+extension EmbeddingProvider {
+    var isAvailable: Bool { dimension > 0 }
+}
+
+/// Default on-device backend: Apple's `NLEmbedding` sentence embedding.
+///
+/// Built into macOS (no bundled model, no download, negligible incremental app
+/// size, modest RAM). `sentenceEmbedding(for:)` returns nil when the OS has no
+/// model assets for the language (e.g. some headless/CI images) — in that case
+/// `isAvailable` is false and the index simply skips semantic indexing, leaving
+/// lexical search fully functional.
+final class NLEmbeddingProvider: EmbeddingProvider, @unchecked Sendable {
+    let modelID: String
+    private let embedding: NLEmbedding?
+    // NLEmbedding is not documented as thread-safe; serialize vector() calls.
+    private let lock = NSLock()
+
+    init(language: NLLanguage = .english) {
+        let model = NLEmbedding.sentenceEmbedding(for: language)
+        self.embedding = model
+        self.modelID = "nl.sentence.\(language.rawValue).v1"
+    }
+
+    var dimension: Int { embedding?.dimension ?? 0 }
+    var isAvailable: Bool { embedding != nil }
+
+    func embed(_ text: String) -> [Float]? {
+        guard let embedding else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        lock.lock()
+        let raw = embedding.vector(for: trimmed)
+        lock.unlock()
+        guard let raw, !raw.isEmpty else { return nil }
+        return VectorMath.normalized(raw.map { Float($0) })
+    }
+}
+
+/// Small float-vector helpers shared by the provider and the vector store.
+enum VectorMath {
+    /// L2-normalize a vector. A zero vector is returned unchanged.
+    static func normalized(_ v: [Float]) -> [Float] {
+        var sum: Float = 0
+        for x in v { sum += x * x }
+        let norm = sum.squareRoot()
+        guard norm > 0 else { return v }
+        return v.map { $0 / norm }
+    }
+
+    /// Dot product. For L2-normalized inputs this equals cosine similarity.
+    static func dot(_ a: [Float], _ b: [Float]) -> Float {
+        let n = min(a.count, b.count)
+        var sum: Float = 0
+        var i = 0
+        while i < n {
+            sum += a[i] * b[i]
+            i += 1
+        }
+        return sum
+    }
+
+    /// Pack a vector into a Float32 blob for SQLite storage.
+    static func blob(from v: [Float]) -> Data {
+        v.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    /// Unpack a Float32 blob back into a vector.
+    static func vector(from data: Data) -> [Float] {
+        let count = data.count / MemoryLayout<Float>.stride
+        guard count > 0 else { return [] }
+        return data.withUnsafeBytes { raw in
+            Array(raw.bindMemory(to: Float.self).prefix(count))
+        }
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
@@ -1,0 +1,391 @@
+import Foundation
+import SQLite3
+
+/// On-device vector store for semantic search.
+///
+/// Owns its own SQLite connection to the *same* `mcp_index.sqlite` file the
+/// lexical `TranscriptIndex` uses, but only ever writes its own additive tables
+/// (`embedding_meta`, `utterance_vectors`, `dictation_entry_vectors`). It reads
+/// the lexical tables (`utterances`, `meetings`, `dictation_entries`,
+/// `dictation_days`) to find rows that still need embedding and to hydrate search
+/// results. Keeping it on a separate connection means the embedding work and the
+/// vector schema stay fully decoupled from the lexical index's write path.
+///
+/// Everything here is best-effort: if the embedding provider is unavailable or a
+/// write fails, lexical search keeps working untouched.
+final class EmbeddingStore: @unchecked Sendable {
+    private var db: OpaquePointer?
+    private let queue = DispatchQueue(label: "com.transcripted.mcp.vectors", qos: .utility)
+    private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    private let provider: EmbeddingProvider
+    private let dbPath: URL
+
+    /// Minimum cosine similarity for a row to count as a semantic match.
+    /// NLEmbedding sentence vectors have a fairly high similarity floor (even
+    /// unrelated short sentences land around ~0.30), so this trims the obvious
+    /// tail rather than acting as a precise relevance cut. Hybrid mode is
+    /// rank-based and still surfaces exact FTS hits regardless of this value.
+    private let minimumSimilarity: Float = 0.30
+
+    /// Cap on candidate rows scanned per query, newest first, to bound work on
+    /// very large libraries. Personal-scale libraries stay well under this.
+    private let maxCandidateRows = 50_000
+
+    var isAvailable: Bool { provider.isAvailable }
+
+    init(dbPath: URL, provider: EmbeddingProvider) throws {
+        self.dbPath = dbPath
+        self.provider = provider
+        try queue.sync {
+            if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
+                throw MCPIndexError.databaseOpenFailed(dbErrorLocked())
+            }
+            sqlite3_exec(db, "PRAGMA busy_timeout=5000", nil, nil, nil)
+            sqlite3_exec(db, "PRAGMA journal_mode=WAL", nil, nil, nil)
+            sqlite3_exec(db, "PRAGMA synchronous=NORMAL", nil, nil, nil)
+            createTablesLocked()
+        }
+    }
+
+    deinit {
+        queue.sync {
+            if let db = db { sqlite3_close(db) }
+        }
+    }
+
+    private func createTablesLocked() {
+        execLocked("""
+            CREATE TABLE IF NOT EXISTS embedding_meta (
+                id INTEGER PRIMARY KEY CHECK (id = 0),
+                model_id TEXT NOT NULL,
+                dimension INTEGER NOT NULL
+            )
+        """)
+        // rowid mirrors utterances.rowid / dictation_entries.rowid. Those rows are
+        // deleted and re-inserted on reindex, so vectors can be orphaned — the
+        // reconcile pass cleans orphans and embeds the new rows.
+        execLocked("""
+            CREATE TABLE IF NOT EXISTS utterance_vectors (
+                rowid INTEGER PRIMARY KEY,
+                vec BLOB NOT NULL
+            )
+        """)
+        execLocked("""
+            CREATE TABLE IF NOT EXISTS dictation_entry_vectors (
+                rowid INTEGER PRIMARY KEY,
+                vec BLOB NOT NULL
+            )
+        """)
+    }
+
+    // MARK: - Embedding reconciliation
+
+    /// Embed any indexed rows that don't yet have a vector, drop orphaned
+    /// vectors, and re-embed everything if the model identity changed. Safe to
+    /// call after every lexical reconcile; it only does work for new/changed rows.
+    func reconcileEmbeddings() {
+        guard provider.isAvailable else { return }
+        queue.sync {
+            invalidateOnModelChangeLocked()
+            // Drop vectors whose backing rows are gone (reindex churns rowids).
+            execLocked("DELETE FROM utterance_vectors WHERE rowid NOT IN (SELECT rowid FROM utterances)")
+            execLocked("DELETE FROM dictation_entry_vectors WHERE rowid NOT IN (SELECT rowid FROM dictation_entries)")
+
+            embedMissingLocked(
+                selectSQL: """
+                    SELECT u.rowid, u.text FROM utterances u
+                    LEFT JOIN utterance_vectors v ON v.rowid = u.rowid
+                    WHERE v.rowid IS NULL
+                """,
+                insertSQL: "INSERT OR REPLACE INTO utterance_vectors (rowid, vec) VALUES (?, ?)"
+            )
+            embedMissingLocked(
+                selectSQL: """
+                    SELECT e.rowid, e.text FROM dictation_entries e
+                    LEFT JOIN dictation_entry_vectors v ON v.rowid = e.rowid
+                    WHERE v.rowid IS NULL
+                """,
+                insertSQL: "INSERT OR REPLACE INTO dictation_entry_vectors (rowid, vec) VALUES (?, ?)"
+            )
+        }
+    }
+
+    private func invalidateOnModelChangeLocked() {
+        var storedModel: String?
+        var storedDim: Int = 0
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "SELECT model_id, dimension FROM embedding_meta WHERE id = 0", -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                storedModel = String(cString: sqlite3_column_text(stmt, 0))
+                storedDim = Int(sqlite3_column_int64(stmt, 1))
+            }
+        }
+        sqlite3_finalize(stmt)
+
+        if storedModel == provider.modelID, storedDim == provider.dimension { return }
+
+        if storedModel != nil {
+            log("Embedding model changed (\(storedModel ?? "?")/\(storedDim) -> \(provider.modelID)/\(provider.dimension)); re-embedding")
+            execLocked("DELETE FROM utterance_vectors")
+            execLocked("DELETE FROM dictation_entry_vectors")
+        }
+        var upsert: OpaquePointer?
+        if sqlite3_prepare_v2(db, "INSERT OR REPLACE INTO embedding_meta (id, model_id, dimension) VALUES (0, ?, ?)", -1, &upsert, nil) == SQLITE_OK {
+            sqlite3_bind_text(upsert, 1, (provider.modelID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_int64(upsert, 2, Int64(provider.dimension))
+            sqlite3_step(upsert)
+        }
+        sqlite3_finalize(upsert)
+    }
+
+    private func embedMissingLocked(selectSQL: String, insertSQL: String) {
+        // Collect (rowid, text) first so the read cursor isn't open while we write.
+        var pending: [(rowid: Int64, text: String)] = []
+        var selectStmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, selectSQL, -1, &selectStmt, nil) == SQLITE_OK {
+            while sqlite3_step(selectStmt) == SQLITE_ROW {
+                let rowid = sqlite3_column_int64(selectStmt, 0)
+                let text = sqlite3_column_text(selectStmt, 1).map { String(cString: $0) } ?? ""
+                pending.append((rowid, text))
+            }
+        }
+        sqlite3_finalize(selectStmt)
+        guard !pending.isEmpty else { return }
+
+        sqlite3_exec(db, "BEGIN", nil, nil, nil)
+        var inserted = 0
+        for item in pending {
+            guard let vec = provider.embed(item.text) else { continue }
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK else { continue }
+            sqlite3_bind_int64(stmt, 1, item.rowid)
+            let blob = VectorMath.blob(from: vec)
+            _ = blob.withUnsafeBytes { raw in
+                sqlite3_bind_blob(stmt, 2, raw.baseAddress, Int32(blob.count), SQLITE_TRANSIENT)
+            }
+            if sqlite3_step(stmt) == SQLITE_DONE { inserted += 1 }
+            sqlite3_finalize(stmt)
+        }
+        sqlite3_exec(db, "COMMIT", nil, nil, nil)
+        if inserted > 0 { log("Embedded \(inserted) rows") }
+    }
+
+    // MARK: - Semantic search
+
+    /// Cosine-ranked meeting utterance search, grouped per meeting (same shape as
+    /// the lexical path). Returns empty when the query can't be embedded.
+    func semanticSearchUtterances(
+        query: String,
+        speaker: String?,
+        dateFrom: String?,
+        dateTo: String?,
+        maxMeetings: Int = 10,
+        snippetsPerMeeting: Int = 3
+    ) -> GroupedSearchResult {
+        guard let qvec = provider.embed(query) else {
+            return GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false)
+        }
+
+        return queue.sync {
+            var sql = """
+                SELECT u.filename, u.speaker_name, u.utterance_start, u.text,
+                       m.date, m.datetime, m.duration_seconds, v.vec
+                FROM utterance_vectors v
+                JOIN utterances u ON u.rowid = v.rowid
+                JOIN meetings m ON m.filename = u.filename
+                WHERE 1 = 1
+            """
+            var binders: [(OpaquePointer?, Int32) -> Void] = []
+            var nextIndex: Int32 = 1
+
+            if let speaker = speaker {
+                let names = NameVariants.expandName(speaker)
+                let exact = names.map { _ in "u.speaker_name COLLATE NOCASE = ?" }
+                let like = names.map { _ in "u.speaker_name COLLATE NOCASE LIKE ?" }
+                sql += " AND (\((exact + like).joined(separator: " OR ")))"
+                for name in names {
+                    binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (name as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+                }
+                for name in names {
+                    let pattern = "%\(name)%"
+                    binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (pattern as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+                }
+            }
+            if let dateFrom = dateFrom {
+                sql += " AND m.date >= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateFrom as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            if let dateTo = dateTo {
+                sql += " AND m.date <= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateTo as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            sql += " ORDER BY m.datetime DESC LIMIT \(maxCandidateRows)"
+
+            struct Scored {
+                let filename: String, speaker: String, start: Double, text: String
+                let date: String, datetime: String, duration: Int, score: Float
+            }
+            var scored: [Scored] = []
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                return GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false)
+            }
+            for binder in binders { binder(stmt, nextIndex); nextIndex += 1 }
+
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard let blobPtr = sqlite3_column_blob(stmt, 7) else { continue }
+                let blobLen = Int(sqlite3_column_bytes(stmt, 7))
+                let vec = VectorMath.vector(from: Data(bytes: blobPtr, count: blobLen))
+                let score = VectorMath.dot(qvec, vec)
+                guard score >= minimumSimilarity else { continue }
+                scored.append(Scored(
+                    filename: colText(stmt, 0),
+                    speaker: colText(stmt, 1),
+                    start: sqlite3_column_double(stmt, 2),
+                    text: colText(stmt, 3),
+                    date: colText(stmt, 4),
+                    datetime: colText(stmt, 5),
+                    duration: Int(sqlite3_column_int64(stmt, 6)),
+                    score: score
+                ))
+            }
+            sqlite3_finalize(stmt)
+
+            scored.sort { $0.score > $1.score }
+
+            // Group by meeting, ordered by best-scoring hit (first appearance).
+            var grouped: [String: (date: String, datetime: String, snippets: [SearchSnippet])] = [:]
+            var order: [String] = []
+            for row in scored {
+                if grouped[row.filename] == nil {
+                    order.append(row.filename)
+                    grouped[row.filename] = (row.date, row.datetime, [])
+                }
+                if (grouped[row.filename]?.snippets.count ?? 0) < snippetsPerMeeting {
+                    let mins = Int(row.start) / 60
+                    let secs = Int(row.start) % 60
+                    grouped[row.filename]?.snippets.append(SearchSnippet(
+                        speaker: row.speaker,
+                        speakerId: nil,
+                        timestamp: String(format: "%d:%02d", mins, secs),
+                        text: row.text
+                    ))
+                }
+            }
+
+            let total = order.count
+            let results = order.prefix(maxMeetings).compactMap { filename -> MeetingSearchGroup? in
+                guard let g = grouped[filename] else { return nil }
+                let title = filename
+                    .replacingOccurrences(of: "Call_", with: "")
+                    .replacingOccurrences(of: "_", with: " ")
+                    .replacingOccurrences(of: "-", with: ":")
+                return MeetingSearchGroup(
+                    meetingTitle: title,
+                    meetingDate: g.date,
+                    meetingDateTime: g.datetime,
+                    filename: filename,
+                    snippets: g.snippets
+                )
+            }
+            return GroupedSearchResult(
+                results: Array(results),
+                totalMeetingsMatched: total,
+                truncated: total > maxMeetings
+            )
+        }
+    }
+
+    /// Cosine-ranked dictation entry search, one snippet per entry (same shape as
+    /// the lexical path). Returns empty when the query can't be embedded.
+    func semanticSearchDictationEntries(
+        query: String,
+        dateFrom: String?,
+        dateTo: String?,
+        maxItems: Int = 10
+    ) -> [ContextSearchGroup] {
+        guard let qvec = provider.embed(query) else { return [] }
+
+        return queue.sync {
+            var sql = """
+                SELECT e.filename, e.entry_id, e.title, e.created_at, e.text,
+                       e.source_app_name, e.delivery, d.date, v.vec
+                FROM dictation_entry_vectors v
+                JOIN dictation_entries e ON e.rowid = v.rowid
+                JOIN dictation_days d ON d.filename = e.filename
+                WHERE 1 = 1
+            """
+            var binders: [(OpaquePointer?, Int32) -> Void] = []
+            var nextIndex: Int32 = 1
+            if let dateFrom = dateFrom {
+                sql += " AND d.date >= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateFrom as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            if let dateTo = dateTo {
+                sql += " AND d.date <= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateTo as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            sql += " ORDER BY d.datetime DESC LIMIT \(maxCandidateRows)"
+
+            struct Scored {
+                let group: ContextSearchGroup
+                let score: Float
+            }
+            var scored: [Scored] = []
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+            for binder in binders { binder(stmt, nextIndex); nextIndex += 1 }
+
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard let blobPtr = sqlite3_column_blob(stmt, 8) else { continue }
+                let blobLen = Int(sqlite3_column_bytes(stmt, 8))
+                let vec = VectorMath.vector(from: Data(bytes: blobPtr, count: blobLen))
+                let score = VectorMath.dot(qvec, vec)
+                guard score >= minimumSimilarity else { continue }
+                let group = ContextSearchGroup(
+                    kind: .dictation,
+                    title: colText(stmt, 2),
+                    filename: colText(stmt, 0),
+                    entryId: colText(stmt, 1),
+                    date: colText(stmt, 7),
+                    datetime: colText(stmt, 3),
+                    snippets: [
+                        ContextSearchSnippet(
+                            text: colText(stmt, 4),
+                            speaker: nil,
+                            speakerId: nil,
+                            timestamp: nil,
+                            sourceAppName: colText(stmt, 5),
+                            delivery: colText(stmt, 6)
+                        )
+                    ]
+                )
+                scored.append(Scored(group: group, score: score))
+            }
+            sqlite3_finalize(stmt)
+
+            scored.sort { $0.score > $1.score }
+            return Array(scored.prefix(maxItems).map(\.group))
+        }
+    }
+
+    // MARK: - SQLite helpers (own connection)
+
+    private func execLocked(_ sql: String) {
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            log("Vector store SQL failed: \(dbErrorLocked()) for: \(sql)")
+        }
+    }
+
+    private func colText(_ stmt: OpaquePointer?, _ col: Int32) -> String {
+        guard let ptr = sqlite3_column_text(stmt, col) else { return "" }
+        return String(cString: ptr)
+    }
+
+    private func dbErrorLocked() -> String {
+        if let db = db { return String(cString: sqlite3_errmsg(db)) }
+        return "database not open"
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -38,7 +38,16 @@ struct TranscriptedMCP {
         // Create and populate index
         let index: TranscriptIndex
         do {
-            index = try TranscriptIndex(indexDir: directories.indexDir)
+            // On-device semantic search. NLEmbedding ships with macOS (no bundled
+            // model, no download); when its language assets are missing the
+            // provider reports unavailable and search stays lexical-only.
+            let embeddingProvider = NLEmbeddingProvider()
+            if embeddingProvider.isAvailable {
+                log("Semantic search enabled (\(embeddingProvider.modelID), dim \(embeddingProvider.dimension))")
+            } else {
+                log("Semantic search unavailable on this host; using lexical search only")
+            }
+            index = try TranscriptIndex(indexDir: directories.indexDir, embeddingProvider: embeddingProvider)
             try index.reconcile(meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
         } catch {
             log("Failed to initialize index: \(error.localizedDescription)")

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
@@ -553,6 +553,27 @@ struct DigestResult: Codable {
     }
 }
 
+// MARK: - WS2.3 Cross-Meeting Retrieval
+
+struct CrossMeetingReceipt: Codable {
+    let meetingId: String
+    var meetingTitle: String
+    let timestamp: String?
+    let quote: String
+    let date: String
+    let datetime: String
+    let kind: String?
+    let person: String?
+}
+
+struct CrossMeetingToolResult: Codable {
+    let query: String?
+    let range: String?
+    let count: Int
+    let truncated: Bool
+    var results: [CrossMeetingReceipt]
+}
+
 // MARK: - Errors
 
 enum MCPIndexError: Error, LocalizedError {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
@@ -390,6 +390,63 @@ struct EmptyQueryResult: Codable {
     }
 }
 
+// MARK: - Bounded Reads (read_meeting / read_dictation pagination)
+
+/// Paginated window over a meeting transcript, returned when the caller asks
+/// for one (offset/limit) or when the raw markdown would exceed the read
+/// character budget. Frontmatter metadata is preserved; the dialogue is
+/// bounded to the requested utterance window.
+struct MeetingTranscriptPage: Codable {
+    let filename: String
+    let frontmatter: String?
+    let totalUtterances: Int
+    let offset: Int
+    let returned: Int
+    let truncated: Bool
+    let nextOffset: Int?
+    let hint: String
+    let utterances: [MeetingTranscriptPageUtterance]
+
+    enum CodingKeys: String, CodingKey {
+        case filename, frontmatter, offset, returned, truncated, hint, utterances
+        case totalUtterances = "total_utterances"
+        case nextOffset = "next_offset"
+    }
+}
+
+struct MeetingTranscriptPageUtterance: Codable {
+    let start: Double
+    let end: Double
+    let speaker: String
+    let speakerId: String
+    let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case start, end, speaker, text
+        case speakerId = "speaker_id"
+    }
+}
+
+/// Paginated window over a dictation day's entries, mirroring
+/// `MeetingTranscriptPage` for `read_dictation` reads without an entry_id.
+struct DictationDayPage: Codable {
+    let filename: String
+    let date: String
+    let totalEntries: Int
+    let offset: Int
+    let returned: Int
+    let truncated: Bool
+    let nextOffset: Int?
+    let hint: String
+    let entries: [AgentDictationEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case filename, date, offset, returned, truncated, hint, entries
+        case totalEntries = "total_entries"
+        case nextOffset = "next_offset"
+    }
+}
+
 // MARK: - Summary-Fact Rollups (cross-meeting tools)
 
 /// Open/all filter for `list_action_items`.

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/SemanticSearchFusion.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/SemanticSearchFusion.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Combines lexical (FTS) and semantic (vector) result lists using Reciprocal
+/// Rank Fusion. RRF is scale-free — it only uses each item's rank within its own
+/// list, so it merges two scores (FTS `rank`, cosine similarity) that aren't
+/// otherwise comparable without tuning weights.
+///
+/// Fusion happens at the grouped level (per meeting / per dictation entry), which
+/// is the granularity the MCP API already returns. The result is a strict
+/// superset of the lexical list's recall: any FTS hit keeps its snippets and
+/// only gets reordered, while semantic-only matches are appended by score.
+enum SemanticSearchFusion {
+    /// Standard RRF damping constant. Larger = flatter contribution from rank.
+    static let rrfK: Double = 60
+
+    private static func rrf(_ rank: Int) -> Double { 1.0 / (rrfK + Double(rank)) }
+
+    /// Fuse two meeting-grouped result sets.
+    static func fuseGrouped(
+        lexical: GroupedSearchResult,
+        semantic: GroupedSearchResult,
+        maxMeetings: Int,
+        snippetsPerMeeting: Int
+    ) -> GroupedSearchResult {
+        var score: [String: Double] = [:]
+        var lexByName: [String: MeetingSearchGroup] = [:]
+        var semByName: [String: MeetingSearchGroup] = [:]
+        var order: [String] = []
+
+        for (rank, group) in lexical.results.enumerated() {
+            score[group.filename, default: 0] += rrf(rank)
+            if lexByName[group.filename] == nil { order.append(group.filename) }
+            lexByName[group.filename] = group
+        }
+        for (rank, group) in semantic.results.enumerated() {
+            score[group.filename, default: 0] += rrf(rank)
+            if lexByName[group.filename] == nil, semByName[group.filename] == nil {
+                order.append(group.filename)
+            }
+            semByName[group.filename] = group
+        }
+
+        let ranked = order.sorted { (score[$0] ?? 0) > (score[$1] ?? 0) }
+
+        let fused: [MeetingSearchGroup] = ranked.compactMap { name in
+            let base = lexByName[name] ?? semByName[name]
+            guard let base else { return nil }
+            let lexSnippets = lexByName[name]?.snippets ?? []
+            let semSnippets = semByName[name]?.snippets ?? []
+            let snippets = mergeSnippets(lexSnippets, semSnippets, limit: snippetsPerMeeting)
+            return MeetingSearchGroup(
+                meetingTitle: base.meetingTitle,
+                meetingDate: base.meetingDate,
+                meetingDateTime: base.meetingDateTime,
+                filename: name,
+                snippets: snippets
+            )
+        }
+
+        let total = ranked.count
+        return GroupedSearchResult(
+            results: Array(fused.prefix(maxMeetings)),
+            totalMeetingsMatched: total,
+            truncated: total > maxMeetings
+        )
+    }
+
+    /// Fuse two dictation/context result lists keyed by (filename, entry).
+    static func fuseContextGroups(
+        lexical: [ContextSearchGroup],
+        semantic: [ContextSearchGroup],
+        maxItems: Int
+    ) -> [ContextSearchGroup] {
+        func key(_ g: ContextSearchGroup) -> String { "\(g.filename)\u{1}\(g.entryId ?? "")" }
+
+        var score: [String: Double] = [:]
+        var byKey: [String: ContextSearchGroup] = [:]
+        var order: [String] = []
+
+        for (rank, group) in lexical.enumerated() {
+            let k = key(group)
+            score[k, default: 0] += rrf(rank)
+            if byKey[k] == nil { order.append(k); byKey[k] = group }
+        }
+        for (rank, group) in semantic.enumerated() {
+            let k = key(group)
+            score[k, default: 0] += rrf(rank)
+            if byKey[k] == nil { order.append(k); byKey[k] = group }
+        }
+
+        let ranked = order.sorted { (score[$0] ?? 0) > (score[$1] ?? 0) }
+        let fused = ranked.compactMap { byKey[$0] }
+        return Array(fused.prefix(maxItems))
+    }
+
+    /// Lexical snippets first (they're exact matches), then any semantic snippet
+    /// not already present, capped at `limit`. Dedupe on timestamp+text.
+    private static func mergeSnippets(
+        _ lexical: [SearchSnippet],
+        _ semantic: [SearchSnippet],
+        limit: Int
+    ) -> [SearchSnippet] {
+        var seen: Set<String> = []
+        var out: [SearchSnippet] = []
+        for snippet in lexical + semantic {
+            guard out.count < limit else { break }
+            let id = "\(snippet.timestamp)\u{1}\(snippet.text)"
+            if seen.insert(id).inserted {
+                out.append(snippet)
+            }
+        }
+        return out
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -936,7 +936,7 @@ private func handleWhoIs(params: CallTool.Parameters, index: TranscriptIndex) th
 
 // MARK: - recap
 
-private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
     // Use local calendar so "today" matches transcript dates (which are stored in local time)
     let today = DateFormatter.localYYYYMMDD.string(from: Date())
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? String(today)
@@ -951,7 +951,6 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
     var recapParts: [RecapEntry] = []
 
     for meeting in meetings {
-        // Read first ~200 words of transcript as preview
         guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
             named: meeting.filename,
             appendingExtension: "md",
@@ -959,9 +958,23 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
         ) else { continue }
         var preview = ""
         var title = meeting.filename
+        var decisions: [String] = []
+        var actionItems: [RecapActionItem] = []
+        var openQuestions: [String] = []
+        var summarySource = "transcript_fallback"
+
         if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
             title = extractTitle(from: content) ?? meeting.filename
-            preview = extractDialogueLines(from: content).prefix(15).joined(separator: "\n")
+            if let summary = TranscriptLoader.loadMeetingSummary(forTranscript: mdURL) {
+                title = summary.title ?? title
+                decisions = summary.decisions
+                actionItems = summary.actionItems.map { RecapActionItem(owner: $0.owner, text: $0.text) }
+                openQuestions = summary.openQuestions
+                preview = summaryPreview(decisions: decisions, actionItems: actionItems, openQuestions: openQuestions)
+                summarySource = "summary"
+            } else {
+                preview = extractDialogueLines(from: content).prefix(15).joined(separator: "\n")
+            }
         }
 
         recapParts.append(RecapEntry(
@@ -972,7 +985,11 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
             durationFormatted: formatDuration(meeting.durationSeconds),
             speakers: meeting.speakers.map { $0.name },
             wordCount: meeting.wordCount,
-            preview: preview
+            preview: preview,
+            decisions: decisions,
+            actionItems: actionItems,
+            openQuestions: openQuestions,
+            summarySource: summarySource
         ))
     }
 
@@ -1104,6 +1121,15 @@ struct RecapEntry: Codable {
     let speakers: [String]
     let wordCount: Int
     let preview: String
+    let decisions: [String]
+    let actionItems: [RecapActionItem]
+    let openQuestions: [String]
+    let summarySource: String
+}
+
+struct RecapActionItem: Codable, Equatable {
+    let owner: String?
+    let text: String
 }
 
 struct RecapResult: Codable {
@@ -1188,6 +1214,33 @@ private func formatDuration(_ seconds: Int) -> String {
     let m = (seconds % 3600) / 60
     if h > 0 { return "\(h)h \(m)m" }
     return "\(m)m"
+}
+
+private func summaryPreview(
+    decisions: [String],
+    actionItems: [RecapActionItem],
+    openQuestions: [String]
+) -> String {
+    var sections: [String] = []
+    appendSummarySection("Decisions", decisions, to: &sections)
+    appendSummarySection(
+        "Action Items",
+        actionItems.map { item in
+            if let owner = item.owner, !owner.isEmpty {
+                return "\(owner): \(item.text)"
+            }
+            return item.text
+        },
+        to: &sections
+    )
+    appendSummarySection("Open Questions", openQuestions, to: &sections)
+    return sections.joined(separator: "\n\n")
+}
+
+private func appendSummarySection(_ title: String, _ items: [String], to sections: inout [String]) {
+    guard !items.isEmpty else { return }
+    let body = items.map { "- \($0)" }.joined(separator: "\n")
+    sections.append("## \(title)\n\(body)")
 }
 
 private func latestMeetingDate(in results: [MeetingSummary]) -> Date? {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -1078,8 +1078,13 @@ func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, meetingDir
                 decisions = summary.decisions
                 actionItems = summary.actionItems.map { RecapActionItem(owner: $0.owner, text: $0.text) }
                 openQuestions = summary.openQuestions
-                preview = summaryPreview(decisions: decisions, actionItems: actionItems, openQuestions: openQuestions)
-                summarySource = "summary"
+                let hasStructuredFacts = !decisions.isEmpty || !actionItems.isEmpty || !openQuestions.isEmpty
+                if hasStructuredFacts {
+                    preview = summaryPreview(decisions: decisions, actionItems: actionItems, openQuestions: openQuestions)
+                    summarySource = "summary"
+                } else {
+                    preview = extractDialogueLines(from: content).prefix(15).joined(separator: "\n")
+                }
             } else {
                 preview = extractDialogueLines(from: content).prefix(15).joined(separator: "\n")
             }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -207,7 +207,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "search",
-                description: "Full-text search across all meeting transcripts. Returns matching utterances with speaker, timestamp, and meeting context. Optionally filter by speaker name (supports variants: Mike finds Michael) or date range.",
+                description: "Search meeting transcripts. Defaults to hybrid search: exact full-text matches PLUS on-device semantic matches, so paraphrases hit (e.g. 'pricing pushback' finds 'they balked at the cost'). Returns matching utterances with speaker, timestamp, and meeting context. Optionally filter by speaker name (supports variants: Mike finds Michael) or date range.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -218,6 +218,10 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         "speaker": .object([
                             "type": .string("string"),
                             "description": .string("Filter to utterances by this speaker")
+                        ]),
+                        "mode": .object([
+                            "type": .string("string"),
+                            "description": .string("Search strategy: 'hybrid' (default — FTS + semantic), 'lexical' (exact/stemmed only), or 'semantic' (paraphrase only). Semantic and hybrid fall back to lexical when the on-device embedding model is unavailable.")
                         ]),
                         "date_from": .object([
                             "type": .string("string"),
@@ -261,7 +265,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "search_context",
-                description: "Search across saved meetings, dictations, or both. Great for finding everything you captured about a topic, regardless of whether it came from a meeting or a quick dictated note.",
+                description: "Search across saved meetings, dictations, or both. Defaults to hybrid (full-text + on-device semantic), so paraphrases match, not just exact wording. Great for finding everything you captured about a topic, regardless of whether it came from a meeting or a quick dictated note.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -272,6 +276,10 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         "kind": .object([
                             "type": .string("string"),
                             "description": .string("Which context to search: 'all' (default), 'meeting', or 'dictation'")
+                        ]),
+                        "mode": .object([
+                            "type": .string("string"),
+                            "description": .string("Search strategy: 'hybrid' (default — FTS + semantic), 'lexical', or 'semantic'. Falls back to lexical when the embedding model is unavailable.")
                         ]),
                         "speaker": .object([
                             "type": .string("string"),
@@ -927,8 +935,9 @@ private func handleSearch(params: CallTool.Parameters, index: TranscriptIndex, m
     let speaker = params.arguments?["speaker"]?.stringValue
     let dateFrom = params.arguments?["date_from"]?.stringValue
     let dateTo = params.arguments?["date_to"]?.stringValue
+    let mode = parseSearchMode(params.arguments?["mode"]?.stringValue)
 
-    var results = try index.searchUtterances(query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo)
+    var results = try index.searchUtterances(query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo, mode: mode)
     hydrateMeetingSearchTitles(in: &results, meetingDirs: meetingDirs)
 
     if results.results.isEmpty {
@@ -956,6 +965,7 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
     let count = max(1, min(params.arguments?["count"]?.intValue ?? 10, 50))
     let dateFrom = params.arguments?["date_from"]?.stringValue
     let dateTo = params.arguments?["date_to"]?.stringValue
+    let mode = parseSearchMode(params.arguments?["mode"]?.stringValue)
 
     var results = try index.searchContext(
         query: query,
@@ -963,7 +973,8 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
         kind: kind,
         dateFrom: dateFrom,
         dateTo: dateTo,
-        maxItems: count
+        maxItems: count,
+        mode: mode
     )
 
     hydrateMeetingTitles(in: &results.results, kind: \.kind, filename: \.filename, title: \.title, meetingDirs: meetingDirs)
@@ -1409,6 +1420,15 @@ private func parseContextKind(_ raw: String?) -> ContextKind {
         return .all
     }
     return kind
+}
+
+/// Default to hybrid so paraphrase matches surface without the caller opting in.
+/// Falls back to lexical automatically when no embedding backend is available.
+private func parseSearchMode(_ raw: String?) -> SearchMode {
+    guard let raw, let mode = SearchMode(rawValue: raw.lowercased()) else {
+        return .hybrid
+    }
+    return mode
 }
 
 /// Frontmatter title for a meeting markdown file, or nil when the file is

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -432,6 +432,95 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 annotations: .init(readOnlyHint: true)
             ),
             Tool(
+                name: "decisions",
+                description: "Find decisions across meeting summaries. Returns local structured receipts with meetingId, timestamp when available, and quote. No semantic embeddings or LLM synthesis.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "topic": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional topic filter, e.g. pricing")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "commitments",
+                description: "Find action-item commitments across meeting summaries. Filter by person and date range. Returns local structured receipts with meetingId, timestamp when available, and quote.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "person": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional person/owner filter, e.g. Sarah")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "open_questions",
+                description: "Find open questions across meeting summaries for a project/topic. Returns local structured receipts with meetingId, timestamp when available, and quote.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "project": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional project/topic filter")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "search_meetings",
+                description: "Keyword search over local meeting transcript utterances. Returns structured receipts with meetingId, timestamp, and quote. This is not semantic search.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "query": .object([
+                            "type": .string("string"),
+                            "description": .string("Keyword query")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                    "required": .array([.string("query")]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
                 name: "status",
                 description: "Server status and configuration: version, resolved capture directories, which resolution rule selected them, index location, and indexed counts. Call this when other tools return empty results to see whether anything is indexed at all.",
                 inputSchema: .object([
@@ -470,6 +559,14 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 return try handleListDecisions(params: params, index: index, meetingDirs: directories.meetingDirs)
             case "digest":
                 return try handleDigest(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "decisions":
+                return try handleDecisions(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "commitments":
+                return try handleCommitments(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "open_questions":
+                return try handleOpenQuestions(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "search_meetings":
+                return try handleSearchMeetings(params: params, index: index, meetingDirs: directories.meetingDirs)
             case "status":
                 return try handleStatus(index: index, directories: directories)
             default:
@@ -1110,6 +1207,152 @@ func handleStatus(index: TranscriptIndex, directories: TranscriptedDataDirectori
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
+// MARK: - decisions / commitments / open_questions / search_meetings
+
+func handleDecisions(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let topic = params.arguments?["topic"]?.stringValue
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    let indexed = try index.listDecisions(
+        query: topic,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        maxItems: count + 1
+    )
+    var receipts = indexed.decisions.prefix(count).map { item in
+        CrossMeetingReceipt(
+            meetingId: item.filename,
+            meetingTitle: meetingTitle(for: item.filename, meetingDirs: meetingDirs),
+            timestamp: nil,
+            quote: item.text,
+            date: item.date,
+            datetime: item.datetime,
+            kind: "decision",
+            person: nil
+        )
+    }
+    hydrateReceiptTitles(&receipts, meetingDirs: meetingDirs)
+    let result = CrossMeetingToolResult(
+        query: topic,
+        range: range.label,
+        count: receipts.count,
+        truncated: indexed.truncated || indexed.decisions.count > count,
+        results: receipts
+    )
+    return try encodedToolResult(result)
+}
+
+func handleCommitments(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let person = params.arguments?["person"]?.stringValue
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    let indexed = try index.listActionItems(
+        owner: person,
+        query: nil,
+        status: .open,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        maxItems: count + 1
+    )
+    var receipts = indexed.items.prefix(count).map { item in
+        CrossMeetingReceipt(
+            meetingId: item.filename,
+            meetingTitle: meetingTitle(for: item.filename, meetingDirs: meetingDirs),
+            timestamp: nil,
+            quote: item.owner.map { "\($0): \(item.text)" } ?? item.text,
+            date: item.date,
+            datetime: item.datetime,
+            kind: "commitment",
+            person: item.owner
+        )
+    }
+    hydrateReceiptTitles(&receipts, meetingDirs: meetingDirs)
+    let result = CrossMeetingToolResult(
+        query: person,
+        range: range.label,
+        count: receipts.count,
+        truncated: indexed.truncated || indexed.items.count > count,
+        results: receipts
+    )
+    return try encodedToolResult(result)
+}
+
+func handleOpenQuestions(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let project = params.arguments?["project"]?.stringValue
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    let fetchLimit = project?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? 1000 : count + 1
+    let indexed = try index.listSummaryItems(
+        kind: TranscriptIndex.SummaryItemKind.openQuestion,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        limit: fetchLimit
+    )
+    let filtered = filterSummaryItems(indexed, matching: project)
+    var receipts = filtered.prefix(count).map { item in
+        CrossMeetingReceipt(
+            meetingId: item.filename,
+            meetingTitle: meetingTitle(for: item.filename, meetingDirs: meetingDirs),
+            timestamp: nil,
+            quote: item.text,
+            date: item.meetingDate,
+            datetime: item.meetingDateTime,
+            kind: "open_question",
+            person: nil
+        )
+    }
+    hydrateReceiptTitles(&receipts, meetingDirs: meetingDirs)
+    let result = CrossMeetingToolResult(
+        query: project,
+        range: range.label,
+        count: receipts.count,
+        truncated: filtered.count > count,
+        results: receipts
+    )
+    return try encodedToolResult(result)
+}
+
+func handleSearchMeetings(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    guard let query = params.arguments?["query"]?.stringValue, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return textResult("Missing required parameter: query", isError: true)
+    }
+
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    var groups = try index.searchUtterances(
+        query: query,
+        speaker: nil,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        maxMeetings: count,
+        snippetsPerMeeting: 3
+    )
+    hydrateMeetingSearchTitles(in: &groups, meetingDirs: meetingDirs)
+
+    let receipts = groups.results.flatMap { group in
+        group.snippets.map { snippet in
+            CrossMeetingReceipt(
+                meetingId: group.filename,
+                meetingTitle: group.meetingTitle,
+                timestamp: snippet.timestamp,
+                quote: snippet.text,
+                date: group.meetingDate,
+                datetime: group.meetingDateTime,
+                kind: "utterance",
+                person: snippet.speaker
+            )
+        }
+    }
+    let result = CrossMeetingToolResult(
+        query: query,
+        range: range.label,
+        count: min(receipts.count, count),
+        truncated: groups.truncated || receipts.count > count,
+        results: Array(receipts.prefix(count))
+    )
+    return try encodedToolResult(result)
+}
+
 // MARK: - Output Types
 
 struct RecapEntry: Codable {
@@ -1207,6 +1450,65 @@ private func hydrateMeetingTitles<T>(
     for index in collection.indices where collection[index][keyPath: kind] == .meeting {
         collection[index][keyPath: title] = meetingTitle(for: collection[index][keyPath: filename], meetingDirs: meetingDirs)
     }
+}
+
+private func hydrateReceiptTitles(_ receipts: inout [CrossMeetingReceipt], meetingDirs: [URL]) {
+    for index in receipts.indices {
+        receipts[index].meetingTitle = meetingTitle(for: receipts[index].meetingId, meetingDirs: meetingDirs)
+    }
+}
+
+private struct ParsedToolRange {
+    let dateFrom: String?
+    let dateTo: String?
+    let label: String?
+}
+
+private func parseToolRange(_ raw: String?) -> ParsedToolRange {
+    guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+        return ParsedToolRange(dateFrom: nil, dateTo: nil, label: nil)
+    }
+    let lower = raw.lowercased()
+    if lower == "all" || lower == "all time" {
+        return ParsedToolRange(dateFrom: nil, dateTo: nil, label: raw)
+    }
+    if lower == "today" {
+        let today = DateFormatter.localYYYYMMDD.string(from: Date())
+        return ParsedToolRange(dateFrom: today, dateTo: today, label: today)
+    }
+
+    let separators = ["..", " to ", " - "]
+    for separator in separators where raw.contains(separator) {
+        let parts = raw.components(separatedBy: separator).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        if parts.count == 2 {
+            let from = parts[0].isEmpty ? nil : parts[0]
+            let to = parts[1].isEmpty ? nil : parts[1]
+            return ParsedToolRange(dateFrom: from, dateTo: to, label: raw)
+        }
+    }
+
+    return ParsedToolRange(dateFrom: raw, dateTo: raw, label: raw)
+}
+
+private func cappedCrossMeetingCount(_ raw: Int?) -> Int {
+    max(1, min(raw ?? 20, 100))
+}
+
+private func filterSummaryItems(_ items: [TranscriptIndex.IndexedSummaryItem], matching query: String?) -> [TranscriptIndex.IndexedSummaryItem] {
+    guard let query = query?.trimmingCharacters(in: .whitespacesAndNewlines), !query.isEmpty else {
+        return items
+    }
+    let terms = query.lowercased().split(whereSeparator: \.isWhitespace).map(String.init)
+    guard !terms.isEmpty else { return items }
+    return items.filter { item in
+        let haystack = item.text.lowercased()
+        return terms.allSatisfy { haystack.contains($0) }
+    }
+}
+
+private func encodedToolResult<T: Encodable>(_ result: T) throws -> CallTool.Result {
+    let json = try JSONEncoder.pretty.encode(result)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
 private func formatDuration(_ seconds: Int) -> String {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -19,6 +19,32 @@ private func textResult(_ text: String, isError: Bool = false) -> CallTool.Resul
     .init(content: [.text(text: text, annotations: nil, _meta: nil)], isError: isError)
 }
 
+/// Character budget for read_meeting / read_dictation raw markdown responses.
+/// Anything larger switches to a paginated window even when the caller did not
+/// pass offset/limit, so one 90-minute transcript cannot blow out an agent's
+/// context window. ~30k characters is roughly 7-8k tokens — big enough that
+/// typical meetings and dictation days pass through byte-identical, small
+/// enough that a runaway dump stays readable.
+let maxUnpaginatedReadCharacters = 30_000
+
+/// Rough per-item JSON encoding overhead (keys, timestamps, speaker names)
+/// used when auto-sizing a pagination window against the character budget.
+private let paginationItemOverheadCharacters = 80
+
+/// Index one past the last item that fits the character budget starting at
+/// `start`. Always advances by at least one item when any remain, so an
+/// oversized single item still makes progress.
+private func autoWindowEnd<T>(items: [T], start: Int, cost: (T) -> Int) -> Int {
+    var end = start
+    var used = 0
+    while end < items.count {
+        used += cost(items[end])
+        if used > maxUnpaginatedReadCharacters, end > start { break }
+        end += 1
+    }
+    return end
+}
+
 /// Which artifact population a tool reads; drives which indexed counts and
 /// hint an empty response carries.
 private enum EmptyResultScope {
@@ -128,7 +154,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "read_meeting",
-                description: "Read the full transcript of a specific meeting. Returns the complete dialogue with speaker names and timestamps. Use list_meetings first to get the filename.",
+                description: "Read a meeting transcript by filename (from list_meetings). Long meetings are token-heavy: pass offset/limit to page through utterances, or section 'speakers' for metadata and analytics without dialogue. Full or transcript responses over ~30k characters are automatically truncated to a bounded window with total_utterances, next_offset, and a continuation hint.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -138,7 +164,15 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         ]),
                         "section": .object([
                             "type": .string("string"),
-                            "description": .string("Which section to return: 'full' (default — complete transcript), 'transcript' (dialogue only), or 'speakers' (analytics only)")
+                            "description": .string("Which section to return: 'full' (default — complete transcript), 'transcript' (dialogue only), or 'speakers' (frontmatter + analytics, cheapest for long meetings)")
+                        ]),
+                        "offset": .object([
+                            "type": .string("integer"),
+                            "description": .string("0-based utterance index to start the transcript window at (default: 0). Applies to sections 'full' and 'transcript'.")
+                        ]),
+                        "limit": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum utterances to return. Setting this (or exceeding the size guard) switches the response to a paginated JSON window with total_utterances, next_offset, and a hint.")
                         ]),
                     ]),
                     "required": .array([.string("filename")]),
@@ -200,7 +234,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "read_dictation",
-                description: "Read a saved dictation day or one specific dictation entry by ID. Use list_dictations or recent_context first to find the filename or entry_id you need.",
+                description: "Read a saved dictation day, one specific entry by ID, or a bounded window of entries. Use list_dictations or recent_context first to find the filename or entry_id you need. Prefer entry_id for a single entry. Without entry_id, pass offset/limit to page through entries; day files over ~30k characters are automatically truncated to a window with total_entries, next_offset, and a continuation hint.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -211,6 +245,14 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         "entry_id": .object([
                             "type": .string("string"),
                             "description": .string("Optional entry ID from recent_context or search_context to return one dictation entry")
+                        ]),
+                        "offset": .object([
+                            "type": .string("integer"),
+                            "description": .string("0-based entry index to start the window at (default: 0). Ignored when entry_id is set.")
+                        ]),
+                        "limit": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum entries to return. Setting this (or exceeding the size guard) switches the response to a paginated JSON window with total_entries, next_offset, and a hint. Ignored when entry_id is set.")
                         ]),
                     ]),
                     "required": .array([.string("filename")]),
@@ -515,12 +557,15 @@ private func extractDialogueLines(from content: String) -> [String] {
 
 // MARK: - read_meeting
 
-private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) throws -> CallTool.Result {
     guard let filename = params.arguments?["filename"]?.stringValue, !filename.isEmpty else {
         return textResult("Missing required parameter: filename", isError: true)
     }
 
     let section = params.arguments?["section"]?.stringValue ?? "full"
+    let offset = max(0, params.arguments?["offset"]?.intValue ?? 0)
+    let limit = params.arguments?["limit"]?.intValue
+    let paginationRequested = limit != nil || offset > 0
 
     let mdURL: URL
     switch PathSecurity.resolveReadableFile(named: filename, appendingExtension: "md", in: meetingDirs) {
@@ -536,24 +581,32 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) 
         return textResult("Meeting not found: \(filename). Use list_meetings to see available meetings.", isError: true)
     }
 
+    let parsed = CaptureMarkdownParser.parseMeeting(from: content)
+
     trackAgentCaptureQueryObserved(
         queryKind: "read",
         artifactKind: "meeting",
-        captureDate: captureDateFromMeetingMarkdown(content),
+        captureDate: parsed.flatMap { parseCaptureDate($0.datetime) },
         sourceCount: 1
     )
 
     switch section {
     case "transcript":
         let dialogue = extractDialogueLines(from: content).joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        return textResult(dialogue.isEmpty ? content : dialogue)
+        let raw = dialogue.isEmpty ? content : dialogue
+        if !paginationRequested, raw.count <= maxUnpaginatedReadCharacters {
+            return textResult(raw)
+        }
+        return try meetingTranscriptPageResult(
+            parsed: parsed, content: content, filename: filename,
+            offset: offset, limit: limit, includeFrontmatter: false, rawFallback: raw
+        )
 
     case "speakers":
         // Return YAML frontmatter + speaker analytics section
         var result = ""
-        if content.count >= 8, content.hasPrefix("---"),
-           let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex) {
-            result += String(content[content.startIndex...endRange.upperBound])
+        if let frontmatter = frontmatterBlock(of: content) {
+            result += frontmatter
         }
         if let analyticsRange = content.range(of: "## Channel & Speaker Analytics") {
             if let transcriptRange = content.range(of: "## Full Transcript") {
@@ -565,11 +618,95 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) 
         return textResult(result.isEmpty ? content : result)
 
     default: // "full"
-        return textResult(content)
+        if !paginationRequested, content.count <= maxUnpaginatedReadCharacters {
+            return textResult(content)
+        }
+        return try meetingTranscriptPageResult(
+            parsed: parsed, content: content, filename: filename,
+            offset: offset, limit: limit, includeFrontmatter: true, rawFallback: content
+        )
     }
 }
 
-private func handleReadDictation(params: CallTool.Parameters, dictationDirs: [URL]) throws -> CallTool.Result {
+/// Bounded transcript read: frontmatter metadata plus one utterance window and
+/// explicit pagination fields, so a long meeting never comes back as an
+/// unbounded dump. Falls back to the raw markdown when the file does not parse
+/// as a windowable transcript — we can only page what the parser understands.
+private func meetingTranscriptPageResult(
+    parsed: ParsedMeetingCapture?,
+    content: String,
+    filename: String,
+    offset: Int,
+    limit: Int?,
+    includeFrontmatter: Bool,
+    rawFallback: String
+) throws -> CallTool.Result {
+    guard let parsed, !parsed.utterances.isEmpty else {
+        return textResult(rawFallback)
+    }
+
+    let total = parsed.utterances.count
+    let start = min(offset, total)
+    let end: Int
+    if let limit {
+        end = min(start + max(1, limit), total)
+    } else {
+        end = autoWindowEnd(items: parsed.utterances, start: start) {
+            $0.text.count + paginationItemOverheadCharacters
+        }
+    }
+
+    let speakerNames = Dictionary(uniqueKeysWithValues: parsed.speakers.map { ($0.id, $0.name) })
+    let utterances = parsed.utterances[start..<end].map { utterance in
+        MeetingTranscriptPageUtterance(
+            start: utterance.start,
+            end: utterance.end,
+            speaker: speakerNames[utterance.speakerId] ?? utterance.speakerId,
+            speakerId: utterance.speakerId,
+            text: utterance.text
+        )
+    }
+
+    let returned = utterances.count
+    let truncated = start + returned < total
+    let nextOffset = truncated ? start + returned : nil
+
+    let hint: String
+    if offset >= total {
+        hint = "offset \(offset) is past the end — this transcript has \(total) utterances. Retry with a smaller offset."
+    } else if let nextOffset {
+        hint = "Showing utterances \(start)-\(end - 1) of \(total). Call read_meeting again with offset=\(nextOffset) to continue, or use section \"speakers\" for the overview without dialogue."
+    } else {
+        hint = "End of transcript — all remaining utterances included."
+    }
+
+    let page = MeetingTranscriptPage(
+        filename: filename,
+        frontmatter: includeFrontmatter ? frontmatterBlock(of: content) : nil,
+        totalUtterances: total,
+        offset: offset,
+        returned: returned,
+        truncated: truncated,
+        nextOffset: nextOffset,
+        hint: hint,
+        utterances: utterances
+    )
+
+    let json = try JSONEncoder.pretty.encode(page)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
+}
+
+/// Raw YAML frontmatter block, matching the exact slice the speakers section
+/// has always returned (both fences plus the character after the closing one).
+private func frontmatterBlock(of content: String) -> String? {
+    guard content.count >= 8, content.hasPrefix("---"),
+          let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex) else {
+        return nil
+    }
+    return String(content[content.startIndex...endRange.upperBound])
+}
+
+func handleReadDictation(params: CallTool.Parameters, dictationDirs: [URL]) throws -> CallTool.Result {
     guard let filename = params.arguments?["filename"]?.stringValue, !filename.isEmpty else {
         return textResult("Missing required parameter: filename", isError: true)
     }
@@ -621,12 +758,66 @@ private func handleReadDictation(params: CallTool.Parameters, dictationDirs: [UR
         sourceCount: day.entries.count
     )
 
+    let offset = max(0, params.arguments?["offset"]?.intValue ?? 0)
+    let limit = params.arguments?["limit"]?.intValue
+    let paginationRequested = limit != nil || offset > 0
+
     guard let content = try? String(contentsOf: markdownURL, encoding: .utf8) else {
         let json = try JSONEncoder.pretty.encode(day)
         return textResult(String(data: json, encoding: .utf8) ?? "{}")
     }
 
-    return textResult(content)
+    if !paginationRequested, content.count <= maxUnpaginatedReadCharacters {
+        return textResult(content)
+    }
+
+    return try dictationDayPageResult(day: day, filename: filename, offset: offset, limit: limit)
+}
+
+/// Bounded dictation-day read: day metadata plus one entry window and explicit
+/// pagination fields, mirroring the meeting transcript window.
+private func dictationDayPageResult(day: AgentDictationDay, filename: String, offset: Int, limit: Int?) throws -> CallTool.Result {
+    let total = day.entries.count
+    let start = min(offset, total)
+    let end: Int
+    if let limit {
+        end = min(start + max(1, limit), total)
+    } else {
+        end = autoWindowEnd(items: day.entries, start: start) {
+            $0.text.count + $0.title.count + paginationItemOverheadCharacters * 3
+        }
+    }
+
+    let entries = Array(day.entries[start..<end])
+    let returned = entries.count
+    let truncated = start + returned < total
+    let nextOffset = truncated ? start + returned : nil
+
+    let hint: String
+    if total == 0 {
+        hint = "This dictation day has no entries."
+    } else if offset >= total {
+        hint = "offset \(offset) is past the end — this day has \(total) entries. Retry with a smaller offset."
+    } else if let nextOffset {
+        hint = "Showing entries \(start)-\(end - 1) of \(total). Call read_dictation again with offset=\(nextOffset) to continue, or pass entry_id for one specific entry."
+    } else {
+        hint = "End of day — all remaining entries included."
+    }
+
+    let page = DictationDayPage(
+        filename: filename,
+        date: day.date,
+        totalEntries: total,
+        offset: offset,
+        returned: returned,
+        truncated: truncated,
+        nextOffset: nextOffset,
+        hint: hint,
+        entries: entries
+    )
+
+    let json = try JSONEncoder.pretty.encode(page)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
 // MARK: - search
@@ -1035,11 +1226,6 @@ private func artifactKind(for kinds: [ContextKind]) -> String {
         return "dictation"
     }
     return "mixed"
-}
-
-private func captureDateFromMeetingMarkdown(_ content: String) -> Date? {
-    guard let parsed = CaptureMarkdownParser.parseMeeting(from: content) else { return nil }
-    return parseCaptureDate(parsed.datetime)
 }
 
 extension JSONEncoder {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -8,9 +8,18 @@ final class TranscriptIndex: @unchecked Sendable {
     private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     private let indexPath: URL
 
-    init(indexDir: URL) throws {
+    /// Optional semantic-search sidecar. Nil when no embedding provider was
+    /// supplied or the provider is unavailable on this host; in that case every
+    /// search transparently runs lexical-only. Additive: it manages its own
+    /// vector tables on a separate connection to the same database file.
+    private(set) var embeddingStore: EmbeddingStore?
+
+    init(indexDir: URL, embeddingProvider: EmbeddingProvider? = nil) throws {
         self.indexPath = indexDir.appendingPathComponent("mcp_index.sqlite")
         try queue.sync { try self.openAndSetup() }
+        if let provider = embeddingProvider, provider.isAvailable {
+            self.embeddingStore = try EmbeddingStore(dbPath: indexPath, provider: provider)
+        }
     }
 
     deinit {
@@ -328,6 +337,10 @@ final class TranscriptIndex: @unchecked Sendable {
                 try removeFromIndex(filename: filename)
             }
         }
+
+        // Best-effort: embed any newly indexed rows. Never fails the reconcile —
+        // lexical search must keep working even if embedding hits a snag.
+        embeddingStore?.reconcileEmbeddings()
     }
 
     func indexSingleFile(_ url: URL, allowedRoots: [URL]) throws {
@@ -362,6 +375,8 @@ final class TranscriptIndex: @unchecked Sendable {
 
             try removeFromIndex(filename: filename)
         }
+
+        embeddingStore?.reconcileEmbeddings()
     }
 
     private func getIndexedModDates() throws -> [String: TimeInterval] {
@@ -691,7 +706,26 @@ final class TranscriptIndex: @unchecked Sendable {
 
     // MARK: - Queries
 
-    func searchUtterances(query: String, speaker: String?, dateFrom: String?, dateTo: String?, maxMeetings: Int = 10, snippetsPerMeeting: Int = 3) throws -> GroupedSearchResult {
+    func searchUtterances(query: String, speaker: String?, dateFrom: String?, dateTo: String?, maxMeetings: Int = 10, snippetsPerMeeting: Int = 3, mode: SearchMode = .lexical) throws -> GroupedSearchResult {
+        // Semantic / hybrid routing. Falls through to lexical when no vector store
+        // is available, so these modes degrade gracefully rather than returning
+        // nothing. The lexical branch below is unchanged.
+        if mode != .lexical, let store = embeddingStore, store.isAvailable {
+            let semantic = store.semanticSearchUtterances(
+                query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo,
+                maxMeetings: maxMeetings, snippetsPerMeeting: snippetsPerMeeting
+            )
+            if mode == .semantic { return semantic }
+            let lexical = try searchUtterances(
+                query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo,
+                maxMeetings: maxMeetings, snippetsPerMeeting: snippetsPerMeeting, mode: .lexical
+            )
+            return SemanticSearchFusion.fuseGrouped(
+                lexical: lexical, semantic: semantic,
+                maxMeetings: maxMeetings, snippetsPerMeeting: snippetsPerMeeting
+            )
+        }
+
         return try queue.sync {
             guard let ftsQuery = ftsQuery(from: query) else {
                 return GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false)
@@ -1036,7 +1070,20 @@ final class TranscriptIndex: @unchecked Sendable {
         }
     }
 
-    func searchDictationEntries(query: String, dateFrom: String?, dateTo: String?, maxItems: Int = 10) throws -> [ContextSearchGroup] {
+    func searchDictationEntries(query: String, dateFrom: String?, dateTo: String?, maxItems: Int = 10, mode: SearchMode = .lexical) throws -> [ContextSearchGroup] {
+        if mode != .lexical, let store = embeddingStore, store.isAvailable {
+            let semantic = store.semanticSearchDictationEntries(
+                query: query, dateFrom: dateFrom, dateTo: dateTo, maxItems: maxItems
+            )
+            if mode == .semantic { return semantic }
+            let lexical = try searchDictationEntries(
+                query: query, dateFrom: dateFrom, dateTo: dateTo, maxItems: maxItems, mode: .lexical
+            )
+            return SemanticSearchFusion.fuseContextGroups(
+                lexical: lexical, semantic: semantic, maxItems: maxItems
+            )
+        }
+
         return try queue.sync {
             let tokens = query.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
             let ftsQuery = tokens.map { "\"\($0.replacingOccurrences(of: "\"", with: ""))\"" }.joined(separator: " ")
@@ -1154,7 +1201,7 @@ final class TranscriptIndex: @unchecked Sendable {
         }
     }
 
-    func searchContext(query: String, speaker: String?, kind: ContextKind, dateFrom: String?, dateTo: String?, maxItems: Int = 10) throws -> ContextSearchResult {
+    func searchContext(query: String, speaker: String?, kind: ContextKind, dateFrom: String?, dateTo: String?, maxItems: Int = 10, mode: SearchMode = .lexical) throws -> ContextSearchResult {
         var combined: [ContextSearchGroup] = []
 
         if kind != .dictation {
@@ -1164,7 +1211,8 @@ final class TranscriptIndex: @unchecked Sendable {
                 dateFrom: dateFrom,
                 dateTo: dateTo,
                 maxMeetings: maxItems,
-                snippetsPerMeeting: 3
+                snippetsPerMeeting: 3,
+                mode: mode
             )
             combined.append(contentsOf: meetings.results.map {
                 ContextSearchGroup(
@@ -1193,7 +1241,8 @@ final class TranscriptIndex: @unchecked Sendable {
                 query: query,
                 dateFrom: dateFrom,
                 dateTo: dateTo,
-                maxItems: maxItems
+                maxItems: maxItems,
+                mode: mode
             ))
         }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+@testable import transcripted_mcp
+
+/// Deterministic embedding provider for tests. Maps a small fixed lexicon of
+/// words to "concept" axes so paraphrases (different words, same concept) land on
+/// the same vector and unrelated text stays orthogonal. This keeps the semantic
+/// tests independent of whether the OS NLEmbedding assets are present in CI.
+private struct StubEmbeddingProvider: EmbeddingProvider {
+    let modelID: String
+    var dimension: Int { concepts.count }
+    var isAvailable: Bool { true }
+
+    /// concept index -> member words
+    private static let concepts: [[String]] = [
+        ["cost", "pricing", "price", "expensive", "balked", "pushback", "budget"],
+        ["weather", "sunny", "rain", "cloudy", "forecast"],
+        ["roadmap", "plan", "timeline", "schedule", "milestone"],
+    ]
+    private let concepts = StubEmbeddingProvider.concepts
+
+    private var lexicon: [String: Int] {
+        var map: [String: Int] = [:]
+        for (idx, words) in concepts.enumerated() {
+            for word in words { map[word] = idx }
+        }
+        return map
+    }
+
+    init(modelID: String = "stub.v1") { self.modelID = modelID }
+
+    func embed(_ text: String) -> [Float]? {
+        let lex = lexicon
+        var vec = [Float](repeating: 0, count: concepts.count)
+        var hits = 0
+        for token in text.lowercased().split(whereSeparator: { !$0.isLetter }) {
+            if let idx = lex[String(token)] {
+                vec[idx] += 1
+                hits += 1
+            }
+        }
+        guard hits > 0 else { return nil }
+        return VectorMath.normalized(vec)
+    }
+}
+
+private struct UnavailableEmbeddingProvider: EmbeddingProvider {
+    let modelID = "unavailable"
+    var dimension: Int { 0 }
+    var isAvailable: Bool { false }
+    func embed(_ text: String) -> [Float]? { nil }
+}
+
+final class SemanticSearchTests: XCTestCase {
+    var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = makeTempDir()
+    }
+
+    override func tearDown() {
+        removeTempDir(tempDir)
+        super.tearDown()
+    }
+
+    private func makeIndex(_ provider: EmbeddingProvider? = StubEmbeddingProvider()) throws -> TranscriptIndex {
+        try TranscriptIndex(indexDir: tempDir, embeddingProvider: provider)
+    }
+
+    // MARK: - The headline unlock: paraphrase queries hit
+
+    func testSemanticFindsParaphraseThatLexicalMisses() throws {
+        let index = try makeIndex()
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "Honestly they balked at the cost"),
+            ("mic_0", 5.0, 10.0, "The weather is sunny today"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        // Lexical alone misses the paraphrase: none of these words appear verbatim.
+        let lexical = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .lexical)
+        XCTAssertTrue(lexical.results.isEmpty)
+
+        // Semantic matches the "cost" concept utterance, not the weather one.
+        let semantic = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic)
+        XCTAssertEqual(semantic.results.count, 1)
+        XCTAssertEqual(semantic.results[0].snippets.count, 1)
+        XCTAssertTrue(semantic.results[0].snippets[0].text.contains("balked"))
+    }
+
+    // MARK: - Hybrid is a strict superset of lexical recall
+
+    func testHybridUnionsLexicalAndSemantic() throws {
+        let index = try makeIndex()
+        // Meeting A contains the literal word "cost"; meeting B only paraphrases it.
+        try writeFixture(makeFixtureJSON(date: "2026-03-29T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "The cost was discussed at length"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try writeFixture(makeFixtureJSON(date: "2026-03-30T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "They balked at the expensive pricing"),
+        ]), filename: "Call_2026-03-30_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let lexical = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .lexical)
+        XCTAssertEqual(lexical.results.count, 1)
+        XCTAssertEqual(lexical.results[0].filename, "Call_2026-03-29_10-00-00")
+
+        let hybrid = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        let filenames = Set(hybrid.results.map(\.filename))
+        XCTAssertEqual(hybrid.results.count, 2)
+        XCTAssertTrue(filenames.contains("Call_2026-03-29_10-00-00")) // exact hit preserved
+        XCTAssertTrue(filenames.contains("Call_2026-03-30_10-00-00")) // paraphrase added
+    }
+
+    func testSemanticRespectsDateFilter() throws {
+        let index = try makeIndex()
+        try writeFixture(makeFixtureJSON(date: "2026-03-28T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "They balked at the cost"),
+        ]), filename: "Call_2026-03-28_10-00-00", to: tempDir)
+        try writeFixture(makeFixtureJSON(date: "2026-03-30T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "The pricing was too expensive"),
+        ]), filename: "Call_2026-03-30_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let semantic = try index.searchUtterances(query: "budget pushback", speaker: nil, dateFrom: "2026-03-29", dateTo: nil, mode: .semantic)
+        XCTAssertEqual(semantic.results.count, 1)
+        XCTAssertEqual(semantic.results[0].filename, "Call_2026-03-30_10-00-00")
+    }
+
+    func testSemanticDoesNotMatchUnrelatedConcept() throws {
+        let index = try makeIndex()
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The weather forecast looks cloudy"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let semantic = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic)
+        XCTAssertTrue(semantic.results.isEmpty)
+    }
+
+    // MARK: - Dictation semantic search
+
+    func testSemanticSearchOnDictationEntries() throws {
+        let index = try makeIndex()
+        try writeFixture(makeDictationDayJSON(entries: [
+            ("dictation-20260407-091500-000", "2026-04-07T09:15:00-0500", "Budget note", "Client balked at the pricing again", "Slack", "copied"),
+            ("dictation-20260407-181500-000", "2026-04-07T18:15:00-0500", "Weather note", "Tomorrow looks sunny and clear", "Notes", "copied"),
+        ]), filename: "Dictations_2026-04-07", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let results = try index.searchContext(query: "cost pushback", speaker: nil, kind: .dictation, dateFrom: nil, dateTo: nil, maxItems: 10, mode: .semantic)
+        XCTAssertEqual(results.results.count, 1)
+        XCTAssertEqual(results.results[0].kind, .dictation)
+        XCTAssertTrue(results.results[0].snippets[0].text.contains("balked"))
+    }
+
+    // MARK: - Graceful degradation
+
+    func testHybridFallsBackToLexicalWhenProviderUnavailable() throws {
+        let index = try makeIndex(UnavailableEmbeddingProvider())
+        XCTAssertNil(index.embeddingStore)
+
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The cost was discussed"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        // Hybrid with no backend must behave exactly like lexical, not error.
+        let hybrid = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        XCTAssertEqual(hybrid.results.count, 1)
+
+        let paraphrase = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        XCTAssertTrue(paraphrase.results.isEmpty) // no semantic recall without a backend
+    }
+
+    func testNoProviderLeavesSemanticDisabled() throws {
+        let index = try TranscriptIndex(indexDir: tempDir) // default: no provider
+        XCTAssertNil(index.embeddingStore)
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The cost was discussed"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let hybrid = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        XCTAssertEqual(hybrid.results.count, 1)
+    }
+
+    // MARK: - Re-embedding on model change
+
+    func testModelChangeReEmbeds() throws {
+        // Index once with stub v1.
+        let index1 = try makeIndex(StubEmbeddingProvider(modelID: "stub.v1"))
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "They balked at the cost"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index1.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertEqual(try index1.searchUtterances(query: "pricing", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic).results.count, 1)
+
+        // Reopen with a different model id — vectors must be rebuilt, not stale.
+        let index2 = try makeIndex(StubEmbeddingProvider(modelID: "stub.v2"))
+        try index2.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertEqual(try index2.searchUtterances(query: "pricing", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic).results.count, 1)
+    }
+}
+
+// MARK: - Vector math + fusion unit tests
+
+final class VectorMathTests: XCTestCase {
+    func testBlobRoundTrip() {
+        let v: [Float] = [0.1, -2.0, 3.5, 0.0, 42.25]
+        let restored = VectorMath.vector(from: VectorMath.blob(from: v))
+        XCTAssertEqual(restored, v)
+    }
+
+    func testNormalizedIsUnitLength() {
+        let v = VectorMath.normalized([3, 4])
+        XCTAssertEqual(VectorMath.dot(v, v), 1.0, accuracy: 1e-5)
+    }
+
+    func testDotOfOrthogonalIsZero() {
+        let a = VectorMath.normalized([1, 0])
+        let b = VectorMath.normalized([0, 1])
+        XCTAssertEqual(VectorMath.dot(a, b), 0.0, accuracy: 1e-6)
+    }
+
+    func testZeroVectorNormalizeIsSafe() {
+        XCTAssertEqual(VectorMath.normalized([0, 0, 0]), [0, 0, 0])
+    }
+}
+
+final class SemanticSearchFusionTests: XCTestCase {
+    private func meetingGroup(_ filename: String, snippetText: String = "x") -> MeetingSearchGroup {
+        MeetingSearchGroup(
+            meetingTitle: filename, meetingDate: "2026-03-29", meetingDateTime: "2026-03-29T10:00:00-0500",
+            filename: filename,
+            snippets: [SearchSnippet(speaker: "You", speakerId: nil, timestamp: "0:00", text: snippetText)]
+        )
+    }
+
+    func testFusionPreservesLexicalAndAppendsSemanticOnly() {
+        let lexical = GroupedSearchResult(results: [meetingGroup("A"), meetingGroup("B")], totalMeetingsMatched: 2, truncated: false)
+        let semantic = GroupedSearchResult(results: [meetingGroup("B"), meetingGroup("C")], totalMeetingsMatched: 2, truncated: false)
+
+        let fused = SemanticSearchFusion.fuseGrouped(lexical: lexical, semantic: semantic, maxMeetings: 10, snippetsPerMeeting: 3)
+        let names = fused.results.map(\.filename)
+        XCTAssertEqual(Set(names), ["A", "B", "C"])
+        // B ranks in both lists, so it should fuse to the top.
+        XCTAssertEqual(names.first, "B")
+        XCTAssertEqual(fused.totalMeetingsMatched, 3)
+    }
+
+    func testFusionMergesSnippetsAndDedupes() {
+        let lexical = GroupedSearchResult(results: [meetingGroup("A", snippetText: "shared")], totalMeetingsMatched: 1, truncated: false)
+        let semantic = GroupedSearchResult(results: [
+            MeetingSearchGroup(
+                meetingTitle: "A", meetingDate: "2026-03-29", meetingDateTime: "2026-03-29T10:00:00-0500",
+                filename: "A",
+                snippets: [
+                    SearchSnippet(speaker: "You", speakerId: nil, timestamp: "0:00", text: "shared"),
+                    SearchSnippet(speaker: "You", speakerId: nil, timestamp: "1:00", text: "unique"),
+                ]
+            )
+        ], totalMeetingsMatched: 1, truncated: false)
+
+        let fused = SemanticSearchFusion.fuseGrouped(lexical: lexical, semantic: semantic, maxMeetings: 10, snippetsPerMeeting: 3)
+        XCTAssertEqual(fused.results.count, 1)
+        let texts = fused.results[0].snippets.map(\.text)
+        XCTAssertEqual(texts, ["shared", "unique"]) // dedup on (timestamp,text), lexical first
+    }
+
+    func testFusionRespectsSnippetCap() {
+        let many = (0..<5).map { SearchSnippet(speaker: "You", speakerId: nil, timestamp: "\($0):00", text: "s\($0)") }
+        let lexical = GroupedSearchResult(results: [
+            MeetingSearchGroup(meetingTitle: "A", meetingDate: "d", meetingDateTime: "dt", filename: "A", snippets: many)
+        ], totalMeetingsMatched: 1, truncated: false)
+        let fused = SemanticSearchFusion.fuseGrouped(lexical: lexical, semantic: GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false), maxMeetings: 10, snippetsPerMeeting: 2)
+        XCTAssertEqual(fused.results[0].snippets.count, 2)
+    }
+
+    func testContextFusionUnionsByEntry() {
+        func group(_ file: String, _ entry: String) -> ContextSearchGroup {
+            ContextSearchGroup(kind: .dictation, title: entry, filename: file, entryId: entry, date: "2026-04-07", datetime: "2026-04-07T09:00:00-0500", snippets: [])
+        }
+        let lexical = [group("D", "e1")]
+        let semantic = [group("D", "e1"), group("D", "e2")]
+        let fused = SemanticSearchFusion.fuseContextGroups(lexical: lexical, semantic: semantic, maxItems: 10)
+        XCTAssertEqual(fused.count, 2)
+        XCTAssertEqual(fused.first?.entryId, "e1") // appears in both -> top
+    }
+}

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
@@ -1,6 +1,22 @@
 import Foundation
 @testable import transcripted_mcp
 
+/// Sequential system-channel utterances for pagination fixtures. Built with a
+/// loop: mapping to labeled tuples with inline Double math makes the type
+/// checker time out on CI.
+func makeSequentialUtterances(
+    count: Int,
+    text: (Int) -> String
+) -> [(speakerId: String, start: Double, end: Double, text: String)] {
+    var utterances: [(speakerId: String, start: Double, end: Double, text: String)] = []
+    for index in 0..<count {
+        let start = Double(index * 10)
+        let end = Double(index * 10 + 5)
+        utterances.append((speakerId: "system_0", start: start, end: end, text: text(index)))
+    }
+    return utterances
+}
+
 func makeFixtureJSON(
     title: String? = nil,
     date: String = "2026-03-29T10:00:00-0500",

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -269,6 +269,198 @@ final class ToolHandlersTests: XCTestCase {
         XCTAssertTrue(payload.hint.contains("No structured summaries are indexed"))
     }
 
+    func testReadMeetingSmallFullReadStaysByteIdenticalRawMarkdown() throws {
+        let content = makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500")
+        try writeFixture(content, filename: "Call_2026-03-26_16-04-11", to: tempDir)
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: ["filename": .string("Call_2026-03-26_16-04-11")]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        XCTAssertEqual(try resultText(result), content)
+    }
+
+    func testReadMeetingWindowedReadReturnsRequestedUtterances() throws {
+        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
+            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
+        }
+        try writeFixture(
+            makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500", utterances: utterances),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: [
+                "filename": .string("Call_2026-03-26_16-04-11"),
+                "offset": .int(2),
+                "limit": .int(2),
+            ]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(page.totalUtterances, 6)
+        XCTAssertEqual(page.offset, 2)
+        XCTAssertEqual(page.returned, 2)
+        XCTAssertTrue(page.truncated)
+        XCTAssertEqual(page.nextOffset, 4)
+        XCTAssertEqual(page.utterances.map(\.text), ["Utterance number 2", "Utterance number 3"])
+        XCTAssertEqual(page.utterances.first?.speaker, "Jenny Wen")
+        // Full-section pages keep the frontmatter metadata.
+        let frontmatter = try XCTUnwrap(page.frontmatter)
+        XCTAssertTrue(frontmatter.contains("title: \"Roadmap Sync\""))
+        XCTAssertTrue(page.hint.contains("offset=4"))
+    }
+
+    func testReadMeetingTranscriptSectionWindowOmitsFrontmatter() throws {
+        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
+            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
+        }
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: [
+                "filename": .string("Call_2026-03-26_16-04-11"),
+                "section": .string("transcript"),
+                "limit": .int(3),
+            ]),
+            meetingDirs: [tempDir]
+        )
+
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        XCTAssertNil(page.frontmatter)
+        XCTAssertEqual(page.totalUtterances, 6)
+        XCTAssertEqual(page.offset, 0)
+        XCTAssertEqual(page.returned, 3)
+        XCTAssertEqual(page.nextOffset, 3)
+    }
+
+    func testReadMeetingOffsetBeyondEndReturnsEmptyWindowWithTotals() throws {
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500"),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: [
+                "filename": .string("Call_2026-03-26_16-04-11"),
+                "offset": .int(50),
+                "limit": .int(5),
+            ]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        // Default fixture has 2 utterances.
+        XCTAssertEqual(page.totalUtterances, 2)
+        XCTAssertEqual(page.offset, 50)
+        XCTAssertEqual(page.returned, 0)
+        XCTAssertTrue(page.utterances.isEmpty)
+        XCTAssertFalse(page.truncated)
+        XCTAssertNil(page.nextOffset)
+        XCTAssertTrue(page.hint.contains("past the end"))
+    }
+
+    func testReadMeetingOversizedTranscriptAutoTruncatesWithNextOffset() throws {
+        let filler = String(repeating: "budget planning detail ", count: 14)
+        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<200).map {
+            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance \($0): \(filler)")
+        }
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        // No offset/limit — the size guard alone must trigger pagination.
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: ["filename": .string("Call_2026-03-26_16-04-11")]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(page.totalUtterances, 200)
+        XCTAssertEqual(page.offset, 0)
+        XCTAssertTrue(page.truncated)
+        XCTAssertGreaterThan(page.returned, 0)
+        XCTAssertLessThan(page.returned, 200)
+        let nextOffset = try XCTUnwrap(page.nextOffset)
+        XCTAssertEqual(nextOffset, page.returned)
+        XCTAssertTrue(page.hint.contains("offset=\(nextOffset)"))
+    }
+
+    func testReadDictationSmallDayFullReadStaysByteIdenticalRawMarkdown() throws {
+        let content = makeDictationDayJSON()
+        try writeFixture(content, filename: "Dictations_2026-04-07", to: tempDir)
+
+        let result = try handleReadDictation(
+            params: CallTool.Parameters(name: "read_dictation", arguments: ["filename": .string("Dictations_2026-04-07")]),
+            dictationDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        XCTAssertEqual(try resultText(result), content)
+    }
+
+    func testReadDictationEntryWindowing() throws {
+        let entries: [(id: String, createdAt: String, title: String, text: String, sourceAppName: String, delivery: String)] = [
+            ("dictation-20260407-091500-000", "2026-04-07T09:15:00-0500", "First note", "Alpha text for the morning", "Slack", "copied"),
+            ("dictation-20260407-120000-000", "2026-04-07T12:00:00-0500", "Second note", "Beta text for midday", "Mail", "pasted"),
+            ("dictation-20260407-183000-000", "2026-04-07T18:30:00-0500", "Third note", "Gamma text for the evening", "Notes", "copied"),
+        ]
+        try writeFixture(makeDictationDayJSON(entries: entries), filename: "Dictations_2026-04-07", to: tempDir)
+
+        let result = try handleReadDictation(
+            params: CallTool.Parameters(name: "read_dictation", arguments: [
+                "filename": .string("Dictations_2026-04-07"),
+                "offset": .int(1),
+                "limit": .int(1),
+            ]),
+            dictationDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(DictationDayPage.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(page.totalEntries, 3)
+        XCTAssertEqual(page.offset, 1)
+        XCTAssertEqual(page.returned, 1)
+        XCTAssertTrue(page.truncated)
+        XCTAssertEqual(page.nextOffset, 2)
+        XCTAssertEqual(page.entries.map(\.title), ["Second note"])
+        XCTAssertTrue(page.hint.contains("offset=2"))
+    }
+
+    func testReadDictationEntryIdBehaviorUnchangedByPaginationParams() throws {
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
+
+        let result = try handleReadDictation(
+            params: CallTool.Parameters(name: "read_dictation", arguments: [
+                "filename": .string("Dictations_2026-04-07"),
+                "entry_id": .string("dictation-20260407-091500-000"),
+                "offset": .int(1),
+                "limit": .int(1),
+            ]),
+            dictationDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let text = try resultText(result)
+        XCTAssertTrue(text.hasPrefix("# Morning note"))
+        XCTAssertTrue(text.contains("Ship the follow-up note to product today"))
+        XCTAssertFalse(text.contains("total_entries"))
+    }
+
     func testListActionItemsDoneStatusReturnsExplicitError() throws {
         let result = try handleListActionItems(
             params: CallTool.Parameters(name: "list_action_items", arguments: ["status": .string("done")]),

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -539,6 +539,173 @@ final class ToolHandlersTests: XCTestCase {
         XCTAssertTrue(text.contains("\"all\""))
     }
 
+    func testDecisionsToolReturnsStructuredReceipts() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                decisions: ["Keep pricing simple", "Ship the beta on Friday"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleDecisions(
+            params: CallTool.Parameters(
+                name: "decisions",
+                arguments: ["topic": .string("pricing"), "range": .string("2026-04-18")]
+            ),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.meetingId, "Call_2026-04-18_09-15-00")
+        XCTAssertEqual(decoded.results.first?.timestamp, nil)
+        XCTAssertEqual(decoded.results.first?.quote, "Keep pricing simple")
+    }
+
+    func testCommitmentsToolFiltersByPerson() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                actionItems: ["Jenny: send the revised spec", "Sam: draft the launch note"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleCommitments(
+            params: CallTool.Parameters(
+                name: "commitments",
+                arguments: ["person": .string("Jenny"), "range": .string("2026-04-01..2026-04-30")]
+            ),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.person, "Jenny")
+        XCTAssertEqual(decoded.results.first?.quote, "Jenny: send the revised spec")
+    }
+
+    func testOpenQuestionsToolFiltersByProject() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                openQuestions: ["Should the pricing page mention credits?", "Do we need a migration window?"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleOpenQuestions(
+            params: CallTool.Parameters(
+                name: "open_questions",
+                arguments: ["project": .string("pricing credits")]
+            ),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.kind, "open_question")
+        XCTAssertEqual(decoded.results.first?.quote, "Should the pricing page mention credits?")
+    }
+
+    func testSearchMeetingsToolReturnsUtteranceReceiptsWithTimestamps() throws {
+        try writeFixture(
+            makeFixtureJSON(
+                utterances: [
+                    ("mic_0", 0.0, 5.0, "Good morning everyone"),
+                    ("system_0", 125.0, 135.0, "The pricing decision needs a receipt"),
+                ]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleSearchMeetings(
+            params: CallTool.Parameters(name: "search_meetings", arguments: ["query": .string("pricing receipt")]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.meetingId, "Call_2026-04-18_09-15-00")
+        XCTAssertEqual(decoded.results.first?.timestamp, "2:05")
+        XCTAssertEqual(decoded.results.first?.quote, "The pricing decision needs a receipt")
+    }
+
+    func testCrossMeetingToolsReturnStructuredEmptyCorpusResults() throws {
+        let decisions = try decodeCrossMeetingResult(try handleDecisions(
+            params: CallTool.Parameters(name: "decisions", arguments: ["topic": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+        let commitments = try decodeCrossMeetingResult(try handleCommitments(
+            params: CallTool.Parameters(name: "commitments", arguments: ["person": .string("Jenny")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+        let questions = try decodeCrossMeetingResult(try handleOpenQuestions(
+            params: CallTool.Parameters(name: "open_questions", arguments: ["project": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+        let search = try decodeCrossMeetingResult(try handleSearchMeetings(
+            params: CallTool.Parameters(name: "search_meetings", arguments: ["query": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+
+        XCTAssertEqual(decisions.count, 0)
+        XCTAssertEqual(commitments.count, 0)
+        XCTAssertEqual(questions.count, 0)
+        XCTAssertEqual(search.count, 0)
+    }
+
+    func testCrossMeetingToolsIgnoreMeetingsWithoutSummaries() throws {
+        try writeFixture(makeFixtureJSON(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleDecisions(
+            params: CallTool.Parameters(name: "decisions", arguments: ["topic": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 0)
+        XCTAssertTrue(decoded.results.isEmpty)
+    }
+
+    func testCrossMeetingToolResultLimitsAreCappedAndTruncated() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                decisions: ["Decision one", "Decision two", "Decision three"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleDecisions(
+            params: CallTool.Parameters(name: "decisions", arguments: ["count": .int(2)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 2)
+        XCTAssertTrue(decoded.truncated)
+        XCTAssertEqual(decoded.results.map(\.quote), ["Decision one", "Decision two"])
+    }
+
     private func resultText(_ result: CallTool.Result) throws -> String {
         guard case .text(let text, _, _) = try XCTUnwrap(result.content.first) else {
             XCTFail("Expected text content")
@@ -575,4 +742,12 @@ private extension CallTool.Result {
         }
         return text
     }
+}
+
+private func decodeCrossMeetingResult(_ result: CallTool.Result) throws -> CrossMeetingToolResult {
+    guard case .text(let text, _, _) = result.content.first else {
+        XCTFail("Expected text tool result")
+        throw NSError(domain: "ToolHandlersTests", code: 1)
+    }
+    return try JSONDecoder().decode(CrossMeetingToolResult.self, from: Data(text.utf8))
 }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -283,9 +283,7 @@ final class ToolHandlersTests: XCTestCase {
     }
 
     func testReadMeetingWindowedReadReturnsRequestedUtterances() throws {
-        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
-            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
-        }
+        let utterances = makeSequentialUtterances(count: 6) { "Utterance number \($0)" }
         try writeFixture(
             makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500", utterances: utterances),
             filename: "Call_2026-03-26_16-04-11",
@@ -317,9 +315,7 @@ final class ToolHandlersTests: XCTestCase {
     }
 
     func testReadMeetingTranscriptSectionWindowOmitsFrontmatter() throws {
-        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
-            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
-        }
+        let utterances = makeSequentialUtterances(count: 6) { "Utterance number \($0)" }
         try writeFixture(
             makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
             filename: "Call_2026-03-26_16-04-11",
@@ -373,9 +369,7 @@ final class ToolHandlersTests: XCTestCase {
 
     func testReadMeetingOversizedTranscriptAutoTruncatesWithNextOffset() throws {
         let filler = String(repeating: "budget planning detail ", count: 14)
-        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<200).map {
-            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance \($0): \(filler)")
-        }
+        let utterances = makeSequentialUtterances(count: 200) { "Utterance \($0): \(filler)" }
         try writeFixture(
             makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
             filename: "Call_2026-03-26_16-04-11",

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -138,6 +138,77 @@ final class ToolHandlersTests: XCTestCase {
         XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
     }
 
+    func testRecapReturnsStructuredSummaryWhenPresent() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                date: "2026-04-18",
+                time: "09:15:00",
+                decisions: ["Ship the beta on Friday"],
+                actionItems: ["Jenny: send the revised spec"],
+                openQuestions: ["Do we need a migration window?"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let recap = try decodedRecap(date: "2026-04-18")
+        let meeting = try XCTUnwrap(recap.meetings.first)
+
+        XCTAssertEqual(meeting.title, "Beta launch sync")
+        XCTAssertEqual(meeting.summarySource, "summary")
+        XCTAssertEqual(meeting.decisions, ["Ship the beta on Friday"])
+        XCTAssertEqual(meeting.actionItems, [RecapActionItem(owner: "Jenny", text: "send the revised spec")])
+        XCTAssertEqual(meeting.openQuestions, ["Do we need a migration window?"])
+        XCTAssertTrue(meeting.preview.contains("## Decisions"))
+        XCTAssertFalse(meeting.preview.contains("[00:00]"), "recap should not leak raw dialogue when a summary exists")
+    }
+
+    func testRecapFallsBackToRawLinesWhenSummaryIsMissing() throws {
+        try writeFixture(
+            makeFixtureJSON(
+                title: "Fallback Sync",
+                date: "2026-04-19T10:00:00-0500",
+                utterances: [
+                    ("mic_0", 0.0, 5.0, "This raw line is only for fallback"),
+                    ("system_0", 5.0, 10.0, "Second fallback line"),
+                ]
+            ),
+            filename: "Call_2026-04-19_10-00-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let meeting = try XCTUnwrap(decodedRecap(date: "2026-04-19").meetings.first)
+        XCTAssertEqual(meeting.summarySource, "transcript_fallback")
+        XCTAssertTrue(meeting.decisions.isEmpty)
+        XCTAssertTrue(meeting.actionItems.isEmpty)
+        XCTAssertTrue(meeting.openQuestions.isEmpty)
+        XCTAssertTrue(meeting.preview.contains("This raw line is only for fallback"))
+    }
+
+    func testRecapFallsBackForMalformedEmptySummary() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                date: "2026-04-20",
+                time: "11:00:00",
+                decisions: [],
+                actionItems: [],
+                openQuestions: []
+            ),
+            filename: "Call_2026-04-20_11-00-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let meeting = try XCTUnwrap(decodedRecap(date: "2026-04-20").meetings.first)
+        XCTAssertEqual(meeting.summarySource, "transcript_fallback")
+        XCTAssertTrue(meeting.decisions.isEmpty)
+        XCTAssertTrue(meeting.actionItems.isEmpty)
+        XCTAssertTrue(meeting.openQuestions.isEmpty)
+        XCTAssertTrue(meeting.preview.contains("Let's lock the launch."))
+    }
+
     func testEmptyListDoesNotTrackAgentQueryTelemetry() throws {
         _ = try handleListMeetings(
             params: CallTool.Parameters(name: "list_meetings", arguments: ["count": .int(10)]),
@@ -475,6 +546,17 @@ final class ToolHandlersTests: XCTestCase {
         }
         return text
     }
+
+    private func decodedRecap(date: String) throws -> RecapResult {
+        let result = try handleRecap(
+            params: CallTool.Parameters(name: "recap", arguments: ["date_from": .string(date), "date_to": .string(date)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+        let text = try XCTUnwrap(result.textContent)
+        let data = try XCTUnwrap(text.data(using: .utf8))
+        return try JSONDecoder().decode(RecapResult.self, from: data)
+    }
 }
 
 private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTelemetryRecording {
@@ -482,5 +564,15 @@ private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTeleme
 
     func track(_ observation: AgentCaptureQueryObservation) {
         observations.append(observation)
+    }
+}
+
+private extension CallTool.Result {
+    var textContent: String? {
+        guard let first = content.first,
+              case .text(let text, _, _) = first else {
+            return nil
+        }
+        return text
     }
 }

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -65,6 +65,9 @@ SWIFT_SOURCES=(
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/NameVariants.swift"
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift"
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift"
+    "Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingProvider.swift"
+    "Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift"
+    "Tools/TranscriptedMCP/Sources/TranscriptedMCP/SemanticSearchFusion.swift"
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift"
 )
 


### PR DESCRIPTION
## Summary
- rebuild useful MCP/search slices from stale PRs #1368, #1369, and #1365 on current main
- build on the now-merged #1373 summary index and #1363 bounded-read pagination already present on main
- add summary-backed recap responses, cross-meeting receipt tools, and local-only semantic/hybrid search
- preserve privacy boundaries: search/receipt telemetry remains bucketed and allowlisted; no raw transcript text, query strings, titles, names, paths, audio, or PII are added to telemetry

## Checks
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 11,758 passed
- `bash run-integration-smoke.sh`
- `swift test` — 590 passed, 2 skipped
- `swift test --package-path Tools/TranscriptedMCP` — 157 passed
- `git diff --check origin/main...HEAD`
- after merging latest main: `swift test --package-path Tools/TranscriptedMCP` — 157 passed; `git diff --check origin/main...HEAD`

## Stale PRs
- Supersedes/rebuilds useful current-compatible work from #1368, #1369, and #1365.
- #1363 and #1373 are already merged to main and are used as the base.

COORD_DONE: GREEN | PRs opened: this draft replacement | stale PRs salvaged/held: #1368/#1369/#1365 salvaged here; #1363/#1373 already merged to main | checks run: build-deps, build, tests, integration smoke, swift test, MCP swift test, diff-check | lanes used: Codex=rebuilt/resolved/tested/opened PR; Claude=skipped unavailable (not logged in); Local=attempted triage but output unusable, proof /Users/redbars/.codex/maestro/runs/20260703T105917Z-transcripted-mcp-pr-triage-local; Windows=skipped unavailable | smallest next action: review draft PR and merge only after CI/human review