### PR TITLE
Docs: disclose MCP anonymous usage ping

### DIFF
--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -49,3 +49,22 @@ If `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 `dictations/` subfolders, `transcripted-mcp` uses those subfolders
 automatically and stores its SQLite index in that shared root unless
 `TRANSCRIPTED_INDEX_DIR` is also set.
+
+## Telemetry
+
+The server can emit one anonymous PostHog event per successful tool call
+(`agent_capture_query_observed`, see `AgentCaptureQueryTelemetry.swift`). The
+payload is bucketed metadata only: query kind, artifact kind, capture-age
+bucket, and source-count bucket. It is validated against an allow-list;
+transcript text, query strings, titles, speaker names, file paths, and audio are
+never sent.
+
+It is gated twice:
+
+- it honors the app's anonymous analytics toggle
+  (`observability-anonymous-analytics-enabled`; off means nothing is sent)
+- it no-ops entirely unless a PostHog API key and HTTPS host are configured via
+  `POSTHOG_API_KEY`/`POSTHOG_HOST`, a local override, or the bundle's
+  `TranscriptedPostHogAPIKey`; source builds have none by default
+
+Transcripts and audio never leave the Mac in any mode.

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -74,6 +74,19 @@ Current `transcripted-mcp` capabilities:
 These tools are read-only, but they are not redacted. `read_meeting` and
 `read_dictation` can return local transcript text to the agent you connected.
 
+### Anonymous Usage Ping
+
+Like the app, the MCP helper can send one anonymous analytics event per
+successful tool call (`agent_capture_query_observed`) so we can tell whether
+the agent connection gets used. It carries only bucketed metadata: which kind
+of tool ran, meeting vs. dictation, rough capture age, and rough source count.
+It never includes transcript text, queries, titles, speaker names, file paths,
+or audio, and your captures still never leave your Mac.
+
+It follows the same anonymous analytics switch as the app: turn off analytics
+in Settings > Privacy and the helper sends nothing. Source builds send nothing
+by default because they ship without an analytics key.
+
 ## Local Coding Agents
 
 Claude Code, Codex, and Cursor get the same one-click `Connect` as Claude


### PR DESCRIPTION
## Summary
- rebuild the intended #1357 telemetry disclosure on fresh main
- add plain-language disclosure to `docs/agent-connect.md`
- add technical telemetry gating/details to `Tools/TranscriptedMCP/README.md`
- intentionally did not bring over unrelated #1356 stacked docs sync changes

## Checks
- `git diff --check`
- `bash scripts/dev/agent-preflight.sh origin/main`
- `swift test --package-path Tools/TranscriptedMCP` — 131 passed
- `bash run-e2e-smoke.sh`

## #1357 status
- #1357 was closed while stacked on #1356; this is the fresh main-based replacement docs slice.

COORD_DONE: GREEN | PRs opened: this tiny draft docs PR | stale PRs salvaged/held: #1357 salvaged here, #1356 not included | checks run: diff-check, agent-preflight, MCP swift test, e2e smoke | lanes used: Codex=rebuilt/tested/opened PR; Claude=skipped unavailable; Local=skipped not needed; Windows=skipped unavailable | smallest next action: review and merge after CI