### PR TITLE
Docs: disclose MCP anonymous usage ping

### DIFF
--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -50,6 +50,25 @@ If `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 automatically and stores its SQLite index in that shared root unless
 `TRANSCRIPTED_INDEX_DIR` is also set.
 
+## Telemetry
+
+The server can emit one anonymous PostHog event per successful tool call
+(`agent_capture_query_observed`, see `AgentCaptureQueryTelemetry.swift`). The
+payload is bucketed metadata only: query kind, artifact kind, capture-age
+bucket, and source-count bucket. It is validated against an allow-list;
+transcript text, query strings, titles, speaker names, file paths, and audio are
+never sent.
+
+It is gated twice:
+
+- it honors the app's anonymous analytics toggle
+  (`observability-anonymous-analytics-enabled`; off means nothing is sent)
+- it no-ops entirely unless a PostHog API key and HTTPS host are configured via
+  `POSTHOG_API_KEY`/`POSTHOG_HOST`, a local override, or the bundle's
+  `TranscriptedPostHogAPIKey`; source builds have none by default
+
+Transcripts and audio never leave the Mac in any mode.
+
 ## Cross-Meeting Receipt Tools
 
 WS2.3 adds local structured retrieval tools for agents:

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -81,6 +81,19 @@ that have a saved summary; see `docs/cross-meeting-tools.md`.
 These tools are read-only, but they are not redacted. `read_meeting` and
 `read_dictation` can return local transcript text to the agent you connected.
 
+### Anonymous Usage Ping
+
+Like the app, the MCP helper can send one anonymous analytics event per
+successful tool call (`agent_capture_query_observed`) so we can tell whether
+the agent connection gets used. It carries only bucketed metadata: which kind
+of tool ran, meeting vs. dictation, rough capture age, and rough source count.
+It never includes transcript text, queries, titles, speaker names, file paths,
+or audio, and your captures still never leave your Mac.
+
+It follows the same anonymous analytics switch as the app: turn off analytics
+in Settings > Privacy and the helper sends nothing. Source builds send nothing
+by default because they ship without an analytics key.
+
 ## Local Coding Agents
 
 Claude Code, Codex, and Cursor get the same one-click `Connect` as Claude


### PR DESCRIPTION
Rebuilds the useful docs-only part of #1376 on current main after #1375 made that branch dirty.\n\nChanges:\n- Documents MCP telemetry payload boundaries in Tools/TranscriptedMCP/README.md\n- Adds the same anonymous usage ping disclosure to docs/agent-connect.md\n\nProof:\n- git diff --check