### PR TITLE
Make Home meeting rename discoverable

### DIFF
--- a/Sources/UI/Settings/HomePresentation.swift
+++ b/Sources/UI/Settings/HomePresentation.swift
@@ -10,6 +10,16 @@ enum HomeCaptureListCopy {
     static let noMeetingMatches = "No meetings match your search. Older meetings load with Show more."
 }
 
+// MARK: - Meeting rename affordance
+
+/// Pinned copy and identifiers for the Home meeting-title rename control.
+enum HomeMeetingRenameAffordance {
+    static let title = "Rename"
+    static let help = "Rename meeting"
+    static let symbolName = "pencil"
+    static let automationIdentifier = "transcripted.home.meeting-preview.rename"
+}
+
 // MARK: - Day section labels
 
 /// Foundation-pure day-section label derivation for the Home capture lists.

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -2417,13 +2417,30 @@ struct HomeMeetingPreviewSheet: View {
                 .onExitCommand { cancelTitleEdit() }
                 .accessibilityIdentifier("transcripted.home.meeting-preview.title-field")
         } else {
-            Text(preview.title)
-                .font(.system(size: 22, weight: .semibold))
-                .lineLimit(2)
-                .contentShape(Rectangle())
-                .onTapGesture(count: 2) { beginTitleEdit() }
-                .help("Double-click to rename")
-                .accessibilityIdentifier("transcripted.home.meeting-preview.title")
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(preview.title)
+                    .font(.system(size: 22, weight: .semibold))
+                    .lineLimit(2)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) { beginTitleEdit() }
+                    .help(HomeMeetingRenameAffordance.help)
+                    .accessibilityIdentifier("transcripted.home.meeting-preview.title")
+
+                Button(action: beginTitleEdit) {
+                    Image(systemName: HomeMeetingRenameAffordance.symbolName)
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 26, height: 26)
+                }
+                .buttonStyle(SettingsHoverButtonStyle(
+                    tone: .neutral,
+                    cornerRadius: 7,
+                    normalFill: Color.primary.opacity(0.035),
+                    normalStroke: Color.primary.opacity(0.08)
+                ))
+                .help(HomeMeetingRenameAffordance.help)
+                .accessibilityLabel(HomeMeetingRenameAffordance.title)
+                .accessibilityIdentifier(HomeMeetingRenameAffordance.automationIdentifier)
+            }
         }
     }
 

--- a/Tests/HomePresentationTests.swift
+++ b/Tests/HomePresentationTests.swift
@@ -90,4 +90,14 @@ func testHomePresentation() {
         )
         assertEqual(HomeCaptureListCopy.emptyDictations, "No recent dictations.")
     }
+
+    runSuite("HomeMeetingRenameAffordance — pinned discoverable edit control") {
+        assertEqual(HomeMeetingRenameAffordance.title, "Rename")
+        assertEqual(HomeMeetingRenameAffordance.help, "Rename meeting")
+        assertEqual(HomeMeetingRenameAffordance.symbolName, "pencil")
+        assertEqual(
+            HomeMeetingRenameAffordance.automationIdentifier,
+            "transcripted.home.meeting-preview.rename"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- add a visible pencil button next to the Home meeting preview title
- keep the existing double-click title rename path and rename mechanics unchanged
- pin the rename affordance copy, symbol, and automation id in Home presentation tests

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh --filter HomePresentationTests
- bash run-tests.sh --filter HomeMeetingRenameTests
- bash run-tests.sh
- bash scripts/ops/transcripted-qa-bench.sh --mode ui
- git diff --check
- codex review --base origin/main: no actionable findings

## Lane closeout
lanes used: Codex=implemented, built, tested, reviewed, pushed; Claude=skipped; Local=attempted diff review, low-value output, not counted as proof; Windows=skipped