### PR TITLE
perf(home): cache recent meeting metadata

### DIFF
--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -399,14 +399,20 @@ enum RecentMeetingsScanner {
         return .ok
     }
 
-    static func loadRecent(limit: Int = 3, directory: URL? = nil) -> [RecentMeetingItem] {
+    static func loadRecent(
+        limit: Int = 3,
+        directory: URL? = nil,
+        cache: RecentMeetingMetadataCache? = .shared
+    ) -> [RecentMeetingItem] {
         guard limit > 0 else { return [] }
 
         let dir = directory ?? MeetingStoragePaths.transcriptsFolder
         let fm = FileManager.default
         guard fm.fileExists(atPath: dir.path) else { return [] }
 
-        let keys: [URLResourceKey] = [.creationDateKey, .contentModificationDateKey, .isRegularFileKey]
+        let keys: [URLResourceKey] = [
+            .creationDateKey, .contentModificationDateKey, .isRegularFileKey, .fileSizeKey
+        ]
         let requestedKeys = Set(keys)
         guard let urls = try? fm.contentsOfDirectory(
             at: dir,
@@ -414,7 +420,7 @@ enum RecentMeetingsScanner {
             options: [.skipsHiddenFiles]
         ) else { return [] }
 
-        var candidates: [(url: URL, date: Date)] = []
+        var candidates: [(url: URL, date: Date, modified: Double, size: Int64)] = []
         for url in urls {
             if Task.isCancelled { return [] }
             guard isMarkdownCandidate(url) else { continue }
@@ -423,12 +429,39 @@ enum RecentMeetingsScanner {
                 continue
             }
             let date = values?.creationDate ?? values?.contentModificationDate ?? .distantPast
-            candidates.append((url, date))
+            let modified = values?.contentModificationDate?.timeIntervalSinceReferenceDate ?? 0
+            let size = Int64(values?.fileSize ?? 0)
+            candidates.append((url, date, modified, size))
         }
 
         var recentItems: [RecentMeetingItem] = []
         for entry in candidates.sorted(by: { $0.date > $1.date }) {
             if Task.isCancelled { return [] }
+
+            let stamp = cacheStamp(
+                transcriptModified: entry.modified,
+                transcriptSize: entry.size,
+                transcriptURL: entry.url
+            )
+
+            // Warm path: serve the row straight from the index, with no transcript
+            // or summary content read. Only the live audio attachment is resolved.
+            if let cache,
+               let cached = cache.lookup(path: entry.url.path, stamp: stamp) {
+                recentItems.append(
+                    cached.makeItem(
+                        transcriptURL: entry.url,
+                        audio: MeetingAudioArchiveResolver.attachment(forTranscript: entry.url)
+                    )
+                )
+                if recentItems.count >= limit {
+                    break
+                }
+                continue
+            }
+
+            // Cold path: parse the transcript (and any summary sidecar), then
+            // populate the index so the next refresh stays off disk.
             guard let styled = MeetingTranscriptStyler.displayTranscriptPreview(at: entry.url) else {
                 continue
             }
@@ -439,25 +472,51 @@ enum RecentMeetingsScanner {
                 fallbackDate: entry.date
             )
             let displayDate = timing.start ?? entry.date
-            recentItems.append(
-                RecentMeetingItem(
-                    title: styled.title,
-                    date: displayDate,
-                    startDate: timing.start,
-                    endDate: timing.end,
-                    transcriptURL: styled.url,
-                    audio: MeetingAudioArchiveResolver.attachment(forTranscript: styled.url),
-                    speakerStatus: RecentMeetingSpeakerStatus.detect(in: markdown),
-                    summaryPreview: loadSummaryPreview(for: styled.url, markdown: markdown, frontmatter: frontmatter),
-                    audioHealth: RecentMeetingAudioHealth.detect(frontmatter: frontmatter)
-                )
+            let item = RecentMeetingItem(
+                title: styled.title,
+                date: displayDate,
+                startDate: timing.start,
+                endDate: timing.end,
+                transcriptURL: styled.url,
+                audio: MeetingAudioArchiveResolver.attachment(forTranscript: styled.url),
+                speakerStatus: RecentMeetingSpeakerStatus.detect(in: markdown),
+                summaryPreview: loadSummaryPreview(for: styled.url, markdown: markdown, frontmatter: frontmatter),
+                audioHealth: RecentMeetingAudioHealth.detect(frontmatter: frontmatter)
             )
+            cache?.store(
+                path: entry.url.path,
+                stamp: stamp,
+                metadata: CachedRecentMeetingMetadata(item: item)
+            )
+            recentItems.append(item)
             if recentItems.count >= limit {
                 break
             }
         }
 
         return recentItems
+    }
+
+    /// Build the cache validity stamp from cheap `stat` metadata only. The summary
+    /// sidecar is folded in so a sidecar that appears or changes without rewriting
+    /// the transcript still invalidates the cached row.
+    private static func cacheStamp(
+        transcriptModified: Double,
+        transcriptSize: Int64,
+        transcriptURL: URL
+    ) -> RecentMeetingCacheStamp {
+        let summaryURL = LocalMeetingSummaryStore.summaryURL(for: transcriptURL)
+        let summaryValues = try? summaryURL.resourceValues(
+            forKeys: [.contentModificationDateKey, .fileSizeKey]
+        )
+        let summaryModified = summaryValues?.contentModificationDate?.timeIntervalSinceReferenceDate ?? 0
+        let summarySize = summaryValues?.fileSize.map(Int64.init) ?? -1
+        return RecentMeetingCacheStamp(
+            transcriptModified: transcriptModified,
+            transcriptSize: transcriptSize,
+            summaryModified: summaryModified,
+            summarySize: summarySize
+        )
     }
 
     private static func isMarkdownCandidate(_ url: URL) -> Bool {

--- a/Sources/UI/Shared/RecentMeetingMetadataCache.swift
+++ b/Sources/UI/Shared/RecentMeetingMetadataCache.swift
@@ -1,0 +1,231 @@
+// RecentMeetingMetadataCache.swift
+// A small SQLite-backed index for the Home capture list.
+//
+// The Home list used to re-read and re-parse every meeting transcript (full
+// Markdown read + frontmatter parse + speaker-label regex + summary parse) on
+// every refresh, which does not scale to a large library. This cache stores the
+// already-derived row metadata keyed by transcript path and validated by the
+// transcript + summary-sidecar modification time and size. On a warm refresh the
+// scanner reads the row straight from SQLite (a few cheap `stat`s, no file
+// content reads); on a miss or when the on-disk file changed it falls back to the
+// normal parse and repopulates the row.
+//
+// The cache stores only the content-derived fields. Retained-audio attachments
+// are still resolved live by `MeetingAudioArchiveResolver` on every refresh —
+// that is a cheap directory probe, and it already has its own invalidation path
+// (`HomeCaptureRefreshObserver`) for background WAV→M4A recompression and renames.
+
+import Foundation
+import SQLite3
+
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+/// File-identity stamp used to decide whether a cached row is still valid.
+/// All four values come from `stat`-level metadata, never from reading content.
+struct RecentMeetingCacheStamp: Equatable, Sendable {
+    let transcriptModified: Double
+    let transcriptSize: Int64
+    /// `summaryModified`/`summarySize` are `0`/`-1` when no summary sidecar exists.
+    let summaryModified: Double
+    let summarySize: Int64
+}
+
+/// The exact content-derived fields a Home meeting row needs, minus the live
+/// audio attachment. Persisted as a JSON payload so nested summary sections
+/// round-trip without a relational schema.
+struct CachedRecentMeetingMetadata: Codable, Sendable {
+    let title: String
+    let displayDate: Date
+    let startDate: Date?
+    let endDate: Date?
+    /// `nil` means speakers are ready; otherwise the needs-review label count.
+    let speakerNeedsReviewCount: Int?
+    let summaryPreview: CachedSummaryPreview?
+    let hasAudioHealth: Bool
+    let audioHealthMicBoostOutcome: String?
+
+    struct CachedSummaryPreview: Codable, Sendable {
+        let title: String?
+        let summary: String
+        let sections: [CachedSection]
+        let urlPath: String
+    }
+
+    struct CachedSection: Codable, Sendable {
+        let title: String
+        let text: String
+    }
+}
+
+extension CachedRecentMeetingMetadata {
+    /// Build a cache payload from a freshly parsed Home row.
+    init(item: RecentMeetingItem) {
+        self.title = item.title
+        self.displayDate = item.date
+        self.startDate = item.startDate
+        self.endDate = item.endDate
+        if case .needsReview(let count) = item.speakerStatus {
+            self.speakerNeedsReviewCount = count
+        } else {
+            self.speakerNeedsReviewCount = nil
+        }
+        self.summaryPreview = item.summaryPreview.map { preview in
+            CachedSummaryPreview(
+                title: preview.title,
+                summary: preview.summary,
+                sections: preview.sections.map { CachedSection(title: $0.title, text: $0.text) },
+                urlPath: preview.url.path
+            )
+        }
+        self.hasAudioHealth = item.audioHealth != nil
+        self.audioHealthMicBoostOutcome = item.audioHealth?.micBoostPromptOutcome
+    }
+
+    /// Rebuild a Home row from a cached payload. The audio attachment is resolved
+    /// live by the caller so it stays correct across background recompression.
+    func makeItem(transcriptURL: URL, audio: MeetingAudioAttachment?) -> RecentMeetingItem {
+        RecentMeetingItem(
+            title: title,
+            date: displayDate,
+            startDate: startDate,
+            endDate: endDate,
+            transcriptURL: transcriptURL,
+            audio: audio,
+            speakerStatus: speakerNeedsReviewCount.map { .needsReview($0) } ?? .ready,
+            summaryPreview: summaryPreview.map { preview in
+                RecentMeetingSummaryPreview(
+                    title: preview.title,
+                    summary: preview.summary,
+                    sections: preview.sections.map {
+                        RecentMeetingSummarySection(title: $0.title, text: $0.text)
+                    },
+                    url: URL(fileURLWithPath: preview.urlPath)
+                )
+            },
+            audioHealth: hasAudioHealth
+                ? RecentMeetingAudioHealth(micBoostPromptOutcome: audioHealthMicBoostOutcome)
+                : nil
+        )
+    }
+}
+
+/// Thread-safe SQLite cache. Reads and writes are serialized through a lock so it
+/// is safe to share the singleton across the background scan task and any future
+/// concurrent caller.
+final class RecentMeetingMetadataCache: @unchecked Sendable {
+    /// App-wide cache, persisted under the app cache directory. Safe to delete;
+    /// it is rebuilt lazily from disk on the next refresh.
+    static let shared = RecentMeetingMetadataCache(
+        databaseURL: MeetingStoragePaths.cacheFolder
+            .appendingPathComponent("home_meeting_metadata.sqlite", isDirectory: false)
+    )
+
+    private let lock = NSLock()
+    private var db: OpaquePointer?
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    /// - Parameter databaseURL: pass `nil` for a private in-memory cache (tests).
+    init(databaseURL: URL?) {
+        if let databaseURL {
+            try? FileManager.default.createDirectory(
+                at: databaseURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            guard sqlite3_open(databaseURL.path, &db) == SQLITE_OK else {
+                db = nil
+                return
+            }
+            // Owner-only: this is a derived cache of meeting metadata, keep it off
+            // broader default permissions on multi-user systems.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o600],
+                ofItemAtPath: databaseURL.path
+            )
+        } else {
+            guard sqlite3_open(":memory:", &db) == SQLITE_OK else {
+                db = nil
+                return
+            }
+        }
+        createTable()
+    }
+
+    deinit {
+        if let db { sqlite3_close(db) }
+    }
+
+    private func createTable() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS meeting_metadata (
+            path TEXT PRIMARY KEY,
+            transcript_modified REAL NOT NULL,
+            transcript_size INTEGER NOT NULL,
+            summary_modified REAL NOT NULL,
+            summary_size INTEGER NOT NULL,
+            payload TEXT NOT NULL
+        );
+        """
+        sqlite3_exec(db, sql, nil, nil, nil)
+    }
+
+    /// Return the cached metadata for `path` only when the stored stamp matches
+    /// the on-disk stamp exactly. Any change to the transcript or summary sidecar
+    /// is a miss, so the caller re-parses and the row stays correct.
+    func lookup(path: String, stamp: RecentMeetingCacheStamp) -> CachedRecentMeetingMetadata? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let db else { return nil }
+
+        let sql = """
+        SELECT payload FROM meeting_metadata
+        WHERE path = ? AND transcript_modified = ? AND transcript_size = ?
+          AND summary_modified = ? AND summary_size = ?;
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_double(stmt, 2, stamp.transcriptModified)
+        sqlite3_bind_int64(stmt, 3, stamp.transcriptSize)
+        sqlite3_bind_double(stmt, 4, stamp.summaryModified)
+        sqlite3_bind_int64(stmt, 5, stamp.summarySize)
+
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              let cString = sqlite3_column_text(stmt, 0) else { return nil }
+        let json = String(cString: cString)
+        guard let data = json.data(using: .utf8),
+              let payload = try? decoder.decode(CachedRecentMeetingMetadata.self, from: data) else {
+            return nil
+        }
+        return payload
+    }
+
+    /// Insert or replace the cached row for `path`.
+    func store(path: String, stamp: RecentMeetingCacheStamp, metadata: CachedRecentMeetingMetadata) {
+        guard let json = try? encoder.encode(metadata),
+              let jsonString = String(data: json, encoding: .utf8) else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+        guard let db else { return }
+
+        let sql = """
+        INSERT OR REPLACE INTO meeting_metadata
+            (path, transcript_modified, transcript_size, summary_modified, summary_size, payload)
+        VALUES (?, ?, ?, ?, ?, ?);
+        """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_double(stmt, 2, stamp.transcriptModified)
+        sqlite3_bind_int64(stmt, 3, stamp.transcriptSize)
+        sqlite3_bind_double(stmt, 4, stamp.summaryModified)
+        sqlite3_bind_int64(stmt, 5, stamp.summarySize)
+        sqlite3_bind_text(stmt, 6, jsonString, -1, SQLITE_TRANSIENT)
+        sqlite3_step(stmt)
+    }
+}

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -988,6 +988,124 @@ func testRecentCaptureLoader() async {
         }
     }
 
+    await runSuite("RecentMeetingsScanner serves a warm metadata index without re-reading transcripts") {
+        await withTemporaryRecentCaptureLibrary { captureRoot in
+            let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
+            let meetingURL = meetingsRoot.appendingPathComponent("indexed.md", isDirectory: false)
+
+            // Generic speaker labels + an audio-health key so non-trivial derived
+            // fields (needs-review count, audio health) must round-trip through the
+            // index, not just the title.
+            try? writeRecentLoaderMeeting(
+                title: "Indexed Sync",
+                date: recentLoaderDate("2026-06-06T14:00:00Z"),
+                to: meetingURL,
+                micLabel: "Speaker 1",
+                systemLabel: "Speaker 2",
+                extraFrontmatterLines: [
+                    "audio_health: mic_attenuated_by_call_app",
+                    "mic_boost_prompt: shown",
+                ]
+            )
+
+            let cache = RecentMeetingMetadataCache(databaseURL: nil)
+
+            // Cold load parses the file and populates the index.
+            let cold = RecentMeetingsScanner.loadRecent(limit: 1, cache: cache)
+            assertEqual(cold.count, 1, "cold load should return the meeting row")
+            let coldItem = cold.first
+            assertEqual(coldItem?.title, "Indexed Sync", "cold load should read the title from the file")
+            assertEqual(
+                coldItem?.speakerStatus,
+                .needsReview(2),
+                "cold load should flag the two generic speaker labels"
+            )
+            assertEqual(
+                coldItem?.audioHealth,
+                RecentMeetingAudioHealth(micBoostPromptOutcome: "shown"),
+                "cold load should surface the audio-health hint"
+            )
+
+            // Make the transcript content unreadable. Any code path that opens the
+            // file for reading would now fail and drop the row; `stat` metadata
+            // (mtime/size) the index validity check relies on is unaffected.
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o000],
+                ofItemAtPath: meetingURL.path
+            )
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o644],
+                    ofItemAtPath: meetingURL.path
+                )
+            }
+
+            // Control: with a fresh empty index the unreadable file produces no row,
+            // proving the warm hit below genuinely avoided reading the file.
+            let control = RecentMeetingsScanner.loadRecent(
+                limit: 1,
+                cache: RecentMeetingMetadataCache(databaseURL: nil)
+            )
+            assertEqual(
+                control.count,
+                0,
+                "an unreadable transcript should yield no row when the index is cold"
+            )
+
+            // Warm load serves the row straight from the index — no transcript read.
+            let warm = RecentMeetingsScanner.loadRecent(limit: 1, cache: cache)
+            assertEqual(warm.count, 1, "warm load should still return the row from the index")
+            let warmItem = warm.first
+            assertEqual(warmItem?.title, coldItem?.title, "warm title should match the indexed value")
+            assertEqual(warmItem?.date, coldItem?.date, "warm display date should match the indexed value")
+            assertEqual(warmItem?.startDate, coldItem?.startDate, "warm start date should match the indexed value")
+            assertEqual(warmItem?.endDate, coldItem?.endDate, "warm end date should match the indexed value")
+            assertEqual(
+                warmItem?.speakerStatus,
+                coldItem?.speakerStatus,
+                "warm speaker status should match the indexed value"
+            )
+            assertEqual(
+                warmItem?.audioHealth,
+                coldItem?.audioHealth,
+                "warm audio health should match the indexed value"
+            )
+        }
+    }
+
+    await runSuite("RecentMeetingsScanner re-parses when the transcript changes under a warm index") {
+        await withTemporaryRecentCaptureLibrary { captureRoot in
+            let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
+            let meetingURL = meetingsRoot.appendingPathComponent("mutating.md", isDirectory: false)
+
+            try? writeRecentLoaderMeeting(
+                title: "Before Edit",
+                date: recentLoaderDate("2026-06-06T14:00:00Z"),
+                to: meetingURL
+            )
+
+            let cache = RecentMeetingMetadataCache(databaseURL: nil)
+            let first = RecentMeetingsScanner.loadRecent(limit: 1, cache: cache)
+            assertEqual(first.first?.title, "Before Edit", "first load should read the original title")
+
+            // Rewrite with a new title and a fresh modification stamp; the stamp
+            // change must invalidate the cached row so the new title is reflected.
+            try? writeRecentLoaderMeeting(
+                title: "After Edit",
+                date: recentLoaderDate("2026-06-06T14:00:00Z"),
+                to: meetingURL,
+                fileDate: recentLoaderDate("2026-06-07T09:00:00Z")
+            )
+
+            let second = RecentMeetingsScanner.loadRecent(limit: 1, cache: cache)
+            assertEqual(
+                second.first?.title,
+                "After Edit",
+                "a changed transcript should invalidate the index and re-parse"
+            )
+        }
+    }
+
     runSuite("RecentMeetingMicBoostHintPolicy offers the enable action only while it can still help") {
         let unprompted = RecentMeetingAudioHealth(micBoostPromptOutcome: nil)
         let shown = RecentMeetingAudioHealth(micBoostPromptOutcome: "shown")

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -55,6 +55,7 @@ SWIFT_SOURCES=(
     "Sources/UI/Shared/MeetingAudioArchiveResolver.swift"
     "Sources/UI/Shared/HomeMeetingDeletion.swift"
     "Sources/UI/Shared/RecentCaptureScanners.swift"
+    "Sources/UI/Shared/RecentMeetingMetadataCache.swift"
     "Sources/UI/Settings/HomeMeetingPreviewFormatter.swift"
     "Sources/Observability/ObservabilityTextRedactor.swift"
     "Sources/Observability/PayloadSanitizationCore.swift"

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -402,6 +402,7 @@ APP_SOURCES=(
     "Sources/UI/Shared/MeetingAudioArchiveResolver.swift"
     "Sources/UI/Shared/MeetingAudioPlayback.swift"
     "Sources/UI/Shared/RecentCaptureScanners.swift"
+    "Sources/UI/Shared/RecentMeetingMetadataCache.swift"
     "Sources/UI/Shared/HomeCaptureRefreshObserver.swift"
     "Sources/UI/Shared/SpeakerReviewQueueScanner.swift"
     "Sources/UI/Settings/TypingTimeSavedFormatter.swift"


### PR DESCRIPTION
Rebuilds the useful #1329 Home metadata-cache slice on current main after the stale branch became dirty.\n\nPreserves:\n- RecentMeetingMetadataCache SQLite warm path for Home recent meetings\n- Scanner cache invalidation by transcript and summary-sidecar stat metadata\n- Tests proving warm-cache reads avoid transcript content and invalidate on changes\n\nLocal proof:\n- bash build-deps.sh --force\n- bash build.sh --no-open\n- bash run-tests.sh (11806 passed)\n- bash run-e2e-smoke.sh\n\nStale PR replaced: #1329