### PR TITLE
Harden Sentry support diagnostics

### DIFF
--- a/Sources/Observability/AppLogger.swift
+++ b/Sources/Observability/AppLogger.swift
@@ -35,7 +35,7 @@ private actor AppLogFileWriter {
             }
             // File exists and is either small enough or just rotated — open for append
         } else {
-            fm.createFile(atPath: path, contents: nil)
+            fm.createFile(atPath: path, contents: nil, attributes: [.posixPermissions: 0o600])
         }
 
         fm.restrictFileToOwnerOnly(at: URL(fileURLWithPath: path))

--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -77,31 +77,24 @@ final class CrashReporter {
         previousUncaughtHandler?(exception)
     }
 
+    // `capture(error:)` and `capture(message:)` forwarded arbitrary
+    // error/message text to Sentry gated only by text sanitization, with no
+    // positive event allowlist (unlike `captureObservabilityEvent`). They have
+    // no callers anywhere in the app target, so rather than keep an
+    // allowlist-bypassing path alive we make them inert no-ops. If a real need
+    // for ad-hoc error capture returns, route it through `SentryEventPolicy`
+    // like `captureObservabilityEvent` instead of re-enabling these.
+    @available(*, deprecated, message: "Unused; allowlist-bypassing. Route new error capture through captureObservabilityEvent + SentryEventPolicy.")
     func capture(error: Error, context: String = "") {
-        var extra: [String: String] = [:]
-        if !context.isEmpty {
-            // Keyed "detail", not "context": "context" is a sensitive-key fragment in
-            // SentryPayloadSanitizer, so that key would be dropped before send.
-            extra["detail"] = context
-        }
-
-        _ = captureMessageEvent(
-            level: .error,
-            title: String(describing: type(of: error)),
-            message: "Swift error captured",
-            tags: ["source": "swift_error"],
-            extra: extra
-        )
+        _ = error
+        _ = context
     }
 
+    @available(*, deprecated, message: "Unused; allowlist-bypassing. Route new message capture through captureObservabilityEvent + SentryEventPolicy.")
     func capture(message: String, level: String = "warning", extra: [String: String] = [:]) {
-        _ = captureMessageEvent(
-            level: sentryLevel(for: level),
-            title: message,
-            message: message,
-            tags: ["source": "manual_message"],
-            extra: extra
-        )
+        _ = message
+        _ = level
+        _ = extra
     }
 
     static func setRuntimeDiagnosticsContext(_ context: [String: String]) {
@@ -121,6 +114,15 @@ final class CrashReporter {
 
     @discardableResult
     func captureSupportDiagnosticEvent(extra: [String: String]) -> String? {
+        // Support-diagnostic extras are built from app state and can pick up
+        // free-text values under innocuous-looking keys (e.g. the
+        // `latest_reliability_packet` blob, interpolated `route_*`/`runtime_*`/
+        // `storage_*` keys that the sensitive-key fragment list does not catch).
+        // The off-device contract is positive-allowlist gated like
+        // `captureObservabilityEvent`, not just key-drop + redaction, so we
+        // filter to the known-safe key set owned by `SupportDiagnosticsBundle`
+        // before send. Surviving values still pass through the text redactor
+        // inside `captureMessageEvent` as defense-in-depth.
         captureMessageEvent(
             level: .warning,
             title: "support_diagnostic_event",
@@ -130,7 +132,7 @@ final class CrashReporter {
                 "engine": "support",
                 "event": "diagnostic_event",
             ],
-            extra: extra,
+            extra: SupportDiagnosticsBundle.allowlistedSentryContext(extra),
             fingerprint: ["support", "diagnostic_event"]
         )
     }
@@ -309,19 +311,6 @@ final class CrashReporter {
             return .warning
         case .info:
             return .info
-        }
-    }
-
-    private func sentryLevel(for level: String) -> SentryLevel {
-        switch level.lowercased() {
-        case "fatal":
-            return .fatal
-        case "error":
-            return .error
-        case "info":
-            return .info
-        default:
-            return .warning
         }
     }
 }

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -133,7 +133,11 @@ private actor EventFileWriter {
         }
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: fileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
             print("📊 EVENT | created events.jsonl")
         }
         FileManager.default.restrictFileToOwnerOnly(at: fileURL)

--- a/Sources/Observability/JSONLWriter.swift
+++ b/Sources/Observability/JSONLWriter.swift
@@ -27,7 +27,11 @@ actor JSONLWriter {
         }
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: fileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
         }
 
         if handle == nil {

--- a/Sources/Observability/ReliabilityPacketRecorder.swift
+++ b/Sources/Observability/ReliabilityPacketRecorder.swift
@@ -153,7 +153,11 @@ enum ReliabilityPacketRecorder {
         )
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: fileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
         }
         FileManager.default.restrictFileToOwnerOnly(at: fileURL)
 

--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -21,8 +21,25 @@ struct SentryEventPolicy: Equatable {
             tags["wait_bucket"] = waitBucket
         }
 
+        // `reason` is allowlisted because callers usually set it to a short
+        // enum-style value (e.g. "preferred_built_in_for_bluetooth_headset"),
+        // but some producers pass free-text error strings. The redactor in
+        // `sanitizeTags` strips obvious paths/emails/secrets, yet a hard length
+        // cap is the cheaper backstop against an accidental free-text blob
+        // riding off-device under a "safe" key. We keep `reason` (it carries
+        // diagnostic signal `failure_kind` does not always duplicate) but bound
+        // it tightly; enum-style values fit well under the cap.
+        if let reason = tags["reason"], reason.count > maxReasonTagLength {
+            tags["reason"] = String(reason.prefix(maxReasonTagLength)) + "..."
+        }
+
         return SentryPayloadSanitizer.sanitizeTags(tags)
     }
+
+    /// Hard cap for the free-text-capable `reason` diagnostic tag. Enum-style
+    /// reason values stay well below this; anything longer is truncated before
+    /// redaction so a stray error message cannot ship a large blob to Sentry.
+    static let maxReasonTagLength = 80
 
     private static let allowedDiagnosticTagKeys: Set<String> = [
         "attenuation_kind",

--- a/Sources/UI/Shared/SupportDiagnosticsBundle.swift
+++ b/Sources/UI/Shared/SupportDiagnosticsBundle.swift
@@ -109,9 +109,11 @@ enum SupportDiagnosticsBundle {
             "reliability_packet_count": "\(min(snapshot.reliabilityPackets.count, maxReliabilityPackets))",
             "system_recording_granted": bool(snapshot.systemAudioRecordingGranted),
         ]
-        if let latest = snapshot.reliabilityPackets.last {
-            context["latest_reliability_packet"] = latest
-        }
+        // The free-text `latest_reliability_packet` blob is intentionally not
+        // emitted here: it can carry paths / free text, and
+        // `reliability_packet_count` already gives the coarse signal that reaches
+        // Sentry. (The human-readable diagnostics text, built separately, still
+        // summarizes recent reliability packets for copied support bundles.)
 
         for (key, value) in snapshot.audioRoute {
             context["route_\(key)"] = value
@@ -126,6 +128,55 @@ enum SupportDiagnosticsBundle {
         }
 
         return context
+    }
+
+    /// Static positive key allowlist for the support-diagnostic extras that
+    /// reach Sentry. `sentryContext` builds a fixed set of coarse keys plus
+    /// interpolated `route_*` / `runtime_*` / `storage_*` keys and (previously)
+    /// a free-text `latest_reliability_packet` blob. The off-device contract is
+    /// allowlist-gated, not just key-drop + redaction, so anything not on this
+    /// allowlist or matching a bucketed prefix is dropped before send. The
+    /// free-text `latest_reliability_packet` is intentionally excluded —
+    /// `reliability_packet_count` already carries the coarse signal. Surviving
+    /// values still pass through `SentryPayloadSanitizer` (fragment drop + text
+    /// redaction) at the call site as defense-in-depth, so a prefixed key whose
+    /// suffix is sensitive (e.g. `runtime_file_path`, `route_raw_url`) is also
+    /// dropped downstream. Keep in sync with `sentryContext` above.
+    static let sentryContextAllowedKeys: Set<String> = [
+        "analytics_available",
+        "analytics_enabled",
+        "app_version",
+        "build_version",
+        "calendar_granted",
+        "crash_reporting_available",
+        "crash_reporting_enabled",
+        "meeting_display_status",
+        "meeting_duration_bucket",
+        "meeting_recording",
+        "meeting_review_pending",
+        "meeting_shortcut",
+        "meeting_state",
+        "microphone_status",
+        "pasteback_granted",
+        "queued_meeting_count",
+        "reliability_packet_count",
+        "system_recording_granted",
+    ]
+
+    static let sentryContextAllowedKeyPrefixes: [String] = [
+        "route_",
+        "runtime_",
+        "storage_",
+    ]
+
+    /// Apply the positive key allowlist to a `sentryContext` dictionary,
+    /// dropping any key (notably the free-text `latest_reliability_packet`)
+    /// that is neither explicitly allowlisted nor a bucketed prefix key.
+    static func allowlistedSentryContext(_ context: [String: String]) -> [String: String] {
+        context.filter { key, _ in
+            sentryContextAllowedKeys.contains(key)
+                || sentryContextAllowedKeyPrefixes.contains(where: { key.hasPrefix($0) })
+        }
     }
 
     private static func render(_ values: [String: String]) -> String {

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -303,4 +303,31 @@ func testSentryEventPolicy() {
 
         assertTrue(tags.isEmpty, "local-only events should not get Sentry diagnostic tags")
     }
+
+    runSuite("SentryEventPolicy diagnosticTags hard-caps the free-text reason tag") {
+        let enumReason = "preferred_built_in_for_bluetooth_headset"
+        let shortTags = SentryEventPolicy.diagnosticTags(
+            forEngine: "meeting",
+            event: "recording_capture_degraded",
+            context: ["reason": enumReason]
+        )
+        assertEqual(shortTags["reason"], enumReason, "short enum-style reasons should pass through untruncated")
+
+        let freeText = String(repeating: "a", count: 400)
+        let cappedTags = SentryEventPolicy.diagnosticTags(
+            forEngine: "meeting",
+            event: "recording_capture_degraded",
+            context: ["reason": freeText]
+        )
+        let cappedReason = cappedTags["reason"]
+        assertTrue(cappedReason != nil, "reason should still be forwarded after capping")
+        assertTrue(
+            (cappedReason?.count ?? 0) <= SentryEventPolicy.maxReasonTagLength + 3,
+            "an oversized free-text reason should be truncated to the hard cap plus ellipsis"
+        )
+        assertTrue(
+            cappedReason?.hasSuffix("...") ?? false,
+            "a truncated reason should be marked with an ellipsis"
+        )
+    }
 }

--- a/Tests/SupportDiagnosticsBundleTests.swift
+++ b/Tests/SupportDiagnosticsBundleTests.swift
@@ -119,4 +119,109 @@ func testSupportDiagnosticsBundle() {
         assertNil(sanitized["system_audio_recording_granted"], "support diagnostics should avoid audio-prefixed permission keys")
         assertNil(sanitized["audio_input_device_class"], "support diagnostics should not use audio-prefixed Sentry keys")
     }
+
+    runSuite("SupportDiagnosticsBundle Sentry context is positive-allowlist gated") {
+        let snapshot = SupportDiagnosticsSnapshot(
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osVersion: "Version 26.0",
+            crashReportingAvailable: true,
+            crashReportingEnabled: true,
+            analyticsAvailable: true,
+            analyticsEnabled: true,
+            microphoneStatus: "authorized",
+            systemAudioRecordingGranted: true,
+            pastebackGranted: true,
+            calendarGranted: true,
+            // Adversarial injection: each entry hides a sensitive value behind a
+            // route_/runtime_/storage_ prefix or an off-allowlist key.
+            audioRoute: [
+                "input_device_class": "bluetooth",
+                "raw_url": "https://meet.example.com/private-room",
+                "audio_device": "MacBook Pro Microphone",
+            ],
+            runtime: [
+                "session_stage": "recording",
+                "file_path": "/Users/redbars/private-runtime.json",
+                "transcript_title": "Private Customer Call",
+                "speaker_name": "Alice Customer",
+                "email": "person@example.com",
+            ],
+            storage: [
+                "known_stale_model_count": "1",
+            ],
+            meetingState: "recording",
+            meetingRecording: true,
+            meetingDurationBucket: "2_9m",
+            meetingDisplayStatus: "transcribing",
+            speakerReviewPending: false,
+            queuedMeetingCount: 2,
+            meetingShortcut: "⌥M",
+            // The latest reliability packet is a free-text blob with a path — it
+            // must never ride to Sentry as `latest_reliability_packet`.
+            reliabilityPackets: [
+                "2026-05-03T01:15:11Z meeting.stop recovered path=/Users/redbars/private.txt"
+            ],
+            recentLogLines: []
+        )
+
+        let rawContext = SupportDiagnosticsBundle.sentryContext(snapshot: snapshot)
+        // Mirror the real send path: positive allowlist, then the Sentry
+        // payload sanitizer (fragment drop + redaction) as defense-in-depth.
+        let allowlisted = SupportDiagnosticsBundle.allowlistedSentryContext(rawContext)
+        let sent = SentryPayloadSanitizer.sanitizeContext(allowlisted)
+
+        // Known-safe coarse keys survive.
+        assertEqual(sent["app_version"], "1.2.3", "coarse app version should survive the allowlist")
+        assertEqual(sent["meeting_state"], "recording", "coarse meeting state should survive the allowlist")
+        assertEqual(sent["route_input_device_class"], "bluetooth", "coarse route facts should survive the allowlist")
+        assertEqual(sent["runtime_session_stage"], "recording", "coarse runtime session stage should survive the allowlist")
+        assertEqual(sent["storage_known_stale_model_count"], "1", "coarse storage facts should survive the allowlist")
+        assertEqual(sent["reliability_packet_count"], "1", "the coarse packet count should survive the allowlist")
+
+        // The free-text reliability packet blob must never leave under its key.
+        assertNil(rawContext["latest_reliability_packet"], "sentryContext should no longer emit the free-text reliability packet blob")
+        assertNil(allowlisted["latest_reliability_packet"], "the allowlist should drop the free-text reliability packet blob")
+        assertNil(sent["latest_reliability_packet"], "the free-text reliability packet blob must not reach Sentry")
+
+        // Sensitive values hidden behind prefixed keys must be dropped by the
+        // downstream fragment-drop sanitizer.
+        assertNil(sent["route_raw_url"], "raw route URLs must not reach Sentry even behind a route_ prefix")
+        assertNil(sent["route_audio_device"], "raw device names must not reach Sentry even behind a route_ prefix")
+        assertNil(sent["runtime_file_path"], "runtime file paths must not reach Sentry even behind a runtime_ prefix")
+        assertNil(sent["runtime_transcript_title"], "runtime transcript titles must not reach Sentry even behind a runtime_ prefix")
+        assertNil(sent["runtime_speaker_name"], "runtime speaker names must not reach Sentry even behind a runtime_ prefix")
+        assertNil(sent["runtime_email"], "runtime emails must not reach Sentry even behind a runtime_ prefix")
+
+        // Defense-in-depth: any value that still slipped through must not carry
+        // the raw injected secrets.
+        for value in sent.values {
+            assertFalse(value.contains("/Users/redbars"), "no allowlisted value should retain a home path")
+            assertFalse(value.contains("person@example.com"), "no allowlisted value should retain an email")
+            assertFalse(value.contains("Private Customer Call"), "no allowlisted value should retain a meeting title")
+            assertFalse(value.contains("https://meet.example.com"), "no allowlisted value should retain a raw URL")
+        }
+    }
+
+    runSuite("SupportDiagnosticsBundle allowlist drops unknown off-allowlist keys") {
+        let injected = [
+            "app_version": "1.2.3",
+            "route_input_device_class": "bluetooth",
+            "latest_reliability_packet": "free text with /Users/redbars/private.txt",
+            "device_name": "Justin's MacBook Pro",
+            "meeting_title": "Private Customer Call",
+            "operator_email": "person@example.com",
+            "arbitrary_blob": "anything not on the allowlist",
+        ]
+
+        let allowlisted = SupportDiagnosticsBundle.allowlistedSentryContext(injected)
+
+        assertEqual(allowlisted["app_version"], "1.2.3", "static allowlisted keys should survive")
+        assertEqual(allowlisted["route_input_device_class"], "bluetooth", "bucketed prefix keys should survive")
+        assertNil(allowlisted["latest_reliability_packet"], "free-text reliability blob should be dropped")
+        assertNil(allowlisted["device_name"], "off-allowlist device keys should be dropped")
+        assertNil(allowlisted["meeting_title"], "off-allowlist title keys should be dropped")
+        assertNil(allowlisted["operator_email"], "off-allowlist email keys should be dropped")
+        assertNil(allowlisted["arbitrary_blob"], "arbitrary off-allowlist keys should be dropped")
+    }
 }


### PR DESCRIPTION
Salvages the focused observability/security slice from stale PR #1335.\n\nPreserves:\n- Owner-only file creation for app/event/jsonl/reliability logs\n- Deprecates/inerts unused allowlist-bypassing CrashReporter capture paths\n- Applies Sentry reason tag length cap\n- Positive allowlist for support diagnostic context before Sentry send\n- Tests for Sentry reason capping and support diagnostic context allowlisting\n\nLocal proof:\n- git diff --check\n- bash run-tests.sh --filter SentryEventPolicyTests\n- bash run-tests.sh --filter SupportDiagnosticsBundleTests\n\nRemaining #1335 work still to salvage separately: paste-target hardening, companion-tool transcript size caps, file-permission/umask and build-deps pin checks, docs/license updates.