### PR TITLE
Add Home recent-capture performance budget

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -125,7 +125,7 @@ rules:
     checks:
       - "scripts/dev/agent-preflight.sh"
       - "bash -n scripts/dev/benchmark-home-recent-captures.sh"
-      - "scripts/dev/benchmark-home-recent-captures.sh"
+      - "scripts/dev/benchmark-home-recent-captures.sh --max-average-load-ms 750 --max-cancellation-ms 100"
 
   - paths:
       - "scripts/ops/generate-nightly-digest.py"

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -77,6 +77,12 @@ jobs:
         # here instead of skipping it.
         run: bash build.sh --no-open
 
+      - name: Premium performance budget
+        shell: bash
+        env:
+          TRANSCRIPTED_DISABLE_FILE_LOGGER: "1"
+        run: scripts/ops/performance-budget.rb --check-home-recent-captures --allow-missing-parakeet-model --max-app-mb 220 --max-resources-mb 80
+
       - name: Fast tests
         shell: bash
         env:

--- a/Tests/Benchmarks/HomeRecentCaptureBenchmark.swift
+++ b/Tests/Benchmarks/HomeRecentCaptureBenchmark.swift
@@ -60,15 +60,18 @@ struct HomeRecentCaptureBenchmark {
         _ = await task.value
         let cancellationDuration = milliseconds(since: cancellationStart)
 
-        print(
-            BenchmarkResult(
-                captures: configuration.captures,
-                meetings: fixture.meetingCount,
-                dictations: fixture.dictationCount,
-                repetitions: configuration.repetitions,
-                loadDurations: loadDurations,
-                cancellationDuration: cancellationDuration
-            ).markdownRow
+        let result = BenchmarkResult(
+            captures: configuration.captures,
+            meetings: fixture.meetingCount,
+            dictations: fixture.dictationCount,
+            repetitions: configuration.repetitions,
+            loadDurations: loadDurations,
+            cancellationDuration: cancellationDuration
+        )
+        print(result.markdownRow)
+        try result.validateBudget(
+            maxAverageLoadMS: configuration.maxAverageLoadMS,
+            maxCancellationMS: configuration.maxCancellationMS
         )
     }
 
@@ -111,13 +114,23 @@ private struct BenchmarkConfiguration {
     let captures: Int
     let repetitions: Int
     let visibleLimit: Int
+    let maxAverageLoadMS: Double?
+    let maxCancellationMS: Double?
 
     init(arguments: [String]) throws {
         captures = try Self.intValue(for: "--captures", in: arguments) ?? 1_000
         repetitions = try Self.intValue(for: "--repetitions", in: arguments) ?? 3
         visibleLimit = try Self.intValue(for: "--visible-limit", in: arguments) ?? 10
+        maxAverageLoadMS = try Self.doubleValue(for: "--max-average-load-ms", in: arguments)
+        maxCancellationMS = try Self.doubleValue(for: "--max-cancellation-ms", in: arguments)
         guard captures > 0, repetitions > 0, visibleLimit > 0 else {
             throw BenchmarkError.configuration("captures, repetitions, and visible-limit must be positive")
+        }
+        if let maxAverageLoadMS, maxAverageLoadMS <= 0 {
+            throw BenchmarkError.configuration("max-average-load-ms must be positive")
+        }
+        if let maxCancellationMS, maxCancellationMS <= 0 {
+            throw BenchmarkError.configuration("max-cancellation-ms must be positive")
         }
     }
 
@@ -126,6 +139,15 @@ private struct BenchmarkConfiguration {
         let valueIndex = arguments.index(after: index)
         guard arguments.indices.contains(valueIndex), let value = Int(arguments[valueIndex]) else {
             throw BenchmarkError.configuration("missing integer value for \(flag)")
+        }
+        return value
+    }
+
+    private static func doubleValue(for flag: String, in arguments: [String]) throws -> Double? {
+        guard let index = arguments.firstIndex(of: flag) else { return nil }
+        let valueIndex = arguments.index(after: index)
+        guard arguments.indices.contains(valueIndex), let value = Double(arguments[valueIndex]) else {
+            throw BenchmarkError.configuration("missing numeric value for \(flag)")
         }
         return value
     }
@@ -271,9 +293,26 @@ private struct BenchmarkResult {
 
     var markdownRow: String {
         let raw = loadDurations.map { String(format: "%.1f", $0) }.joined(separator: ", ")
-        let average = loadDurations.reduce(0, +) / Double(loadDurations.count)
+        let average = averageLoadDuration
         let best = loadDurations.min() ?? 0
         return "| \(captures) | \(meetings) | \(dictations) | \(repetitions) | \(raw) | \(String(format: "%.1f", average)) | \(String(format: "%.1f", best)) | \(String(format: "%.1f", cancellationDuration)) |"
+    }
+
+    private var averageLoadDuration: Double {
+        loadDurations.reduce(0, +) / Double(loadDurations.count)
+    }
+
+    func validateBudget(maxAverageLoadMS: Double?, maxCancellationMS: Double?) throws {
+        var failures: [String] = []
+        if let maxAverageLoadMS, averageLoadDuration > maxAverageLoadMS {
+            failures.append("average load \(String(format: "%.1f", averageLoadDuration))ms > \(String(format: "%.1f", maxAverageLoadMS))ms")
+        }
+        if let maxCancellationMS, cancellationDuration > maxCancellationMS {
+            failures.append("cancel \(String(format: "%.1f", cancellationDuration))ms > \(String(format: "%.1f", maxCancellationMS))ms")
+        }
+        guard failures.isEmpty else {
+            throw BenchmarkError.validation("performance budget failed for \(captures) captures: \(failures.joined(separator: ", "))")
+        }
     }
 }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,7 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
 
 - `scripts/dev/agent-preflight.sh` — summarize branch state, changed paths, trusted docs, and suggested checks from the agent test matrix
 - `scripts/dev/check-build-source-lists.py` — fast raw-`swiftc` guardrail for app, fast-test, and smoke source-list drift
-- `scripts/dev/benchmark-home-recent-captures.sh` — compile and run the Settings Home recent-capture loader benchmark
+- `scripts/dev/benchmark-home-recent-captures.sh` — compile and run the Settings Home recent-capture loader benchmark; pass `--max-average-load-ms` and `--max-cancellation-ms` to fail on regression
 - `scripts/download_ami.sh` — fetch the gitignored AMI ES2002 audio/RTTM subset used by `Tools/SpeakerEvalHarness`
 - `scripts/run_speaker_eval.sh` — build and run the AMI speaker-naming sweep, writing local reports under `data/eval/`
 - `scripts/score_speaker_eval.py` — score speaker-eval hypotheses against AMI RTTM labels without printing private transcript text
@@ -113,6 +113,8 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Optional strict dictation stop proof: `scripts/ops/performance-budget.rb --events "$HOME/Library/Application Support/Transcripted/logs/events.jsonl" --require-dictation-stop-latency-samples 3`
   - Fresh-window verification: `scripts/ops/performance-budget.rb --events "$HOME/Library/Application Support/Transcripted/logs/events.jsonl" --events-since 2026-06-01T01:13:00Z --require-dictation-stop-latency-samples 3`
   - Optional meeting throughput verification: `scripts/ops/performance-budget.rb --stats "$HOME/Library/Application Support/Transcripted/state/stats.sqlite"` (defaults to recordings 30s or longer)
+  - CI-safe Home list/action budget: `scripts/ops/performance-budget.rb --check-home-recent-captures --allow-missing-parakeet-model --max-app-mb 220 --max-resources-mb 80`
+  - Manual hardware proof still owns meeting-list 120fps on Apple Silicon; CI checks deterministic loader latency (<750 ms for the 10k stress fixture) and cancellation acknowledgement (<100 ms) only.
 - `scripts/ops/dictation-stop-autoeval.sh` — synthetic local-audio benchmark for dictation stop-to-text, stop-to-saved, and stop-to-delivery timing
   - Usage: `bash scripts/ops/dictation-stop-autoeval.sh --label baseline --variant native`
   - Writes ignored scratch output under `.autoeval/dictation-stop/`

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -175,7 +175,7 @@ if [ -n "$changed_paths" ]; then
         if matches_any "$path" "scripts/dev/benchmark-home-recent-captures.sh" "Tests/Benchmarks/HomeRecentCaptureBenchmark.swift"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "bash -n scripts/dev/benchmark-home-recent-captures.sh"
-            add_command "scripts/dev/benchmark-home-recent-captures.sh"
+            add_command "scripts/dev/benchmark-home-recent-captures.sh --max-average-load-ms 750 --max-cancellation-ms 100"
         fi
 
         if matches_any "$path" "scripts/ops/generate-nightly-digest.py"; then

--- a/scripts/dev/benchmark-home-recent-captures.sh
+++ b/scripts/dev/benchmark-home-recent-captures.sh
@@ -13,14 +13,17 @@ swiftc \
   "$ROOT_DIR/Sources/Dictation/DictationStoragePaths.swift" \
   "$ROOT_DIR/Sources/Dictation/DictationTranscriptWriter.swift" \
   "$ROOT_DIR/Sources/Dictation/DictationTranscriptStore.swift" \
+  "$ROOT_DIR/Sources/Meeting/MeetingArtifactRenamer.swift" \
   "$ROOT_DIR/Sources/Meeting/MeetingStoragePaths.swift" \
   "$ROOT_DIR/Sources/Meeting/MeetingTranscriptStyler.swift" \
   "$ROOT_DIR/Sources/Meeting/LocalMeetingSummarizer.swift" \
+  "$ROOT_DIR/Sources/Support/LocalMeetingSummaryPreferences.swift" \
   "$ROOT_DIR/Sources/TranscriptedCore/Speaker/SpeakerProfile.swift" \
   "$ROOT_DIR/Sources/TranscriptedCore/Models/TranscriptionTypes.swift" \
   "$ROOT_DIR/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift" \
   "$ROOT_DIR/Sources/UI/Shared/MeetingAudioArchiveResolver.swift" \
   "$ROOT_DIR/Sources/UI/Shared/RecentCaptureScanners.swift" \
+  "$ROOT_DIR/Sources/UI/Shared/RecentMeetingMetadataCache.swift" \
   -framework AppKit \
   -parse-as-library \
   -O \
@@ -28,5 +31,5 @@ swiftc \
 
 echo "| captures | meetings | dictations | reps | raw load ms | avg load ms | best load ms | cancel ms |"
 echo "|---:|---:|---:|---:|---|---:|---:|---:|"
-"$BINARY" --captures 1000 --repetitions "${REPETITIONS:-3}"
-"$BINARY" --captures 10000 --repetitions "${REPETITIONS:-3}"
+"$BINARY" --captures 1000 --repetitions "${REPETITIONS:-3}" "$@"
+"$BINARY" --captures 10000 --repetitions "${REPETITIONS:-3}" "$@"

--- a/scripts/ops/performance-budget.rb
+++ b/scripts/ops/performance-budget.rb
@@ -22,6 +22,8 @@ MAX_DICTATION_START_TO_FIRST_SAMPLE_P95_MS = 350.0
 MAX_DICTATION_STOP_TO_PASTE_P95_MS = 750.0
 MAX_DICTATION_STOP_TO_DONE_P95_MS = 1_000.0
 MAX_MEETING_P95_RTF = 0.05
+MAX_HOME_RECENT_CAPTURE_AVERAGE_LOAD_MS = 750.0
+MAX_HOME_RECENT_CAPTURE_CANCEL_MS = 100.0
 MIN_MEETING_DURATION_SECONDS = 30.0
 MIN_TRANSCRIPTION_SAMPLES = 10
 MIN_STARTUP_SAMPLES = 3
@@ -55,6 +57,9 @@ options = {
   min_meeting_duration_seconds: MIN_MEETING_DURATION_SECONDS,
   min_transcription_samples: MIN_TRANSCRIPTION_SAMPLES,
   min_meeting_samples: MIN_MEETING_SAMPLES,
+  check_home_recent_captures: false,
+  max_home_recent_capture_average_load_ms: MAX_HOME_RECENT_CAPTURE_AVERAGE_LOAD_MS,
+  max_home_recent_capture_cancel_ms: MAX_HOME_RECENT_CAPTURE_CANCEL_MS,
   require_launch_model_ready_samples: 0,
   require_dictation_fast_start_samples: 0,
   require_dictation_stop_latency_samples: 0,
@@ -82,6 +87,9 @@ OptionParser.new do |parser|
   parser.on("--min-meeting-duration-s SECONDS", Float, "Minimum recording duration for meeting throughput stats") { |seconds| options[:min_meeting_duration_seconds] = seconds }
   parser.on("--min-transcription-samples N", Integer, "Minimum dictation transcription samples to require when --events is provided") { |count| options[:min_transcription_samples] = count }
   parser.on("--min-meeting-samples N", Integer, "Minimum meeting throughput samples to require when --stats is provided") { |count| options[:min_meeting_samples] = count }
+  parser.on("--check-home-recent-captures", "Run deterministic Home recent-captures loader budget") { options[:check_home_recent_captures] = true }
+  parser.on("--max-home-recent-capture-average-load-ms MS", Float, "Home recent-captures average load budget") { |ms| options[:max_home_recent_capture_average_load_ms] = ms }
+  parser.on("--max-home-recent-capture-cancel-ms MS", Float, "Home recent-captures cancellation acknowledgement budget") { |ms| options[:max_home_recent_capture_cancel_ms] = ms }
   parser.on("--require-launch-model-ready-samples N", Integer, "Require at least N launch-to-model-ready samples in --events logs") { |count| options[:require_launch_model_ready_samples] = count }
   parser.on("--require-dictation-fast-start-samples N", Integer, "Require at least N fast-start samples in --events logs") { |count| options[:require_dictation_fast_start_samples] = count }
   parser.on("--require-dictation-stop-latency-samples N", Integer, "Require at least N stop-latency samples in --events logs") { |count| options[:require_dictation_stop_latency_samples] = count }
@@ -212,6 +220,27 @@ def fail_budget!(errors)
   warn "Performance budget failed:"
   errors.each { |error| warn "- #{error}" }
   exit 1
+end
+
+def run_home_recent_capture_benchmark(max_average_load_ms:, max_cancel_ms:)
+  command = [
+    "scripts/dev/benchmark-home-recent-captures.sh",
+    "--max-average-load-ms",
+    max_average_load_ms.to_s,
+    "--max-cancellation-ms",
+    max_cancel_ms.to_s
+  ]
+  stdout, stderr, status = Open3.capture3(
+    { "REPETITIONS" => "5" },
+    *command,
+    chdir: REPO_ROOT.to_s
+  )
+  {
+    command: command.join(" "),
+    stdout: stdout,
+    stderr: stderr,
+    status: status
+  }
 end
 
 app_path = Pathname.new(options[:app_path]).expand_path
@@ -432,6 +461,22 @@ if options[:stats_path]
   end
 end
 
+home_recent_capture_summary = nil
+if options[:check_home_recent_captures]
+  result = run_home_recent_capture_benchmark(
+    max_average_load_ms: options[:max_home_recent_capture_average_load_ms],
+    max_cancel_ms: options[:max_home_recent_capture_cancel_ms]
+  )
+  home_recent_capture_summary = result
+  unless result[:status].success?
+    errors << [
+      "Home recent-captures benchmark failed",
+      result[:stderr].strip,
+      result[:stdout].strip
+    ].reject(&:empty?).join(": ")
+  end
+end
+
 fail_budget!(errors)
 
 puts "Performance budget OK"
@@ -505,4 +550,8 @@ if stats_summary
   else
     puts "Meeting processing p95 RTF: n/a"
   end
+end
+if home_recent_capture_summary
+  puts "Home recent-captures benchmark:"
+  puts home_recent_capture_summary[:stdout].strip
 end


### PR DESCRIPTION
Rebuilds the useful #1367 guardrail on current main after #1380 landed.\n\nPreserves:\n- Home recent-captures benchmark pass/fail thresholds\n- performance-budget.rb integration for deterministic Home loader latency and cancellation checks\n- Swift CI premium performance budget step\n- Agent test-matrix/docs updates\n\nAdjustment from stale #1367:\n- Average-load threshold is 750ms instead of 500ms because current main measured 523ms/603ms on local 10k runs; 500ms was too brittle. The wrapper run passed at 446.3ms average.\n\nLocal proof:\n- ruby -c scripts/ops/performance-budget.rb\n- bash -n scripts/dev/benchmark-home-recent-captures.sh\n- scripts/dev/benchmark-home-recent-captures.sh --max-average-load-ms 750 --max-cancellation-ms 100\n- scripts/ops/performance-budget.rb --app build/Transcripted.app --check-home-recent-captures --allow-missing-parakeet-model --max-app-mb 220 --max-resources-mb 80\n- python3 scripts/dev/check-build-source-lists.py\n- git diff --check\n\nStale PR replaced: #1367