### PR TITLE
Cap capture Markdown reads

### DIFF
--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -212,7 +212,7 @@ enum CLIContextStore {
         }
 
         guard let markdownURL,
-              let content = try? String(contentsOf: markdownURL, encoding: .utf8),
+              let content = CaptureMarkdown.readBoundedContents(of: markdownURL),
               CaptureMarkdown.looksLikeCaptureMarkdown(markdownURL),
               !markdownURL.deletingPathExtension().lastPathComponent.hasPrefix("Dictations_") else {
             throw ValidationError("Meeting not found: \(filename)")
@@ -277,7 +277,7 @@ enum CLIContextStore {
             return DictationRead(markdown: markdown, date: day.payload.date, entries: [entry])
         }
 
-        if let content = try? String(contentsOf: markdownURL, encoding: .utf8) {
+        if let content = CaptureMarkdown.readBoundedContents(of: markdownURL) {
             return DictationRead(markdown: content, date: day.payload.date, entries: day.entries)
         }
 
@@ -401,7 +401,7 @@ enum CLIContextStore {
     }
 
     private static func loadMeeting(at url: URL) -> CLIAgentTranscript? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        guard let content = CaptureMarkdown.readBoundedContents(of: url) else { return nil }
         return meetingTranscript(fromMarkdown: content)
     }
 
@@ -434,7 +434,7 @@ enum CLIContextStore {
     }
 
     private static func loadDictationDay(at url: URL) -> (payload: CLIAgentDictationDay, entries: [CLIClientDictationEntry])? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
+        guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else { return nil }
 
         let entries = parsed.entries.map { entry in
@@ -465,7 +465,7 @@ enum CLIContextStore {
 
     private static func readMeetingTitle(filename: String, from directory: URL) -> String {
         let mdURL = directory.appendingPathComponent(filename + ".md")
-        guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+        guard let content = CaptureMarkdown.readBoundedContents(of: mdURL) else {
             return filename
         }
         return CaptureMarkdown.extractTitle(from: content) ?? filename

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
@@ -1,8 +1,25 @@
 import Foundation
 
+/// Shared size guards for reading capture Markdown from disk.
+public enum CaptureFileLimits {
+    /// Maximum byte size for a capture Markdown file we will read into memory.
+    /// 16 MB is far larger than normal transcript text while bounding worst-case allocation.
+    public static let maxTranscriptBytes = 16 * 1024 * 1024
+}
+
 /// Detection helpers for Transcripted capture Markdown artifacts (meetings and
 /// dictation day files). Shared by TranscriptedCLI and TranscriptedMCP.
 public enum CaptureMarkdown {
+    /// Read a capture Markdown file as UTF-8, refusing files larger than
+    /// `CaptureFileLimits.maxTranscriptBytes`.
+    public static func readBoundedContents(of url: URL) -> String? {
+        guard let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,
+              size <= CaptureFileLimits.maxTranscriptBytes else {
+            return nil
+        }
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+
     /// Whether a Markdown file looks like a Transcripted capture artifact:
     /// either a dictation day file by name, or a file with YAML frontmatter.
     public static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
@@ -11,7 +28,7 @@ public enum CaptureMarkdown {
             return true
         }
 
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+        guard let content = readBoundedContents(of: url) else {
             return false
         }
 

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
@@ -614,6 +614,23 @@ final class CaptureMarkdownParserTests: XCTestCase {
         XCTAssertTrue(CaptureMarkdown.directoryHasCaptureMarkdownFiles(tempDir))
     }
 
+    func testCaptureMarkdownRefusesOversizedFiles() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let oversized = tempDir.appendingPathComponent("Oversized.md")
+        try Data().write(to: oversized)
+        let handle = try FileHandle(forWritingTo: oversized)
+        defer { try? handle.close() }
+        handle.write(Data("---\ntitle: Too Large\n---\n".utf8))
+        handle.truncateFile(atOffset: UInt64(CaptureFileLimits.maxTranscriptBytes + 1))
+
+        XCTAssertNil(CaptureMarkdown.readBoundedContents(of: oversized))
+        XCTAssertFalse(CaptureMarkdown.looksLikeCaptureMarkdown(oversized))
+        XCTAssertFalse(CaptureMarkdown.directoryHasCaptureMarkdownFiles(tempDir))
+    }
+
     // MARK: - Format-sync round trip with the Core writer
 
     // Parser side of the format-sync contract. The fixture below is a faithful

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -603,7 +603,7 @@ func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, mee
             appendingExtension: "md",
             in: meetingDirs
         ) else { continue }
-        if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
+        if let content = CaptureMarkdown.readBoundedContents(of: mdURL) {
             results[i].title = extractTitle(from: content) ?? results[i].filename
         }
     }
@@ -682,7 +682,7 @@ func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) throws -
         return textResult("Invalid filename: \(filename)", isError: true)
     }
 
-    guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+    guard let content = CaptureMarkdown.readBoundedContents(of: mdURL) else {
         return textResult("Meeting not found: \(filename). Use list_meetings to see available meetings.", isError: true)
     }
 
@@ -867,7 +867,7 @@ func handleReadDictation(params: CallTool.Parameters, dictationDirs: [URL]) thro
     let limit = params.arguments?["limit"]?.intValue
     let paginationRequested = limit != nil || offset > 0
 
-    guard let content = try? String(contentsOf: markdownURL, encoding: .utf8) else {
+    guard let content = CaptureMarkdown.readBoundedContents(of: markdownURL) else {
         let json = try JSONEncoder.pretty.encode(day)
         return textResult(String(data: json, encoding: .utf8) ?? "{}")
     }
@@ -1071,7 +1071,7 @@ func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, meetingDir
         var openQuestions: [String] = []
         var summarySource = "transcript_fallback"
 
-        if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
+        if let content = CaptureMarkdown.readBoundedContents(of: mdURL) {
             title = extractTitle(from: content) ?? meeting.filename
             if let summary = TranscriptLoader.loadMeetingSummary(forTranscript: mdURL) {
                 title = summary.title ?? title
@@ -1444,7 +1444,7 @@ private func frontmatterMeetingTitle(for filename: String, meetingDirs: [URL]) -
         appendingExtension: "md",
         in: meetingDirs
     ),
-    let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+    let content = CaptureMarkdown.readBoundedContents(of: mdURL) else {
         return nil
     }
     return extractTitle(from: content)

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -21,7 +21,7 @@ enum TranscriptLoader {
     }
 
     static func loadMeeting(_ url: URL) -> AgentTranscript? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
+        guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseMeeting(from: content) else {
             log("Cannot read markdown meeting: \(url.lastPathComponent)")
             return nil
@@ -70,13 +70,13 @@ enum TranscriptLoader {
     /// isolation does not bump the parent transcript's mtime, so its items only
     /// refresh on the next reindex of the transcript itself.
     static func loadMeetingSummary(forTranscript url: URL) -> ParsedMeetingSummary? {
-        if let content = try? String(contentsOf: url, encoding: .utf8),
+        if let content = CaptureMarkdown.readBoundedContents(of: url),
            let summary = CaptureSummaryParser.parse(from: content) {
             return summary
         }
 
         let sidecarURL = summarySidecarURL(forTranscript: url)
-        if let content = try? String(contentsOf: sidecarURL, encoding: .utf8),
+        if let content = CaptureMarkdown.readBoundedContents(of: sidecarURL),
            let summary = CaptureSummaryParser.parse(from: content) {
             return summary
         }
@@ -95,7 +95,7 @@ enum TranscriptLoader {
     }
 
     static func loadDictationDay(_ url: URL) -> AgentDictationDay? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
+        guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else {
             log("Cannot read markdown dictation day: \(url.lastPathComponent)")
             return nil


### PR DESCRIPTION
## Summary
- salvage the useful #1335 transcript-read availability hardening as a small current-main PR
- add a shared CaptureKit size cap for capture Markdown reads
- route CLI and MCP capture-file ingestion through the bounded reader
- add a CaptureKit regression test for oversized capture Markdown files

## Proof
- swift test --package-path Tools/TranscriptedCaptureKit
- swift test --package-path Tools/TranscriptedMCP
- swift test --package-path Tools/TranscriptedCLI
- git diff --check

Replaces part of #1335; the original PR still has other useful security deltas to inspect separately.