### PR TITLE
Add floating capture pill

### DIFF
--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -82,6 +82,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     @available(macOS 14.0, *)
     lazy var meetingOverlayController = MeetingOverlayController()
     @available(macOS 14.0, *)
+    lazy var capturePillController = CapturePillController()
+    @available(macOS 14.0, *)
     lazy var meetingPromptDetector = MeetingPromptDetector()
     @available(macOS 14.0, *)
     lazy var micActivityMonitor = MicActivityMonitor()
@@ -140,7 +142,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 ).allowsDetectedMeetingPrompt
             }
             meetingOverlayController.setup(meetingSession: meetingSession)
-            meetingOverlayController.onPromptRecord = { [weak self] candidate in
+            let recordPrompt: (MeetingPromptDetector.Candidate) -> Void = { [weak self] candidate in
                 guard let self else { return }
                 AnalyticsReporter.track(
                     "meeting_prompt_record_selected",
@@ -161,7 +163,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                     }
                 }
             }
-            meetingOverlayController.onPromptDismiss = { [weak self] candidate in
+            let dismissPrompt: (MeetingPromptDetector.Candidate) -> Void = { [weak self] candidate in
                 guard let self else { return }
                 let backoffDecision = self.meetingPromptDetector.dismiss(candidate: candidate)
                 AnalyticsReporter.track(
@@ -206,6 +208,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                     )
                 )
             }
+            meetingOverlayController.onPromptRecord = recordPrompt
+            meetingOverlayController.onPromptDismiss = dismissPrompt
             meetingOverlayController.onPromptRemindSoon = { [weak self] candidate in
                 guard let self else { return }
                 let backoffDecision = self.meetingPromptDetector.remindSoon(candidate: candidate)
@@ -228,6 +232,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                     )
                 )
             }
+            capturePillController.onRecord = recordPrompt
+            capturePillController.onDismiss = dismissPrompt
             meetingPromptDetector.onPromptSuppressed = { [weak self] suppression in
                 guard let self else { return }
                 AnalyticsReporter.track(
@@ -251,7 +257,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingPromptDetector.onPromptRequest = { [weak self] candidate in
                 guard PermissionsOnboardingPreferences.hasCompleted() else { return false }
                 guard let self else { return false }
-                let presented = self.meetingOverlayController.presentDetectedMeetingPrompt(candidate)
+                let presented = self.capturePillController.present(candidate: candidate)
                 if presented {
                     AnalyticsReporter.track(
                         "meeting_prompt_shown",

--- a/Sources/UI/Overlay/CapturePillController.swift
+++ b/Sources/UI/Overlay/CapturePillController.swift
@@ -1,0 +1,290 @@
+import AppKit
+
+@available(macOS 14.0, *)
+@MainActor
+final class CapturePillController {
+    private var panel: CapturePillPanel?
+    private var pillView: CapturePillView?
+    private var representedCandidate: MeetingPromptDetector.Candidate?
+    private var dismissTask: Task<Void, Never>?
+    private var eventMonitor: Any?
+
+    var onRecord: ((MeetingPromptDetector.Candidate) -> Void)?
+    var onDismiss: ((MeetingPromptDetector.Candidate) -> Void)?
+
+    deinit {
+        dismissTask?.cancel()
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+        }
+    }
+
+    @discardableResult
+    func present(
+        candidate: MeetingPromptDetector.Candidate,
+        timeout: TimeInterval = 30
+    ) -> Bool {
+        ensurePanel()
+        guard let panel, let pillView else { return false }
+
+        representedCandidate = candidate
+        pillView.update(candidate: candidate)
+        panel.onCancel = { [weak self] in self?.dismiss(notify: true) }
+        panel.onDefault = { [weak self] in self?.record() }
+
+        position(panel: panel)
+        panel.orderFrontRegardless()
+        panel.makeKey()
+
+        installEventMonitor()
+        scheduleDismiss(timeout: timeout)
+        return true
+    }
+
+    func dismiss(notify: Bool) {
+        dismissTask?.cancel()
+        dismissTask = nil
+
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+
+        let candidate = representedCandidate
+        representedCandidate = nil
+        panel?.orderOut(nil)
+
+        if notify, let candidate {
+            onDismiss?(candidate)
+        }
+    }
+
+    private func ensurePanel() {
+        guard panel == nil else { return }
+
+        let frame = NSRect(origin: .zero, size: CapturePillView.preferredSize)
+        let panel = CapturePillPanel(
+            contentRect: frame,
+            styleMask: [.nonactivatingPanel, .fullSizeContentView, .borderless],
+            backing: .buffered,
+            defer: true
+        )
+        let pillView = CapturePillView(frame: NSRect(origin: .zero, size: CapturePillView.preferredSize))
+        pillView.autoresizingMask = [.width, .height]
+        pillView.onRecord = { [weak self] in self?.record() }
+        pillView.onDismiss = { [weak self] in self?.dismiss(notify: true) }
+        panel.contentView = pillView
+
+        self.panel = panel
+        self.pillView = pillView
+    }
+
+    private func record() {
+        guard let candidate = representedCandidate else { return }
+        dismiss(notify: false)
+        onRecord?(candidate)
+    }
+
+    private func scheduleDismiss(timeout: TimeInterval) {
+        dismissTask?.cancel()
+        dismissTask = Task { @MainActor [weak self] in
+            let nanoseconds = UInt64(max(1, timeout) * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            guard !Task.isCancelled else { return }
+            self?.dismiss(notify: true)
+        }
+    }
+
+    private func installEventMonitor() {
+        guard eventMonitor == nil else { return }
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, self.panel?.isVisible == true else { return event }
+            switch event.keyCode {
+            case 36:
+                self.record()
+                return nil
+            case 53:
+                self.dismiss(notify: true)
+                return nil
+            default:
+                return event
+            }
+        }
+    }
+
+    private func position(panel: NSPanel) {
+        let screen = NSScreen.main ?? NSScreen.screens.first
+        let visibleFrame = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let size = panel.frame.size
+        let inset: CGFloat = 18
+        let origin = NSPoint(
+            x: visibleFrame.midX - size.width / 2,
+            y: visibleFrame.maxY - size.height - inset
+        )
+        panel.setFrameOrigin(origin)
+    }
+}
+
+@available(macOS 14.0, *)
+final class CapturePillPanel: NSPanel {
+    var onCancel: (() -> Void)?
+    var onDefault: (() -> Void)?
+
+    override init(
+        contentRect: NSRect,
+        styleMask style: NSWindow.StyleMask,
+        backing backingStoreType: NSWindow.BackingStoreType,
+        defer flag: Bool
+    ) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.nonactivatingPanel, .fullSizeContentView, .borderless],
+            backing: .buffered,
+            defer: true
+        )
+        self.level = .popUpMenu
+        self.isFloatingPanel = true
+        self.becomesKeyOnlyIfNeeded = true
+        self.backgroundColor = .clear
+        self.isOpaque = false
+        self.hasShadow = true
+        self.titlebarAppearsTransparent = true
+        self.titleVisibility = .hidden
+        self.isMovableByWindowBackground = false
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        self.sharingType = .none
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+
+    override func cancelOperation(_ sender: Any?) {
+        onCancel?()
+    }
+
+    override func keyDown(with event: NSEvent) {
+        switch event.keyCode {
+        case 36:
+            onDefault?()
+        case 53:
+            onCancel?()
+        default:
+            super.keyDown(with: event)
+        }
+    }
+}
+
+@available(macOS 14.0, *)
+private final class CapturePillView: NSView {
+    static let preferredSize = NSSize(width: 430, height: 74)
+
+    var onRecord: (() -> Void)?
+    var onDismiss: (() -> Void)?
+
+    private let iconView = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let detailLabel = NSTextField(labelWithString: "")
+    private let dismissButton = NSButton(title: "Not now", target: nil, action: nil)
+    private let recordButton = NSButton(title: "Record", target: nil, action: nil)
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        wantsLayer = true
+        layer?.cornerRadius = 18
+        layer?.backgroundColor = NSColor.windowBackgroundColor.withAlphaComponent(0.98).cgColor
+        layer?.borderWidth = 1
+        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.35).cgColor
+
+        iconView.image = NSApp.applicationIconImage
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+        addSubview(iconView)
+
+        titleLabel.font = .systemFont(ofSize: 13, weight: .semibold)
+        titleLabel.textColor = .labelColor
+        titleLabel.lineBreakMode = .byTruncatingTail
+        addSubview(titleLabel)
+
+        detailLabel.font = .systemFont(ofSize: 11, weight: .regular)
+        detailLabel.textColor = .secondaryLabelColor
+        detailLabel.lineBreakMode = .byTruncatingTail
+        addSubview(detailLabel)
+
+        configureButton(dismissButton, title: "Not now", isPrimary: false, action: #selector(dismissTapped))
+        configureButton(recordButton, title: "Record", isPrimary: true, action: #selector(recordTapped))
+
+        setAccessibilityElement(true)
+        setAccessibilityRole(.group)
+        setAccessibilityLabel("Meeting capture prompt")
+        setAccessibilityHelp("Choose whether Transcripted should record this meeting.")
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layout() {
+        super.layout()
+
+        let pad: CGFloat = 14
+        let iconSize: CGFloat = 36
+        iconView.frame = NSRect(x: pad, y: (bounds.height - iconSize) / 2, width: iconSize, height: iconSize)
+
+        let recordSize = NSSize(width: 72, height: 32)
+        let dismissSize = NSSize(width: 82, height: 32)
+        recordButton.frame = NSRect(
+            x: bounds.width - pad - recordSize.width,
+            y: (bounds.height - recordSize.height) / 2,
+            width: recordSize.width,
+            height: recordSize.height
+        )
+        dismissButton.frame = NSRect(
+            x: recordButton.frame.minX - 8 - dismissSize.width,
+            y: (bounds.height - dismissSize.height) / 2,
+            width: dismissSize.width,
+            height: dismissSize.height
+        )
+
+        let textX = iconView.frame.maxX + 12
+        let textWidth = dismissButton.frame.minX - 12 - textX
+        titleLabel.frame = NSRect(x: textX, y: 38, width: max(40, textWidth), height: 18)
+        detailLabel.frame = NSRect(x: textX, y: 18, width: max(40, textWidth), height: 16)
+    }
+
+    func update(candidate: MeetingPromptDetector.Candidate) {
+        let meetingName = candidate.suggestedTranscriptTitle ?? candidate.title
+        titleLabel.stringValue = meetingName
+        detailLabel.stringValue = candidate.detail
+        setAccessibilityValue("\(meetingName). \(candidate.detail)")
+        needsLayout = true
+    }
+
+    private func configureButton(
+        _ button: NSButton,
+        title: String,
+        isPrimary: Bool,
+        action: Selector
+    ) {
+        button.title = title
+        button.target = self
+        button.action = action
+        button.isBordered = false
+        button.font = .systemFont(ofSize: 12, weight: .semibold)
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 8
+        button.layer?.backgroundColor = isPrimary
+            ? NSColor.controlAccentColor.cgColor
+            : NSColor.controlColor.withAlphaComponent(0.85).cgColor
+        button.contentTintColor = isPrimary ? .white : .labelColor
+        button.setAccessibilityLabel(title)
+        button.setAccessibilityHelp(isPrimary ? "Start recording this meeting." : "Dismiss this meeting prompt.")
+        addSubview(button)
+    }
+
+    @objc private func recordTapped() {
+        onRecord?()
+    }
+
+    @objc private func dismissTapped() {
+        onDismiss?()
+    }
+}

--- a/Tests/OverlayScreenSharePrivacyTests.swift
+++ b/Tests/OverlayScreenSharePrivacyTests.swift
@@ -15,9 +15,9 @@ import Foundation
 
 @MainActor
 func testOverlayScreenSharePrivacy() async {
-    // Behavioral: the dictation overlay panel is dependency-free, so the fast
-    // runner can instantiate it and assert the real runtime property instead of
-    // only inspecting source.
+    // Behavioral: these panels are dependency-free, so the fast runner can
+    // instantiate them and assert the real runtime property instead of only
+    // inspecting source.
     runSuite("FloatingOverlayPanel is excluded from screen capture") {
         _ = NSApplication.shared
         let panel = FloatingOverlayPanel(
@@ -33,10 +33,27 @@ func testOverlayScreenSharePrivacy() async {
         )
     }
 
+    runSuite("CapturePillPanel is excluded from screen capture") {
+        _ = NSApplication.shared
+        let panel = CapturePillPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 430, height: 74),
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: true
+        )
+        assertEqual(
+            panel.sharingType,
+            .none,
+            "the capture pill must not be visible to screen sharing / capture"
+        )
+        assertTrue(panel.canBecomeKey, "the capture pill must be keyboard-dismissable")
+    }
+
     // Source contract: most app surfaces live in files the fast runner cannot
     // compile in isolation, so guard their init bodies at the source level.
     runSuite("every Transcripted NSWindow/NSPanel init sets sharingType = .none") {
         let floating = overlayPrivacySource("Sources/UI/Overlay/FloatingOverlayPanel.swift")
+        let capturePill = overlayPrivacySource("Sources/UI/Overlay/CapturePillController.swift")
         let controller = overlayPrivacySource("Sources/UI/Overlay/MeetingOverlayController.swift")
         let pasteFeedback = overlayPrivacySource("Sources/UI/MenuBar/PasteLastDictationFeedback.swift")
         let settingsWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedSettingsWindowController.swift")
@@ -50,6 +67,14 @@ func testOverlayScreenSharePrivacy() async {
                     floating,
                     from: "class FloatingOverlayPanel: NSPanel {",
                     to: "override var canBecomeKey"
+                )
+            ),
+            (
+                "CapturePillPanel",
+                overlayPrivacySlice(
+                    capturePill,
+                    from: "final class CapturePillPanel: NSPanel {",
+                    to: "private final class CapturePillView"
                 )
             ),
             (
@@ -113,6 +138,7 @@ func testOverlayScreenSharePrivacy() async {
     runSuite("new NSWindow/NSPanel surfaces must be added to the screen-share contract") {
         let expectedMarkers: [String] = [
             "Sources/UI/MenuBar/PasteLastDictationFeedback.swift|private final class PasteLastDictationFeedbackPanel: NSPanel {",
+            "Sources/UI/Overlay/CapturePillController.swift|final class CapturePillPanel: NSPanel {",
             "Sources/UI/Overlay/FloatingOverlayPanel.swift|class FloatingOverlayPanel: NSPanel {",
             "Sources/UI/Overlay/MeetingOverlayController.swift|final class MeetingOverlayPanel: NSPanel {",
             "Sources/UI/Overlay/MeetingOverlayController.swift|final class MeetingOverlayTooltipPanel: NSPanel {",
@@ -125,6 +151,23 @@ func testOverlayScreenSharePrivacy() async {
             markers,
             expectedMarkers,
             "any new Transcripted NSWindow/NSPanel must be reviewed here and set sharingType = .none"
+        )
+    }
+
+    runSuite("detected meeting prompts route through the capture pill") {
+        let app = overlayPrivacySource("Sources/TranscriptedApp.swift")
+        let promptRequest = overlayPrivacySlice(
+            app,
+            from: "meetingPromptDetector.onPromptRequest =",
+            to: "// Ad-hoc call detection:"
+        )
+        assertTrue(
+            promptRequest.contains("capturePillController.present(candidate: candidate)"),
+            "detected meeting prompts should use the floating capture pill"
+        )
+        assertFalse(
+            promptRequest.contains("meetingOverlayController.presentDetectedMeetingPrompt(candidate)"),
+            "detected meeting prompts should not reuse the recording overlay prompt surface"
         )
     }
 }

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -391,6 +391,7 @@ APP_SOURCES=(
     "Sources/UI/Settings/HomeFailedMeetingInlinePresentation.swift"
     "Sources/UI/Settings/FailedMeetingRecoveryPresentation.swift"
     "Sources/UI/Settings/HomeMeetingPreviewFormatter.swift"
+    "Sources/UI/Overlay/CapturePillController.swift"
     "Sources/UI/Overlay/FloatingOverlayPanel.swift"
     "Sources/UI/Overlay/DictationMeterPolicy.swift"
     "Sources/UI/Overlay/MeetingLiveViewAffordancePolicy.swift"


### PR DESCRIPTION
## Summary
- rebuild #1370 on fresh main as a clean replacement
- add the AppKit capture pill prompt surface for detected meetings
- route detected meeting prompts through the pill while keeping current prompt-expiry telemetry
- extend screen-share privacy coverage to the new pill panel

## Proof
- scripts/dev/agent-preflight.sh
- python3 scripts/dev/check-build-source-lists.py
- bash run-tests.sh --filter OverlayScreenSharePrivacyTests
- bash build-deps.sh --force
- TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 bash build.sh --no-open
- git diff --check

## Notes
- Replaces #1370.
- Local launch smoke via build.sh failed earlier on this machine with LSOpenURLsWithCompletionHandler error -10810, so this build used the repo's explicit skip flag. App compile/sign/performance budget passed, but live launch/UI/screen-share proof remains manual/UNKNOWN.