### PR TITLE
Fix dictation audio-engine rebuild loop on Bluetooth/AirPods routes

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -38,6 +38,8 @@ class ParakeetEngine: ObservableObject {
     private var isEnginePrewarmed = false
     private var wakeObserver: NSObjectProtocol?
     private var inputDeviceChangeListener: AudioObjectPropertyListenerBlock?
+    private var recentAudioEngineRebuildTimestamps: [CFAbsoluteTime] = []
+    private var didReportAudioEngineRebuildChurn = false
 
     // Live streaming text is intentionally disabled — the product focuses on
     // stable capture and final transcription rather than provisional text.
@@ -716,11 +718,15 @@ class ParakeetEngine: ObservableObject {
                     selection: snapshot.selection,
                     readiness: readiness
                 ))
-            if readiness == .routeNotSettled {
-                let rebuildGeneration = audioGraphGeneration + 1
-                await rebuildAudioEngine(reason: "audio_route_not_settled")
-                guard canContinuePrewarm(generation: rebuildGeneration) else { return }
-            }
+            // Do NOT rebuild the engine here, even for .routeNotSettled. The override
+            // this snapshot just applied (built-in mic instead of a Bluetooth headset)
+            // lives on this engine's AUHAL; discarding the engine forces the next
+            // snapshot to touch the AirPods mic again to rebind the AUHAL to the
+            // system default before re-applying the override — audibly bumping the
+            // Bluetooth route on every retry and racing settling with churn instead
+            // of waiting it out. Keep the engine and let schedulePrewarmRetry() poll;
+            // applyPreferredDictationInputDevice() is a no-op once the deviceID already
+            // matches, so retries here are cheap format reads with no route touch.
             markFormatUnreadyAndPublish()
             schedulePrewarmRetry()
             return
@@ -1442,7 +1448,8 @@ class ParakeetEngine: ObservableObject {
             // Avoid touching the current default input before the override is applied.
             // On AirPods routes, even a short read of the default input can briefly
             // pull playback toward headset-mode audio.
-            ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0
+            ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent()
+                + TranscriptedConstants.selfInducedConfigChangeIgnoreWindow
         }
 
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
@@ -1730,7 +1737,36 @@ class ParakeetEngine: ObservableObject {
         isEnginePrewarmed = false
     }
 
+    /// Tracks rebuild frequency and reports once if rebuilds are churning —
+    /// a guardrail against a route-settling loop silently re-knocking Bluetooth
+    /// audio instead of surfacing as a diagnosable failure.
+    private func trackAudioEngineRebuildChurn(reason: String) {
+        let now = CFAbsoluteTimeGetCurrent()
+        recentAudioEngineRebuildTimestamps.append(now)
+        let windowStart = now - TranscriptedConstants.audioEngineRebuildChurnWindow
+        recentAudioEngineRebuildTimestamps.removeAll { $0 < windowStart }
+
+        guard recentAudioEngineRebuildTimestamps.count >= TranscriptedConstants.audioEngineRebuildChurnThreshold else {
+            didReportAudioEngineRebuildChurn = false
+            return
+        }
+        guard !didReportAudioEngineRebuildChurn else { return }
+        didReportAudioEngineRebuildChurn = true
+        EventReporter.shared.capture(
+            level: .error,
+            engine: "parakeet",
+            event: "audio_engine_rebuild_churn_detected",
+            message: "Audio engine rebuilt repeatedly in a short window — likely a route-settling loop",
+            context: [
+                "reason": reason,
+                "rebuild_count": "\(recentAudioEngineRebuildTimestamps.count)",
+                "window_seconds": "\(TranscriptedConstants.audioEngineRebuildChurnWindow)"
+            ]
+        )
+    }
+
     private func rebuildAudioEngine(reason: String) async {
+        trackAudioEngineRebuildChurn(reason: reason)
         audioGraphGeneration += 1
         removeAudioEngineConfigObserver()
         let retiredEngine = audioEngine
@@ -1762,6 +1798,7 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func abandonBlockedAudioEngine(reason: String) {
+        trackAudioEngineRebuildChurn(reason: reason)
         audioGraphGeneration += 1
         removeAudioEngineConfigObserver()
         let retiredEngine = audioEngine
@@ -2426,7 +2463,8 @@ class ParakeetEngine: ObservableObject {
             self.isRecording = false
             self.audioLevel = 0
             self.configChangeWasRecording = false
-            self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0
+            self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent()
+                + TranscriptedConstants.selfInducedConfigChangeIgnoreWindow
             await self.eouManager?.reset()
             await self.removeRecordingTap()
             await self.stopAudioEngine()

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -44,6 +44,26 @@ enum TranscriptedConstants {
     /// Delay for audio input readiness retry after device change (nanoseconds)
     static let audioRecoveryDelay: UInt64 = 300_000_000  // 300ms
 
+    /// Window (seconds) during which Parakeet ignores its own config-change
+    /// notifications after intentionally touching the input graph (applying
+    /// the built-in-mic override, or resetting a zombie engine). Bluetooth
+    /// route renegotiation after that kind of touch commonly takes longer
+    /// than 1s, so this must outlast typical AirPods HFP/A2DP settling —
+    /// otherwise the self-induced notification re-enters the device-change
+    /// handler and triggers an unnecessary rebuild.
+    static let selfInducedConfigChangeIgnoreWindow: TimeInterval = 2.5
+
+    /// Rolling window (seconds) used to detect a rebuild-churn loop — repeated
+    /// full audio-engine rebuilds in quick succession, which on Bluetooth routes
+    /// audibly disrupts other apps' playback each time. This should never fire
+    /// under normal device-change recovery; it exists as a guardrail so a
+    /// regression here shows up in telemetry instead of only as "my music keeps
+    /// cutting out."
+    static let audioEngineRebuildChurnWindow: TimeInterval = 10.0
+
+    /// Rebuild count within `audioEngineRebuildChurnWindow` that counts as churn.
+    static let audioEngineRebuildChurnThreshold: Int = 5
+
     /// Watchdog timeout — if no audio samples arrive within this window after starting
     /// recording, the engine is likely a zombie (running but disconnected from hardware)
     static let audioWatchdogTimeout: UInt64 = 2_000_000_000  // 2 seconds

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -650,7 +650,7 @@ func testParakeetStartRecordingFailurePolicy() {
         guard let markRestartPending = watchdog.range(of: "self.zombieRecoveryRestartPending = true"),
               let markIdle = watchdog.range(of: "self.isRecording = false"),
               let clearRestartFlag = watchdog.range(of: "self.configChangeWasRecording = false"),
-              let suppressConfigChanges = watchdog.range(of: "self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0"),
+              let suppressConfigChanges = watchdog.range(of: "self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent()"),
               let pendingRestartGuard = watchdog.range(of: "self.zombieRecoveryRestartPending else"),
               let clearPendingBeforeRetry = watchdog.range(of: "self.zombieRecoveryRestartPending = false", range: pendingRestartGuard.upperBound..<watchdog.endIndex),
               let retryStart = watchdog.range(of: "await self.startRecording(isRecoveryAttempt: true)"),


### PR DESCRIPTION
## Summary
- Root-caused a Bluetooth/AirPods dictation reliability issue from field logs: `prewarm()` rebuilt the entire `AVAudioEngine` whenever the built-in-mic override reported `.routeNotSettled` — backwards, since it did *not* rebuild for genuinely invalid formats. Discarding the already-overridden engine forced every retry to re-instantiate the AUHAL bound to the AirPods mic before re-applying the override, audibly bumping the Bluetooth route and looping (observed: 82 rebuilds/day, start latency up to 33s, `microphone_start_failed`). Removed the rebuild-on-`.routeNotSettled` call; retries now poll the same engine, which is a no-op once the override is already applied.
- Widened the self-induced config-change ignore window from a hardcoded 1.0s to `TranscriptedConstants.selfInducedConfigChangeIgnoreWindow` (2.5s) — real Bluetooth renegotiation routinely outlasts 1s.
- Added a rebuild-churn telemetry guardrail (`audio_engine_rebuild_churn_detected`, fires at ≥5 rebuilds/10s) so a regression here surfaces as a diagnostic event instead of only as "my music keeps cutting out."

## Test plan
- [x] `bash build.sh --no-open` — clean signed build
- [x] `bash run-tests.sh` — 11946/11946 passed (fixed one implementation-pinning text-contract test that matched the old hardcoded `1.0` literal)
- [x] `bash run-integration-smoke.sh` — app/core linkage + wake recovery passed
- [ ] Manual: real AirPods hardware verification (music playing + repeated dictations, confirm no `audio_engine_rebuilt` churn) — not done in this PR, needs a local session with the device connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)