### PR TITLE
Tell dictation clipboard fallbacks what to do, not just what failed

### DIFF
--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -200,7 +200,7 @@ final class ClipboardRestoringTextPaster {
            !waitForTargetActivation(target, timeout: activationWait) {
             copyTextToClipboard(text, to: pasteboard)
             return .copied(
-                "Focus changed before Transcripted could paste, so the text was copied.",
+                "Focus moved before the text could paste. It's on your clipboard — press ⌘V to paste it.",
                 reason: .focusChanged
             )
         }
@@ -209,7 +209,7 @@ final class ClipboardRestoringTextPaster {
             requestAccessibilityTrust()
             copyTextToClipboard(text, to: pasteboard)
             return .copied(
-                "Couldn't paste automatically. Accessibility is off, so the text was copied.",
+                "Accessibility is off, so Transcripted can't paste for you. Your text is on the clipboard — press ⌘V.",
                 reason: .accessibilityMissing
             )
         }
@@ -237,7 +237,7 @@ final class ClipboardRestoringTextPaster {
             pasteboard.clearContents()
             guard pasteboard.setString(text, forType: .string),
                   pasteboard.string(forType: .string) == text else {
-                return .failed("Couldn't prepare the clipboard for automatic paste. The dictation was saved, but paste-back did not run.")
+                return .failed("Couldn't paste or copy the text automatically. It's still saved in your dictation history.")
             }
         }
         temporaryChangeCount = pasteboard.changeCount
@@ -254,10 +254,10 @@ final class ClipboardRestoringTextPaster {
         guard pasteDispatcher() else {
             cancelPendingClipboardRestore()
             guard copyTextToClipboard(text, to: pasteboard) else {
-                return .failed("Couldn't prepare the clipboard for automatic paste. The dictation was saved, but paste-back did not run.")
+                return .failed("Couldn't paste or copy the text automatically. It's still saved in your dictation history.")
             }
             return .copied(
-                "Couldn't paste automatically. The text was copied instead.",
+                "Couldn't paste automatically. Your text is on the clipboard — press ⌘V.",
                 reason: .pasteEventCreationFailed
             )
         }

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -211,6 +211,9 @@ enum TranscriptedConstants {
     /// Duration to show error messages in overlay before auto-dismiss (nanoseconds)
     static let errorDismissDelay: UInt64 = 2_500_000_000  // 2.5 seconds
     static let noSpeechDismissDelay: UInt64 = 2_200_000_000  // 2.2 seconds — enough time to read the physical-key recovery hint
+    /// Clipboard-fallback notices carry a "press ⌘V" instruction, so they dwell
+    /// longer than plain errors before fading out.
+    static let clipboardNoticeDismissDelay: UInt64 = 4_500_000_000  // 4.5 seconds
 
     // MARK: - Feedback Sounds
 

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1099,7 +1099,15 @@ class DictationSessionController: ObservableObject {
                 } else {
                     overlayController.showSuccessAndDismiss(title: autoSendOutcome.confirmationTitle ?? "Pasted")
                 }
-            case .copied(let message, reason: _), .failed(let message):
+            case .copied(let message, reason: _):
+                if let saveFailureMessage {
+                    overlayController.showError("\(message) \(saveFailureMessage)")
+                } else {
+                    // The text is safe on the clipboard — present it as a calm
+                    // "press ⌘V" notice, not a warning-triangle error.
+                    overlayController.showClipboardNotice(message)
+                }
+            case .failed(let message):
                 let combinedMessage: String
                 if let saveFailureMessage {
                     combinedMessage = "\(message) \(saveFailureMessage)"

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -14,8 +14,8 @@ class FloatingOverlayController {
         let status: String?
 
         static let initial = LoadingPresentation(
-            title: "Loading voice model",
-            detail: "Recording starts automatically when it's ready.",
+            title: "Warming up",
+            detail: "Dictation starts automatically as soon as the voice model is ready.",
             progress: 0.08,
             status: "Starting up"
         )
@@ -32,6 +32,13 @@ class FloatingOverlayController {
         case listening    // Recording dictation
         case drafting     // Processing dictation
         case success      // Finished successfully — brief confirmation before dismiss
+    }
+
+    /// How a drafting-state message should read: a real problem, or a calm
+    /// "your text is safe on the clipboard" fallback that is not the user's fault.
+    enum MessageTone {
+        case error
+        case notice
     }
 
     /// Human-readable shortcut hints (reads live from UserDefaults)
@@ -61,6 +68,7 @@ class FloatingOverlayController {
     }
     var isVisible = false
     var errorMessage: String = ""
+    private var messageTone: MessageTone = .error
     private var errorActionTitle: String?
     private var errorActionHandler: (() -> Void)?
     var loadingElapsedSeconds: Int = 0 {
@@ -215,6 +223,7 @@ class FloatingOverlayController {
             errorMessage: errorMessage,
             errorActionTitle: errorActionTitle,
             onErrorAction: errorActionHandler,
+            messageTone: messageTone,
             loadingPresentation: loadingPresentation,
             loadingElapsedSeconds: loadingElapsedSeconds,
             successTitle: successTitle,
@@ -242,6 +251,7 @@ class FloatingOverlayController {
         loadingTimerTask?.cancel()
         loadingTimerTask = nil
         errorMessage = ""
+        messageTone = .error
         successTitle = "Pasted"
 
         let shouldOpenAtCursor = isCursorMiniPanelMode
@@ -361,6 +371,7 @@ class FloatingOverlayController {
         loadingTimerTask = nil
         cancelMiniLoadingReveal()
         errorMessage = ""
+        messageTone = .error
         errorActionTitle = nil
         errorActionHandler = nil
         state = .starting
@@ -467,6 +478,7 @@ class FloatingOverlayController {
     ) {
         errorDismissTask?.cancel()
         errorMessage = ""
+        messageTone = .error
         errorActionTitle = nil
         errorActionHandler = nil
         if let presentation {
@@ -544,10 +556,27 @@ class FloatingOverlayController {
         actionTitle: String? = nil,
         action: (() -> Void)? = nil
     ) {
+        showMessage(message, tone: .error, actionTitle: actionTitle, action: action)
+    }
+
+    /// Calm variant of showError for "your text is on the clipboard" fallbacks:
+    /// clipboard icon instead of a warning triangle, a longer dwell so the
+    /// ⌘V instruction stays readable, and a clean fade instead of the shake.
+    func showClipboardNotice(_ message: String) {
+        showMessage(message, tone: .notice)
+    }
+
+    private func showMessage(
+        _ message: String,
+        tone: MessageTone,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
         errorDismissTask?.cancel()
         loadingTimerTask?.cancel()
         loadingTimerTask = nil
         errorMessage = message
+        messageTone = tone
         errorActionTitle = actionTitle
         errorActionHandler = action
         state = .drafting
@@ -557,15 +586,22 @@ class FloatingOverlayController {
         }
         pushStateToViews()  // Force update for error message
         guard actionTitle == nil else { return }
+        let dismissDelay = tone == .notice
+            ? TranscriptedConstants.clipboardNoticeDismissDelay
+            : TranscriptedConstants.errorDismissDelay
         errorDismissTask = Task { @MainActor [weak self] in
             do {
-                try await Task.sleep(nanoseconds: TranscriptedConstants.errorDismissDelay)
+                try await Task.sleep(nanoseconds: dismissDelay)
             } catch { return }
             guard let self = self, !self.errorMessage.isEmpty else { return }
             self.errorMessage = ""
             self.errorActionTitle = nil
             self.errorActionHandler = nil
-            self.hideWithCancelAnimation()
+            if tone == .notice {
+                self.hideWithConfirmAnimation()
+            } else {
+                self.hideWithCancelAnimation()
+            }
         }
     }
 
@@ -573,6 +609,7 @@ class FloatingOverlayController {
     func showNoSpeechAndDismiss(trigger: String = "unknown") {
         errorDismissTask?.cancel()
         errorMessage = DictationNoSpeechPresentationPolicy.message(trigger: trigger)
+        messageTone = .error
         errorActionTitle = nil
         errorActionHandler = nil
         state = .drafting
@@ -596,6 +633,7 @@ class FloatingOverlayController {
         loadingTimerTask?.cancel()
         successDismissTask?.cancel()
         errorMessage = ""
+        messageTone = .error
         errorActionTitle = nil
         errorActionHandler = nil
         successTitle = title
@@ -637,6 +675,7 @@ class FloatingOverlayController {
         successDismissTask = nil
         state = .idle
         errorMessage = ""
+        messageTone = .error
         errorActionTitle = nil
         errorActionHandler = nil
         loadingPresentation = .initial
@@ -742,9 +781,12 @@ class FloatingOverlayController {
     }
 
     private func errorPanelSize() -> NSSize {
-        let height = errorActionTitle == nil
+        let base = errorActionTitle == nil
             ? OverlayTokens.panelMinHeight
             : OverlayTokens.panelActionErrorHeight
+        // Messages past roughly one rendered line wrap in the drafting view;
+        // give the panel enough height that the second line stays visible.
+        let height = errorMessage.count > 64 ? base + 18 : base
         return NSSize(width: OverlayTokens.panelWidth, height: height)
     }
 

--- a/Sources/UI/Overlay/OverlayDraftingView.swift
+++ b/Sources/UI/Overlay/OverlayDraftingView.swift
@@ -65,7 +65,7 @@ final class OverlayDraftingView: NSView {
     private let spinner = NSProgressIndicator()
     private let statusLabel = NSTextField(labelWithString: "")
     private let errorIcon = NSImageView()
-    private let errorLabel = NSTextField(labelWithString: "")
+    private let errorLabel = NSTextField(wrappingLabelWithString: "")
     private let errorActionButton = OverlaySecondaryButton(frame: .zero)
 
     // Secondary state: dimmed transcript + "Refining..." spinner
@@ -103,22 +103,19 @@ final class OverlayDraftingView: NSView {
         addSubview(statusLabel)
 
         // Error icon
-        if let image = NSImage(systemSymbolName: "exclamationmark.triangle", accessibilityDescription: "Error") {
-            errorIcon.image = image
-            errorIcon.contentTintColor = OverlayTokens.warningColor
-            let config = NSImage.SymbolConfiguration(pointSize: 18, weight: .regular)
-            errorIcon.symbolConfiguration = config
-        }
+        applyMessageIcon(isNotice: false)
+        errorIcon.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 18, weight: .regular)
         errorIcon.isHidden = true
         addSubview(errorIcon)
 
-        // Error label
+        // Error label — wraps so "press ⌘V" instructions never truncate mid-sentence
         errorLabel.font = NSFont.systemFont(ofSize: 12, weight: .medium)
         errorLabel.textColor = OverlayTokens.textSecondary
         errorLabel.isBezeled = false
         errorLabel.isEditable = false
         errorLabel.drawsBackground = false
         errorLabel.alignment = .center
+        errorLabel.maximumNumberOfLines = 3
         errorLabel.isHidden = true
         addSubview(errorLabel)
 
@@ -165,6 +162,7 @@ final class OverlayDraftingView: NSView {
         if !errorIcon.isHidden {
             // Error mode: icon + label centered
             let iconSize: CGFloat = 24
+            errorLabel.preferredMaxLayoutWidth = bounds.width - pad * 2
             let labelSize = errorLabel.fittingSize
             let buttonSize = errorActionButton.isHidden ? .zero : errorActionButton.fittingSize
             let hasAction = !errorActionButton.isHidden
@@ -216,10 +214,22 @@ final class OverlayDraftingView: NSView {
         }
     }
 
+    /// Swap between the warning triangle for real problems and a calm clipboard
+    /// glyph for "your text is on the clipboard" fallback notices.
+    private func applyMessageIcon(isNotice: Bool) {
+        let symbolName = isNotice ? "doc.on.clipboard" : "exclamationmark.triangle"
+        let description = isNotice ? "Copied to clipboard" : "Error"
+        if let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: description) {
+            errorIcon.image = image
+        }
+        errorIcon.contentTintColor = isNotice ? OverlayTokens.textSecondary : OverlayTokens.warningColor
+    }
+
     func update(
         error: String?,
         errorActionTitle: String?,
         onErrorAction: (() -> Void)?,
+        isNotice: Bool = false,
         isTranscribing: Bool,
         transcriptText: String,
         statusText: String
@@ -227,6 +237,7 @@ final class OverlayDraftingView: NSView {
         if let error = error, !error.isEmpty {
             // Error mode
             errorAction = onErrorAction
+            applyMessageIcon(isNotice: isNotice)
             errorIcon.isHidden = false
             errorLabel.isHidden = false
             errorLabel.stringValue = error

--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -280,11 +280,13 @@ final class OverlayHeaderView: NSView {
         loadingTitle: String?,
         successTitle: String = "Pasted",
         isError: Bool = false,
+        isNotice: Bool = false,
         isMiniCursorMode: Bool = false,
         meterPresentation: DictationMeterPolicy.Presentation
     ) {
+        let showsMessage = isError || isNotice
         usesMiniCursorLayout = isMiniCursorMode
-            && (state == .starting || state == .listening || (state == .drafting && !isError) || state == .success)
+            && (state == .starting || state == .listening || (state == .drafting && !showsMessage) || state == .success)
         let miniWaveformOnly = usesMiniCursorLayout && (state == .starting || state == .listening)
 
         // Mode label text + color
@@ -296,7 +298,11 @@ final class OverlayHeaderView: NSView {
             modeLabel.stringValue = "Listening"
             modeLabel.textColor = OverlayTokens.textPrimary
         case .drafting:
-            modeLabel.stringValue = isError ? "Dictation issue" : "Transcribing"
+            if isNotice {
+                modeLabel.stringValue = "Copied to clipboard"
+            } else {
+                modeLabel.stringValue = isError ? "Dictation issue" : "Transcribing"
+            }
             modeLabel.textColor = OverlayTokens.textPrimary
         case .success:
             modeLabel.stringValue = successTitle
@@ -312,7 +318,7 @@ final class OverlayHeaderView: NSView {
         updateAccessibility(for: state, usesMiniCursorLayout: usesMiniCursorLayout, successTitle: successTitle)
 
         // Spinner visibility
-        let showSpinner = state == .starting || (state == .drafting && !isError) || state == .loading
+        let showSpinner = state == .starting || (state == .drafting && !showsMessage) || state == .loading
         spinner.isHidden = usesMiniCursorLayout || !showSpinner
         if showSpinner { spinner.startAnimation(nil) } else { spinner.stopAnimation(nil) }
 

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -120,6 +120,7 @@ final class OverlayRootView: NSView {
         errorMessage: String,
         errorActionTitle: String?,
         onErrorAction: (() -> Void)?,
+        messageTone: FloatingOverlayController.MessageTone,
         loadingPresentation: FloatingOverlayController.LoadingPresentation,
         loadingElapsedSeconds: Int,
         successTitle: String,
@@ -133,8 +134,9 @@ final class OverlayRootView: NSView {
         currentErrorMessage = errorMessage
 
         let showLoading = state == .loading
-        let showError = state == .drafting && !errorMessage.isEmpty
-        let showContent = showLoading || showError
+        let showMessage = state == .drafting && !errorMessage.isEmpty
+        let isNotice = showMessage && messageTone == .notice
+        let showContent = showLoading || showMessage
 
         // Update header
         headerView.update(
@@ -142,7 +144,8 @@ final class OverlayRootView: NSView {
             dictationShortcutHint: dictationShortcutHint,
             loadingTitle: state == .loading ? "Dictation" : nil,
             successTitle: successTitle,
-            isError: showError,
+            isError: showMessage && !isNotice,
+            isNotice: isNotice,
             isMiniCursorMode: isMiniCursorMode,
             meterPresentation: DictationMeterPolicy.presentation(
                 isListening: state == .listening,
@@ -165,13 +168,14 @@ final class OverlayRootView: NSView {
             )
         }
 
-        if showError {
+        if showMessage {
             draftingView.isHidden = false
             let statusText = isTranscribing ? "Transcribing..." : "Processing..."
             draftingView.update(
                 error: errorMessage.isEmpty ? nil : errorMessage,
                 errorActionTitle: errorActionTitle,
                 onErrorAction: onErrorAction,
+                isNotice: isNotice,
                 isTranscribing: isTranscribing,
                 transcriptText: liveTranscript,
                 statusText: statusText

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -160,7 +160,7 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Couldn't prepare the clipboard for automatic paste. The dictation was saved, but paste-back did not run."),
+                .failed("Couldn't paste or copy the text automatically. It's still saved in your dictation history."),
                 "failed clipboard writes should be reported as paste-back failures"
             )
             assertEqual(postCount, 0, "Cmd+V should not fire when the dictation text is not on the pasteboard")
@@ -195,7 +195,7 @@ func testClipboardRestoringTextPaster() async {
             assertEqual(
                 outcome,
                 .copied(
-                    "Couldn't paste automatically. Accessibility is off, so the text was copied.",
+                    "Accessibility is off, so Transcripted can't paste for you. Your text is on the clipboard — press ⌘V.",
                     reason: .accessibilityMissing
                 ),
                 "missing Accessibility permission should report a copied fallback with the right reason"
@@ -731,7 +731,7 @@ func testClipboardRestoringTextPaster() async {
         assertEqual(
             outcome,
             .copied(
-                "Couldn't paste automatically. The text was copied instead.",
+                "Couldn't paste automatically. Your text is on the clipboard — press ⌘V.",
                 reason: .pasteEventCreationFailed
             ),
             "paste event failures should fall back to a copied result"
@@ -773,7 +773,7 @@ func testClipboardRestoringTextPaster() async {
 
         assertEqual(
             outcome,
-            .failed("Couldn't prepare the clipboard for automatic paste. The dictation was saved, but paste-back did not run."),
+            .failed("Couldn't paste or copy the text automatically. It's still saved in your dictation history."),
             "paste dispatch fallback should report failure when the copied fallback cannot be written"
         )
         let clipboardAfterFailure = await MainActor.run {

--- a/Tests/E2E/SlowPastebackSmoke.swift
+++ b/Tests/E2E/SlowPastebackSmoke.swift
@@ -476,7 +476,7 @@ private struct SmokeScenario {
                 failures.append("final clipboard was \(category(for: finalClipboard, original: originalClipboard, fresh: freshDictation, userCopy: userCopy))")
             }
         case .freshCopied:
-            if outcome != .copied("Couldn't paste automatically. The text was copied instead.", reason: .pasteEventCreationFailed) {
+            if outcome != .copied("Couldn't paste automatically. Your text is on the clipboard — press ⌘V.", reason: .pasteEventCreationFailed) {
                 failures.append("paste outcome was \(outcome.diagnosticName)")
             }
             if finalClipboard != freshDictation {

--- a/Tests/PasteLastDictationFeedbackTests.swift
+++ b/Tests/PasteLastDictationFeedbackTests.swift
@@ -13,14 +13,14 @@ func testPasteLastDictationFeedback() {
 
     runSuite("PasteLastDictationFeedback maps copied and failed outcomes to visible caution copy") {
         let copied = PasteLastDictationFeedback.presentation(
-            for: .copied("Couldn't paste automatically. The text was copied instead.", reason: .pasteEventCreationFailed)
+            for: .copied("Couldn't paste automatically. Your text is on the clipboard — press ⌘V.", reason: .pasteEventCreationFailed)
         )
         let failed = PasteLastDictationFeedback.presentation(
             for: .failed("Couldn't prepare the clipboard for automatic paste.")
         )
 
         assertEqual(copied.title, "Copied instead", "copied title")
-        assertEqual(copied.detail, "Couldn't paste automatically. The text was copied instead.", "copied detail")
+        assertEqual(copied.detail, "Couldn't paste automatically. Your text is on the clipboard — press ⌘V.", "copied detail")
         assertEqual(copied.tone, .caution, "copied tone")
         assertEqual(failed.title, "Paste Last failed", "failed title")
         assertEqual(failed.detail, "Couldn't prepare the clipboard for automatic paste.", "failed detail")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1888,7 +1888,7 @@ func testRepoCommandContract() {
 
         let headerContents = readRepoTextFile("Sources/UI/Overlay/OverlayHeaderView.swift")
         assertTrue(
-            headerContents.contains("state == .starting || state == .listening || (state == .drafting && !isError) || state == .success"),
+            headerContents.contains("state == .starting || state == .listening || (state == .drafting && !showsMessage) || state == .success"),
             "mini cursor dictation should use the tiny centered header layout during startup"
         )
         assertTrue(


### PR DESCRIPTION
## Summary
- When focus moves before dictation paste-back, Accessibility is off, or a paste event can't be posted, the text still lands on the clipboard — but the overlay message never said so, and it read as a scary warning-triangle "Dictation issue" with a shake animation.
- Every clipboard-fallback message now explicitly says "press ⌘V" to recover the text.
- `FloatingOverlayController` gains a calm `MessageTone.notice` presentation (clipboard icon, longer 4.5s dwell, gentle fade) distinct from `MessageTone.error` (warning triangle, shake) — routed for the copied-to-clipboard case, kept as an error for genuine failures.
- Long messages now wrap instead of truncating, since the ⌘V instruction is longer than prior copy.

## Test plan
- [x] `bash run-tests.sh` — full fast suite passes (11968/11968)
- [ ] `bash build.sh --no-open` — full app build (pending; part of a stacked verification, see PR description note below)
- Manual: dictate, then click another app before paste completes → overlay should show a calm "Copied to clipboard" notice with the ⌘V instruction (no shake), and ⌘V should paste the text.

Note: this is PR 1 of 3 in a stack (dictation UX copy overhaul). #2 (phase-aware warmup copy) and #3 (loading-panel status line) build on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)