### PR TITLE
Fix failed meeting queue preservation

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -111,7 +111,7 @@ final class MeetingSessionController: ObservableObject {
             case .recorded:
                 return true
             case .imported:
-                return false
+                return true
             }
         }
     }
@@ -1506,8 +1506,16 @@ final class MeetingSessionController: ObservableObject {
                 ) {
                     preservedCount += 1
                 }
-            case .imported(let audioURL, _, _):
-                try? FileManager.default.removeItem(at: audioURL)
+            case .imported(let audioURL, let suggestedTitle, let recordingDate):
+                if preserveFailedMeetingForRetry(
+                    micAudioURL: audioURL,
+                    systemAudioURL: nil,
+                    errorMessage: errorMessage,
+                    meetingTitle: suggestedTitle,
+                    recordingDate: recordingDate
+                ) {
+                    preservedCount += 1
+                }
             }
         }
         return preservedCount
@@ -2825,7 +2833,7 @@ final class MeetingSessionController: ObservableObject {
                 )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: failureKind.rawValue)
-                finalizeBackgroundTranscriptionStateIfNeeded()
+                handleBackgroundTranscriptionWorkChanged()
                 return
             }
 
@@ -2869,7 +2877,7 @@ final class MeetingSessionController: ObservableObject {
                 )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "speaker_finalization_failed")
-                finalizeBackgroundTranscriptionStateIfNeeded()
+                handleBackgroundTranscriptionWorkChanged()
                 return
             }
 
@@ -2909,7 +2917,7 @@ final class MeetingSessionController: ObservableObject {
             )
             activeTranscriptionCaptureDiagnostics = nil
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_failed")
-            finalizeBackgroundTranscriptionStateIfNeeded()
+            handleBackgroundTranscriptionWorkChanged()
         case .gettingReady:
             if previousStatus.diagnosticName != status.diagnosticName {
                 DiagnosticsTrail.record(

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -56,6 +56,9 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     /// for entries persisted before typed errors were introduced.
     public var isRetryable: Bool {
         if let typed = pipelineError {
+            if case .missingSystemAudio = typed, systemAudioURL == nil {
+                return true
+            }
             return typed.isRetryable
         }
         // Legacy fallback: keyword matching for pre-typed-error entries

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -85,9 +85,22 @@ extension TranscriptionTaskManager {
         removeSourceAudioAfterArchive: Bool = true
     ) async throws -> URL {
 
-        // Require system audio for multichannel transcription
         guard let systemURL = systemURL else {
-            throw PipelineError.missingSystemAudio
+            AppLogger.pipeline.warning("Transcribing mic-only failed meeting audio through single-track path", [
+                "taskId": taskId.uuidString
+            ])
+            return try await transcribeMultichannelPipeline(
+                micURL: nil,
+                systemURL: micURL,
+                outputFolder: outputFolder,
+                taskId: taskId,
+                healthInfo: healthInfo,
+                splitLocalSpeakers: false,
+                meetingTitle: meetingTitle,
+                recordingDate: recordingDate,
+                sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+                removeSourceAudioAfterArchive: removeSourceAudioAfterArchive
+            )
         }
 
         return try await transcribeMultichannelPipeline(

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -107,25 +107,6 @@ public class TranscriptionTaskManager: ObservableObject {
             return
         }
 
-        guard systemURL != nil else {
-            let errorMessage = PipelineError.missingSystemAudio.localizedDescription
-            AppLogger.pipeline.warning("Rejecting transcription — system audio capture is missing")
-            addFailedTranscriptionRetainingAudio(
-                micAudioURL: micURL,
-                systemAudioURL: nil,
-                errorMessage: errorMessage,
-                meetingTitle: meetingTitle,
-                recordingDate: recordingDate
-            )
-            publishFailure(
-                displayMessage: "System audio required",
-                diagnosticMessage: errorMessage
-            )
-            sendFailureNotification(errorMessage: errorMessage)
-            scheduleStatusReset(delay: 4)
-            return
-        }
-
         // Gate: reject only when every available capture track is too short.
         // Meeting recovery can produce a very short mic stub while system audio is still
         // intact and fully transcribable, so don't throw away the whole recording just
@@ -286,6 +267,12 @@ public class TranscriptionTaskManager: ObservableObject {
         let taskId = UUID()
         activeCount += 1
         backgroundTaskCount += 1
+        activeTaskAudio[taskId] = (
+            micURL: audioURL,
+            systemURL: nil,
+            meetingTitle: meetingTitle,
+            recordingDate: recordingDate
+        )
         publishNonFailureStatus(.gettingReady)
 
         AppLogger.pipeline.info("Starting imported transcription task", [

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -8,6 +8,7 @@ public class FailedTranscriptionManager: ObservableObject {
 
     private let storageURL: URL
     private let allowedAudioRoots: [URL]
+    private let audioArchiveRoot: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
@@ -25,6 +26,9 @@ public class FailedTranscriptionManager: ObservableObject {
             ])
         }
         self.storageURL = paths.failedQueue
+        self.audioArchiveRoot = Self.canonicalDirectoryURL(
+            paths.transcripts.appendingPathComponent("audio", isDirectory: true)
+        )
         self.allowedAudioRoots = [
             paths.audioCaptures,
             paths.transcripts
@@ -51,53 +55,68 @@ public class FailedTranscriptionManager: ObservableObject {
             let data = try Data(contentsOf: storageURL)
             let loaded = try decoder.decode([FailedTranscription].self, from: data)
 
-            // Security: audio file paths are deserialized from a JSON file that the user could
-            // tamper with. Canonicalize first, then only accept files under Transcripted-owned
-            // scratch/archive audio roots so cleanup cannot be redirected to arbitrary files.
-            let sandboxedEntries = loaded.filter { entry in
-                let micSafe = isSafeAudioURL(entry.micAudioURL)
-                let systemSafe = entry.systemAudioURL.map(isSafeAudioURL) ?? true
-                if !micSafe || !systemSafe {
-                    AppLogger.pipeline.error("Rejected failed transcription entry with out-of-sandbox audio path", [
-                        "micURL": entry.micAudioURL.path,
-                        "systemURL": entry.systemAudioURL?.path ?? "none"
-                    ])
-                }
-                return micSafe && systemSafe
-            }
-
-            // Heal stale audio references before the existence filter. A crash
-            // between the merger's segment cleanup and the queue repoint leaves
-            // an entry pointing at a deleted pre-merge WAV while
-            // `<stem>_merged.wav` sits on disk — dropping that entry here would
-            // make the meeting disappear permanently.
             var healedCount = 0
-            let healedEntries = sandboxedEntries.map { entry in
-                let healed = healAudioReferences(of: entry)
-                if healed != nil { healedCount += 1 }
-                return healed ?? entry
-            }
+            var removedCount = 0
+            var unavailableCount = 0
+            var reconciledEntries: [FailedTranscription] = []
 
-            // Filter out entries where audio files no longer exist
-            failedTranscriptions = healedEntries.filter { entry in
-                guard entry.audioFilesExist() else {
-                    AppLogger.pipeline.error("Dropping failed transcription entry with missing audio", [
-                        "id": entry.id.uuidString,
-                        "micFile": entry.micAudioURL.lastPathComponent,
-                        "systemFile": entry.systemAudioURL?.lastPathComponent ?? "none"
-                    ])
-                    return false
+            for loadedEntry in loaded {
+                let relocation = healRelocatedAudioReferences(of: loadedEntry)
+                if relocation.didHeal {
+                    healedCount += 1
                 }
-                return true
-            }
+                let relocatedEntry = relocation.entry
 
-            // Save back if we filtered or healed any
-            if failedTranscriptions.count != loaded.count || healedCount > 0 {
+                // Security: audio file paths are deserialized from a JSON file that the user could
+                // tamper with. Canonicalize first, then only accept files under Transcripted-owned
+                // scratch/archive audio roots so cleanup cannot be redirected to arbitrary files.
+                let micSafe = isSafeAudioURL(relocatedEntry.micAudioURL)
+                let systemSafe = relocatedEntry.systemAudioURL.map(isSafeAudioURL) ?? true
+                guard micSafe && systemSafe else {
+                    AppLogger.pipeline.error("Rejected failed transcription entry with out-of-sandbox audio path", [
+                        "micURL": relocatedEntry.micAudioURL.path,
+                        "systemURL": relocatedEntry.systemAudioURL?.path ?? "none"
+                    ])
+                    removedCount += 1
+                    continue
+                }
+
+                // Heal stale audio references before the existence filter. A crash
+                // between the merger's segment cleanup and the queue repoint leaves
+                // an entry pointing at a deleted pre-merge WAV while
+                // `<stem>_merged.wav` sits on disk — dropping that entry here would
+                // make the meeting disappear permanently.
+                let reconciliation = reconcileAudioReferences(of: relocatedEntry)
+                if reconciliation.didHeal {
+                    healedCount += 1
+                }
+                if reconciliation.hasUnavailableAudio {
+                    unavailableCount += 1
+                }
+                guard let entry = reconciliation.entry else {
+                    removedCount += 1
+                    continue
+                }
+                reconciledEntries.append(entry)
+            }
+            failedTranscriptions = reconciledEntries
+
+            // Save back if we filtered or healed any, unless a missing file may
+            // be caused by an unavailable library/volume. In that case, keep the
+            // in-memory queue visible and avoid making any destructive rewrite.
+            if removedCount > 0 || healedCount > 0 {
                 AppLogger.pipeline.info("Reconciled failed transcription entries on load", [
-                    "removed": "\(loaded.count - failedTranscriptions.count)",
-                    "healed": "\(healedCount)"
+                    "removed": "\(removedCount)",
+                    "healed": "\(healedCount)",
+                    "unavailable": "\(unavailableCount)"
                 ])
-                saveFailedTranscriptions()
+                if unavailableCount == 0 {
+                    saveFailedTranscriptions()
+                } else {
+                    AppLogger.pipeline.warning("Skipped saving failed transcription reconciliation because audio root is unavailable", [
+                        "unavailable": "\(unavailableCount)"
+                    ])
+                }
             }
 
             AppLogger.pipeline.info("Loaded failed transcriptions", ["count": "\(failedTranscriptions.count)"])
@@ -119,38 +138,54 @@ public class FailedTranscriptionManager: ObservableObject {
 
     /// Repairs an entry whose audio references no longer match the disk state.
     /// Returns the healed entry, or nil when nothing needed healing.
-    private func healAudioReferences(of entry: FailedTranscription) -> FailedTranscription? {
+    private typealias AudioReconciliation = (
+        entry: FailedTranscription?,
+        didHeal: Bool,
+        hasUnavailableAudio: Bool
+    )
+
+    private func reconcileAudioReferences(of entry: FailedTranscription) -> AudioReconciliation {
         let fileManager = FileManager.default
         var micURL = entry.micAudioURL
         var systemURL = entry.systemAudioURL
         var didHeal = false
+        var hasUnavailableAudio = false
 
         // A merge that completed after the entry was written deletes the
         // pre-merge segments and leaves `<stem>_merged.wav` in their place.
         if !fileManager.fileExists(atPath: micURL.path) {
-            let mergedCandidate = micURL.deletingLastPathComponent()
-                .appendingPathComponent(micURL.deletingPathExtension().lastPathComponent + "_merged.wav")
-            if fileManager.fileExists(atPath: mergedCandidate.path), isSafeAudioURL(mergedCandidate) {
+            if let mergedCandidate = mergedSibling(for: micURL),
+               fileManager.fileExists(atPath: mergedCandidate.path),
+               isSafeAudioURL(mergedCandidate) {
                 micURL = mergedCandidate
                 didHeal = true
                 AppLogger.pipeline.info("Healed failed transcription mic audio to merged file", [
                     "id": entry.id.uuidString,
                     "file": mergedCandidate.lastPathComponent
                 ])
+            } else if !isContainingAudioRootReachable(for: micURL) {
+                hasUnavailableAudio = true
             }
         }
 
         // Keep the meeting retryable with mic audio only rather than dropping
         // it because the system-audio file went missing.
         if let existingSystemURL = systemURL,
-           !fileManager.fileExists(atPath: existingSystemURL.path),
-           fileManager.fileExists(atPath: micURL.path) {
-            systemURL = nil
-            didHeal = true
-            AppLogger.pipeline.warning("Dropped missing system audio reference from failed transcription", [
-                "id": entry.id.uuidString,
-                "file": existingSystemURL.lastPathComponent
-            ])
+           !fileManager.fileExists(atPath: existingSystemURL.path) {
+            if !isContainingAudioRootReachable(for: existingSystemURL) {
+                hasUnavailableAudio = true
+            } else if fileManager.fileExists(atPath: micURL.path) {
+                systemURL = nil
+                didHeal = true
+                AppLogger.pipeline.warning("Dropped missing system audio reference from failed transcription", [
+                    "id": entry.id.uuidString,
+                    "file": existingSystemURL.lastPathComponent
+                ])
+            }
+        }
+
+        if hasUnavailableAudio {
+            return (entry, didHeal, true)
         }
 
         // Audio preserved during a quit that interrupted finalization can have
@@ -161,8 +196,25 @@ public class FailedTranscriptionManager: ObservableObject {
             repairWAVHeaderIfNeeded(at: systemURL, entryId: entry.id)
         }
 
-        guard didHeal else { return nil }
-        return FailedTranscription(
+        if !fileManager.fileExists(atPath: micURL.path) {
+            AppLogger.pipeline.error("Dropping failed transcription entry with missing audio", [
+                "id": entry.id.uuidString,
+                "micFile": micURL.lastPathComponent,
+                "systemFile": systemURL?.lastPathComponent ?? "none"
+            ])
+            return (nil, didHeal, false)
+        }
+        if let systemURL, !fileManager.fileExists(atPath: systemURL.path) {
+            AppLogger.pipeline.error("Dropping failed transcription entry with missing audio", [
+                "id": entry.id.uuidString,
+                "micFile": micURL.lastPathComponent,
+                "systemFile": systemURL.lastPathComponent
+            ])
+            return (nil, didHeal, false)
+        }
+
+        guard didHeal else { return (entry, false, false) }
+        return (FailedTranscription(
             id: entry.id,
             timestamp: entry.timestamp,
             recordingDate: entry.recordingDate,
@@ -172,7 +224,68 @@ public class FailedTranscriptionManager: ObservableObject {
             meetingTitle: entry.meetingTitle,
             retryCount: entry.retryCount,
             lastRetryDate: entry.lastRetryDate
-        )
+        ), true, false)
+    }
+
+    private func healRelocatedAudioReferences(of entry: FailedTranscription) -> (entry: FailedTranscription, didHeal: Bool) {
+        var micURL = entry.micAudioURL
+        var systemURL = entry.systemAudioURL
+        var didHeal = false
+
+        if !isSafeAudioURL(micURL),
+           let relocatedMicURL = relocatedAudioURL(for: micURL),
+           FileManager.default.fileExists(atPath: relocatedMicURL.path),
+           isSafeAudioURL(relocatedMicURL) {
+            micURL = relocatedMicURL
+            didHeal = true
+        }
+
+        if let existingSystemURL = systemURL,
+           !isSafeAudioURL(existingSystemURL),
+           let relocatedSystemURL = relocatedAudioURL(for: existingSystemURL),
+           FileManager.default.fileExists(atPath: relocatedSystemURL.path),
+           isSafeAudioURL(relocatedSystemURL) {
+            systemURL = relocatedSystemURL
+            didHeal = true
+        }
+
+        guard didHeal else { return (entry, false) }
+        AppLogger.pipeline.info("Healed failed transcription audio paths after capture library relocation", [
+            "id": entry.id.uuidString
+        ])
+        return (FailedTranscription(
+            id: entry.id,
+            timestamp: entry.timestamp,
+            recordingDate: entry.recordingDate,
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: entry.errorMessage,
+            meetingTitle: entry.meetingTitle,
+            retryCount: entry.retryCount,
+            lastRetryDate: entry.lastRetryDate
+        ), true)
+    }
+
+    private func relocatedAudioURL(for url: URL) -> URL? {
+        let directory = url.deletingLastPathComponent()
+        guard directory.lastPathComponent.hasSuffix("_audio") else { return nil }
+        return audioArchiveRoot
+            .appendingPathComponent(directory.lastPathComponent, isDirectory: true)
+            .appendingPathComponent(url.lastPathComponent)
+    }
+
+    private func mergedSibling(for url: URL) -> URL? {
+        url.deletingLastPathComponent()
+            .appendingPathComponent(url.deletingPathExtension().lastPathComponent + "_merged.wav")
+    }
+
+    private func isContainingAudioRootReachable(for url: URL) -> Bool {
+        guard let root = allowedAudioRoots.first(where: { Self.isFile(url, containedIn: $0) }) else {
+            return true
+        }
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
     }
 
     private func repairWAVHeaderIfNeeded(at url: URL, entryId: UUID) {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2439,6 +2439,10 @@ func testRepoCommandContract() {
             failureBlock.contains("properties: failureTelemetryContext"),
             "analytics and diagnostics should share the same privacy-safe failure telemetry context"
         )
+        assertTrue(
+            countOccurrences(of: "handleBackgroundTranscriptionWorkChanged()", in: failureBlock) >= 3,
+            "terminal failed statuses should wake the queued-transcription drain even when a task was rejected before activeCount changed"
+        )
     }
 
     runSuite("Repo command contract - shutdown preservation clears live sidecar waits") {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1473,10 +1473,13 @@ func testRepoCommandContract() {
         )
         assertTrue(
             localBuildScript.contains("/usr/bin/open -n -g -F -W")
-                && localBuildScript.contains("--env \"TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT=$ui_report\"")
+                && localBuildScript.contains("mktemp -d \"/tmp/transcripted-launch-smoke.XXXXXX\"")
+                && localBuildScript.contains("--env \"TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT=$launch_ui_report\"")
                 && localBuildScript.contains("--env \"TRANSCRIPTED_LAUNCH_UI_SMOKE_TERMINATE_AFTER_REPORT=1\"")
-                && localBuildScript.contains("\"$APP_BUNDLE\""),
-            "local launch smoke should launch the app bundle through LaunchServices"
+                && localBuildScript.contains("cp -R \"$APP_BUNDLE\" \"$launch_app_bundle\"")
+                && localBuildScript.contains("\"$launch_app_bundle\"")
+                && localBuildScript.contains("cp \"$launch_ui_report\" \"$ui_report\""),
+            "local launch smoke should launch a temporary app-bundle copy through LaunchServices and keep repo-local artifacts"
         )
         assertFalse(
             localBuildScript.contains("\"$APP_BINARY\" >\"$smoke_log\""),
@@ -1485,7 +1488,7 @@ func testRepoCommandContract() {
         assertTrue(
             localBuildScript.contains("pre_launch_app_pids=\"$(snapshot_launch_smoke_app_pids)\"")
                 && localBuildScript.contains("terminate_launch_smoke_app()")
-                && localBuildScript.contains("pgrep -f \"$APP_BINARY\"")
+                && localBuildScript.contains("pgrep -f \"$launch_app_binary\"")
                 && localBuildScript.contains("is_pre_launch_app_pid")
                 && localBuildScript.contains("kill -TERM \"$pid\"")
                 && localBuildScript.contains("kill -KILL \"$pid\""),

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -369,7 +369,7 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
     }
 
-    func testInitKeepsNonRetryableFailuresUntilUserDeletesThem() throws {
+    func testInitKeepsMicOnlyMissingSystemAudioFailuresRetryable() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(
@@ -386,7 +386,7 @@ final class FailedTranscriptionManagerTests: XCTestCase {
             systemAudioURL: nil,
             errorMessage: "System audio is required to transcribe this meeting."
         )
-        XCTAssertFalse(failure.isRetryable)
+        XCTAssertTrue(failure.isRetryable)
         try JSONEncoder.iso8601.encode([failure]).write(to: paths.failedQueue, options: .atomic)
 
         let manager = FailedTranscriptionManager(paths: paths)
@@ -496,6 +496,96 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(manager.failedTranscriptions.count, 1)
         XCTAssertEqual(manager.failedTranscriptions.first?.micAudioURL, micURL)
         XCTAssertNil(manager.failedTranscriptions.first?.systemAudioURL)
+    }
+
+    func testLoadKeepsEntryWhenAudioRootIsUnavailableAndDoesNotRewriteQueue() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(
+            at: paths.failedQueue.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let unavailableMicURL = paths.audioCaptures.appendingPathComponent("external-drive-mic.wav")
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: unavailableMicURL,
+            systemAudioURL: nil,
+            errorMessage: "Temporary transcription failure"
+        )
+        try JSONEncoder.iso8601.encode([entry]).write(to: paths.failedQueue, options: .atomic)
+        let originalData = try Data(contentsOf: paths.failedQueue)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions, [entry])
+        XCTAssertEqual(try Data(contentsOf: paths.failedQueue), originalData)
+    }
+
+    func testLoadDoesNotStripSystemAudioWhenArchiveRootIsUnavailable() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: paths.failedQueue.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+        let unavailableSystemURL = paths.transcripts
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Failed_Call_audio", isDirectory: true)
+            .appendingPathComponent("system.wav")
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: micURL,
+            systemAudioURL: unavailableSystemURL,
+            errorMessage: "Temporary transcription failure"
+        )
+        try JSONEncoder.iso8601.encode([entry]).write(to: paths.failedQueue, options: .atomic)
+        let originalData = try Data(contentsOf: paths.failedQueue)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions, [entry])
+        XCTAssertEqual(manager.failedTranscriptions.first?.systemAudioURL, unavailableSystemURL)
+        XCTAssertEqual(try Data(contentsOf: paths.failedQueue), originalData)
+    }
+
+    func testLoadRewritesRelocatedFailedAudioArchivePaths() throws {
+        let paths = makePaths(root: testRoot)
+        let currentArchiveDirectory = paths.transcripts
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Failed_Customer_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentArchiveDirectory, withIntermediateDirectories: true)
+        let currentMicURL = currentArchiveDirectory.appendingPathComponent("microphone.wav")
+        let currentSystemURL = currentArchiveDirectory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: currentMicURL.path, contents: Data("mic".utf8))
+        FileManager.default.createFile(atPath: currentSystemURL.path, contents: Data("system".utf8))
+
+        let oldArchiveDirectory = testRoot
+            .appendingPathComponent("old-library/meetings/audio/Failed_Customer_Call_audio", isDirectory: true)
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: oldArchiveDirectory.appendingPathComponent("microphone.wav"),
+            systemAudioURL: oldArchiveDirectory.appendingPathComponent("system_audio.wav"),
+            errorMessage: "Temporary transcription failure"
+        )
+        try writeQueue([entry], to: paths)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        let healed = try XCTUnwrap(manager.failedTranscriptions.first)
+        XCTAssertEqual(healed.id, entry.id)
+        XCTAssertEqual(healed.micAudioURL, currentMicURL)
+        XCTAssertEqual(healed.systemAudioURL, currentSystemURL)
+
+        let persisted = try JSONDecoder.iso8601.decode(
+            [FailedTranscription].self,
+            from: Data(contentsOf: paths.failedQueue)
+        )
+        XCTAssertEqual(persisted.first?.micAudioURL, currentMicURL)
+        XCTAssertEqual(persisted.first?.systemAudioURL, currentSystemURL)
     }
 
     func testLoadRepairsUnfinalizedWAVHeader() throws {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -478,8 +478,11 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(obsidianMarkdown.contains("\ntags:"), "embedders can still opt into Obsidian metadata explicitly")
     }
 
-    func testStartTranscriptionRejectsMissingSystemAudioBeforeBackgroundWorkStarts() throws {
-        let manager = makeManager()
+    func testStartTranscriptionWithMicOnlyAudioSavesSingleTrackTranscript() async throws {
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Mic only recovered meeting."),
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments())
+        )
         let micScratchDirectory = tempDirectory.appendingPathComponent("audio")
         try FileManager.default.createDirectory(at: micScratchDirectory, withIntermediateDirectories: true)
         let micURL = micScratchDirectory.appendingPathComponent("mic.wav")
@@ -491,22 +494,20 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             outputFolder: tempDirectory.appendingPathComponent("transcripts")
         )
 
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+
         XCTAssertEqual(manager.activeCount, 0)
         XCTAssertEqual(manager.backgroundTaskCount, 0)
         XCTAssertEqual(manager.activeTasks.count, 0)
-        XCTAssertEqual(manager.failedTranscriptionManager.failedTranscriptions.count, 1)
-        XCTAssertEqual(
-            manager.failedTranscriptionManager.failedTranscriptions.first?.errorMessage,
-            PipelineError.missingSystemAudio.localizedDescription
-        )
-
-        guard case .failed(let message) = manager.displayStatus else {
-            return XCTFail("Expected failed display status when system audio is missing")
-        }
-        XCTAssertEqual(message, "System audio required")
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("Mic only recovered meeting."))
     }
 
-    func testMissingSystemAudioQueuesRetainedArchiveAndRemovesScratch() throws {
+    func testMicOnlyFailedQueueRetainsArchiveAndRemovesScratch() throws {
         let retainedAudioDirectory = tempDirectory
             .appendingPathComponent("transcripts", isDirectory: true)
             .appendingPathComponent("audio", isDirectory: true)
@@ -516,11 +517,11 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         let micURL = micScratchDirectory.appendingPathComponent("mic.wav")
         try writeMonoWAV(to: micURL, duration: 2.5)
 
-        manager.startTranscription(
-            micURL: micURL,
-            systemURL: nil,
-            outputFolder: tempDirectory.appendingPathComponent("transcripts")
-        )
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening."
+        ))
 
         let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
         XCTAssertTrue(
@@ -1153,6 +1154,55 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(markdown.contains("Recovered meeting artifact."))
     }
 
+    func testRetryFailedTranscriptionWithMicOnlyAudioUsesSingleTrackPath() async throws {
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Mic only retry artifact."),
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments())
+        )
+        let audioDirectory = tempDirectory.appendingPathComponent("audio", isDirectory: true)
+        let micURL = audioDirectory.appendingPathComponent("retry-mic-only.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+
+        XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: PipelineError.missingSystemAudio.localizedDescription,
+            meetingTitle: "Mic-only recovered call"
+        ))
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(failed.isRetryable)
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failed.id,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts", isDirectory: true)
+        )
+
+        XCTAssertTrue(didRetry)
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("Mic-only recovered call"))
+        XCTAssertTrue(markdown.contains("Mic only retry artifact."))
+
+        let request = try XCTUnwrap(manager.speakerNamingRequest)
+        XCTAssertEqual(request.sourceFailedTranscriptionId, failed.id)
+        let speaker = try XCTUnwrap(request.speakers.first)
+        request.onComplete([
+            SpeakerNameUpdate(
+                persistentSpeakerId: speaker.id,
+                diarizerSpeakerId: speaker.diarizerSpeakerId,
+                channel: speaker.channel,
+                newName: "Local Mic",
+                previousName: speaker.currentName,
+                action: .named
+            )
+        ])
+
+        try await waitUntil {
+            manager.failedTranscriptionManager.failedTranscriptions.isEmpty
+                && manager.speakerNamingRequest == nil
+        }
+    }
+
     func testCancelAllDuringRetryDoesNotPoisonFutureRetry() async throws {
         let speech = BlockingMetadataStubSpeechToTextEngine(transcript: "Recovered after cancel.")
         let manager = makeManager(speechToText: speech)
@@ -1296,6 +1346,48 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         )
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: externalURL.path))
+    }
+
+    func testPreserveActiveTranscriptionsForShutdownRetainsImportedAudio() async throws {
+        let speech = BlockingMetadataStubSpeechToTextEngine(transcript: "Imported shutdown recovery.")
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments()),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let copiedImportURL = tempDirectory
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("imported-meeting.wav")
+        try writeMonoWAV(to: copiedImportURL, duration: 2.5)
+
+        manager.startImportedTranscription(
+            audioURL: copiedImportURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Imported customer call"
+        )
+
+        try await waitUntil {
+            speech.didStart
+        }
+
+        let preserved = manager.preserveActiveTranscriptionsForShutdown(
+            errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening."
+        )
+
+        XCTAssertEqual(preserved, 1)
+        XCTAssertTrue(manager.activeTasks.isEmpty)
+        XCTAssertEqual(manager.activeCount, 0)
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(failed.meetingTitle, "Imported customer call")
+        XCTAssertNil(failed.systemAudioURL)
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: copiedImportURL.path))
+
+        speech.release()
     }
 
     func testStartSavedAudioRetranscriptionDoesNotDeleteSourceWhenRejectedForActiveTask() throws {
@@ -2255,6 +2347,18 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         }
 
         try file.write(from: buffer)
+    }
+
+    private func singleSpeakerSegments(duration: TimeInterval = 2.0) -> [SpeakerSegment] {
+        [
+            SpeakerSegment(
+                speakerId: 1,
+                startTime: 0,
+                endTime: duration,
+                embedding: [Float](repeating: 0.42, count: 256),
+                qualityScore: 0.95
+            )
+        ]
     }
 
     private func waitUntil(

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -189,17 +189,38 @@ verify_signature() {
 
 verify_launch_smoke() {
     local smoke_log="$REPO_ROOT/$BUILD_DIR/launch-smoke.log"
-    local smoke_home="$REPO_ROOT/$BUILD_DIR/launch-smoke-home"
     local ui_report="$REPO_ROOT/$BUILD_DIR/launch-ui-smoke.json"
     local open_pid=""
     local pre_launch_app_pids=""
+    local launch_smoke_dir=""
+    local launch_app_bundle=""
+    local launch_app_binary=""
+    local launch_smoke_log=""
+    local launch_smoke_home=""
+    local launch_ui_report=""
     rm -f "$smoke_log"
-    rm -rf "$smoke_home"
     rm -f "$ui_report"
-    mkdir -p "$smoke_home"
+
+    cleanup_launch_smoke_app_bundle() {
+        [ -n "$launch_smoke_dir" ] && rm -rf "$launch_smoke_dir"
+    }
+
+    persist_launch_smoke_artifacts() {
+        [ -n "$launch_smoke_log" ] && [ -f "$launch_smoke_log" ] && cp "$launch_smoke_log" "$smoke_log"
+        [ -n "$launch_ui_report" ] && [ -f "$launch_ui_report" ] && cp "$launch_ui_report" "$ui_report"
+    }
+
+    launch_smoke_dir="$(mktemp -d "/tmp/transcripted-launch-smoke.XXXXXX")"
+    launch_app_bundle="$launch_smoke_dir/$APP_NAME.app"
+    launch_app_binary="$launch_app_bundle/Contents/MacOS/$APP_NAME"
+    launch_smoke_log="$launch_smoke_dir/launch-smoke.log"
+    launch_smoke_home="$launch_smoke_dir/home"
+    launch_ui_report="$launch_smoke_dir/launch-ui-smoke.json"
+    mkdir -p "$launch_smoke_home"
+    cp -R "$APP_BUNDLE" "$launch_app_bundle"
 
     snapshot_launch_smoke_app_pids() {
-        pgrep -f "$APP_BINARY" || true
+        pgrep -f "$launch_app_binary" || true
     }
 
     is_pre_launch_app_pid() {
@@ -228,20 +249,20 @@ verify_launch_smoke() {
     pre_launch_app_pids="$(snapshot_launch_smoke_app_pids)"
 
     /usr/bin/open -n -g -F -W \
-        --stdout "$smoke_log" \
-        --stderr "$smoke_log" \
-        --env "CFFIXED_USER_HOME=$smoke_home" \
-        --env "HOME=$smoke_home" \
+        --stdout "$launch_smoke_log" \
+        --stderr "$launch_smoke_log" \
+        --env "CFFIXED_USER_HOME=$launch_smoke_home" \
+        --env "HOME=$launch_smoke_home" \
         --env "TRANSCRIPTED_DISABLE_FILE_LOGGER=1" \
         --env "TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS=1" \
         --env "TRANSCRIPTED_DISABLE_SINGLE_INSTANCE_GUARD=1" \
-        --env "TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT=$ui_report" \
+        --env "TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT=$launch_ui_report" \
         --env "TRANSCRIPTED_LAUNCH_UI_SMOKE_TERMINATE_AFTER_REPORT=1" \
-        "$APP_BUNDLE" >>"$smoke_log" 2>&1 &
+        "$launch_app_bundle" >>"$launch_smoke_log" 2>&1 &
     open_pid=$!
 
     for _ in $(seq 1 50); do
-        if [ -s "$ui_report" ]; then
+        if [ -s "$launch_ui_report" ]; then
             break
         fi
         if ! kill -0 "$open_pid" 2>/dev/null; then
@@ -250,25 +271,29 @@ verify_launch_smoke() {
         sleep 0.1
     done
 
-    if ! kill -0 "$open_pid" 2>/dev/null && [ ! -s "$ui_report" ]; then
+    if ! kill -0 "$open_pid" 2>/dev/null && [ ! -s "$launch_ui_report" ]; then
         wait "$open_pid" || true
+        persist_launch_smoke_artifacts
         echo "Transcripted exited during launch smoke."
         echo "Smoke log:"
         cat "$smoke_log"
-        exit 1
+        cleanup_launch_smoke_app_bundle
+        return 1
     fi
 
-    if [ ! -s "$ui_report" ]; then
+    if [ ! -s "$launch_ui_report" ]; then
+        persist_launch_smoke_artifacts
         echo "Transcripted launch UI smoke report was not written."
         echo "Smoke log:"
         cat "$smoke_log"
         terminate_launch_smoke_app
         kill "$open_pid" 2>/dev/null || true
         wait "$open_pid" 2>/dev/null || true
-        exit 1
+        cleanup_launch_smoke_app_bundle
+        return 1
     fi
 
-    if ! /usr/bin/python3 - "$ui_report" <<'PY'
+    if ! /usr/bin/python3 - "$launch_ui_report" <<'PY'
 import json
 import sys
 
@@ -338,18 +363,25 @@ if errors:
     sys.exit(1)
 PY
     then
+        persist_launch_smoke_artifacts
         terminate_launch_smoke_app
         kill "$open_pid" 2>/dev/null || true
         wait "$open_pid" 2>/dev/null || true
-        exit 1
+        cleanup_launch_smoke_app_bundle
+        return 1
     fi
 
     if ! wait "$open_pid"; then
+        persist_launch_smoke_artifacts
         echo "Transcripted exited with an error during launch smoke."
         echo "Smoke log:"
         cat "$smoke_log"
-        exit 1
+        cleanup_launch_smoke_app_bundle
+        return 1
     fi
+
+    persist_launch_smoke_artifacts
+    cleanup_launch_smoke_app_bundle
 }
 
 sign_embedded_code() {


### PR DESCRIPTION
## Summary
- keep failed queue rows visible when capture/audio roots are unavailable instead of rewriting storage destructively
- heal relocated retained audio paths after capture library moves
- preserve queued and in-flight imported audio on shutdown
- allow mic-only failed meetings to retry through the single-track path
- wake queued transcription drain after terminal failure statuses
- stabilize local launch smoke by copying the signed app and smoke artifacts through `/tmp` before LaunchServices launch, while preserving `build/launch-smoke.log` and `build/launch-ui-smoke.json`

## Verification
- PASS: bash build-deps.sh --force
- PASS: swift test --filter FailedTranscriptionManagerTests
- PASS: swift test --filter TranscriptionTaskManagerMetadataTests
- PASS: swift test
- PASS: bash build.sh --no-open
- PASS: scripts/dev/agent-preflight.sh
- PASS: python3 scripts/dev/check-build-source-lists.py
- PASS: bash -n build.sh && bash -n scripts/entrypoints/build.sh
- PASS: bash run-tests.sh
- PASS: bash run-integration-smoke.sh
- NOTE: swift test --filter RepoCommandContractTests had 0 matching tests in this package; the repo command contracts ran via bash run-tests.sh

## Maestro lanes
- Codex: implemented, reviewed diff, ran checks, opened/updated draft PR
- Claude: attempted via maestro-delegate, blocked because Claude CLI is not logged in; proof at ~/.codex/maestro/runs/20260703T192526Z-transcripted-storage-queue-design-review-claude
- Local: duplicate clustering attempted via maestro-delegate; proof at ~/.codex/maestro/runs/20260703T192525Z-transcripted-failed-queue-duplicates-local
- Windows: attempted/unavailable; maestro smoke reported Windows worker not configured

## Cleanup recommendations
- Keep this as a separate PR from the broader audit cleanup.
- The launch-smoke stabilization is verifier-only; release packaging remains owned by build-beta/notarization.
