### PR TITLE
Improve hotkey event tap recovery

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -81,17 +81,16 @@ private enum PhysicalShortcutPhase {
 
 private final class PhysicalShortcutDetector {
     /// Cached binding snapshot, rebuilt by ContextCaptureEngine on
-    /// .hotkeysDidChange. The tap callback runs on the main run loop for every
-    /// system-wide keyDown/keyUp/flagsChanged, so it must read this cache
-    /// instead of hitting UserDefaults per keystroke — per-event preference
-    /// reads add latency to all typing on the machine and raise the
-    /// tapDisabledByTimeout risk. Both the tap callback and the engine's
-    /// configure path run on the main thread, so a plain property is safe.
-    var shortcutBindings: [PhysicalShortcutBinding] = []
+    /// .hotkeysDidChange. The event tap runs on a dedicated run loop so
+    /// Transcripted main-thread work cannot delay global keyboard delivery.
+    private var shortcutBindings: [PhysicalShortcutBinding] = []
     var onShortcut: ((PhysicalShortcutAction, PhysicalShortcutPhase) -> Void)?
 
+    private let stateLock = NSRecursiveLock()
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var tapRunLoop: CFRunLoop?
+    private var tapThread: Thread?
     private var activePushToTalkKeyCode: UInt32?
     private var consumedKeyCodes: Set<UInt32> = []
     private var pendingModifierShortcut: PendingModifierShortcut?
@@ -110,6 +109,12 @@ private final class PhysicalShortcutDetector {
             .fromOpaque(userInfo)
             .takeUnretainedValue()
         return detector.handle(type: type, event: event)
+    }
+
+    func updateShortcutBindings(_ bindings: [PhysicalShortcutBinding]) {
+        stateLock.lock()
+        shortcutBindings = bindings
+        stateLock.unlock()
     }
 
     func install() -> String? {
@@ -143,22 +148,66 @@ private final class PhysicalShortcutDetector {
 
         eventTap = tap
         runLoopSource = source
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+        startTapThread(tap: tap, source: source)
         return nil
     }
 
     func remove() {
-        if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
+        stateLock.lock()
+        let source = runLoopSource
+        let eventTap = eventTap
+        let tapRunLoop = tapRunLoop
+        runLoopSource = nil
+        self.eventTap = nil
+        self.tapRunLoop = nil
+        self.tapThread = nil
+        stateLock.unlock()
+
+        if let source {
+            CFRunLoopRemoveSource(tapRunLoop ?? CFRunLoopGetMain(), source, .commonModes)
         }
         if let eventTap {
             CGEvent.tapEnable(tap: eventTap, enable: false)
             CFMachPortInvalidate(eventTap)
         }
-        runLoopSource = nil
-        eventTap = nil
+        if let tapRunLoop {
+            CFRunLoopStop(tapRunLoop)
+        }
+
+        stateLock.lock()
         resetState()
+        stateLock.unlock()
+    }
+
+    private func startTapThread(tap: CFMachPort, source: CFRunLoopSource) {
+        let ready = DispatchSemaphore(value: 0)
+        let thread = Thread { [weak self] in
+            autoreleasepool {
+                guard let self else {
+                    ready.signal()
+                    return
+                }
+
+                let runLoop = CFRunLoopGetCurrent()
+                self.stateLock.lock()
+                self.tapRunLoop = runLoop
+                self.stateLock.unlock()
+
+                CFRunLoopAddSource(runLoop, source, .commonModes)
+                CGEvent.tapEnable(tap: tap, enable: true)
+                ready.signal()
+                CFRunLoopRun()
+            }
+        }
+        thread.name = "TranscriptedPhysicalShortcutTap"
+        thread.qualityOfService = .userInteractive
+
+        stateLock.lock()
+        tapThread = thread
+        stateLock.unlock()
+
+        thread.start()
+        ready.wait()
     }
 
     private func resetState() {
@@ -169,7 +218,11 @@ private final class PhysicalShortcutDetector {
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            reconcileStateAfterTapWasDisabled()
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }
@@ -339,8 +392,10 @@ private final class PhysicalShortcutDetector {
                     return
                 }
 
+                self.stateLock.lock()
                 self.pendingModifierShortcut = nil
                 self.activePushToTalkKeyCode = keyCode
+                self.stateLock.unlock()
                 self.onShortcut?(action, .press)
             }
             workItem = delayedWorkItem
@@ -360,6 +415,23 @@ private final class PhysicalShortcutDetector {
         pendingModifierShortcut?.workItem?.cancel()
         pendingModifierShortcut = nil
     }
+
+    private func reconcileStateAfterTapWasDisabled() {
+        cancelPendingModifierShortcut()
+
+        if let keyCode = activePushToTalkKeyCode,
+           !Self.isKeyPhysicallyDown(keyCode) {
+            activePushToTalkKeyCode = nil
+            consumedKeyCodes.remove(keyCode)
+            onShortcut?(.dictationPushToTalk, .release)
+        }
+
+        consumedKeyCodes = consumedKeyCodes.filter { Self.isKeyPhysicallyDown($0) }
+    }
+
+    private static func isKeyPhysicallyDown(_ keyCode: UInt32) -> Bool {
+        CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
+    }
 }
 
 // MARK: - Context Capture Engine
@@ -367,6 +439,7 @@ private final class PhysicalShortcutDetector {
 @MainActor
 class ContextCaptureEngine: ObservableObject {
     private var hotkeyChangeObserver: NSObjectProtocol?
+    private var accessibilityRetryTask: Task<Void, Never>?
     private let physicalShortcutDetector = PhysicalShortcutDetector()
     private var physicalTriggerError: String?
 
@@ -378,6 +451,10 @@ class ContextCaptureEngine: ObservableObject {
 
     /// Non-nil when hotkey registration failed — shown as a dismissible banner in MenuBarPanel
     @Published var hotkeyError: String?
+
+    var hotkeyRegistrationError: String? {
+        physicalTriggerError
+    }
 
     /// Set by TranscriptedAppDelegate to wire the hotkey to the session controller
     var sessionController: DictationSessionController? {
@@ -471,7 +548,7 @@ class ContextCaptureEngine: ObservableObject {
         // here through reRegisterHotkeys(), so the detector's cache never goes
         // stale — and the per-keystroke tap callback stays free of
         // UserDefaults reads and migration-fallback work.
-        physicalShortcutDetector.shortcutBindings = Self.currentShortcutBindings()
+        physicalShortcutDetector.updateShortcutBindings(Self.currentShortcutBindings())
         physicalShortcutDetector.onShortcut = { [weak self] action, phase in
             Task { @MainActor [weak self] in
                 self?.handlePhysicalShortcut(action, phase: phase)
@@ -492,6 +569,7 @@ class ContextCaptureEngine: ObservableObject {
             )
         }
         updateHotkeyError()
+        updateAccessibilityRetryMonitor()
     }
 
     private static func currentShortcutBindings() -> [PhysicalShortcutBinding] {
@@ -539,6 +617,27 @@ class ContextCaptureEngine: ObservableObject {
         let nextError = errors.isEmpty ? nil : errors.joined(separator: " and ")
         if hotkeyError != nextError {
             hotkeyError = nextError
+        }
+    }
+
+    private func updateAccessibilityRetryMonitor() {
+        guard physicalTriggerError == "Shortcut trigger needs Accessibility permission" else {
+            accessibilityRetryTask?.cancel()
+            accessibilityRetryTask = nil
+            return
+        }
+
+        guard accessibilityRetryTask == nil else { return }
+        accessibilityRetryTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard !Task.isCancelled, let self else { return }
+                guard TranscriptedPermissionAccess.isGranted(.accessibility) else { continue }
+                self.accessibilityRetryTask?.cancel()
+                self.accessibilityRetryTask = nil
+                self.reRegisterHotkeys()
+                return
+            }
         }
     }
 
@@ -674,6 +773,8 @@ class ContextCaptureEngine: ObservableObject {
     }
 
     func unregisterHotkey() {
+        accessibilityRetryTask?.cancel()
+        accessibilityRetryTask = nil
         if let observer = hotkeyChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             hotkeyChangeObserver = nil

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -39,7 +39,7 @@ class TranscriptedAppState: ObservableObject {
             self?.contextCapture.registerHotkey()
         },
         currentHotkeyError: { [weak self] in
-            self?.contextCapture.hotkeyError
+            self?.contextCapture.hotkeyRegistrationError
         },
         onHotkeyAttempt: { [weak self] attempt, error in
             guard let self else { return }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -800,6 +800,9 @@ class DictationSessionController: ObservableObject {
         }
 
         guard stopDecision == .stopRecording else {
+            if overlayController.state == .drafting {
+                overlayController.showError("Still finishing the last dictation. Try again in a moment.")
+            }
             DiagnosticsTrail.record(
                 logger: appState.logger,
                 level: .warning,

--- a/Tests/ContextCaptureEnginePolicyTests.swift
+++ b/Tests/ContextCaptureEnginePolicyTests.swift
@@ -104,7 +104,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     // MARK: - Cached binding snapshot
-    // The CGEventTap callback runs on the main run loop for every system-wide
+    // The CGEventTap callback runs for every system-wide
     // keyDown/keyUp/flagsChanged. It must read a cached binding snapshot —
     // rebuilt on .hotkeysDidChange — instead of hitting UserDefaults (4 binding
     // lookups plus migration fallbacks) per keystroke, which added latency to
@@ -114,12 +114,94 @@ func testContextCaptureEnginePolicy() {
         let source = readContextCaptureEngineSource()
 
         assertTrue(
-            source.contains("physicalShortcutDetector.shortcutBindings = Self.currentShortcutBindings()"),
+            source.contains("physicalShortcutDetector.updateShortcutBindings(Self.currentShortcutBindings())"),
             "engine should rebuild the detector's cached binding snapshot when it (re)configures the detector"
         )
         assertFalse(
             source.contains("bindingProvider"),
             "per-event binding provider closure must stay removed — the tap callback reads the cached snapshot instead of resolving preferences per keystroke"
+        )
+    }
+
+    runSuite("ContextCaptureEngine event tap — serviced on dedicated run loop instead of main") {
+        let source = readContextCaptureEngineSource()
+
+        assertTrue(
+            source.contains("TranscriptedPhysicalShortcutTap"),
+            "physical shortcut event tap should run on its own named thread"
+        )
+        assertTrue(
+            source.contains("CFRunLoopAddSource(runLoop, source, .commonModes)"),
+            "event tap source should be installed on the dedicated thread run loop"
+        )
+        assertFalse(
+            source.contains("CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)"),
+            "system-wide keyboard events must not be serviced on the app's main run loop"
+        )
+    }
+
+    runSuite("ContextCaptureEngine tap-disabled recovery — reconciles missed push-to-talk release") {
+        let source = readContextCaptureEngineSource()
+
+        assertTrue(
+            source.contains("reconcileStateAfterTapWasDisabled()"),
+            "tap-disabled events should reconcile detector state before re-enabling the tap"
+        )
+        assertTrue(
+            source.contains("CGEventSource.keyState(.combinedSessionState"),
+            "reconciliation should check the physical key state for a missed keyUp"
+        )
+        assertTrue(
+            source.contains("onShortcut?(.dictationPushToTalk, .release)"),
+            "a released push-to-talk key should synthesize the missing release callback"
+        )
+    }
+
+    runSuite("ContextCaptureEngine Accessibility retry — re-registers after permission is granted") {
+        let source = readContextCaptureEngineSource()
+
+        assertTrue(
+            source.contains("accessibilityRetryTask"),
+            "engine should keep a lightweight retry task while Accessibility is missing"
+        )
+        assertTrue(
+            source.contains("TranscriptedPermissionAccess.isGranted(.accessibility)"),
+            "retry task should poll the real Accessibility grant state"
+        )
+        assertTrue(
+            source.contains("self.reRegisterHotkeys()"),
+            "granting Accessibility should re-attempt physical trigger registration without waiting for wake or relaunch"
+        )
+    }
+
+    runSuite("TranscriptedAppState wake recovery — uses registration error, not advisory warning") {
+        let appStateSource = readRepoSource("Sources/TranscriptedAppState.swift")
+        let contextSource = readContextCaptureEngineSource()
+
+        assertTrue(
+            contextSource.contains("var hotkeyRegistrationError: String?"),
+            "ContextCaptureEngine should expose the real registration failure separately from advisory banner text"
+        )
+        assertTrue(
+            appStateSource.contains("self?.contextCapture.hotkeyRegistrationError"),
+            "wake recovery should ignore Fn-conflict advisory warnings when deciding whether registration succeeded"
+        )
+        assertFalse(
+            appStateSource.contains("self?.contextCapture.hotkeyError"),
+            "wake recovery must not treat advisory hotkeyError banner text as registration failure"
+        )
+    }
+
+    runSuite("DictationSessionController finishing hotkey — shows visible feedback instead of silent swallow") {
+        let source = readRepoSource("Sources/UI/Overlay/DictationSessionController.swift")
+
+        assertTrue(
+            source.contains("if overlayController.state == .drafting"),
+            "ignored stop/start intent during the drafting/transcribing window should be surfaced to the user"
+        )
+        assertTrue(
+            source.contains("overlayController.showError(\"Still finishing the last dictation. Try again in a moment.\")"),
+            "finishing-window hotkey press should reuse the existing visible finishing message"
         )
     }
 
@@ -686,7 +768,11 @@ private func makeContextCaptureDefaults() -> (UserDefaults, String) {
 }
 
 private func readContextCaptureEngineSource() -> String {
+    readRepoSource("Sources/Capture/ContextCaptureEngine.swift")
+}
+
+private func readRepoSource(_ path: String) -> String {
     let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        .appendingPathComponent("Sources/Capture/ContextCaptureEngine.swift")
+        .appendingPathComponent(path)
     return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
 }


### PR DESCRIPTION
## Summary
- move the physical shortcut CGEventTap off the main run loop and onto a dedicated user-interactive thread
- keep shortcut bindings cached, add tap-disabled reconciliation for missed push-to-talk keyUp, and retry registration after Accessibility is granted
- split wake recovery to use the real registration error instead of Fn advisory banner text
- show visible finishing feedback when a hotkey press arrives during dictation transcription/drafting

## Audit Findings
Addresses audit findings #22, #30, #31, #32, #33, and #62. #30's UserDefaults-per-keypress portion was already fixed on current main; this PR preserves that cached-binding path and fixes the remaining main-run-loop/tap recovery pieces.

## Verification
- `bash run-tests.sh --filter ContextCaptureEnginePolicyTests` — 79 passed
- `bash run-tests.sh` — 11,982 passed
- `bash run-integration-smoke.sh` — core smoke, wake smoke, and recovery merge package tests passed
- `bash build.sh` — attempted; blocked from completing with reused stale prebuilt deps after local `build-deps.sh --force` hit disk pressure (`No space left on device`). No remaining compiler errors were reported from touched files on the post-fix build attempt before stale dependency API mismatches stopped the build.

## Manual Proof
Manual keyboard/Accessibility proof not run; remains UNKNOWN.

## Maestro Lanes
- Codex: implemented, reviewed diff, ran tests/smokes, opened PR
- Claude: attempted risk review, but lane exited nonzero with no output; proof `/Users/redbars/.codex/maestro/runs/20260703T200819Z-transcripted-hotkey-risk-review-claude`
- Local: triage ran but returned no useful file mapping; proof `/Users/redbars/.codex/maestro/runs/20260703T192840Z-transcripted-hotkey-triage-local`
- Windows: unavailable because `WINDOWS_WORKER_BASE_URL` is not set; proof `/Users/redbars/.codex/maestro/runs/20260703T192902Z-transcripted-hotkey-first-pass-windows`
