### PR TITLE
Serialize meeting transcript rewrites

### DIFF
--- a/Sources/Meeting/MeetingArtifactRenamer.swift
+++ b/Sources/Meeting/MeetingArtifactRenamer.swift
@@ -3,6 +3,26 @@ import Foundation
 import TranscriptedCore
 #endif
 
+enum MeetingTranscriptFileUpdateSerializer {
+    private static let fallbackQueueSpecific = DispatchSpecificKey<Void>()
+    private static let fallbackQueue: DispatchQueue = {
+        let queue = DispatchQueue(label: "Transcripted.MeetingTranscriptFileUpdateSerializer", qos: .utility)
+        queue.setSpecific(key: fallbackQueueSpecific, value: ())
+        return queue
+    }()
+
+    static func sync<T>(_ update: () throws -> T) rethrows -> T {
+        #if canImport(TranscriptedCore)
+        return try TranscriptSaver.serializeTranscriptFileUpdate(update)
+        #else
+        if DispatchQueue.getSpecific(key: fallbackQueueSpecific) != nil {
+            return try update()
+        }
+        return try fallbackQueue.sync(execute: update)
+        #endif
+    }
+}
+
 /// Shared rename mechanics for the on-disk artifacts that make up a saved meeting:
 /// the Markdown transcript, its retained `audio/<stem>_audio/` directory, and the
 /// optional `<stem>.summary.md` sidecar.

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -29,7 +29,9 @@ enum MeetingTranscriptStyler {
     private static let formatterQueue = DispatchQueue(label: "Transcripted.MeetingTranscriptStyler.formatters")
 
     static func restyleTranscript(at url: URL) -> StyledMeetingTranscript {
-        styledTranscript(at: url, persistChanges: true)
+        MeetingTranscriptFileUpdateSerializer.sync {
+            styledTranscript(at: url, persistChanges: true)
+        }
     }
 
     static func displayTranscript(at url: URL) -> StyledMeetingTranscript {

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -95,6 +95,12 @@ extension TranscriptSaver {
 
             // Write back atomically
             do {
+                guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                    AppLogger.pipeline.warning("Skipped retroactive speaker update because transcript moved before write", [
+                        "file": fileURL.lastPathComponent
+                    ])
+                    continue
+                }
                 try content.write(to: fileURL, atomically: true, encoding: .utf8)
                 restrictTranscriptToOwnerOnly(fileURL)
                 updatedCount += 1

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Handles automatic saving of transcripts to the filesystem
 public class TranscriptSaver {
+    private static let fileUpdateQueueSpecific = DispatchSpecificKey<Void>()
 
     /// Default save location for the standalone Transcripted app.
     /// Falls back to `CoreStoragePaths.default.transcripts` unless the user has set a
@@ -43,7 +44,19 @@ public class TranscriptSaver {
     }
 
     /// Serial queue for file updates — prevents concurrent reads/writes from corrupting transcripts
-    static let fileUpdateQueue = DispatchQueue(label: "com.transcripted.fileupdate", qos: .utility)
+    static let fileUpdateQueue: DispatchQueue = {
+        let queue = DispatchQueue(label: "com.transcripted.fileupdate", qos: .utility)
+        queue.setSpecific(key: fileUpdateQueueSpecific, value: ())
+        return queue
+    }()
+
+    /// Run a whole-file transcript update under the same serializer as speaker-name rewrites.
+    public static func serializeTranscriptFileUpdate<T>(_ update: () throws -> T) rethrows -> T {
+        if DispatchQueue.getSpecific(key: fileUpdateQueueSpecific) != nil {
+            return try update()
+        }
+        return try fileUpdateQueue.sync(execute: update)
+    }
 
     /// Save transcript to file with automatic timestamped naming
     /// - Parameters:

--- a/Sources/UI/Shared/HomeMeetingRename.swift
+++ b/Sources/UI/Shared/HomeMeetingRename.swift
@@ -33,6 +33,16 @@ enum HomeMeetingRename {
         to rawTitle: String,
         fileManager: FileManager = .default
     ) throws -> HomeMeetingRenameResult {
+        try MeetingTranscriptFileUpdateSerializer.sync {
+            try renameSerialized(transcriptAt: url, to: rawTitle, fileManager: fileManager)
+        }
+    }
+
+    private static func renameSerialized(
+        transcriptAt url: URL,
+        to rawTitle: String,
+        fileManager: FileManager
+    ) throws -> HomeMeetingRenameResult {
         guard let normalizedTitle = MeetingRecordingTitlePolicy.normalized(rawTitle) else {
             throw HomeMeetingRenameError.emptyTitle
         }

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -17,6 +17,7 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerPreservesObsidianSpeakerLinks()
         testMeetingTranscriptStylerPreservesLocalGemmaSummaryBlock()
         testMeetingTranscriptStylerRestrictsRewrittenTranscript()
+        testMeetingTranscriptStylerSerializesAgainstStaleWholeFileWriters()
         testMeetingTranscriptStylerPreservesImportedRecordingDate()
         testMeetingTranscriptStylerFailsClosedOnUnparseableBody()
         testMeetingTranscriptStylerStillRewritesGenuinelyEmptyTranscript()
@@ -267,6 +268,74 @@ private func testMeetingTranscriptStylerPreservesImportedRecordingDate() {
     assertTrue(
         updatedMarkdown.contains("time: \"09:14:00\""),
         "Restyling must preserve the imported recording time in the front matter"
+    )
+}
+
+private func testMeetingTranscriptStylerSerializesAgainstStaleWholeFileWriters() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleMeetingTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let staleReadFinished = DispatchSemaphore(value: 0)
+    let releaseStaleWriter = DispatchSemaphore(value: 0)
+    let writerFinished = DispatchSemaphore(value: 0)
+    var writerError: String?
+
+    DispatchQueue.global(qos: .userInitiated).async {
+        let staleRaw: String
+        do {
+            staleRaw = try String(contentsOf: transcriptURL, encoding: .utf8)
+        } catch {
+            writerError = "stale read failed: \(error)"
+            staleReadFinished.signal()
+            writerFinished.signal()
+            return
+        }
+
+        staleReadFinished.signal()
+        releaseStaleWriter.wait()
+
+        do {
+            try MeetingTranscriptFileUpdateSerializer.sync {
+                guard FileManager.default.fileExists(atPath: transcriptURL.path) else { return }
+                let staleRename = staleRaw.replacingOccurrences(of: "[System/Alex]", with: "[System/Jamie]")
+                try staleRename.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            }
+        } catch {
+            writerError = "stale write failed: \(error)"
+        }
+        writerFinished.signal()
+    }
+
+    assertEqual(
+        staleReadFinished.wait(timeout: .now() + 2),
+        .success,
+        "stale writer should capture its old snapshot before restyle starts"
+    )
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    releaseStaleWriter.signal()
+
+    assertEqual(
+        writerFinished.wait(timeout: .now() + 2),
+        .success,
+        "stale writer should finish after restyle releases the shared serializer"
+    )
+    assertNil(writerError, "stale writer should not fail")
+    assertFalse(
+        FileManager.default.fileExists(atPath: transcriptURL.path),
+        "A stale whole-file writer must not recreate the pre-restyle path"
+    )
+    assertTrue(
+        FileManager.default.fileExists(atPath: styled.url.path),
+        "The restyled transcript should remain at its canonical path"
+    )
+    let finalMarkdown = (try? String(contentsOf: styled.url, encoding: .utf8)) ?? ""
+    assertTrue(
+        finalMarkdown.contains("[System/Alex]"),
+        "The stale snapshot must not overwrite the canonical transcript"
     )
 }
 


### PR DESCRIPTION
## Summary
- add a shared TranscriptSaver serializer for whole-file transcript updates
- route meeting restyle and Home title rename through the shared serializer
- guard retroactive speaker rewrites from recreating an old path if a transcript moved
- add a focused regression for stale whole-file writers after restyle rename

## Verification
- PASS: bash build-deps.sh --force
- PASS: TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 bash build.sh --no-open
- PASS: bash run-tests.sh --filter MeetingTranscriptStyler
- PASS: bash run-tests.sh
- PASS: bash run-integration-smoke.sh
- PASS: swift test
- PASS: codex review --base origin/main, no actionable findings
- NOTE: unskipped bash build.sh --no-open compiled and signed, but failed launch smoke with _LSOpenURLsWithCompletionHandler() failed with error -10810; launch remains unverified locally

## Maestro lanes
- Codex: implemented, tested, reviewed, committed, pushed, opened draft PR
- Claude: attempted via ~/.codex/bin/maestro-delegate; proof path /Users/redbars/.codex/maestro/runs/20260703T193026Z-meeting-markdown-concurrency-review-claude, no usable output
- Local: scan/review attempted via ~/.codex/bin/maestro-delegate; proof paths /Users/redbars/.codex/maestro/runs/20260703T193026Z-meeting-markdown-scan-local and /Users/redbars/.codex/maestro/runs/20260703T201738Z-transcripted-meeting-markdown-serialization-review-local, outputs not relied on
- Windows: attempted via ~/.codex/bin/maestro-delegate; proof path /Users/redbars/.codex/maestro/runs/20260703T193027Z-meeting-markdown-first-pass-windows, not reachable/useful