### PR TITLE
Render the dictation warmup status line instead of dropping it

### DIFF
--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -192,6 +192,7 @@ final class OverlayRootView: NSView {
 @MainActor
 final class OverlayLoadingView: NSView {
     private let titleLabel = NSTextField(labelWithString: "Getting ready")
+    private let statusLabel = NSTextField(labelWithString: "")
     private let detailLabel = NSTextField(wrappingLabelWithString: "")
     private let progressBar = NSProgressIndicator()
 
@@ -211,7 +212,16 @@ final class OverlayLoadingView: NSView {
         titleLabel.isBezeled = false
         titleLabel.isEditable = false
         titleLabel.drawsBackground = false
+        titleLabel.lineBreakMode = .byTruncatingTail
         addSubview(titleLabel)
+
+        statusLabel.font = NSFont.systemFont(ofSize: 10, weight: .medium)
+        statusLabel.textColor = OverlayTokens.textMuted
+        statusLabel.isBezeled = false
+        statusLabel.isEditable = false
+        statusLabel.drawsBackground = false
+        statusLabel.alignment = .right
+        addSubview(statusLabel)
 
         detailLabel.font = NSFont.systemFont(ofSize: 11)
         detailLabel.textColor = OverlayTokens.textSecondary
@@ -230,8 +240,10 @@ final class OverlayLoadingView: NSView {
         super.layout()
         let pad: CGFloat = 14
         let contentWidth = max(0, bounds.width - pad * 2)
+        let statusWidth = min(statusLabel.fittingSize.width, contentWidth * 0.5)
 
-        titleLabel.frame = NSRect(x: pad, y: 9, width: contentWidth, height: 16)
+        titleLabel.frame = NSRect(x: pad, y: 9, width: contentWidth - statusWidth - 6, height: 16)
+        statusLabel.frame = NSRect(x: pad + contentWidth - statusWidth, y: 11, width: statusWidth, height: 13)
         detailLabel.frame = NSRect(x: pad, y: 29, width: contentWidth, height: 28)
         progressBar.frame = NSRect(x: pad, y: 59, width: contentWidth, height: 6)
     }
@@ -243,6 +255,13 @@ final class OverlayLoadingView: NSView {
         titleLabel.stringValue = presentation.title
         detailLabel.stringValue = presentation.detail
         progressBar.doubleValue = presentation.progress
+        // Keep the user oriented during long warmups: show the concrete stage
+        // ("42% downloaded", "Almost ready") and how long it has been waiting.
+        var status = presentation.status ?? ""
+        if elapsedSeconds >= 10 {
+            status = status.isEmpty ? "\(elapsedSeconds)s" : "\(status) · \(elapsedSeconds)s"
+        }
+        statusLabel.stringValue = status
         needsLayout = true
     }
 }


### PR DESCRIPTION
## Summary
- Stacked on #1393 — diff below shows only this PR's changes.
- `LoadingPresentation.status` (download percent, "Almost ready", device-retry status) was already computed by every loading-copy source, but `OverlayLoadingView` never rendered it — so a slow model load or download showed a static title/detail with no sense of progress.
- Adds a right-aligned status label next to the title, and appends an elapsed-seconds readout once a warmup passes 10s so a stuck-looking wait still reads as "in progress" rather than frozen.

## Test plan
- [x] `bash run-tests.sh` — full fast suite passes (11990/11990)
- [x] `bash build.sh --no-open` — full app build passes (ran at the top of this stack, deps fresh)
- [x] `bash run-slow-pasteback-smoke.sh` — 8/8 checks pass
- Manual: trigger a model download/warmup and watch the loading panel show "42% downloaded" / "Almost ready" plus a growing "…12s" readout past 10 seconds.

Last of a 3-PR stack: #1389 → #1393 → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)