### PR TITLE
Fix meeting capture failure recovery

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -35,6 +35,8 @@ final class MeetingCaptureBridge: ObservableObject {
     /// `.micAttenuatedByForeignVoiceProcessing` cue. Reset at the next start.
     @Published private(set) var micAttenuationCueObserved: Bool = false
 
+    var onUnexpectedRecordingComplete: ((CaptureStopResult) -> Void)?
+
     // MARK: - Underlying capture
 
     /// Core's CoreAudio capture. NOT @MainActor — UI updates come via the
@@ -45,6 +47,7 @@ final class MeetingCaptureBridge: ObservableObject {
     private let completionAttempt = MeetingCaptureAttempt<CaptureStopResult>()
     private let startAttempt = MeetingCaptureAttempt<Bool>()
     private var timedOutStopCompletionHandler: ((CaptureStopResult) -> Void)?
+    private var isAwaitingTimedOutStopCompletion = false
 
     init(audio: Audio? = nil) {
         self.audio = audio ?? Audio(
@@ -73,6 +76,8 @@ final class MeetingCaptureBridge: ObservableObject {
     /// Start a new recording session. Returns immediately; the session remains
     /// active until `stopAndAwaitFiles()` is called.
     func startRecording() async -> Bool {
+        isAwaitingTimedOutStopCompletion = false
+        timedOutStopCompletionHandler = nil
         completionAttempt.reset()?.resume(returning: currentStopResult())
         if audio.isRecording { return true }
 
@@ -122,6 +127,8 @@ final class MeetingCaptureBridge: ObservableObject {
         )
 
         return await withCheckedContinuation { continuation in
+            isAwaitingTimedOutStopCompletion = false
+            timedOutStopCompletionHandler = nil
             let attemptID = completionAttempt.begin(continuation)
             audio.stop()
 
@@ -144,6 +151,7 @@ final class MeetingCaptureBridge: ObservableObject {
                         uniquingKeysWith: { _, new in new }
                     )
                 )
+                self.isAwaitingTimedOutStopCompletion = true
                 self.timedOutStopCompletionHandler = onTimedOutCompletion
                 continuation.resume(returning: self.currentStopResult(didTimeOut: true))
             })
@@ -213,14 +221,21 @@ final class MeetingCaptureBridge: ObservableObject {
                     didTimeOut: false
                 )
                 if let continuation = self.completionAttempt.reset() {
+                    self.isAwaitingTimedOutStopCompletion = false
                     self.timedOutStopCompletionHandler = nil
                     continuation.resume(returning: result)
                     return
                 }
 
-                let handler = self.timedOutStopCompletionHandler
-                self.timedOutStopCompletionHandler = nil
-                handler?(result)
+                if self.isAwaitingTimedOutStopCompletion {
+                    self.isAwaitingTimedOutStopCompletion = false
+                    let handler = self.timedOutStopCompletionHandler
+                    self.timedOutStopCompletionHandler = nil
+                    handler?(result)
+                    return
+                }
+
+                self.onUnexpectedRecordingComplete?(result)
             }
         }
 

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -339,6 +339,10 @@ final class MeetingSessionController: ObservableObject {
         // Model downloader — coordinates selected STT + PyAnnote readiness.
         self.downloader = MeetingModelDownloader(stt: sttAdapter, diarization: diarization)
 
+        capture.onUnexpectedRecordingComplete = { [weak self] result in
+            self?.handleUnexpectedCaptureStop(result)
+        }
+
         wireSubscriptions()
 
         // Recover recordings orphaned by a crash before any failed-queue entry
@@ -1481,6 +1485,73 @@ final class MeetingSessionController: ObservableObject {
         while isFinishingRecording && Date() < deadline {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
+    }
+
+    private func handleUnexpectedCaptureStop(_ stopResult: CaptureStopResult) {
+        guard case .recording = state, !isFinishingRecording else { return }
+
+        _ = audioInactivityDetector.stopRecording()
+        audioInactivityWarning = nil
+        isMicBoostPromptVisible = false
+
+        let recordingSnapshot = makeRecordingStopSnapshot()
+        let files = (micURL: stopResult.micURL, systemURL: stopResult.systemURL)
+        let failureMessage = capture.errorMessage
+            ?? "Recording stopped unexpectedly. Open Transcripted Home to retry the saved audio."
+
+        finishLiveCodexSessionForActiveRecording(status: .failed, shouldAwaitFinalTranscript: false)
+        clearActiveRecordingIdentity()
+        activeRecordingTrigger = .unknown
+        activeRecordingSuggestedTitle = nil
+        activeRecordingStartedAt = nil
+
+        let preserved = preserveFailedMeetingForRetry(
+            micAudioURL: files.micURL,
+            systemAudioURL: files.systemURL,
+            errorMessage: failureMessage,
+            meetingTitle: recordingSnapshot.suggestedTitle,
+            recordingDate: recordingSnapshot.recordingStartedAt
+        )
+
+        DiagnosticsTrail.record(
+            level: .error,
+            engine: "meeting",
+            event: "meeting_capture_stopped_under_controller",
+            message: "Meeting capture stopped before the app stop path ran",
+            context: baseDiagnosticsContext(
+                extra: [
+                    "mic_file_present": boolString(files.micURL != nil),
+                    "system_file_present": boolString(files.systemURL != nil),
+                    "preserved_for_retry": boolString(preserved),
+                    "capture_quality": recordingSnapshot.healthInfo.captureQuality.rawValue,
+                    "audio_gaps": "\(recordingSnapshot.healthInfo.audioGaps)",
+                    "device_switches": "\(recordingSnapshot.healthInfo.deviceSwitches)"
+                ]
+            )
+        )
+
+        AnalyticsReporter.track(
+            "meeting_capture_stopped_under_controller",
+            properties: MeetingCaptureHealthTelemetry.snapshotProperties(
+                .init(
+                    captureDiagnostics: meetingCaptureAnalyticsProperties(snapshot: recordingSnapshot.pipelineSnapshot),
+                    health: captureHealthFacts(from: recordingSnapshot.healthInfo),
+                    trigger: recordingSnapshot.trigger.rawValue,
+                    reason: "internal_stop",
+                    durationSeconds: recordingSnapshot.durationSeconds,
+                    systemStreamPresent: files.systemURL != nil,
+                    stopTimedOut: stopResult.didTimeOut
+                )
+            )
+        )
+
+        state = preserved
+            ? .error("Recording stopped early. Open Transcripted Home to retry the saved audio.")
+            : .error("Recording stopped early and no meeting audio was saved.")
+        Self.runtimeDiagnosticsRecorder?.clearSession(
+            kind: "meeting",
+            outcome: preserved ? "capture_stopped_under_controller" : "capture_stopped_no_audio"
+        )
     }
 
     private func preserveQueuedTranscriptionJobsForShutdown(errorMessage: String) -> Int {

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -211,13 +211,7 @@ extension Audio {
                                 try audioFile.write(from: bufferForAsyncUse)
                                 self.consecutiveSystemWriteErrors = 0
                             } catch {
-                                self.consecutiveSystemWriteErrors += 1
-                                if self.consecutiveSystemWriteErrors <= 3 || self.consecutiveSystemWriteErrors == self.maxConsecutiveWriteErrors {
-                                    AppLogger.audioSystem.error("System audio write failed", ["bufferNumber": "\(currentBufferCount)", "error": error.localizedDescription, "consecutive": "\(self.consecutiveSystemWriteErrors)"])
-                                }
-                                if self.consecutiveSystemWriteErrors >= self.maxConsecutiveWriteErrors {
-                                    AppLogger.audioSystem.error("Too many consecutive system write errors, stopping system writes")
-                                }
+                                self.recordSystemWriteFailure(error, bufferNumber: currentBufferCount)
                             }
                         }
                     }
@@ -431,6 +425,26 @@ extension Audio {
         return true
     }
 
+    @discardableResult
+    func recordSystemWriteFailure(_ error: Error, bufferNumber: Int? = nil) -> Bool {
+        consecutiveSystemWriteErrors += 1
+        let count = consecutiveSystemWriteErrors
+        if count <= 3 || count == maxConsecutiveWriteErrors {
+            var context = [
+                "error": error.localizedDescription,
+                "consecutive": "\(count)"
+            ]
+            if let bufferNumber {
+                context["bufferNumber"] = "\(bufferNumber)"
+            }
+            AppLogger.audioSystem.error("System audio write failed", context)
+        }
+        guard count >= maxConsecutiveWriteErrors else { return false }
+        AppLogger.audioSystem.error("Too many consecutive system write errors, stopping recording")
+        surfaceSystemWriteFailureAndStop()
+        return true
+    }
+
     /// Stops the recording and surfaces a write-failure error, mirroring the
     /// disk-full stop path in `startTimer()`. Callers run on a file-write queue,
     /// so this hops to main. No-ops if recording already ended (a cap crossed
@@ -441,6 +455,16 @@ extension Audio {
         DispatchQueue.main.async { [weak self] in
             guard let self, self.isRecording else { return }
             self.error = "Recording stopped \u{2014} Transcripted couldn't save audio to disk. Check that there's free space and the save location is still available, then start a new recording."
+            self.stop()
+        }
+    }
+
+    func surfaceSystemWriteFailureAndStop() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isRecording else { return }
+            self.systemAudioFailed = true
+            self.systemAudioStatus = .failed
+            self.error = "Recording stopped \u{2014} Transcripted couldn't save system audio to disk. Check that there's free space and the save location is still available, then start a new recording."
             self.stop()
         }
     }
@@ -671,6 +695,7 @@ extension Audio {
                 }
             } else if message.contains("unavailable") || message.contains("failed") {
                 systemAudioStatus = .failed
+                systemAudioFailed = true
             }
         } else {
             // No error - status is healthy (if we're recording)

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Combine
 import CoreMedia
+import QuartzCore
 import ScreenCaptureKit
 
 /// ScreenCaptureKit-based system audio capture (macOS 26+).
@@ -44,7 +45,7 @@ private final class SCKStopCallbackState {
 }
 
 @available(macOS 26.0, *)
-final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked Sendable {
+final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngine, SCStreamDelegate, @unchecked Sendable {
     @Published var errorMessage: String?
 
     private var stream: SCStream?
@@ -55,10 +56,19 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
     private var _generation: UInt64 = 0
     private let generationLock = NSLock()
     private var isWaitingForTimedOutStopCallback = false
+    private var recoveryAttempts = 0
+    private var isRecovering = false
     private static let callbackTimeoutSeconds = 8
     private static let permissionPromptCallbackTimeoutSeconds = 120
     private static let callbackTimeout: DispatchTimeInterval = .seconds(callbackTimeoutSeconds)
     private static let permissionPromptCallbackTimeout: DispatchTimeInterval = .seconds(permissionPromptCallbackTimeoutSeconds)
+    private static let maxRecoveryAttempts = 1
+    private static let bufferStallTimeoutSeconds: CFTimeInterval = 5
+    private let watchdogQueue = DispatchQueue(label: "SCKAudioCapture.watchdog", qos: .utility)
+    private var watchdogTimer: DispatchSourceTimer?
+    private let watchdogLock = NSLock()
+    private var _lastBufferTime: CFTimeInterval = CACurrentMediaTime()
+    private var _hasReceivedFirstBuffer = false
 
     var diagnosticBackendName: String { "screen_capture_kit" }
 
@@ -144,7 +154,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
             interleaved: false
         )
 
-        let preparedStream = SCStream(filter: filter, configuration: config, delegate: nil)
+        let preparedStream = SCStream(filter: filter, configuration: config, delegate: self)
         guard currentGeneration() == prepareGeneration else {
             stopStreamSynchronously(preparedStream)
             throw AudioCaptureStaleSessionError()
@@ -176,6 +186,10 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         let startGeneration = currentGeneration()
 
         self.bufferCallback = bufferCallback
+        resetBufferWatchdogState()
+        if !isRecovering {
+            recoveryAttempts = 0
+        }
         publishErrorMessage(nil)
 
         // Output handler converts CMSampleBuffer → AVAudioPCMBuffer
@@ -186,6 +200,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
             self._totalBuffers += 1
             self._buffersWithData += 1
             self.statsLock.unlock()
+            self.markBufferReceived()
             bufferCallback(buffer)
         }
         self.streamOutput = output
@@ -213,6 +228,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
                 throw AudioCaptureStaleSessionError()
             }
             _isCapturing = true
+            startWatchdog(generation: startGeneration)
             AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
         } catch {
             AppLogger.audioSystem.error("SCKAudioCapture: start failed", ["error": error.localizedDescription])
@@ -236,6 +252,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         }
 
         _isCapturing = false
+        stopWatchdog()
         stream.stopCapture { [weak self, stream] error in
             if let error = error {
                 AppLogger.audioSystem.warning("SCKAudioCapture: stop error", ["error": error.localizedDescription])
@@ -257,6 +274,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         }
 
         _isCapturing = false
+        stopWatchdog()
         if stopStreamSynchronously(stream, cleanupAfterLateCallback: { [weak self, stream] in
             self?.cleanupIfCurrent(generation: stopGeneration, stream: stream)
         }) {
@@ -339,6 +357,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
 
         _isCapturing = true
         isWaitingForTimedOutStopCallback = true
+        startWatchdog(generation: currentGeneration())
         AppLogger.audioSystem.warning("SCKAudioCapture: keeping stream reference after stop timeout")
     }
 
@@ -393,11 +412,24 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         logStats()
         _isCapturing = false
         isWaitingForTimedOutStopCallback = false
+        stopWatchdog()
         stream = nil
         streamOutput = nil
         bufferCallback = nil
         _audioFormat = nil
         resetStats()
+        resetBufferWatchdogState()
+    }
+
+    func stream(_ stream: SCStream, didStopWithError error: Error) {
+        AppLogger.audioSystem.error("SCKAudioCapture: stream stopped with error", [
+            "error": error.localizedDescription
+        ])
+        handleMidRecordingFailure(
+            "System audio failed - ScreenCaptureKit stopped delivering audio.",
+            generation: currentGeneration(),
+            attemptRestart: true
+        )
     }
 
     private func logStats() {
@@ -424,6 +456,96 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         } else {
             DispatchQueue.main.async { [weak self] in
                 self?.errorMessage = message
+            }
+        }
+    }
+
+    private func resetBufferWatchdogState() {
+        watchdogLock.lock()
+        _lastBufferTime = CACurrentMediaTime()
+        _hasReceivedFirstBuffer = false
+        watchdogLock.unlock()
+    }
+
+    private func markBufferReceived() {
+        watchdogLock.lock()
+        _lastBufferTime = CACurrentMediaTime()
+        _hasReceivedFirstBuffer = true
+        watchdogLock.unlock()
+    }
+
+    private func startWatchdog(generation: UInt64) {
+        stopWatchdog()
+        let timer = DispatchSource.makeTimerSource(queue: watchdogQueue)
+        let interval = DispatchTimeInterval.milliseconds(Int(Self.bufferStallTimeoutSeconds * 1000))
+        timer.schedule(deadline: .now() + interval, repeating: interval)
+        timer.setEventHandler { [weak self] in
+            self?.checkWatchdog(generation: generation)
+        }
+        watchdogLock.lock()
+        watchdogTimer = timer
+        watchdogLock.unlock()
+        timer.resume()
+    }
+
+    private func stopWatchdog() {
+        watchdogLock.lock()
+        let timer = watchdogTimer
+        watchdogTimer = nil
+        watchdogLock.unlock()
+        timer?.cancel()
+    }
+
+    private func checkWatchdog(generation: UInt64) {
+        guard currentGeneration() == generation, _isCapturing else { return }
+        watchdogLock.lock()
+        let hasReceivedFirstBuffer = _hasReceivedFirstBuffer
+        let elapsed = CACurrentMediaTime() - _lastBufferTime
+        watchdogLock.unlock()
+
+        guard hasReceivedFirstBuffer, elapsed >= Self.bufferStallTimeoutSeconds else { return }
+        AppLogger.audioSystem.error("SCKAudioCapture: buffer watchdog timed out", [
+            "elapsedSeconds": String(format: "%.1f", elapsed)
+        ])
+        handleMidRecordingFailure(
+            "System audio failed - ScreenCaptureKit stopped sending audio buffers.",
+            generation: generation,
+            attemptRestart: true
+        )
+    }
+
+    private func handleMidRecordingFailure(
+        _ message: String,
+        generation: UInt64,
+        attemptRestart: Bool
+    ) {
+        guard currentGeneration() == generation, _isCapturing else { return }
+        publishErrorMessage(message)
+        guard attemptRestart,
+              recoveryAttempts < Self.maxRecoveryAttempts,
+              !isRecovering,
+              let callback = bufferCallback else {
+            return
+        }
+
+        recoveryAttempts += 1
+        isRecovering = true
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else { return }
+            defer { self.isRecovering = false }
+            do {
+                AppLogger.audioSystem.info("SCKAudioCapture: attempting stream recovery", [
+                    "attempt": "\(self.recoveryAttempts)"
+                ])
+                self.stopSync()
+                try self.prepare()
+                try self.start(bufferCallback: callback)
+                AppLogger.audioSystem.info("SCKAudioCapture: stream recovery succeeded")
+            } catch {
+                AppLogger.audioSystem.error("SCKAudioCapture: stream recovery failed", [
+                    "error": error.localizedDescription
+                ])
+                self.publishErrorMessage("System audio failed - ScreenCaptureKit could not restart audio capture.")
             }
         }
     }

--- a/Sources/TranscriptedCore/Models/RecordingHealthInfo.swift
+++ b/Sources/TranscriptedCore/Models/RecordingHealthInfo.swift
@@ -31,6 +31,8 @@ public struct RecordingHealthInfo: Sendable {
     public let micAttenuatedByCallApp: Bool?
     /// MeetingMicBoostPromptOutcome rawValue from the host's in-meeting prompt.
     public let micBoostPrompt: String?
+    /// True when only microphone audio was available for recovery/transcription.
+    public let systemAudioMissing: Bool?
 
     public init(
         captureQuality: CaptureQuality,
@@ -38,7 +40,8 @@ public struct RecordingHealthInfo: Sendable {
         deviceSwitches: Int,
         gapDescriptions: [String],
         micAttenuatedByCallApp: Bool? = nil,
-        micBoostPrompt: String? = nil
+        micBoostPrompt: String? = nil,
+        systemAudioMissing: Bool? = nil
     ) {
         self.captureQuality = captureQuality
         self.audioGaps = audioGaps
@@ -46,6 +49,19 @@ public struct RecordingHealthInfo: Sendable {
         self.gapDescriptions = gapDescriptions
         self.micAttenuatedByCallApp = micAttenuatedByCallApp
         self.micBoostPrompt = micBoostPrompt
+        self.systemAudioMissing = systemAudioMissing
+    }
+
+    public func markingSystemAudioMissing() -> RecordingHealthInfo {
+        RecordingHealthInfo(
+            captureQuality: captureQuality == .excellent ? .degraded : captureQuality,
+            audioGaps: audioGaps,
+            deviceSwitches: deviceSwitches,
+            gapDescriptions: gapDescriptions,
+            micAttenuatedByCallApp: micAttenuatedByCallApp,
+            micBoostPrompt: micBoostPrompt,
+            systemAudioMissing: true
+        )
     }
 
     /// Create health info from Audio instance.

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -656,6 +656,122 @@ extension Transcription {
         }
     }
 
+    /// Recover/transcribe a live meeting when only the microphone WAV survived.
+    /// This intentionally uses the single-"You" mic path: the speaker-review flow
+    /// currently owns system-audio cleanup, so mic-only recovery should save a
+    /// trustworthy transcript instead of opening a review sheet it cannot clean up.
+    nonisolated func transcribeMicrophoneOnly(
+        micURL: URL,
+        onProgress: ((Double) -> Void)? = nil
+    ) async throws -> TranscriptionResult {
+        let parakeet = await MainActor.run { self.parakeet }
+
+        await MainActor.run {
+            self.isProcessing = true
+            self.error = nil
+            self.processingStatus = "Preparing microphone audio..."
+        }
+
+        let processingStartTime = Date()
+
+        do {
+            onProgress?(0.0)
+            await MainActor.run {
+                self.processingStatus = "Loading microphone audio..."
+            }
+
+            var micSamples = try AudioResampler.loadAndResample(url: micURL, targetRate: 16000)
+            let duration = try Self.audioDuration(at: micURL)
+            guard micSamples.count >= 16000 else {
+                throw PipelineError.recordingTooShort(duration: Double(micSamples.count) / 16000.0)
+            }
+
+            await MainActor.run {
+                self.processingStatus = "Transcribing microphone audio..."
+            }
+
+            let micSegments = Self.detectSpeechSegments(samples: micSamples, sampleRate: 16000)
+            AppLogger.transcription.info("Mic-only audio segmented by silence", [
+                "segments": "\(micSegments.count)"
+            ])
+
+            var micUtterances: [TranscriptionUtterance] = []
+            var droppedSegments = 0
+            for (index, segment) in micSegments.enumerated() {
+                try Task.checkCancellation()
+                let segmentSamples = AudioResampler.extractSlice(
+                    from: micSamples,
+                    sampleRate: 16000,
+                    startTime: segment.start,
+                    endTime: segment.end
+                )
+                guard let preparedSegment = Self.prepareMicSegmentForTranscription(
+                    samples: segmentSamples,
+                    sampleRate: 16000
+                ) else {
+                    droppedSegments += 1
+                    continue
+                }
+
+                let text = try await parakeet.transcribeSegment(
+                    samples: preparedSegment.samples,
+                    source: .microphone
+                )
+                guard !text.isEmpty else {
+                    droppedSegments += 1
+                    continue
+                }
+
+                micUtterances.append(TranscriptionUtterance(
+                    start: segment.start,
+                    end: segment.end,
+                    channel: 0,
+                    speakerId: 0,
+                    persistentSpeakerId: nil,
+                    matchSimilarity: nil,
+                    transcript: text
+                ))
+
+                let progress = 0.10 + (Double(index + 1) / Double(max(1, micSegments.count))) * 0.85
+                onProgress?(progress)
+            }
+
+            micSamples = []
+            let mergedMicUtterances = Self.mergeConsecutiveUtterances(micUtterances, maxGap: 1.5)
+            guard !mergedMicUtterances.isEmpty else {
+                throw PipelineError.noSpeechDetected
+            }
+
+            let processingTime = Date().timeIntervalSince(processingStartTime)
+            await MainActor.run {
+                self.processingStatus = "Transcription complete!"
+                self.isProcessing = false
+            }
+            onProgress?(1.0)
+
+            AppLogger.transcription.info("Mic-only transcription complete", [
+                "micUtterances": "\(mergedMicUtterances.count)",
+                "processingTime": "\(String(format: "%.1f", processingTime))s",
+                "droppedSegments": "\(droppedSegments)"
+            ])
+
+            return TranscriptionResult(
+                micUtterances: mergedMicUtterances,
+                systemUtterances: [],
+                duration: duration,
+                processingTime: processingTime,
+                droppedSegments: droppedSegments
+            )
+        } catch {
+            await MainActor.run {
+                self.error = "Transcription failed: \(error.localizedDescription)"
+                self.isProcessing = false
+                self.processingStatus = ""
+            }
+            throw error
+        }
+    }
+
     nonisolated private static func longestAudioDuration(micURL: URL?, systemURL: URL) throws -> TimeInterval {
         var durations = [try audioDuration(at: systemURL)]
         if let micURL {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -85,17 +85,12 @@ extension TranscriptionTaskManager {
         removeSourceAudioAfterArchive: Bool = true
     ) async throws -> URL {
 
-        guard let systemURL = systemURL else {
-            AppLogger.pipeline.warning("Transcribing mic-only failed meeting audio through single-track path", [
-                "taskId": taskId.uuidString
-            ])
-            return try await transcribeMultichannelPipeline(
-                micURL: nil,
-                systemURL: micURL,
+        guard let systemURL else {
+            return try await transcribeMicrophoneOnlyPipeline(
+                micURL: micURL,
                 outputFolder: outputFolder,
                 taskId: taskId,
                 healthInfo: healthInfo,
-                splitLocalSpeakers: false,
                 meetingTitle: meetingTitle,
                 recordingDate: recordingDate,
                 sourceFailedTranscriptionId: sourceFailedTranscriptionId,
@@ -115,6 +110,116 @@ extension TranscriptionTaskManager {
             sourceFailedTranscriptionId: sourceFailedTranscriptionId,
             removeSourceAudioAfterArchive: removeSourceAudioAfterArchive
         )
+    }
+
+    nonisolated func transcribeMicrophoneOnlyPipeline(
+        micURL: URL,
+        outputFolder: URL,
+        taskId: UUID,
+        healthInfo: RecordingHealthInfo?,
+        meetingTitle: String? = nil,
+        recordingDate: Date? = nil,
+        sourceFailedTranscriptionId: UUID? = nil,
+        removeSourceAudioAfterArchive: Bool = true
+    ) async throws -> URL {
+        let transcription = await MainActor.run { self.transcription }
+        try await transcription.ensureModelsReadyForPipeline()
+
+        let speechEngine = await MainActor.run {
+            transcription.parakeet.transcriptionEngineDescriptor
+        }
+
+        AppLogger.pipeline.info("Using local \(speechEngine.displayName) mic-only recovery pipeline", [
+            "transcription_engine": speechEngine.identifier
+        ])
+
+        let result = try await transcription.transcribeMicrophoneOnly(
+            micURL: micURL,
+            onProgress: { [weak self] progress in
+                Task { @MainActor in
+                    self?.displayStatus = .transcribing(progress: progress)
+                }
+            }
+        )
+
+        let replacementTranscriptRollback = try ReplacementTranscriptRollback.capture(for: nil)
+        let transcriptId = UUID()
+        try Task.checkCancellation()
+
+        let notifier: TranscriptNotifier? = await MainActor.run {
+            self.displayStatus = .finishing
+            return self.notifier
+        }
+        let formatOptions = await MainActor.run {
+            self.resolvedTranscriptFormatOptions(hasMicAudio: true, hasSystemAudio: false)
+        }
+
+        let transcriptDate = recordingDate ?? Date()
+        let micOnlyHealth = healthInfo?.markingSystemAudioMissing()
+            ?? RecordingHealthInfo(
+                captureQuality: .degraded,
+                audioGaps: 0,
+                deviceSwitches: 0,
+                gapDescriptions: [],
+                systemAudioMissing: true
+            )
+        guard let savedURL = TranscriptSaver.saveTranscript(
+            result,
+            transcriptId: transcriptId,
+            speakerMappings: [:],
+            speakerSources: [:],
+            speakerDbIds: [:],
+            directory: outputFolder,
+            meetingTitle: meetingTitle,
+            healthInfo: micOnlyHealth,
+            notifier: nil,
+            speakerStore: nil,
+            statsStore: DeferredTranscriptStatsStore(),
+            recordingDate: transcriptDate,
+            transcriptionEngine: speechEngine,
+            formatOptions: formatOptions
+        ) else {
+            throw PipelineError.saveFailed(detail: "Could not write mic-only transcript to \(outputFolder.lastPathComponent)")
+        }
+        let deleteSavedTranscriptOnCancellation = replacementTranscriptRollback == nil
+        try await checkCancellationAfterTranscriptSideEffects(
+            savedURL: savedURL,
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+            replacementTranscriptRollback: replacementTranscriptRollback
+        )
+
+        let archiveOutcome = await archiveRecordingAudioIfConfigured(
+            micURL: micURL,
+            systemURL: nil,
+            savedURL: savedURL
+        )
+        try await checkCancellationAfterTranscriptSideEffects(
+            savedURL: savedURL,
+            retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
+            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+            replacementTranscriptRollback: replacementTranscriptRollback
+        )
+
+        try await commitSavedTranscriptSideEffectsUnlessCancelled(
+            taskId: taskId,
+            savedURL: savedURL,
+            result: result,
+            transcriptId: transcriptId,
+            meetingTitle: meetingTitle,
+            transcriptDate: transcriptDate,
+            notifier: notifier,
+            retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
+            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+            replacementTranscriptRollback: replacementTranscriptRollback
+        )
+
+        if archiveOutcome.didArchiveRecordingAudio && removeSourceAudioAfterArchive && sourceFailedTranscriptionId == nil {
+            removeManagedCleanupFile(micURL, label: "completed mic-only scratch")
+        }
+
+        return savedURL
     }
 
     /// Transcribe an imported audio file through the system-audio speaker path.
@@ -396,7 +501,7 @@ extension TranscriptionTaskManager {
             return self.notifier
         }
         let formatOptions = await MainActor.run {
-            self.resolvedTranscriptFormatOptions(hasMicAudio: micURL != nil)
+            self.resolvedTranscriptFormatOptions(hasMicAudio: micURL != nil, hasSystemAudio: true)
         }
 
         let transcriptDate = recordingDate ?? Date()
@@ -772,7 +877,7 @@ extension TranscriptionTaskManager {
 
     nonisolated private func archiveRecordingAudioIfConfigured(
         micURL: URL?,
-        systemURL: URL,
+        systemURL: URL?,
         savedURL: URL
     ) async -> RecordingAudioArchiveOutcome {
         let retainedAudioDirectory = await MainActor.run { self.resolvedRetainedAudioDirectory() }
@@ -803,7 +908,7 @@ extension TranscriptionTaskManager {
         } catch {
             AppLogger.pipeline.warning("Failed to retain meeting audio; leaving scratch files in place", [
                 "hasMic": "\(micURL != nil)",
-                "hasSystem": "true",
+                "hasSystem": "\(systemURL != nil)",
                 "errorType": "\(type(of: error))"
             ])
             return RecordingAudioArchiveOutcome(

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -1428,10 +1428,14 @@ public class TranscriptionTaskManager: ObservableObject {
         retainedAudioDirectoryProvider?() ?? retainedAudioDirectory
     }
 
-    func resolvedTranscriptFormatOptions(hasMicAudio: Bool) -> TranscriptFormatOptions {
-        let audioSources: [TranscriptAudioSource] = hasMicAudio
-            ? [.microphone, .systemAudio]
-            : [.systemAudio]
+    func resolvedTranscriptFormatOptions(hasMicAudio: Bool, hasSystemAudio: Bool = true) -> TranscriptFormatOptions {
+        var audioSources: [TranscriptAudioSource] = []
+        if hasMicAudio {
+            audioSources.append(.microphone)
+        }
+        if hasSystemAudio {
+            audioSources.append(.systemAudio)
+        }
         return (transcriptFormatOptionsProvider?() ?? .default)
             .withAudioSources(audioSources)
     }

--- a/Sources/TranscriptedCore/Storage/TranscriptFormatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFormatter.swift
@@ -135,6 +135,9 @@ extension TranscriptSaver {
                     yaml += "\nmic_boost_prompt: \"\(Self.escapeYAML(prompt))\""
                 }
             }
+            if health.systemAudioMissing == true {
+                yaml += "\nsystem_audio_missing: true"
+            }
         }
 
         // Add speaker identification metadata.

--- a/Tests/TranscriptedCoreTests/AudioStateTransitionTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioStateTransitionTests.swift
@@ -70,6 +70,7 @@ final class AudioStateTransitionTests: XCTestCase {
 
         audio.updateSystemAudioStatus(fromError: "capture failed unexpectedly")
         XCTAssertEqual(audio.systemAudioStatus, .failed)
+        XCTAssertTrue(audio.systemAudioFailed)
     }
 
     func testUpdateSystemAudioStatusKeepsSilentWhenClearedDuringRecording() {
@@ -231,6 +232,17 @@ final class AudioStateTransitionTests: XCTestCase {
                      "system file URL from a stale session must not leak into the active session")
         XCTAssertEqual(audio.systemAudioStatus, .unknown,
                        "status repair must not fire for stale assignments")
+    }
+
+    func testSystemWriteFailureCapReturnsTerminalFailure() {
+        let audio = makeAudio()
+
+        for _ in 1..<audio.maxConsecutiveWriteErrors {
+            XCTAssertFalse(audio.recordSystemWriteFailure(NSError(domain: "test", code: 1)))
+        }
+
+        XCTAssertTrue(audio.recordSystemWriteFailure(NSError(domain: "test", code: 1)))
+        XCTAssertEqual(audio.consecutiveSystemWriteErrors, audio.maxConsecutiveWriteErrors)
     }
 
     // MARK: - createRouteVolumeDiagnosticsContext multi-phase

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -478,10 +478,9 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(obsidianMarkdown.contains("\ntags:"), "embedders can still opt into Obsidian metadata explicitly")
     }
 
-    func testStartTranscriptionWithMicOnlyAudioSavesSingleTrackTranscript() async throws {
+    func testStartTranscriptionAllowsMicOnlyRecovery() async throws {
         let manager = makeManager(
-            speechToText: MetadataStubSpeechToTextEngine(transcript: "Mic only recovered meeting."),
-            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments())
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Mic only recovery worked.")
         )
         let micScratchDirectory = tempDirectory.appendingPathComponent("audio")
         try FileManager.default.createDirectory(at: micScratchDirectory, withIntermediateDirectories: true)
@@ -502,16 +501,23 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(manager.backgroundTaskCount, 0)
         XCTAssertEqual(manager.activeTasks.count, 0)
         XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        XCTAssertEqual(manager.displayStatus, .transcriptSaved)
+
         let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
         let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
-        XCTAssertTrue(markdown.contains("Mic only recovered meeting."))
+        XCTAssertTrue(markdown.contains("sources: [mic]"))
+        XCTAssertTrue(markdown.contains("system_audio_missing: true"))
+        XCTAssertTrue(markdown.contains("Mic only recovery worked."))
     }
 
-    func testMicOnlyFailedQueueRetainsArchiveAndRemovesScratch() throws {
+    func testMicOnlyTranscriptionRetainsMicAudioAndRemovesScratch() async throws {
         let retainedAudioDirectory = tempDirectory
             .appendingPathComponent("transcripts", isDirectory: true)
             .appendingPathComponent("audio", isDirectory: true)
-        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Recovered from the microphone."),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
         let micScratchDirectory = tempDirectory.appendingPathComponent("audio")
         try FileManager.default.createDirectory(at: micScratchDirectory, withIntermediateDirectories: true)
         let micURL = micScratchDirectory.appendingPathComponent("mic.wav")
@@ -523,19 +529,20 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening."
         ))
 
-        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
-        XCTAssertTrue(
-            failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"),
-            "failed queue should point at retained archive audio, not scratch audio"
-        )
-        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
         XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "scratch mic audio should be removed after archiving")
 
-        let archivedDirectory = failed.micAudioURL.deletingLastPathComponent()
-        manager.failedTranscriptionManager.deleteFailedTranscription(id: failed.id)
-
-        XCTAssertFalse(FileManager.default.fileExists(atPath: failed.micAudioURL.path), "delete should remove archived failed audio")
-        XCTAssertFalse(FileManager.default.fileExists(atPath: archivedDirectory.path), "delete should remove the empty failed-audio directory")
+        let retainedFiles = FileManager.default
+            .enumerator(at: retainedAudioDirectory, includingPropertiesForKeys: nil)?
+            .compactMap { $0 as? URL } ?? []
+        XCTAssertTrue(
+            retainedFiles.contains { $0.lastPathComponent == "microphone.wav" },
+            "successful mic-only transcription should retain the microphone WAV beside the transcript"
+        )
     }
 
     func testManualFailedQueueRetainsAudioBeforeRemovingScratch() throws {
@@ -1154,10 +1161,9 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(markdown.contains("Recovered meeting artifact."))
     }
 
-    func testRetryFailedTranscriptionWithMicOnlyAudioUsesSingleTrackPath() async throws {
+    func testRetryFailedTranscriptionSupportsMicOnlyRecoveredAudio() async throws {
         let manager = makeManager(
-            speechToText: MetadataStubSpeechToTextEngine(transcript: "Mic only retry artifact."),
-            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments())
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Recovered from mic only.")
         )
         let audioDirectory = tempDirectory.appendingPathComponent("audio", isDirectory: true)
         let micURL = audioDirectory.appendingPathComponent("retry-mic-only.wav")
@@ -1166,7 +1172,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
             micAudioURL: micURL,
             systemAudioURL: nil,
-            errorMessage: PipelineError.missingSystemAudio.localizedDescription,
+            errorMessage: "Recording was interrupted before it could be saved. The recovered audio is ready to transcribe.",
             meetingTitle: "Mic-only recovered call"
         ))
         let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
@@ -1178,29 +1184,12 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         )
 
         XCTAssertTrue(didRetry)
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
         let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
         let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
-        XCTAssertTrue(markdown.contains("Mic-only recovered call"))
-        XCTAssertTrue(markdown.contains("Mic only retry artifact."))
-
-        let request = try XCTUnwrap(manager.speakerNamingRequest)
-        XCTAssertEqual(request.sourceFailedTranscriptionId, failed.id)
-        let speaker = try XCTUnwrap(request.speakers.first)
-        request.onComplete([
-            SpeakerNameUpdate(
-                persistentSpeakerId: speaker.id,
-                diarizerSpeakerId: speaker.diarizerSpeakerId,
-                channel: speaker.channel,
-                newName: "Local Mic",
-                previousName: speaker.currentName,
-                action: .named
-            )
-        ])
-
-        try await waitUntil {
-            manager.failedTranscriptionManager.failedTranscriptions.isEmpty
-                && manager.speakerNamingRequest == nil
-        }
+        XCTAssertTrue(markdown.contains("sources: [mic]"))
+        XCTAssertTrue(markdown.contains("system_audio_missing: true"))
+        XCTAssertTrue(markdown.contains("Recovered from mic only."))
     }
 
     func testCancelAllDuringRetryDoesNotPoisonFutureRetry() async throws {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -523,11 +523,11 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         let micURL = micScratchDirectory.appendingPathComponent("mic.wav")
         try writeMonoWAV(to: micURL, duration: 2.5)
 
-        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
-            micAudioURL: micURL,
-            systemAudioURL: nil,
-            errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening."
-        ))
+        manager.startTranscription(
+            micURL: micURL,
+            systemURL: nil,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
 
         try await waitUntil {
             manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
@@ -543,6 +543,37 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             retainedFiles.contains { $0.lastPathComponent == "microphone.wav" },
             "successful mic-only transcription should retain the microphone WAV beside the transcript"
         )
+    }
+
+    func testMicOnlyFailedQueueRetainsArchiveAndRemovesScratch() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let micScratchDirectory = tempDirectory.appendingPathComponent("audio")
+        try FileManager.default.createDirectory(at: micScratchDirectory, withIntermediateDirectories: true)
+        let micURL = micScratchDirectory.appendingPathComponent("mic.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening."
+        ))
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(
+            failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"),
+            "failed queue should point at retained archive audio, not scratch audio"
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "scratch mic audio should be removed after archiving")
+
+        let archivedDirectory = failed.micAudioURL.deletingLastPathComponent()
+        manager.failedTranscriptionManager.deleteFailedTranscription(id: failed.id)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: failed.micAudioURL.path), "delete should remove archived failed audio")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: archivedDirectory.path), "delete should remove the empty failed-audio directory")
     }
 
     func testManualFailedQueueRetainsAudioBeforeRemovingScratch() throws {


### PR DESCRIPTION
## Summary
- Surface internal/early capture stops to the meeting controller and preserve available audio for retry instead of leaving the overlay in a fake recording state.
- Stop recording on repeated system-audio disk write failures and mark system audio failed.
- Add SCK mid-recording failure detection via delegate/watchdog plus one bounded recovery attempt.
- Allow mic-only failed meeting recovery/transcription with explicit `system_audio_missing` metadata.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (11968 passed, 0 failed)
- `bash run-integration-smoke.sh`
- `swift test` (600 passed, 2 skipped, 0 failed)
- `swift test --filter 'TranscriptionTaskManagerMetadataTests|AudioStateTransitionTests'` (82 passed, 0 failed)\n\n## Notes\n- Deterministic/local proof only. No live meeting, hardware, or real ScreenCaptureKit failure injection was performed.\n- Codex review was attempted; it inspected the risky paths and reran `swift test`, but its nested review process looped on startup warnings and was stopped before a clean final verdict.