### PR TITLE
Fix permission and storage audit UX

### DIFF
--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -19,6 +19,7 @@ enum TranscriptedPermissionAccess {
     private static let systemAudioRecordingGrantedKey = "systemAudioRecordingPermissionGranted"
     private static let systemAudioRecordingKnownKey = "systemAudioRecordingPermissionKnown"
     @MainActor private static var activeSystemAudioRequester: SystemAudioPermissionRequester?
+    @MainActor private static var activeSystemAudioRevalidator: Task<Bool, Never>?
 
     static func isGranted(_ kind: TranscriptedPermissionKind) -> Bool {
         switch kind {
@@ -100,16 +101,14 @@ enum TranscriptedPermissionAccess {
             notifyPermissionsDidChange(kind: .accessibility)
             return AXIsProcessTrusted()
         case .systemAudioRecording:
-            if systemAudioRecordingStatus() == .granted {
+            let granted = await requestSystemAudioRecordingAccessIfNeeded(forceRefresh: true)
+            notifyPermissionsDidChange(kind: .systemAudioRecording)
+            if granted {
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
                 return true
             }
 
-            let granted = await requestSystemAudioRecordingAccessIfNeeded()
-            notifyPermissionsDidChange(kind: .systemAudioRecording)
-            if !granted {
-                openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
-            }
+            openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
             return granted
         case .calendar:
             activateForPermissionPrompt()
@@ -189,6 +188,34 @@ enum TranscriptedPermissionAccess {
         activateForPermissionPrompt()
         let granted = await performSystemAudioRecordingAccessRequest()
         setSystemAudioRecordingGranted(granted)
+        return granted
+    }
+
+    @MainActor
+    static func revalidateSystemAudioRecordingStatus() async -> Bool {
+        if let activeSystemAudioRevalidator {
+            return await activeSystemAudioRevalidator.value
+        }
+
+        let task = Task { @MainActor in
+            let granted = await performSystemAudioRecordingAccessRequest()
+            setSystemAudioRecordingGranted(granted)
+            notifyPermissionsDidChange(kind: .systemAudioRecording)
+            return granted
+        }
+        activeSystemAudioRevalidator = task
+        let granted = await task.value
+        activeSystemAudioRevalidator = nil
+        return granted
+    }
+
+    @MainActor
+    static func revalidateSystemAudioRecordingStatus(
+        requester: @escaping @MainActor () async -> Bool
+    ) async -> Bool {
+        let granted = await requester()
+        setSystemAudioRecordingGranted(granted)
+        notifyPermissionsDidChange(kind: .systemAudioRecording)
         return granted
     }
 

--- a/Sources/Support/TranscriptedPermissionKind.swift
+++ b/Sources/Support/TranscriptedPermissionKind.swift
@@ -32,6 +32,13 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
         }
     }
 
+    static func requiredForCurrentUse(dictationShortcutsEnabled: Bool) -> [TranscriptedPermissionKind] {
+        if dictationShortcutsEnabled {
+            return [.microphone, .accessibility]
+        }
+        return [.microphone, .systemAudioRecording]
+    }
+
     var title: String {
         switch self {
         case .microphone:

--- a/Sources/Support/TranscriptedStoragePaths.swift
+++ b/Sources/Support/TranscriptedStoragePaths.swift
@@ -18,22 +18,51 @@ enum TranscriptedStoragePreferences {
         userDefaults: UserDefaults = .standard,
         fileManager: FileManager = .default
     ) -> URL {
-        if let customPath = userDefaults.string(forKey: captureLibraryLocationKey)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !customPath.isEmpty {
+        customCaptureLibraryURL(userDefaults: userDefaults, fileManager: fileManager)
+            ?? fileManager.transcriptedDefaultCaptureLibraryDir
+    }
+
+    static func customCaptureLibraryURL(
+        userDefaults: UserDefaults = .standard,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        if let customPath = storedCustomCaptureLibraryPath(userDefaults: userDefaults) {
             guard customPath.hasPrefix("/") else {
-                return fileManager.transcriptedDefaultCaptureLibraryDir
+                return nil
             }
 
             let candidate = URL(fileURLWithPath: customPath, isDirectory: true)
             // Security: reject tampered preferences that target traversal or system
             // roots while preserving the user's ability to choose their own library.
-            if isSafeCaptureLibraryURL(candidate) {
+            if isSafeCaptureLibraryURL(candidate),
+               isExistingCaptureLibraryURL(candidate, fileManager: fileManager) {
                 return candidate.standardizedFileURL
             }
         }
 
-        return fileManager.transcriptedDefaultCaptureLibraryDir
+        return nil
+    }
+
+    static func storedCustomCaptureLibraryPath(
+        userDefaults: UserDefaults = .standard
+    ) -> String? {
+        guard let customPath = userDefaults.string(forKey: captureLibraryLocationKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !customPath.isEmpty else {
+            return nil
+        }
+        return customPath
+    }
+
+    static func unavailableCustomCaptureLibraryPath(
+        userDefaults: UserDefaults = .standard,
+        fileManager: FileManager = .default
+    ) -> String? {
+        guard let customPath = storedCustomCaptureLibraryPath(userDefaults: userDefaults),
+              customCaptureLibraryURL(userDefaults: userDefaults, fileManager: fileManager) == nil else {
+            return nil
+        }
+        return customPath
     }
 
     @discardableResult
@@ -79,6 +108,16 @@ enum TranscriptedStoragePreferences {
         return !forbiddenPrefixes.contains { prefix in
             candidate.path == prefix || candidate.path.hasPrefix(prefix + "/")
         }
+    }
+
+    static func isExistingCaptureLibraryURL(
+        _ url: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let candidate = url.standardizedFileURL
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
     }
 
     static func prepareCaptureLibraryURL(

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -48,6 +48,7 @@ struct PermissionsOnboardingView: View {
     @State private var claudeDesktopConnectPhase: OnboardingAgentConnectPhase = .idle
     @State private var copiedResetTask: Task<Void, Never>?
     @State private var pollTask: Task<Void, Never>?
+    @State private var permissionRevalidationTask: Task<Void, Never>?
     @State private var flowStartedAt: CFAbsoluteTime?
     @State private var stepStartedAt: CFAbsoluteTime?
     @State private var didTrackCompletion = false
@@ -564,12 +565,23 @@ struct PermissionsOnboardingView: View {
         accessibilityGranted = TranscriptedPermissionAccess.isGranted(.accessibility)
         screenRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
         calendarGranted = TranscriptedPermissionAccess.isGranted(.calendar)
+        revalidateSystemAudioPermissionForStatusSurfaces()
 
         let updatedStatuses = currentPermissionStatuses()
         if trackChanges && !previousStatuses.isEmpty {
             trackPermissionStatusChanges(from: previousStatuses, to: updatedStatuses)
         }
         lastPermissionStatuses = updatedStatuses
+    }
+
+    private func revalidateSystemAudioPermissionForStatusSurfaces() {
+        guard permissionRevalidationTask == nil else { return }
+        guard TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown else { return }
+        permissionRevalidationTask = Task { @MainActor in
+            _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
+            screenRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
+            permissionRevalidationTask = nil
+        }
     }
 
     private func startPolling() {
@@ -589,6 +601,8 @@ struct PermissionsOnboardingView: View {
     private func stopPolling() {
         pollTask?.cancel()
         pollTask = nil
+        permissionRevalidationTask?.cancel()
+        permissionRevalidationTask = nil
     }
 
     private func completeOnboarding() {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -48,7 +48,9 @@ struct TranscriptedSettingsView: View {
     @State private var sentryTestStatus: String?
     @State private var diagnosticsActionStatus: String?
     @State private var permissionStates = PermissionSnapshot.current()
+    @State private var permissionRevalidationTask: Task<Void, Never>?
     @State private var captureLibraryURL = FileManager.default.transcriptedCaptureLibraryDir
+    @State private var unavailableCaptureLibraryPath = TranscriptedStoragePreferences.unavailableCustomCaptureLibraryPath()
     @State private var pendingCaptureLibraryChoice: PendingCaptureLibraryChoice?
     @State private var captureLibraryMigrationInProgress = false
     @State private var captureLibraryMigrationStatus: String?
@@ -3063,6 +3065,19 @@ struct TranscriptedSettingsView: View {
                 StorageRow(title: "Meeting captures", url: MeetingStoragePaths.transcriptsFolder)
                 StorageRow(title: "Dictation captures", url: DictationStoragePaths.transcriptsFolder)
 
+                if let unavailableCaptureLibraryPath {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "externaldrive.badge.exclamationmark")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.orange)
+                            .frame(width: 20)
+                        Text("Transcripted can't reach \(unavailableCaptureLibraryPath). It is using the default capture library until that folder is available again or you choose a new one.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
                 HStack {
                     SettingsInlineActionButton(title: "Choose Folder", symbolName: "folder") {
                         trackSettingsAction("choose_capture_library", page: .storage)
@@ -3073,16 +3088,7 @@ struct TranscriptedSettingsView: View {
 
                     SettingsInlineActionButton(title: "Reset to Default") {
                         trackSettingsAction("reset_capture_library", page: .storage)
-                        TranscriptedStoragePreferences.setCaptureLibraryURL(nil)
-                        refreshStoragePaths()
-                        CaptureLibraryChangeBroadcaster.shared.noteLibraryWideChange()
-                        AnalyticsReporter.track(
-                            "settings_capture_library_changed",
-                            properties: [
-                                "location_type": "default",
-                                "page_id": TranscriptedSettingsPage.storage.analyticsValue,
-                            ]
-                        )
+                        resetCaptureLibraryToDefault()
                     }
                     .disabled(captureLibraryMigrationInProgress)
                     .help(captureLibraryMigrationInProgress ? captureLibraryMigrationBusyHelp : "")
@@ -3112,7 +3118,7 @@ struct TranscriptedSettingsView: View {
                 isPresented: captureLibraryChoicePromptBinding,
                 presenting: pendingCaptureLibraryChoice
             ) { choice in
-                Button("Copy to New Folder") {
+                Button(choice.copyButtonTitle) {
                     copyCapturesThenSwitchLibrary(choice)
                 }
                 .keyboardShortcut(.defaultAction)
@@ -3121,7 +3127,7 @@ struct TranscriptedSettingsView: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: { choice in
-                Text("Your current library still has saved meetings or dictations. Copy puts a copy of them in the new folder and never deletes the originals. Just Switch leaves everything in \(choice.currentLibrary.path) - Transcripted and connected agents will only see the new folder.")
+                Text("Your current library still has saved meetings or dictations. Copy puts a copy of them in the \(choice.destinationDescription) and never deletes the originals. Just Switch leaves everything in \(choice.currentLibrary.path) - Transcripted and connected agents will only see the \(choice.destinationDescription).")
             }
 
             SettingsSection(
@@ -4387,8 +4393,10 @@ struct TranscriptedSettingsView: View {
     }
 
     private var missingRequiredPermissions: [TranscriptedPermissionKind] {
-        TranscriptedPermissionKind.allCases.filter { kind in
-            kind.isRequiredOnFirstLaunch && !(permissionStates[kind] ?? false)
+        TranscriptedPermissionKind.requiredForCurrentUse(
+            dictationShortcutsEnabled: dictationShortcutsEnabled
+        ).filter { kind in
+            !(permissionStates[kind] ?? false)
         }
     }
 
@@ -4401,9 +4409,14 @@ struct TranscriptedSettingsView: View {
 
     private var permissionsDetailLine: String {
         if missingRequiredPermissions.isEmpty {
-            return "Required permissions are on. Meeting permissions are optional."
+            return dictationShortcutsEnabled
+                ? "Dictation permissions are on. Meeting audio can be enabled when you need it."
+                : "Meeting recording permissions are on. Dictation shortcuts can stay off."
         }
-        return "Turn on \(missingRequiredPermissions.map(\.title).joined(separator: " and ")) to record and paste back."
+        let permissions = missingRequiredPermissions.map(\.title).joined(separator: " and ")
+        return dictationShortcutsEnabled
+            ? "Turn on \(permissions) to record and paste back."
+            : "Turn on \(permissions) to record meetings."
     }
 
     private var isUsingDefaultCaptureLibrary: Bool {
@@ -4600,10 +4613,22 @@ struct TranscriptedSettingsView: View {
 
     private func refreshPermissions() {
         permissionStates = PermissionSnapshot.current()
+        revalidateSystemAudioPermissionForStatusSurfaces()
+    }
+
+    private func revalidateSystemAudioPermissionForStatusSurfaces() {
+        guard permissionRevalidationTask == nil else { return }
+        guard TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown else { return }
+        permissionRevalidationTask = Task { @MainActor in
+            _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
+            permissionStates = PermissionSnapshot.current()
+            permissionRevalidationTask = nil
+        }
     }
 
     private func refreshStoragePaths() {
         captureLibraryURL = FileManager.default.transcriptedCaptureLibraryDir
+        unavailableCaptureLibraryPath = TranscriptedStoragePreferences.unavailableCustomCaptureLibraryPath()
     }
 
     private func refreshModelCacheSnapshot() {
@@ -4968,7 +4993,9 @@ struct TranscriptedSettingsView: View {
         if !isSameFolder, CaptureLibraryMigrationPlanner().libraryHasCaptures(at: currentLibrary) {
             pendingCaptureLibraryChoice = PendingCaptureLibraryChoice(
                 currentLibrary: currentLibrary,
-                newLibrary: url
+                newLibrary: url,
+                preferenceURL: url,
+                destinationKind: .custom
             )
             return
         }
@@ -4977,9 +5004,33 @@ struct TranscriptedSettingsView: View {
         applyCaptureLibraryChoice(url)
     }
 
+    private func resetCaptureLibraryToDefault() {
+        let defaultLibrary = FileManager.default.transcriptedDefaultCaptureLibraryDir
+        guard TranscriptedStoragePreferences.prepareCaptureLibraryURL(defaultLibrary) else {
+            refreshStoragePaths()
+            showCaptureLibrarySelectionError()
+            return
+        }
+
+        let currentLibrary = FileManager.default.transcriptedCaptureLibraryDir
+        let isSameFolder = defaultLibrary.standardizedFileURL.path == currentLibrary.standardizedFileURL.path
+        if !isSameFolder, CaptureLibraryMigrationPlanner().libraryHasCaptures(at: currentLibrary) {
+            pendingCaptureLibraryChoice = PendingCaptureLibraryChoice(
+                currentLibrary: currentLibrary,
+                newLibrary: defaultLibrary,
+                preferenceURL: nil,
+                destinationKind: .defaultLibrary
+            )
+            return
+        }
+
+        captureLibraryMigrationStatus = nil
+        applyCaptureLibraryChoice(nil)
+    }
+
     private func switchLibraryWithoutCopying(_ choice: PendingCaptureLibraryChoice) {
         captureLibraryMigrationStatus = "Existing captures stayed in \(choice.currentLibrary.path)."
-        applyCaptureLibraryChoice(choice.newLibrary)
+        applyCaptureLibraryChoice(choice.preferenceURL)
     }
 
     private func copyCapturesThenSwitchLibrary(_ choice: PendingCaptureLibraryChoice) {
@@ -4999,7 +5050,7 @@ struct TranscriptedSettingsView: View {
                 await MainActor.run {
                     captureLibraryMigrationInProgress = false
                     captureLibraryMigrationStatus = captureLibraryCopySummary(result)
-                    applyCaptureLibraryChoice(choice.newLibrary)
+                    applyCaptureLibraryChoice(choice.preferenceURL)
                 }
             } catch {
                 await MainActor.run {
@@ -5019,7 +5070,7 @@ struct TranscriptedSettingsView: View {
         return summary
     }
 
-    private func applyCaptureLibraryChoice(_ url: URL) {
+    private func applyCaptureLibraryChoice(_ url: URL?) {
         guard TranscriptedStoragePreferences.setCaptureLibraryURL(url) else {
             refreshStoragePaths()
             showCaptureLibrarySelectionError()
@@ -5281,6 +5332,31 @@ struct TranscriptedSettingsView: View {
 private struct PendingCaptureLibraryChoice: Equatable {
     let currentLibrary: URL
     let newLibrary: URL
+    let preferenceURL: URL?
+    let destinationKind: CaptureLibraryDestinationKind
+
+    var copyButtonTitle: String {
+        switch destinationKind {
+        case .custom:
+            return "Copy to New Folder"
+        case .defaultLibrary:
+            return "Copy to Default Folder"
+        }
+    }
+
+    var destinationDescription: String {
+        switch destinationKind {
+        case .custom:
+            return "new folder"
+        case .defaultLibrary:
+            return "default folder"
+        }
+    }
+}
+
+private enum CaptureLibraryDestinationKind: Equatable {
+    case custom
+    case defaultLibrary
 }
 
 // User-facing copy for the "we can't find this artifact on disk" failures that

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -165,6 +165,48 @@ func testTranscriptedPermissionAccess() async {
         )
     }
 
+    runSuite("TranscriptedPermissionKind.requiredForCurrentUse — meetings-first setup requires system audio, not Accessibility") {
+        assertEqual(
+            TranscriptedPermissionKind.requiredForCurrentUse(dictationShortcutsEnabled: true),
+            [.microphone, .accessibility],
+            "dictation shortcut users should still need Accessibility for paste-back"
+        )
+        assertEqual(
+            TranscriptedPermissionKind.requiredForCurrentUse(dictationShortcutsEnabled: false),
+            [.microphone, .systemAudioRecording],
+            "meetings-first users with dictation shortcuts off should need system audio instead of Accessibility"
+        )
+    }
+
+    await runSuite("TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus — updates stale cached grants") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+        }
+
+        UserDefaults.standard.set(true, forKey: knownKey)
+        UserDefaults.standard.set(true, forKey: grantedKey)
+
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus {
+            requestBox.callCount += 1
+            return false
+        }
+
+        assertFalse(granted, "a failed revalidation should return the live denied state")
+        assertEqual(requestBox.callCount, 1, "status-surface revalidation should perform a real probe")
+        assertTrue(
+            UserDefaults.standard.bool(forKey: knownKey),
+            "revalidation should keep the permission state marked as known"
+        )
+        assertFalse(
+            UserDefaults.standard.bool(forKey: grantedKey),
+            "revalidation should clear stale cached grants after revocation"
+        )
+    }
+
     await runSuite("TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded — skips requester when microphone is already authorized") {
         let requestBox = PermissionRequestBox()
         let granted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded(

--- a/Tests/TranscriptedStoragePathsTests.swift
+++ b/Tests/TranscriptedStoragePathsTests.swift
@@ -228,6 +228,46 @@ func testTranscriptedStoragePaths() {
         )
     }
 
+    runSuite("Transcripted capture library helpers — missing custom folders fall back without recreating") {
+        let original = UserDefaults.standard.object(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+        defer {
+            restore(original, forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+        }
+
+        let missingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedStoragePathsTests-missing-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: missingRoot) }
+
+        UserDefaults.standard.set(
+            missingRoot.path,
+            forKey: TranscriptedStoragePreferences.captureLibraryLocationKey
+        )
+
+        assertFalse(
+            FileManager.default.fileExists(atPath: missingRoot.path),
+            "test setup should start with a missing custom capture library"
+        )
+        assertEqual(
+            TranscriptedStoragePreferences.customCaptureLibraryURL(),
+            nil,
+            "missing custom capture-library preferences should not resolve as usable"
+        )
+        assertEqual(
+            TranscriptedStoragePreferences.unavailableCustomCaptureLibraryPath(),
+            missingRoot.path,
+            "settings should be able to explain which saved custom library is unavailable"
+        )
+        assertEqual(
+            FileManager.default.transcriptedCaptureLibraryDir,
+            FileManager.default.transcriptedDefaultCaptureLibraryDir,
+            "runtime storage should fall back to the default capture root when a custom library is gone"
+        )
+        assertFalse(
+            FileManager.default.fileExists(atPath: missingRoot.path),
+            "resolving storage should not recreate a missing custom capture library or phantom mount point"
+        )
+    }
+
     runSuite("Transcripted capture library helpers — reject file-shaped capture folders") {
         let original = UserDefaults.standard.object(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
         defer {


### PR DESCRIPTION
## Summary
- fall back to the default capture library when a saved custom library is missing instead of recreating phantom paths, and show the unavailable path in Storage settings
- make Settings readiness use current setup: dictation shortcuts require Accessibility, meetings-first requires System Audio Recording
- route Reset to Default through the same copy / just switch / cancel migration prompt as Choose Folder
- revalidate cached System Audio Recording state from Settings/onboarding status surfaces and before Review opens settings

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh --filter TranscriptedStoragePathsTests
- bash run-tests.sh --filter TranscriptedPermissionAccessTests
- bash run-tests.sh (11979 passed, after rebased rerun with output redirected to build/run-tests-rebased.log)
- bash scripts/dev/agent-preflight.sh
- git diff --check

## Review notes
- Codex review was attempted with `codex review --base origin/main`; it reran build/tests but did not produce a final verdict before being stopped, so it is not counted as a clean review.
- Maestro Local proof: /Users/redbars/.codex/maestro/runs/20260703T193611Z-permission-storage-triage-local (output was low quality and not used as truth).
- Maestro Claude proof: /Users/redbars/.codex/maestro/runs/20260703T193611Z-permission-storage-risk-review-claude (wrapper exited 1 with empty output).

## Manual proof still needed
- Real macOS System Audio Recording grant/revoke loop in Settings/onboarding.
- Real external-volume custom capture library unmounted/remounted path check.

lanes used: Codex=implemented, built, tested, pushed PR; Claude=attempted via maestro-delegate but failed empty; Local=attempted via maestro-delegate but output rejected as unusable triage; Windows=skipped (not useful for macOS/TCC/storage proof).
