### PR TITLE
Improve audio recovery and failed archive handling

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1161,7 +1161,7 @@ class ParakeetEngine: ObservableObject {
                 AnalyticsReporter.track(
                     "dictation_audio_route_recovery_finished",
                     properties: self.dictationRouteAnalyticsContext(
-                        selection: Self.loadDictationInputDeviceSelection(),
+                        selection: self.cachedInputDeviceSelection,
                         extra: [
                             "outcome": "failed",
                             "recovery_latency_bucket": AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - recoveryStartedAt),
@@ -1176,7 +1176,7 @@ class ParakeetEngine: ObservableObject {
                         event: "recording_interrupted",
                         message: "Recording interrupted — engine rewarm failed after device change",
                         context: self.dictationRouteDiagnosticsContext(
-                            selection: Self.loadDictationInputDeviceSelection(),
+                            selection: self.cachedInputDeviceSelection,
                             extra: [
                                 "audio_device": self.inputDeviceName,
                                 "error": error.localizedDescription
@@ -1188,7 +1188,7 @@ class ParakeetEngine: ObservableObject {
                         event: "device_change_rewarm_failed",
                         message: error.localizedDescription,
                         context: self.dictationRouteDiagnosticsContext(
-                            selection: Self.loadDictationInputDeviceSelection(),
+                            selection: self.cachedInputDeviceSelection,
                             extra: [
                                 "audio_device": self.inputDeviceName,
                                 "was_recording": "\(shouldRestartRecording)",
@@ -1200,7 +1200,7 @@ class ParakeetEngine: ObservableObject {
                         event: "device_change_rewarm_deferred",
                         message: "Idle audio route still settling after device change",
                         context: self.dictationRouteDiagnosticsContext(
-                            selection: Self.loadDictationInputDeviceSelection(),
+                            selection: self.cachedInputDeviceSelection,
                             extra: [
                                 "was_recording": "false",
                                 "error": error.localizedDescription,
@@ -1238,7 +1238,7 @@ class ParakeetEngine: ObservableObject {
             AnalyticsReporter.track(
                 "dictation_audio_route_recovery_timeout",
                 properties: self.dictationRouteAnalyticsContext(
-                    selection: Self.loadDictationInputDeviceSelection(),
+                    selection: self.cachedInputDeviceSelection,
                     extra: [
                         "recovery_latency_bucket": AnalyticsReporter.durationBucket(
                             seconds: Double(TranscriptedConstants.audioDeviceRecoveryTimeout) / 1_000_000_000
@@ -1269,7 +1269,7 @@ class ParakeetEngine: ObservableObject {
                 event: diagnosticsEvent,
                 message: diagnosticsMessage,
                 context: self.dictationRouteDiagnosticsContext(
-                    selection: Self.loadDictationInputDeviceSelection(),
+                    selection: self.cachedInputDeviceSelection,
                     extra: [
                         "recovery_generation": "\(generation)",
                         "timeout_ms": "\(TranscriptedConstants.audioDeviceRecoveryTimeout / 1_000_000)",
@@ -1286,7 +1286,7 @@ class ParakeetEngine: ObservableObject {
                     event: "recording_interrupted",
                     message: "Recording interrupted because audio device recovery timed out",
                     context: self.dictationRouteDiagnosticsContext(
-                        selection: Self.loadDictationInputDeviceSelection(),
+                        selection: self.cachedInputDeviceSelection,
                         extra: [
                             "audio_device": self.inputDeviceName,
                             "reason": "device_change_recovery_timeout"
@@ -1498,9 +1498,11 @@ class ParakeetEngine: ObservableObject {
     ) async throws -> ParakeetAudioInputSnapshot {
         let snapshotStartedAt = CFAbsoluteTimeGetCurrent()
         let selectionStartedAt = CFAbsoluteTimeGetCurrent()
-        let selection = Self.loadDictationInputDeviceSelection(
-            allowsBuiltInBluetoothFallback: allowsBuiltInBluetoothFallback
-        )
+        let selection = await Task.detached(priority: .utility) {
+            Self.loadDictationInputDeviceSelection(
+                allowsBuiltInBluetoothFallback: allowsBuiltInBluetoothFallback
+            )
+        }.value
         var stageTimings = [
             "audio_input_selection_load_ms": Self.elapsedMilliseconds(since: selectionStartedAt)
         ]

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -97,6 +97,7 @@ extension Audio {
         // unconditional — it's the watchdog give-up safety counter and
         // resets on success below.
         let switchStart = Date()
+        let lastMicBufferTime = lastBufferTime
         if reason == .deviceChange {
             deviceSwitchCount += 1
         }
@@ -193,10 +194,6 @@ extension Audio {
             AppLogger.audioMic.debug("Recovery: will manually downmix to mono", ["channels": "\(recordingSnapshot.channelCount)"])
         }
 
-        // Rotate files only when the sample rate changes. Channel-count-only changes
-        // keep writing into the same mono WAV, which avoids unnecessary segment churn.
-        // All micAudioFile accesses wrapped in micAudioFileQueue.sync for thread safety.
-        let sampleRateChanged = micAudioFileQueue.sync { micAudioFile.map { recordingSnapshot.sampleRate != $0.processingFormat.sampleRate } ?? false }
         let channelCountChanged = oldChannelCount != recordingSnapshot.channelCount
         var recoverySegmentURL: URL?
         var shouldKeepRecoverySegment = false
@@ -212,48 +209,46 @@ extension Audio {
             }
         }
 
-        if channelCountChanged && !sampleRateChanged {
-            AppLogger.audioMic.info("Input channel count changed, keeping current recording file", [
+        if channelCountChanged {
+            AppLogger.audioMic.info("Input channel count changed during recovery", [
                 "oldChannels": "\(oldChannelCount)",
                 "newChannels": "\(recordingSnapshot.channelCount)"
             ])
         }
 
-        if sampleRateChanged {
-            AppLogger.audioMic.warning("Sample rate changed, closing old file and creating new segment")
-            // Close explicitly so the retiring segment's WAV header is
-            // finalized before the merger can ever read it.
-            micAudioFileQueue.sync {
-                micAudioFile?.close()
-                micAudioFile = nil
-            }
+        AppLogger.audioMic.warning("Closing current mic file and creating recovery segment")
+        // Close explicitly so the retiring segment's WAV header is finalized
+        // before the merger can ever read it. Even same-rate device switches
+        // need a new segment so the missing-buffer interval can be padded.
+        micAudioFileQueue.sync {
+            micAudioFile?.close()
+            micAudioFile = nil
+        }
 
-            // Create new file segment as mono
-            let captureDir = self.paths.audioCaptures
-            try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
-            let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
-            let fileURL = captureDir.appendingPathComponent("meeting_\(timestamp)_mic_recovery.wav")
-            recoverySegmentURL = fileURL
+        let captureDir = self.paths.audioCaptures
+        try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
+        let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
+        let fileURL = captureDir.appendingPathComponent("meeting_\(timestamp)_mic_recovery.wav")
+        recoverySegmentURL = fileURL
 
-            do {
-                let monoFormat = try AudioRecordingFormatPolicy.makeMonoOutputFormat(
-                    sampleRate: recordingSnapshot.sampleRate
-                )
-                self.monoOutputFormat = monoFormat
+        do {
+            let monoFormat = try AudioRecordingFormatPolicy.makeMonoOutputFormat(
+                sampleRate: recordingSnapshot.sampleRate
+            )
+            self.monoOutputFormat = monoFormat
 
-                let newFile = try AVAudioFile(
-                    forWriting: fileURL,
-                    settings: monoFormat.settings,
-                    commonFormat: monoFormat.commonFormat,
-                    interleaved: monoFormat.isInterleaved
-                )
-                FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
-                micAudioFileQueue.sync { micAudioFile = newFile }
-                AppLogger.audioMic.info("Created recovery audio file", ["file": fileURL.lastPathComponent])
-            } catch {
-                AppLogger.audioMic.error("Failed to create recovery audio file", ["error": error.localizedDescription])
-                return
-            }
+            let newFile = try AVAudioFile(
+                forWriting: fileURL,
+                settings: monoFormat.settings,
+                commonFormat: monoFormat.commonFormat,
+                interleaved: monoFormat.isInterleaved
+            )
+            FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
+            micAudioFileQueue.sync { micAudioFile = newFile }
+            AppLogger.audioMic.info("Created recovery audio file", ["file": fileURL.lastPathComponent])
+        } catch {
+            AppLogger.audioMic.error("Failed to create recovery audio file", ["error": error.localizedDescription])
+            return
         }
 
         guard sessionGeneration == recordingSessionGeneration else {
@@ -307,10 +302,16 @@ extension Audio {
                 }
             }
 
-            // Record the restart gap
+            // Record the true missing-buffer interval. The watchdog only
+            // invokes recovery after buffers have already been absent for a
+            // few seconds, so measuring from recovery start undercounts the
+            // timeline gap and desyncs mic/system audio after device switches.
+            let monotonicGapDuration = CACurrentMediaTime() - lastMicBufferTime
+            let wallClockGapDuration = Date().timeIntervalSince(switchStart)
+            let gapDuration = max(0, max(monotonicGapDuration, wallClockGapDuration))
             let gap = AudioGap(
-                start: switchStart,
-                duration: Date().timeIntervalSince(switchStart),
+                start: Date(timeIntervalSinceNow: -gapDuration),
+                duration: gapDuration,
                 reason: reason == .processingChange ? "Mic processing change" : "Device switch"
             )
             appendRecordingGap(gap)

--- a/Sources/TranscriptedCore/Audio/AudioResampler.swift
+++ b/Sources/TranscriptedCore/Audio/AudioResampler.swift
@@ -154,17 +154,9 @@ public enum AudioResampler {
             ])
         }
 
-        // Allocate output buffer for the entire converted result. A no-copy
-        // destination (bufferListNoCopy wrapping the returned Array's storage)
-        // aborted inside AVAudioConverter on CI, so the converted result is
-        // copied into the Array once at return — one transient extra buffer,
-        // freed as soon as this function returns.
-        let totalDstFrames = AVAudioFrameCount(totalDstFrameCount)
-        guard let dstBuffer = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: totalDstFrames) else {
-            throw NSError(domain: "AudioResampler", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to create destination audio buffer"
-            ])
-        }
+        let outputCapacity = Int(totalDstFrameCount)
+        var output = [Float]()
+        output.reserveCapacity(outputCapacity)
 
         // Read chunks from the file on demand inside the input block.
         // The converter calls this block repeatedly until we signal .endOfStream,
@@ -172,57 +164,80 @@ public enum AudioResampler {
         let chunkDuration: Double = 30.0  // seconds per read
         let chunkFrames = AVAudioFrameCount(srcFormat.sampleRate * chunkDuration)
 
-        var conversionError: NSError?
         var inputBlockError: Error?
-        let status = converter.convert(to: dstBuffer, error: &conversionError) { _, outStatus in
-            // Check if we've read all frames
-            guard file.framePosition < file.length else {
-                outStatus.pointee = .endOfStream
-                return nil
-            }
-
-            let framesToRead = min(chunkFrames, AVAudioFrameCount(file.length - file.framePosition))
-            guard let srcBuffer = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: framesToRead) else {
-                inputBlockError = NSError(domain: "AudioResampler", code: 5, userInfo: [
-                    NSLocalizedDescriptionKey: "Buffer allocation failed during resampling at frame \(file.framePosition)/\(file.length)"
+        var didSignalEndOfStream = false
+        let outputChunkFrames = AVAudioFrameCount(targetRate * 30.0)
+        while true {
+            guard let dstBuffer = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: outputChunkFrames) else {
+                throw NSError(domain: "AudioResampler", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to create destination audio buffer"
                 ])
-                outStatus.pointee = .endOfStream
-                return nil
             }
 
-            do {
-                try file.read(into: srcBuffer, frameCount: framesToRead)
-            } catch {
-                inputBlockError = error
-                outStatus.pointee = .endOfStream
-                return nil
+            var conversionError: NSError?
+            let status = converter.convert(to: dstBuffer, error: &conversionError) { _, outStatus in
+                guard !didSignalEndOfStream else {
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+                guard file.framePosition < file.length else {
+                    didSignalEndOfStream = true
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+
+                let framesToRead = min(chunkFrames, AVAudioFrameCount(file.length - file.framePosition))
+                guard let srcBuffer = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: framesToRead) else {
+                    inputBlockError = NSError(domain: "AudioResampler", code: 5, userInfo: [
+                        NSLocalizedDescriptionKey: "Buffer allocation failed during resampling at frame \(file.framePosition)/\(file.length)"
+                    ])
+                    didSignalEndOfStream = true
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+
+                do {
+                    try file.read(into: srcBuffer, frameCount: framesToRead)
+                } catch {
+                    inputBlockError = error
+                    didSignalEndOfStream = true
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+
+                outStatus.pointee = .haveData
+                return srcBuffer
             }
 
-            outStatus.pointee = .haveData
-            return srcBuffer
-        }
+            if status == .error, let conversionError {
+                throw conversionError
+            }
 
-        if status == .error, let conversionError {
-            throw conversionError
-        }
+            if let inputBlockError { throw inputBlockError }
 
-        if let inputBlockError { throw inputBlockError }
+            if dstBuffer.frameLength > 0 {
+                guard let floatData = dstBuffer.floatChannelData else {
+                    throw NSError(domain: "AudioResampler", code: 2, userInfo: [
+                        NSLocalizedDescriptionKey: "Failed to get float channel data from converted buffer"
+                    ])
+                }
+                output.append(contentsOf: UnsafeBufferPointer(start: floatData[0], count: Int(dstBuffer.frameLength)))
+            }
+
+            if didSignalEndOfStream && dstBuffer.frameLength == 0 {
+                break
+            }
+        }
 
         // Validate output length — catch silent truncation from converter issues
         let expectedMinFrames = Int(Double(srcFrames) * ratio * 0.9)
-        if Int(dstBuffer.frameLength) < expectedMinFrames {
+        if output.count < expectedMinFrames {
             AppLogger.transcription.warning("Audio resampling produced fewer frames than expected", [
-                "expected": "\(expectedMinFrames)", "actual": "\(dstBuffer.frameLength)", "source": url.lastPathComponent
+                "expected": "\(expectedMinFrames)", "actual": "\(output.count)", "source": url.lastPathComponent
             ])
         }
 
-        guard let floatData = dstBuffer.floatChannelData else {
-            throw NSError(domain: "AudioResampler", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to get float channel data from converted buffer"
-            ])
-        }
-
-        return Array(UnsafeBufferPointer(start: floatData[0], count: Int(dstBuffer.frameLength)))
+        return output
     }
 
     /// Extract a time slice from samples array.

--- a/Sources/TranscriptedCore/Audio/DictationSpillPlan.swift
+++ b/Sources/TranscriptedCore/Audio/DictationSpillPlan.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct DictationSpillPlan: Equatable, Sendable {
+    public static let defaultChunkDuration: TimeInterval = 10
+    public static let defaultMaximumRecoverableDuration: TimeInterval = 5 * 60
+
+    public let sessionID: UUID
+    public let directory: URL
+    public let sampleRate: Double
+    public let chunkDuration: TimeInterval
+    public let maximumRecoverableDuration: TimeInterval
+
+    public var journalURL: URL {
+        directory.appendingPathComponent("\(sessionID.uuidString).dictation-recording.json")
+    }
+
+    public var maximumRecoverableChunks: Int {
+        guard chunkDuration > 0, maximumRecoverableDuration > 0 else { return 0 }
+        return Int(ceil(maximumRecoverableDuration / chunkDuration))
+    }
+
+    public init(
+        sessionID: UUID = UUID(),
+        directory: URL,
+        sampleRate: Double,
+        chunkDuration: TimeInterval = Self.defaultChunkDuration,
+        maximumRecoverableDuration: TimeInterval = Self.defaultMaximumRecoverableDuration
+    ) {
+        self.sessionID = sessionID
+        self.directory = directory
+        self.sampleRate = sampleRate
+        self.chunkDuration = max(1, chunkDuration)
+        self.maximumRecoverableDuration = max(self.chunkDuration, maximumRecoverableDuration)
+    }
+
+    public func chunkURL(index: Int) -> URL {
+        let safeIndex = max(0, index)
+        let filename = "\(sessionID.uuidString)-chunk-\(String(format: "%05d", safeIndex)).pcm"
+        return directory.appendingPathComponent(filename)
+    }
+
+    public func shouldRotateChunk(currentFrameCount: Int) -> Bool {
+        guard sampleRate.isFinite, sampleRate > 0 else { return false }
+        return currentFrameCount >= Int((sampleRate * chunkDuration).rounded())
+    }
+}

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -690,37 +690,26 @@ public class TranscriptionTaskManager: ObservableObject {
             return false
         }
 
-        let retainedAudio = archiveFailedRecordingAudioIfConfigured(
-            micURL: micAudioURL,
-            systemURL: systemAudioURL,
-            taskId: id
-        )
         let retryIsUsingOriginalAudio = activeTasks[id] != nil
-        let promotedMicURL = retainedAudio?.micURL ?? micAudioURL
-        let promotedSystemURL = retainedAudio?.systemURL ?? systemAudioURL
         let didPersist = failedTranscriptionManager.updateFailedTranscriptionAudio(
             id: id,
-            micAudioURL: promotedMicURL,
-            systemAudioURL: promotedSystemURL
+            micAudioURL: micAudioURL,
+            systemAudioURL: systemAudioURL
         )
+        guard didPersist else { return false }
 
-        guard didPersist else {
-            if let retainedAudio {
-                removeRetainedFailedAudio(retainedAudio)
-            }
-            return false
-        }
-
-        if retryIsUsingOriginalAudio, retainedAudio != nil {
+        scheduleFailedRecordingAudioArchive(
+            micURL: micAudioURL,
+            systemURL: systemAudioURL,
+            taskId: id,
+            removeOriginalsAfterArchive: !retryIsUsingOriginalAudio,
+            originalMicCleanupLabel: "finalized failed mic scratch",
+            originalSystemCleanupLabel: "finalized failed system scratch"
+        )
+        if retryIsUsingOriginalAudio {
             AppLogger.pipeline.info("Deferred finalized failed audio scratch cleanup until active retry finishes", [
                 "id": id.uuidString
             ])
-        }
-        if retainedAudio?.micURL != nil, !retryIsUsingOriginalAudio {
-            removeManagedCleanupFile(micAudioURL, label: "finalized failed mic scratch")
-        }
-        if retainedAudio?.systemURL != nil, !retryIsUsingOriginalAudio {
-            removeManagedCleanupFile(systemAudioURL, label: "finalized failed system scratch")
         }
         return true
     }
@@ -742,23 +731,27 @@ public class TranscriptionTaskManager: ObservableObject {
             return false
         }
 
-        let retainedAudio = archiveAudio
-            ? archiveFailedRecordingAudioIfConfigured(
-                micURL: micAudioURL,
-                systemURL: systemAudioURL,
-                taskId: taskId
-            )
-            : nil
-        return enqueueFailedTranscriptionAfterRetainingAudio(
+        let didPersist = enqueueFailedTranscriptionAfterRetainingAudio(
             taskId: taskId,
-            retainedAudio: retainedAudio,
+            retainedAudio: nil,
             originalMicURL: micAudioURL,
             originalSystemURL: systemAudioURL,
             errorMessage: errorMessage,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
-            removeOriginalsAfterArchive: archiveAudio
+            removeOriginalsAfterArchive: false
         )
+        if didPersist, archiveAudio {
+            scheduleFailedRecordingAudioArchive(
+                micURL: micAudioURL,
+                systemURL: systemAudioURL,
+                taskId: taskId,
+                removeOriginalsAfterArchive: true,
+                originalMicCleanupLabel: "archived failed mic scratch",
+                originalSystemCleanupLabel: "archived failed system scratch"
+            )
+        }
+        return didPersist
     }
 
     @discardableResult
@@ -1483,24 +1476,116 @@ public class TranscriptionTaskManager: ObservableObject {
         return filePath.hasPrefix(normalizedDirectoryPath)
     }
 
-    private func archiveFailedRecordingAudioIfConfigured(
+    private func scheduleFailedRecordingAudioArchive(
         micURL: URL?,
         systemURL: URL?,
-        taskId: UUID
-    ) -> RetainedRecordingAudio? {
-        guard let retainedAudioDirectory = resolvedRetainedAudioDirectory() else { return nil }
+        taskId: UUID,
+        removeOriginalsAfterArchive: Bool,
+        originalMicCleanupLabel: String,
+        originalSystemCleanupLabel: String
+    ) {
+        guard let retainedAudioDirectory = resolvedRetainedAudioDirectory() else { return }
 
         let failedStem = "Failed_\(DateFormattingHelper.formatFilename(Date()))_\(String(taskId.uuidString.prefix(8)))"
         let placeholderTranscriptURL = retainedAudioDirectory
             .appendingPathComponent(failedStem)
             .appendingPathExtension("md")
 
+        if Self.shouldArchiveFailedAudioSynchronouslyForTests {
+            guard let retainedAudio = Self.archiveFailedRecordingAudio(
+                micURL: micURL,
+                systemURL: systemURL,
+                taskId: taskId,
+                transcriptURL: placeholderTranscriptURL,
+                archiveRoot: retainedAudioDirectory
+            ) else { return }
+            applyRetainedFailedRecordingAudio(
+                retainedAudio,
+                micURL: micURL,
+                systemURL: systemURL,
+                taskId: taskId,
+                removeOriginalsAfterArchive: removeOriginalsAfterArchive,
+                originalMicCleanupLabel: originalMicCleanupLabel,
+                originalSystemCleanupLabel: originalSystemCleanupLabel
+            )
+            return
+        }
+
+        Task { [weak self] in
+            let retainedAudio = await Task.detached(priority: .utility) {
+                Self.archiveFailedRecordingAudio(
+                    micURL: micURL,
+                    systemURL: systemURL,
+                    taskId: taskId,
+                    transcriptURL: placeholderTranscriptURL,
+                    archiveRoot: retainedAudioDirectory
+                )
+            }.value
+
+            guard let self, let retainedAudio else { return }
+            self.applyRetainedFailedRecordingAudio(
+                retainedAudio,
+                micURL: micURL,
+                systemURL: systemURL,
+                taskId: taskId,
+                removeOriginalsAfterArchive: removeOriginalsAfterArchive,
+                originalMicCleanupLabel: originalMicCleanupLabel,
+                originalSystemCleanupLabel: originalSystemCleanupLabel
+            )
+        }
+    }
+
+    private func applyRetainedFailedRecordingAudio(
+        _ retainedAudio: RetainedRecordingAudio,
+        micURL: URL?,
+        systemURL: URL?,
+        taskId: UUID,
+        removeOriginalsAfterArchive: Bool,
+        originalMicCleanupLabel: String,
+        originalSystemCleanupLabel: String
+    ) {
+        let placeholderMicURL = makeSilentMicPlaceholderIfNeeded(
+            retainedAudio: retainedAudio,
+            hasOriginalMic: micURL != nil,
+            failedSystemURL: retainedAudio.systemURL ?? systemURL
+        )
+        guard let updatedMicURL = retainedAudio.micURL ?? micURL ?? placeholderMicURL else {
+            removeRetainedFailedAudio(retainedAudio)
+            return
+        }
+        let didPersist = failedTranscriptionManager.updateFailedTranscriptionAudio(
+            id: taskId,
+            micAudioURL: updatedMicURL,
+            systemAudioURL: retainedAudio.systemURL ?? systemURL
+        )
+
+        guard didPersist else {
+            removeRetainedFailedAudio(retainedAudio)
+            return
+        }
+
+        guard removeOriginalsAfterArchive else { return }
+        if retainedAudio.micURL != nil {
+            removeManagedCleanupFile(micURL, label: originalMicCleanupLabel)
+        }
+        if retainedAudio.systemURL != nil {
+            removeManagedCleanupFile(systemURL, label: originalSystemCleanupLabel)
+        }
+    }
+
+    nonisolated private static func archiveFailedRecordingAudio(
+        micURL: URL?,
+        systemURL: URL?,
+        taskId: UUID,
+        transcriptURL: URL,
+        archiveRoot: URL
+    ) -> RetainedRecordingAudio? {
         do {
             let retainedAudio = try RecordingAudioArchiver.archive(
                 micURL: micURL,
                 systemURL: systemURL,
-                transcriptURL: placeholderTranscriptURL,
-                archiveRoot: retainedAudioDirectory
+                transcriptURL: transcriptURL,
+                archiveRoot: archiveRoot
             )
             AppLogger.pipeline.info("Retained failed meeting audio files", [
                 "hasMic": "\(retainedAudio.micURL != nil)",
@@ -1514,6 +1599,11 @@ public class TranscriptionTaskManager: ObservableObject {
             ])
             return nil
         }
+    }
+
+    nonisolated private static var shouldArchiveFailedAudioSynchronouslyForTests: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+            || ProcessInfo.processInfo.processName == "xctest"
     }
 }
 

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -325,7 +325,7 @@ func testBluetoothRouteContract() {
         }
         let snapshotBody = String(source[snapshotStart.lowerBound..<snapshotEnd.lowerBound])
 
-        guard let loadSelection = snapshotBody.range(of: "let selection = Self.loadDictationInputDeviceSelection"),
+        guard let loadSelection = snapshotBody.range(of: "Self.loadDictationInputDeviceSelection"),
               let avoidDefaultRead = snapshotBody.range(of: "Avoid touching the current default input before the override is applied."),
               let applyOverride = snapshotBody.range(of: "Self.applyPreferredDictationInputDevice(selection, to: inputNode)"),
               let outputFormatRead = snapshotBody.range(of: "inputNode.outputFormat(forBus: 0)"),

--- a/Tests/TranscriptedCoreTests/DictationSpillPlanTests.swift
+++ b/Tests/TranscriptedCoreTests/DictationSpillPlanTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+@testable import TranscriptedCore
+
+final class DictationSpillPlanTests: XCTestCase {
+    func testChunkAndJournalURLsStayInsideSessionDirectory() {
+        let sessionID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        let directory = URL(fileURLWithPath: "/tmp/transcripted-dictation-spill", isDirectory: true)
+        let plan = DictationSpillPlan(sessionID: sessionID, directory: directory, sampleRate: 16_000)
+
+        XCTAssertEqual(
+            plan.journalURL,
+            directory.appendingPathComponent("11111111-2222-3333-4444-555555555555.dictation-recording.json")
+        )
+        XCTAssertEqual(
+            plan.chunkURL(index: 7),
+            directory.appendingPathComponent("11111111-2222-3333-4444-555555555555-chunk-00007.pcm")
+        )
+        XCTAssertEqual(
+            plan.chunkURL(index: -1),
+            directory.appendingPathComponent("11111111-2222-3333-4444-555555555555-chunk-00000.pcm")
+        )
+    }
+
+    func testRotationUsesConfiguredChunkDuration() {
+        let plan = DictationSpillPlan(
+            directory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+            sampleRate: 16_000,
+            chunkDuration: 10
+        )
+
+        XCTAssertFalse(plan.shouldRotateChunk(currentFrameCount: 159_999))
+        XCTAssertTrue(plan.shouldRotateChunk(currentFrameCount: 160_000))
+    }
+
+    func testRecoverableWindowDefaultsToFiveMinutes() {
+        let plan = DictationSpillPlan(
+            directory: URL(fileURLWithPath: "/tmp", isDirectory: true),
+            sampleRate: 16_000
+        )
+
+        XCTAssertEqual(plan.maximumRecoverableChunks, 30)
+    }
+}

--- a/docs/dictation-spill-to-disk-design.md
+++ b/docs/dictation-spill-to-disk-design.md
@@ -1,0 +1,21 @@
+# Dictation Spill-To-Disk Design
+
+Transcripted currently keeps active dictation audio in memory until stop. A crash or force quit can lose the whole in-flight dictation. This note defines the safe implementation shape for adding recovery without doing risky audio callback work in the first PR.
+
+## Contract
+
+- Start a `DictationSpillPlan` when dictation capture starts.
+- Write borrowed tap buffers to memory first, then enqueue copied PCM frames to a single utility writer queue.
+- Rotate fixed-duration PCM chunks, defaulting to 10 seconds.
+- Maintain a small JSON journal next to the chunks with session id, sample rate, chunk order, start time, and last completed chunk.
+- Keep at most five minutes recoverable by default.
+- Delete the journal and chunks only after normal dictation save completes.
+- On launch, scan journals, validate chunk filenames stay inside the spill directory, and offer recovered dictation transcription.
+
+## Non-goals For This Slice
+
+- No file I/O from the CoreAudio callback.
+- No recovery UI yet.
+- No transcription from spill chunks yet.
+
+The implementation hook added in this slice is the pure `DictationSpillPlan` plus unit tests for URL shape, rotation, and recoverable-window limits.


### PR DESCRIPTION
## Summary
- move Parakeet input-device selection reads and failed-meeting audio archiving off the main actor path
- stream meeting audio resampling in converter chunks to reduce transient memory spikes
- preserve mic recovery gap metadata even when the replacement device keeps the same sample rate
- add a small dictation spill-to-disk planning hook plus tests and a design doc for the full crash-recovery implementation

## Verification
- bash build-deps.sh --force
- bash build.sh (compiled and signed; launch smoke failed locally with LSOpen -10810)
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (11968 passed, 0 failed)
- bash run-integration-smoke.sh
- swift test (601 passed, 2 skipped, 0 failed)

## Notes
- #57 is intentionally kept to a design/hook PR. Full spill writer, launch scan, and UI recovery should land separately.