### PR TITLE
Preserve dictation recovery audio

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -222,7 +222,7 @@ private final class PhysicalShortcutDetector {
         defer { stateLock.unlock() }
 
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            reconcileStateAfterTapWasDisabled()
+            reconcileActivePushToTalkAfterTapDisabled()
             if let eventTap {
                 CGEvent.tapEnable(tap: eventTap, enable: true)
             }
@@ -416,21 +416,31 @@ private final class PhysicalShortcutDetector {
         pendingModifierShortcut = nil
     }
 
-    private func reconcileStateAfterTapWasDisabled() {
+    private func reconcileActivePushToTalkAfterTapDisabled() {
         cancelPendingModifierShortcut()
 
-        if let keyCode = activePushToTalkKeyCode,
-           !Self.isKeyPhysicallyDown(keyCode) {
+        if PhysicalShortcutMatcher.shouldSynthesizePushToTalkRelease(
+            activeKeyCode: activePushToTalkKeyCode,
+            isPhysicallyDown: Self.isPhysicalKeyDown
+        ), let releasedKeyCode = activePushToTalkKeyCode {
             activePushToTalkKeyCode = nil
-            consumedKeyCodes.remove(keyCode)
+            consumedKeyCodes.remove(releasedKeyCode)
             onShortcut?(.dictationPushToTalk, .release)
         }
 
-        consumedKeyCodes = consumedKeyCodes.filter { Self.isKeyPhysicallyDown($0) }
+        consumedKeyCodes = consumedKeyCodes.filter { Self.isPhysicalKeyDown($0) }
     }
 
-    private static func isKeyPhysicallyDown(_ keyCode: UInt32) -> Bool {
-        CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
+    private static func isPhysicalKeyDown(_ keyCode: UInt32) -> Bool {
+        if PhysicalDictationTriggerPreferences.isModifierKey(keyCode),
+           let modifier = PhysicalDictationTriggerPreferences.primaryModifierMask(for: keyCode) {
+            let modifiers = PhysicalDictationTriggerPreferences.modifiers(
+                from: CGEventSource.flagsState(.combinedSessionState)
+            )
+            return (modifiers & modifier) != 0
+        }
+
+        return CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
     }
 }
 

--- a/Sources/Capture/PhysicalShortcutMatcher.swift
+++ b/Sources/Capture/PhysicalShortcutMatcher.swift
@@ -25,6 +25,14 @@ struct PhysicalShortcutBinding {
 }
 
 enum PhysicalShortcutMatcher {
+    static func shouldSynthesizePushToTalkRelease(
+        activeKeyCode: UInt32?,
+        isPhysicallyDown: (UInt32) -> Bool
+    ) -> Bool {
+        guard let activeKeyCode else { return false }
+        return !isPhysicallyDown(activeKeyCode)
+    }
+
     static func matchingKeyDownShortcut(
         _ shortcuts: [PhysicalShortcutBinding],
         keyCode: UInt32,

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -22,6 +22,10 @@ class ParakeetEngine: ObservableObject {
     @Published var isRecovering = false
     @Published var inputFormatReady = true
 
+    var hasRecoverableRecording: Bool {
+        !recoveredRecordingTimeline.isEmpty
+    }
+
     private var audioEngine = AVAudioEngine()
     private var audioEngineQueue = ParakeetEngine.makeAudioEngineQueue()
     private var audioGraphGeneration = 0
@@ -1904,9 +1908,7 @@ class ParakeetEngine: ObservableObject {
         let wasRecording = isRecording
         cancelAudioWatchdog()
         if isRecording {
-            pendingSamplesLock.withLock {
-                pendingSamples.removeAll(keepingCapacity: true)
-            }
+            preserveCurrentRecordingBuffersForRecovery()
             streamingSamplesLock.withLock {
                 streamingSampleBuffer.removeAll(keepingCapacity: true)
             }
@@ -1920,7 +1922,7 @@ class ParakeetEngine: ObservableObject {
         isEnginePrewarmed = false
 
         if wasRecording {
-            interruptRecordingAndClearRecoveredTimeline()
+            interruptRecordingPreservingRecoveredTimeline()
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "recording_interrupted",
                 message: "Recording interrupted by system sleep/wake")
         }
@@ -2575,6 +2577,10 @@ class ParakeetEngine: ObservableObject {
                 clearRecoveredRecordingTimeline(keepingCapacity: true)
                 return
             }
+            if preservingRecordingAcrossRecovery || !recoveredRecordingTimeline.isEmpty {
+                cancelPendingRecordingRecovery()
+                return
+            }
             if audioStartInProgress {
                 audioGraphGeneration += 1
             } else {
@@ -2641,7 +2647,33 @@ class ParakeetEngine: ObservableObject {
 
     private func interruptRecordingAndClearRecoveredTimeline() {
         clearRecoveredRecordingTimeline(keepingCapacity: true)
+        markRecordingInterrupted()
+    }
+
+    private func interruptRecordingPreservingRecoveredTimeline() {
+        preservingRecordingAcrossRecovery = !recoveredRecordingTimeline.isEmpty
+        markRecordingInterrupted()
+    }
+
+    private func markRecordingInterrupted() {
         recordingInterrupted = true
+    }
+
+    private func cancelPendingRecordingRecovery() {
+        audioGraphGeneration += 1
+        cancelAudioWatchdog()
+        prewarmRetryTask?.cancel()
+        prewarmRetryTask = nil
+        configChangeDebounceTask?.cancel()
+        configChangeDebounceTask = nil
+        configRecoveryTask?.cancel()
+        configRecoveryTask = nil
+        cancelConfigRecoveryTimeout()
+        configChangeWasRecording = false
+        recoveryState.reset()
+        publishRecoveryState()
+        isRecording = false
+        audioLevel = 0
     }
 
     func loadRecordedSamplesForDictationBenchmark(_ samples: [Float], sampleRate: Double) {

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -47,6 +47,7 @@ class STTRouter: ObservableObject {
     }
 
     var inputDeviceName: String { parakeetEngine.inputDeviceName }
+    var hasRecoverableRecording: Bool { parakeetEngine.hasRecoverableRecording }
     var dictationAudioRouteAnalyticsContext: [String: String] {
         parakeetEngine.currentAudioRouteAnalyticsContext
     }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -797,12 +797,16 @@ class DictationSessionController: ObservableObject {
         )
 
         if stopDecision == .cancelPendingStart {
+            if trigger == .physicalKey {
+                cancelPendingDictationStartAfterEarlyRelease(appState: appState, overlayController: overlayController)
+                return
+            }
             cancelDictation()
             return
         }
 
         guard stopDecision == .stopRecording else {
-            if overlayController.state == .drafting {
+            if overlayController.state == .drafting || appState.sttRouter.isTranscribing {
                 overlayController.showError("Still finishing the last dictation. Try again in a moment.")
             }
             DiagnosticsTrail.record(
@@ -821,7 +825,8 @@ class DictationSessionController: ObservableObject {
             )
             return
         }
-        guard appState.sttRouter.isRecording else {
+        let hasRecoverableRecording = appState.sttRouter.hasRecoverableRecording
+        guard appState.sttRouter.isRecording || hasRecoverableRecording else {
             recordingStartRetryTask?.cancel()
             recordingStartRetryTask = nil
             appState.sttRouter.cancel()
@@ -870,7 +875,9 @@ class DictationSessionController: ObservableObject {
         streamingTask = Task {
             var stopTiming = DictationStopTiming(requestedAt: stopRequestedAt)
             appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "stop_requested")
-            await appState.sttRouter.stopRecording()
+            if appState.sttRouter.isRecording || appState.sttRouter.hasRecoverableRecording {
+                await appState.sttRouter.stopRecording()
+            }
             stopTiming.micStoppedAt = CFAbsoluteTimeGetCurrent()
             guard !Task.isCancelled,
                   self.isDictating,
@@ -1493,10 +1500,24 @@ class DictationSessionController: ObservableObject {
         var timeout = DictationSessionTimeout(timeoutInterval: Self.sessionTimeoutInterval)
         timeout.start(at: ProcessInfo.processInfo.systemUptime)
         sessionTimeoutTask = Task { [weak self] in
+            var didWarnSessionCap = false
             while !Task.isCancelled {
                 let now = ProcessInfo.processInfo.systemUptime
                 if timeout.isExpired(at: now) { break }
                 let remainingSeconds = timeout.remaining(at: now) ?? 0
+                if !didWarnSessionCap, remainingSeconds <= 30 {
+                    didWarnSessionCap = true
+                    self?.overlayController?.showLoadingState(
+                        near: self?.sessionSourceApp,
+                        presentation: .init(
+                            title: "Long dictation",
+                            detail: "Wrapping up soon. Release the key to finish now.",
+                            progress: 0.94,
+                            status: "30 seconds left"
+                        ),
+                        anchorRect: self?.sessionAnchorRect
+                    )
+                }
                 let remainingNanos = UInt64((remainingSeconds * 1_000_000_000).rounded(.up))
                 let sleepNanos = min(remainingNanos, Self.sessionTimeoutPollIntervalNanos)
                 if sleepNanos == 0 { break }
@@ -1504,15 +1525,43 @@ class DictationSessionController: ObservableObject {
             }
             guard !Task.isCancelled, let self = self else { return }
             if self.isDictating {
-                self.appState?.logger.log("DICTATION | session cap reached, finalizing without paste")
+                let shouldAutoPaste = self.sessionPasteTarget?.matchesCurrentFrontmostApp() ?? false
+                self.appState?.logger.log(
+                    shouldAutoPaste
+                        ? "DICTATION | session cap reached, finalizing with original paste target still active"
+                        : "DICTATION | session cap reached, finalizing without paste"
+                )
                 EventReporter.shared.capture(level: .info, engine: "overlay", event: "dictation_timeout",
-                    message: "Dictation reached the 5-minute cap; saving without paste")
-                // Recover the work instead of discarding it: finalize and save,
-                // but suppress auto-paste because the cap fires on walked-away
-                // sessions where the focused app may have changed.
-                self.stopDictationAndPaste(trigger: .sessionCap, autoPaste: false)
+                    message: shouldAutoPaste
+                        ? "Dictation reached the 5-minute cap; pasting because the original target is still active"
+                        : "Dictation reached the 5-minute cap; saving without paste")
+                self.stopDictationAndPaste(trigger: .sessionCap, autoPaste: shouldAutoPaste)
             }
         }
+    }
+
+    private func cancelPendingDictationStartAfterEarlyRelease(
+        appState: TranscriptedAppState,
+        overlayController: FloatingOverlayController
+    ) {
+        cancelActiveTasks(cancelRecording: true)
+        AppSoundPlayer.shared.play(.dictationCancelled)
+        isDictating = false
+        appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "microphone_not_ready")
+        DiagnosticsTrail.record(
+            logger: appState.logger,
+            level: .info,
+            engine: "dictation",
+            event: "dictation_cancelled_before_microphone_ready",
+            message: "Push-to-talk release cancelled before microphone capture started",
+            context: dictationContext(
+                extra: [
+                    "trigger": currentDictationTrigger.rawValue,
+                    "duration_ms": "\(Int((CFAbsoluteTimeGetCurrent() - sessionStartTime) * 1000))"
+                ]
+            )
+        )
+        overlayController.showError("Mic wasn't ready yet. Nothing was recorded. Try again.")
     }
 
     private func overlayStateName(_ state: FloatingOverlayController.OverlayState) -> String {
@@ -1555,7 +1604,8 @@ class DictationSessionController: ObservableObject {
     }
 
     private func handleDictationInterruption() {
-        cancelActiveTasks(cancelRecording: true)
+        let hasRecoverableRecording = appState?.sttRouter.hasRecoverableRecording ?? false
+        cancelActiveTasks(cancelRecording: !hasRecoverableRecording)
         isDictating = false
         appState?.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "interrupted")
         appState?.logger.log("DICTATION | interrupted")
@@ -1573,14 +1623,23 @@ class DictationSessionController: ObservableObject {
             )
         )
         overlayController?.showError(
-            "Recording was interrupted. Check your microphone or audio device, then try again.",
-            actionTitle: "Retry Dictation",
+            hasRecoverableRecording
+                ? "Recording was interrupted. Transcripted kept the audio captured so far."
+                : "Recording was interrupted. Check your microphone or audio device, then try again.",
+            actionTitle: hasRecoverableRecording ? "Transcribe Captured Audio" : "Retry Dictation",
             action: { [weak self] in
-                self?.startDictation(
-                    sourceApp: self?.sessionSourceApp,
-                    trigger: self?.currentDictationTrigger ?? .unknown,
-                    anchorRect: self?.sessionAnchorRect
-                )
+                guard let self else { return }
+                if hasRecoverableRecording {
+                    self.isDictating = true
+                    self.overlayController?.state = .listening
+                    self.stopDictationAndPaste(trigger: .unknown, autoPaste: false)
+                } else {
+                    self.startDictation(
+                        sourceApp: self.sessionSourceApp,
+                        trigger: self.currentDictationTrigger,
+                        anchorRect: self.sessionAnchorRect
+                    )
+                }
             }
         )
     }

--- a/Tests/ContextCaptureEnginePolicyTests.swift
+++ b/Tests/ContextCaptureEnginePolicyTests.swift
@@ -88,6 +88,29 @@ func testContextCaptureEnginePolicy() {
         )
     }
 
+    runSuite("ContextCaptureEngine tap re-enable — reconciles missed push-to-talk release") {
+        let source = readContextCaptureEngineSource()
+
+        assertTrue(
+            source.contains("reconcileActivePushToTalkAfterTapDisabled()"),
+            "tapDisabledByTimeout/userInput should reconcile active push-to-talk state before re-enabling the tap"
+        )
+        assertTrue(
+            source.contains("PhysicalShortcutMatcher.shouldSynthesizePushToTalkRelease("),
+            "the detector should use the pure missed-release policy before synthesizing release"
+        )
+        assertTrue(
+            source.contains("CGEventSource.flagsState(.combinedSessionState)")
+                && source.contains("CGEventSource.keyState(.combinedSessionState"),
+            "reconciliation should query the real physical modifier/key state"
+        )
+        assertTrue(
+            source.contains("consumedKeyCodes.remove(releasedKeyCode)")
+                && source.contains("onShortcut?(.dictationPushToTalk, .release)"),
+            "synthesized release should clear the consumed key and route the normal release callback"
+        )
+    }
+
     // MARK: - Notification.Name.hotkeysDidChange
     // The engine subscribes to this notification to re-register hotkeys when
     // HotkeyRecorderView writes new bindings. Renaming the notification would
@@ -144,8 +167,17 @@ func testContextCaptureEnginePolicy() {
         let source = readContextCaptureEngineSource()
 
         assertTrue(
-            source.contains("reconcileStateAfterTapWasDisabled()"),
+            source.contains("reconcileActivePushToTalkAfterTapDisabled()"),
             "tap-disabled events should reconcile detector state before re-enabling the tap"
+        )
+        assertTrue(
+            source.contains("cancelPendingModifierShortcut()")
+                && source.contains("func reconcileActivePushToTalkAfterTapDisabled"),
+            "reconciliation should cancel any pending modifier-chord shortcut before re-enabling the tap"
+        )
+        assertTrue(
+            source.contains("consumedKeyCodes = consumedKeyCodes.filter { Self.isPhysicalKeyDown($0) }"),
+            "reconciliation should drop consumed key codes that are no longer physically down"
         )
         assertTrue(
             source.contains("CGEventSource.keyState(.combinedSessionState"),

--- a/Tests/DictationSessionCapTests.swift
+++ b/Tests/DictationSessionCapTests.swift
@@ -64,9 +64,10 @@ func testDictationSessionCap() {
         )
     }
 
-    // Source contract: the cap must finalize-and-save, not discard, and the
-    // suppressed-paste finalize path must persist without pasting.
-    runSuite("The session cap finalizes and saves instead of discarding") {
+    // Source contract: the cap must finalize-and-save, not discard. It may
+    // paste only when the original paste target still owns focus; otherwise it
+    // uses the suppressed-paste finalize path.
+    runSuite("The session cap warns, then pastes only when the original target is still active") {
         let source = dictationControllerSource()
 
         let timeoutBody = capSlice(
@@ -75,8 +76,17 @@ func testDictationSessionCap() {
             to: "private func overlayStateName"
         )
         assertTrue(
-            timeoutBody.contains("stopDictationAndPaste(trigger: .sessionCap, autoPaste: false)"),
-            "the session cap should finalize-and-save with auto-paste suppressed"
+            timeoutBody.contains("title: \"Long dictation\"")
+                && timeoutBody.contains("30 seconds left"),
+            "the session cap should warn before it auto-finalizes"
+        )
+        assertTrue(
+            timeoutBody.contains("let shouldAutoPaste = self.sessionPasteTarget?.matchesCurrentFrontmostApp() ?? false"),
+            "the session cap should only paste when the original target still matches the frontmost app"
+        )
+        assertTrue(
+            timeoutBody.contains("stopDictationAndPaste(trigger: .sessionCap, autoPaste: shouldAutoPaste)"),
+            "the session cap should route the target-match decision into the normal stop pipeline"
         )
         assertFalse(
             timeoutBody.contains("cancelDictation()"),
@@ -113,6 +123,58 @@ func testDictationSessionCap() {
         assertFalse(
             finalizeBody.contains("pasteWithClipboardRestore"),
             "the cap finalize path must not paste into the focused app"
+        )
+    }
+
+    runSuite("Dictation stop path preserves recovered audio and surfaces invisible hotkey states") {
+        let source = dictationControllerSource()
+        let stopBody = capSlice(
+            source,
+            from: "func stopDictationAndPaste(",
+            to: "/// Finalize a dictation"
+        )
+
+        assertTrue(
+            stopBody.contains("cancelPendingDictationStartAfterEarlyRelease"),
+            "a push-to-talk release during model/mic warmup should show a clear no-audio message instead of a generic cancel animation"
+        )
+        assertTrue(
+            stopBody.contains("Still finishing the last dictation. Try again in a moment."),
+            "a hotkey press during the drafting/transcribing window should visibly respond"
+        )
+        assertTrue(
+            stopBody.contains("let hasRecoverableRecording = appState.sttRouter.hasRecoverableRecording"),
+            "stop during device recovery should detect preserved recovered audio"
+        )
+        assertTrue(
+            stopBody.contains("guard appState.sttRouter.isRecording || hasRecoverableRecording else"),
+            "a recovered timeline should continue into transcription instead of taking the mic-start failure path"
+        )
+    }
+
+    runSuite("Dictation interruption offers preserved captured audio for transcription") {
+        let source = dictationControllerSource()
+        let interruptionBody = capSlice(
+            source,
+            from: "private func handleDictationInterruption()",
+            to: "private func shouldOfferMicrophoneRecoveryAction"
+        )
+
+        assertTrue(
+            interruptionBody.contains("hasRecoverableRecording"),
+            "interruption UI should branch when the speech engine has retained audio"
+        )
+        assertTrue(
+            interruptionBody.contains("Transcribe Captured Audio"),
+            "wake/device interruption with preserved audio should offer a transcribe action"
+        )
+        assertTrue(
+            interruptionBody.contains("cancelActiveTasks(cancelRecording: !hasRecoverableRecording)"),
+            "preserved-audio interruptions should not clear the recovered timeline before the action can transcribe it"
+        )
+        assertTrue(
+            interruptionBody.contains("stopDictationAndPaste(trigger: .unknown, autoPaste: false)"),
+            "the recovered-audio action should save safely without pasting into a possibly changed app"
         )
     }
 }

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -766,6 +766,41 @@ func testParakeetStartRecordingFailurePolicy() {
             "shared watchdog cancellation should clear pending zombie restart state"
         )
     }
+
+    runSuite("ParakeetEngine preserves recovered dictation audio for stop and wake recovery") {
+        let source = readParakeetEngineSource()
+        guard let wakeStart = source.range(of: "private func handleSystemWake()"),
+              let wakeEnd = source.range(of: "// MARK: - Recording", range: wakeStart.upperBound..<source.endIndex),
+              let stopStart = source.range(of: "func stopRecording()"),
+              let stopEnd = source.range(of: "// MARK: - EOU Streaming", range: stopStart.upperBound..<source.endIndex) else {
+            assertTrue(false, "test should find wake and stopRecording bodies")
+            return
+        }
+
+        let wakeBody = String(source[wakeStart.lowerBound..<wakeEnd.lowerBound])
+        let stopBody = String(source[stopStart.lowerBound..<stopEnd.lowerBound])
+
+        assertTrue(
+            wakeBody.contains("preserveCurrentRecordingBuffersForRecovery()"),
+            "system wake during dictation should move buffered speech into the recovered timeline before teardown"
+        )
+        assertTrue(
+            wakeBody.contains("interruptRecordingPreservingRecoveredTimeline()"),
+            "system wake should mark the interruption without clearing recovered audio"
+        )
+        assertTrue(
+            stopBody.contains("preservingRecordingAcrossRecovery || !recoveredRecordingTimeline.isEmpty"),
+            "stopRecording while recovery holds audio should preserve the timeline"
+        )
+        assertTrue(
+            stopBody.contains("cancelPendingRecordingRecovery()"),
+            "user stop during recovery should cancel pending restart tasks before transcribing recovered audio"
+        )
+        assertTrue(
+            source.contains("var hasRecoverableRecording: Bool"),
+            "the router/UI need a public engine signal for recovered dictation audio"
+        )
+    }
 }
 
 private func readParakeetEngineSource(file: String = #file, line: Int = #line) -> String {

--- a/Tests/PhysicalShortcutMatcherTests.swift
+++ b/Tests/PhysicalShortcutMatcherTests.swift
@@ -135,4 +135,30 @@ func testPhysicalShortcutMatcher() {
         )
         assertTrue(!nonModifier, "a typing key has no shared-modifier chord to guard")
     }
+
+    runSuite("PhysicalShortcutMatcher — tap re-enable synthesizes missed push-to-talk release only when key is up") {
+        let activeKey = UInt32(kVK_Function)
+
+        assertFalse(
+            PhysicalShortcutMatcher.shouldSynthesizePushToTalkRelease(
+                activeKeyCode: nil,
+                isPhysicallyDown: { _ in false }
+            ),
+            "no active push-to-talk key means there is no release to synthesize"
+        )
+        assertFalse(
+            PhysicalShortcutMatcher.shouldSynthesizePushToTalkRelease(
+                activeKeyCode: activeKey,
+                isPhysicallyDown: { _ in true }
+            ),
+            "a still-held push-to-talk key must keep recording after tap re-enable"
+        )
+        assertTrue(
+            PhysicalShortcutMatcher.shouldSynthesizePushToTalkRelease(
+                activeKeyCode: activeKey,
+                isPhysicallyDown: { _ in false }
+            ),
+            "a released push-to-talk key must synthesize release if macOS dropped keyUp while the tap was disabled"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- preserve recovered dictation audio through stop/wake recovery paths and expose a safe UI action to transcribe captured audio
- synthesize missed push-to-talk release after event tap re-enable when the physical key is already up
- make warm-up early release, finishing-window hotkeys, and session-cap behavior visible/safe

## Audit findings
Addresses #7, #33, #34, #46, #47, #57 partial, #62. Full launch-time crash recovery/disk spooling for #57 remains follow-up.

## Verification
- python3 scripts/dev/check-build-source-lists.py
- git diff --check
- bash build-deps.sh --force
- TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 bash build.sh --no-open
- bash run-tests.sh --filter DictationSessionCap
- bash run-tests.sh --filter ContextCaptureEnginePolicy
- bash run-tests.sh --filter PhysicalShortcutMatcher
- bash run-tests.sh --filter ParakeetStartRecordingFailurePolicy
- bash run-tests.sh --filter DictationAudioRecovery
- bash run-tests.sh (11990 passed, 0 failed)
- bash run-integration-smoke.sh
- bash run-slow-pasteback-smoke.sh

## Caveat
- bash build.sh --no-open compiled/signed but failed at launch smoke before app startup: _LSOpenURLsWithCompletionHandler() failed with error -10810. Re-ran build with TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 to prove compile/sign/perf budget; launch smoke remains unverified on this machine.