### PR TITLE
Fix audit prompt and onboarding UX

### DIFF
--- a/Sources/Meeting/MeetingPromptHeuristics.swift
+++ b/Sources/Meeting/MeetingPromptHeuristics.swift
@@ -740,9 +740,9 @@ enum MeetingPromptSessionPromptState: Equatable {
 
     var allowsDetectedMeetingPrompt: Bool {
         switch self {
-        case .idle, .ready, .error:
+        case .idle, .ready, .transcribing, .error:
             return true
-        case .loadingModels, .recording, .transcribing:
+        case .loadingModels, .recording:
             return false
         }
     }

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -101,8 +101,9 @@ enum TranscriptedPermissionAccess {
             return AXIsProcessTrusted()
         case .systemAudioRecording:
             if systemAudioRecordingStatus() == .granted {
+                let stillGranted = await revalidateSystemAudioRecordingStatus()
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
-                return true
+                return stillGranted
             }
 
             let granted = await requestSystemAudioRecordingAccessIfNeeded()
@@ -173,6 +174,24 @@ enum TranscriptedPermissionAccess {
 
     static func systemAudioRecordingGranted() -> Bool {
         systemAudioRecordingStatus().isGranted
+    }
+
+    @MainActor
+    static func revalidateSystemAudioRecordingStatus() async -> Bool {
+        let granted = await performSystemAudioRecordingAccessRequest()
+        setSystemAudioRecordingGranted(granted)
+        notifyPermissionsDidChange(kind: .systemAudioRecording)
+        return granted
+    }
+
+    @MainActor
+    static func revalidateSystemAudioRecordingStatus(
+        requester: @escaping @MainActor () async -> Bool
+    ) async -> Bool {
+        let granted = await requester()
+        setSystemAudioRecordingGranted(granted)
+        notifyPermissionsDidChange(kind: .systemAudioRecording)
+        return granted
     }
 
     private static func setSystemAudioRecordingGranted(_ granted: Bool) {

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -237,6 +237,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             }
             capturePillController.onRecord = recordPrompt
             capturePillController.onDismiss = dismissPrompt
+            capturePillController.onRemind = meetingOverlayController.onPromptRemindSoon
+            capturePillController.onExpired = meetingOverlayController.onPromptExpired
             meetingPromptDetector.onPromptSuppressed = { [weak self] suppression in
                 guard let self else { return }
                 AnalyticsReporter.track(
@@ -260,7 +262,11 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingPromptDetector.onPromptRequest = { [weak self] candidate in
                 guard PermissionsOnboardingPreferences.hasCompleted() else { return false }
                 guard let self else { return false }
-                let presented = self.capturePillController.present(candidate: candidate)
+                let timeout = MeetingPromptHeuristics.promptTimeoutSeconds(
+                    for: candidate.reason,
+                    calendarDefault: 30
+                )
+                let presented = self.capturePillController.present(candidate: candidate, timeout: TimeInterval(timeout))
                 if presented {
                     AnalyticsReporter.track(
                         "meeting_prompt_shown",

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -97,7 +97,7 @@ final class MenuBarPanelController: NSViewController {
 
         content.headerView.update(
             warmupStatus: warmupStatus,
-            hotkeyError: appState.contextCapture.hotkeyError,
+            hotkeyError: HotkeyPreferences.dictationShortcutsEnabled() ? appState.contextCapture.hotkeyError : nil,
             isMeetingRecording: isMeetingRecording
         )
 

--- a/Sources/UI/Overlay/CapturePillController.swift
+++ b/Sources/UI/Overlay/CapturePillController.swift
@@ -11,6 +11,8 @@ final class CapturePillController {
 
     var onRecord: ((MeetingPromptDetector.Candidate) -> Void)?
     var onDismiss: ((MeetingPromptDetector.Candidate) -> Void)?
+    var onRemind: ((MeetingPromptDetector.Candidate) -> Void)?
+    var onExpired: ((MeetingPromptDetector.Candidate) -> Void)?
 
     deinit {
         dismissTask?.cancel()
@@ -34,7 +36,6 @@ final class CapturePillController {
 
         position(panel: panel)
         panel.orderFrontRegardless()
-        panel.makeKey()
 
         installEventMonitor()
         scheduleDismiss(timeout: timeout)
@@ -73,6 +74,7 @@ final class CapturePillController {
         pillView.autoresizingMask = [.width, .height]
         pillView.onRecord = { [weak self] in self?.record() }
         pillView.onDismiss = { [weak self] in self?.dismiss(notify: true) }
+        pillView.onRemind = { [weak self] in self?.remind() }
         panel.contentView = pillView
 
         self.panel = panel
@@ -85,20 +87,29 @@ final class CapturePillController {
         onRecord?(candidate)
     }
 
+    private func remind() {
+        guard let candidate = representedCandidate else { return }
+        dismiss(notify: false)
+        onRemind?(candidate)
+    }
+
     private func scheduleDismiss(timeout: TimeInterval) {
         dismissTask?.cancel()
         dismissTask = Task { @MainActor [weak self] in
             let nanoseconds = UInt64(max(1, timeout) * 1_000_000_000)
             try? await Task.sleep(nanoseconds: nanoseconds)
             guard !Task.isCancelled else { return }
-            self?.dismiss(notify: true)
+            guard let self, let candidate = self.representedCandidate else { return }
+            self.dismiss(notify: false)
+            self.onExpired?(candidate)
         }
     }
 
     private func installEventMonitor() {
         guard eventMonitor == nil else { return }
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard let self, self.panel?.isVisible == true else { return event }
+            guard let self, let panel = self.panel, panel.isVisible else { return event }
+            guard event.window === panel || panel.isKeyWindow else { return event }
             switch event.keyCode {
             case 36:
                 self.record()
@@ -113,7 +124,10 @@ final class CapturePillController {
     }
 
     private func position(panel: NSPanel) {
-        let screen = NSScreen.main ?? NSScreen.screens.first
+        let mouseLocation = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { NSMouseInRect(mouseLocation, $0.frame, false) }
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
         let visibleFrame = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
         let size = panel.frame.size
         let inset: CGFloat = 18
@@ -176,15 +190,17 @@ final class CapturePillPanel: NSPanel {
 
 @available(macOS 14.0, *)
 private final class CapturePillView: NSView {
-    static let preferredSize = NSSize(width: 430, height: 74)
+    static let preferredSize = NSSize(width: 540, height: 74)
 
     var onRecord: (() -> Void)?
     var onDismiss: (() -> Void)?
+    var onRemind: (() -> Void)?
 
     private let iconView = NSImageView()
     private let titleLabel = NSTextField(labelWithString: "")
     private let detailLabel = NSTextField(labelWithString: "")
     private let dismissButton = NSButton(title: "Not now", target: nil, action: nil)
+    private let remindButton = NSButton(title: "Remind me soon", target: nil, action: nil)
     private let recordButton = NSButton(title: "Record", target: nil, action: nil)
 
     override init(frame frameRect: NSRect) {
@@ -211,6 +227,7 @@ private final class CapturePillView: NSView {
         addSubview(detailLabel)
 
         configureButton(dismissButton, title: "Not now", isPrimary: false, action: #selector(dismissTapped))
+        configureButton(remindButton, title: "Remind me soon", isPrimary: false, action: #selector(remindTapped))
         configureButton(recordButton, title: "Record", isPrimary: true, action: #selector(recordTapped))
 
         setAccessibilityElement(true)
@@ -230,6 +247,7 @@ private final class CapturePillView: NSView {
         iconView.frame = NSRect(x: pad, y: (bounds.height - iconSize) / 2, width: iconSize, height: iconSize)
 
         let recordSize = NSSize(width: 72, height: 32)
+        let remindSize = NSSize(width: 118, height: 32)
         let dismissSize = NSSize(width: 82, height: 32)
         recordButton.frame = NSRect(
             x: bounds.width - pad - recordSize.width,
@@ -237,8 +255,14 @@ private final class CapturePillView: NSView {
             width: recordSize.width,
             height: recordSize.height
         )
+        remindButton.frame = NSRect(
+            x: recordButton.frame.minX - 8 - remindSize.width,
+            y: (bounds.height - remindSize.height) / 2,
+            width: remindSize.width,
+            height: remindSize.height
+        )
         dismissButton.frame = NSRect(
-            x: recordButton.frame.minX - 8 - dismissSize.width,
+            x: remindButton.frame.minX - 8 - dismissSize.width,
             y: (bounds.height - dismissSize.height) / 2,
             width: dismissSize.width,
             height: dismissSize.height
@@ -286,5 +310,9 @@ private final class CapturePillView: NSView {
 
     @objc private func dismissTapped() {
         onDismiss?()
+    }
+
+    @objc private func remindTapped() {
+        onRemind?()
     }
 }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -730,6 +730,7 @@ class DictationSessionController: ObservableObject {
                         )
                     }
                 case .denied, .restricted:
+                    overlayController.dismissError()
                     TranscriptedPermissionAccess.openSettings(for: .microphone)
                 case .authorized:
                     self.startDictation(
@@ -738,6 +739,7 @@ class DictationSessionController: ObservableObject {
                         anchorRect: self.sessionAnchorRect
                     )
                 @unknown default:
+                    overlayController.dismissError()
                     TranscriptedPermissionAccess.openSettings(for: .microphone)
                 }
             } : nil

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -215,6 +215,7 @@ class FloatingOverlayController {
             errorMessage: errorMessage,
             errorActionTitle: errorActionTitle,
             onErrorAction: errorActionHandler,
+            onErrorDismiss: { [weak self] in self?.dismissError() },
             loadingPresentation: loadingPresentation,
             loadingElapsedSeconds: loadingElapsedSeconds,
             successTitle: successTitle,
@@ -569,6 +570,16 @@ class FloatingOverlayController {
         }
     }
 
+    func dismissError() {
+        guard state == .drafting, !errorMessage.isEmpty else { return }
+        errorDismissTask?.cancel()
+        errorDismissTask = nil
+        errorMessage = ""
+        errorActionTitle = nil
+        errorActionHandler = nil
+        hideWithCancelAnimation()
+    }
+
     /// Fast dismiss for empty dictation audio — brief flash then clean fade (no shake).
     func showNoSpeechAndDismiss(trigger: String = "unknown") {
         errorDismissTask?.cancel()
@@ -660,6 +671,10 @@ class FloatingOverlayController {
             Task { @MainActor [weak self] in
                 guard let self = self else { return }
                 guard self.state == .starting || self.state == .loading || self.state == .listening || self.state == .drafting else { return }
+                if self.state == .drafting, !self.errorMessage.isEmpty {
+                    self.dismissError()
+                    return
+                }
                 self.onEscapeDuringSession?()
             }
         }

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -666,7 +666,16 @@ final class MeetingOverlayRootView: NSView {
         statusDot.frame = NSRect(x: pad, y: topY - dotSize / 2, width: dotSize, height: dotSize)
 
         let titleX = statusDot.frame.maxX + 8
-        let titleWidth = max(0, bounds.width - titleX - pad)
+        let closeWidth: CGFloat = 70
+        let closeHeight: CGFloat = 24
+        closeButton.frame = NSRect(
+            x: bounds.width - pad - closeWidth,
+            y: topY - closeHeight / 2,
+            width: closeWidth,
+            height: closeHeight
+        )
+
+        let titleWidth = max(0, closeButton.frame.minX - titleX - 8)
         let titleSize = titleLabel.fittingSize
         titleLabel.frame = NSRect(
             x: titleX,
@@ -675,11 +684,12 @@ final class MeetingOverlayRootView: NSView {
             height: titleSize.height
         )
 
+        detailLabel.maximumNumberOfLines = 2
         detailLabel.frame = NSRect(
             x: pad,
-            y: 16,
+            y: 12,
             width: bounds.width - pad * 2,
-            height: 16
+            height: 32
         )
         refreshTooltipTrackingAreas()
     }
@@ -747,7 +757,7 @@ final class MeetingOverlayRootView: NSView {
         } else {
             audioWaveform.isHidden = true
             audioWaveform.alphaValue = 1
-            closeButton.isHidden = isPreparing || !isPrompting
+            closeButton.isHidden = isPreparing || !(isPrompting || isErrorState)
             closeButton.alphaValue = 1
         }
         pillBodyView.isHidden = state != .recording || liveView == nil
@@ -833,6 +843,15 @@ final class MeetingOverlayRootView: NSView {
                 isRetryable: true
             )
             titleLabel.stringValue = copy.title
+            closeButton.attributedTitle = buttonTitle("Dismiss", size: 11, weight: .semibold)
+            closeButton.image = nil
+            closeButton.imagePosition = .noImage
+            closeButton.toolTip = nil
+            closeButton.setAccessibilityLabel("Dismiss meeting failure")
+            closeButton.setAccessibilityHelp("Hides this meeting failure notice. Recovery remains available from Home.")
+            closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
+            closeButton.layer?.cornerRadius = 8
+            closeButton.layer?.borderWidth = 0
             updateStatusDot(
                 color: failureKind == .recordingTooShort
                     ? MeetingOverlayTokens.dotIdle
@@ -1868,8 +1887,8 @@ final class MeetingOverlayController: NSObject {
             promptCandidate = nil
             promptKind = nil
             promptCountdownTask?.cancel()
+            autoHideTask?.cancel()
             showPanel()
-            scheduleAutoHide(after: 5)
         }
         pushToView()
     }

--- a/Sources/UI/Overlay/OverlayDraftingView.swift
+++ b/Sources/UI/Overlay/OverlayDraftingView.swift
@@ -67,12 +67,14 @@ final class OverlayDraftingView: NSView {
     private let errorIcon = NSImageView()
     private let errorLabel = NSTextField(labelWithString: "")
     private let errorActionButton = OverlaySecondaryButton(frame: .zero)
+    private let errorDismissButton = NSButton(frame: .zero)
 
     // Secondary state: dimmed transcript + "Refining..." spinner
     private let dimmedTranscript = NSTextField(wrappingLabelWithString: "")
     private let refiningSpinner = NSProgressIndicator()
     private let refiningLabel = NSTextField(labelWithString: "")
     private var errorAction: (() -> Void)?
+    private var errorDismiss: (() -> Void)?
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -127,6 +129,20 @@ final class OverlayDraftingView: NSView {
         errorActionButton.action = #selector(handleErrorAction)
         addSubview(errorActionButton)
 
+        if let closeImage = NSImage(systemSymbolName: "xmark.circle.fill", accessibilityDescription: "Dismiss error") {
+            errorDismissButton.image = closeImage
+            errorDismissButton.imagePosition = .imageOnly
+        } else {
+            errorDismissButton.title = "x"
+        }
+        errorDismissButton.isBordered = false
+        errorDismissButton.contentTintColor = OverlayTokens.textSecondary
+        errorDismissButton.target = self
+        errorDismissButton.action = #selector(handleErrorDismiss)
+        errorDismissButton.isHidden = true
+        errorDismissButton.setAccessibilityLabel("Dismiss error")
+        addSubview(errorDismissButton)
+
         // Dimmed transcript (for showing text at reduced opacity during processing)
         dimmedTranscript.font = NSFont.systemFont(ofSize: 13)
         dimmedTranscript.textColor = OverlayTokens.textPrimary
@@ -171,6 +187,14 @@ final class OverlayDraftingView: NSView {
             let buttonSpacing: CGFloat = hasAction ? 10 : 0
             let totalHeight = iconSize + 8 + labelSize.height + buttonSpacing + buttonSize.height
             let startY = centerY - totalHeight / 2
+            let dismissSize: CGFloat = 22
+
+            errorDismissButton.frame = NSRect(
+                x: bounds.width - pad - dismissSize,
+                y: bounds.height - pad - dismissSize,
+                width: dismissSize,
+                height: dismissSize
+            )
 
             errorIcon.frame = NSRect(
                 x: centerX - iconSize / 2,
@@ -220,6 +244,7 @@ final class OverlayDraftingView: NSView {
         error: String?,
         errorActionTitle: String?,
         onErrorAction: (() -> Void)?,
+        onErrorDismiss: (() -> Void)?,
         isTranscribing: Bool,
         transcriptText: String,
         statusText: String
@@ -227,9 +252,11 @@ final class OverlayDraftingView: NSView {
         if let error = error, !error.isEmpty {
             // Error mode
             errorAction = onErrorAction
+            errorDismiss = onErrorDismiss
             errorIcon.isHidden = false
             errorLabel.isHidden = false
             errorLabel.stringValue = error
+            errorDismissButton.isHidden = false
             if let errorActionTitle, !errorActionTitle.isEmpty {
                 errorActionButton.title = errorActionTitle
                 errorActionButton.isHidden = false
@@ -245,6 +272,7 @@ final class OverlayDraftingView: NSView {
         } else if isTranscribing, !transcriptText.isEmpty {
             // Dimmed transcript + refining
             errorAction = nil
+            errorDismiss = nil
             dimmedTranscript.isHidden = false
             dimmedTranscript.stringValue = transcriptText
             refiningSpinner.isHidden = false
@@ -256,9 +284,11 @@ final class OverlayDraftingView: NSView {
             errorIcon.isHidden = true
             errorLabel.isHidden = true
             errorActionButton.isHidden = true
+            errorDismissButton.isHidden = true
         } else {
             // Default: spinner + status
             errorAction = nil
+            errorDismiss = nil
             spinner.isHidden = false
             spinner.startAnimation(nil)
             statusLabel.isHidden = false
@@ -269,6 +299,7 @@ final class OverlayDraftingView: NSView {
             refiningSpinner.isHidden = true
             refiningLabel.isHidden = true
             errorActionButton.isHidden = true
+            errorDismissButton.isHidden = true
         }
         needsLayout = true
     }
@@ -276,5 +307,10 @@ final class OverlayDraftingView: NSView {
     @objc
     private func handleErrorAction() {
         errorAction?()
+    }
+
+    @objc
+    private func handleErrorDismiss() {
+        errorDismiss?()
     }
 }

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -120,6 +120,7 @@ final class OverlayRootView: NSView {
         errorMessage: String,
         errorActionTitle: String?,
         onErrorAction: (() -> Void)?,
+        onErrorDismiss: (() -> Void)?,
         loadingPresentation: FloatingOverlayController.LoadingPresentation,
         loadingElapsedSeconds: Int,
         successTitle: String,
@@ -172,6 +173,7 @@ final class OverlayRootView: NSView {
                 error: errorMessage.isEmpty ? nil : errorMessage,
                 errorActionTitle: errorActionTitle,
                 onErrorAction: onErrorAction,
+                onErrorDismiss: onErrorDismiss,
                 isTranscribing: isTranscribing,
                 transcriptText: liveTranscript,
                 statusText: statusText

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -112,6 +112,7 @@ struct PermissionsOnboardingView: View {
                 flowStartedAt = CFAbsoluteTimeGetCurrent()
             }
             checkAllPermissions(trackChanges: false)
+            revalidateSystemAudioPermission(trackChanges: false)
             trackCurrentStepViewed()
             startPolling()
         }
@@ -580,7 +581,7 @@ struct PermissionsOnboardingView: View {
             // user has the System Settings menu open. A Task-driven loop keeps
             // polling regardless and dies cleanly when onDisappear cancels it.
             while !Task.isCancelled {
-                checkAllPermissions(trackChanges: true)
+                await revalidateSystemAudioPermissionNow(trackChanges: true)
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
@@ -589,6 +590,23 @@ struct PermissionsOnboardingView: View {
     private func stopPolling() {
         pollTask?.cancel()
         pollTask = nil
+    }
+
+    private func revalidateSystemAudioPermission(trackChanges: Bool) {
+        Task { @MainActor in
+            await revalidateSystemAudioPermissionNow(trackChanges: trackChanges)
+        }
+    }
+
+    private func revalidateSystemAudioPermissionNow(trackChanges: Bool) async {
+        guard currentStep.kind == .permissions
+            || TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown
+        else {
+            checkAllPermissions(trackChanges: trackChanges)
+            return
+        }
+        _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
+        checkAllPermissions(trackChanges: trackChanges)
     }
 
     private func completeOnboarding() {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -48,6 +48,7 @@ struct TranscriptedSettingsView: View {
     @State private var sentryTestStatus: String?
     @State private var diagnosticsActionStatus: String?
     @State private var permissionStates = PermissionSnapshot.current()
+    @State private var systemAudioPermissionRefreshTask: Task<Void, Never>?
     @State private var captureLibraryURL = FileManager.default.transcriptedCaptureLibraryDir
     @State private var pendingCaptureLibraryChoice: PendingCaptureLibraryChoice?
     @State private var captureLibraryMigrationInProgress = false
@@ -3073,16 +3074,7 @@ struct TranscriptedSettingsView: View {
 
                     SettingsInlineActionButton(title: "Reset to Default") {
                         trackSettingsAction("reset_capture_library", page: .storage)
-                        TranscriptedStoragePreferences.setCaptureLibraryURL(nil)
-                        refreshStoragePaths()
-                        CaptureLibraryChangeBroadcaster.shared.noteLibraryWideChange()
-                        AnalyticsReporter.track(
-                            "settings_capture_library_changed",
-                            properties: [
-                                "location_type": "default",
-                                "page_id": TranscriptedSettingsPage.storage.analyticsValue,
-                            ]
-                        )
+                        resetCaptureLibraryToDefault()
                     }
                     .disabled(captureLibraryMigrationInProgress)
                     .help(captureLibraryMigrationInProgress ? captureLibraryMigrationBusyHelp : "")
@@ -3112,7 +3104,7 @@ struct TranscriptedSettingsView: View {
                 isPresented: captureLibraryChoicePromptBinding,
                 presenting: pendingCaptureLibraryChoice
             ) { choice in
-                Button("Copy to New Folder") {
+                Button(choice.copyButtonTitle) {
                     copyCapturesThenSwitchLibrary(choice)
                 }
                 .keyboardShortcut(.defaultAction)
@@ -3121,7 +3113,7 @@ struct TranscriptedSettingsView: View {
                 }
                 Button("Cancel", role: .cancel) {}
             } message: { choice in
-                Text("Your current library still has saved meetings or dictations. Copy puts a copy of them in the new folder and never deletes the originals. Just Switch leaves everything in \(choice.currentLibrary.path) - Transcripted and connected agents will only see the new folder.")
+                Text("Your current library still has saved meetings or dictations. Copy puts a copy of them in \(choice.destinationName) and never deletes the originals. Just Switch leaves everything in \(choice.currentLibrary.path) - Transcripted and connected agents will only see \(choice.destinationName).")
             }
 
             SettingsSection(
@@ -4387,9 +4379,16 @@ struct TranscriptedSettingsView: View {
     }
 
     private var missingRequiredPermissions: [TranscriptedPermissionKind] {
-        TranscriptedPermissionKind.allCases.filter { kind in
-            kind.isRequiredOnFirstLaunch && !(permissionStates[kind] ?? false)
+        requiredPermissionsForCurrentUsage.filter { kind in
+            !(permissionStates[kind] ?? false)
         }
+    }
+
+    private var requiredPermissionsForCurrentUsage: [TranscriptedPermissionKind] {
+        if dictationShortcutsEnabled {
+            return [.microphone, .accessibility]
+        }
+        return [.microphone, .systemAudioRecording]
     }
 
     private var permissionsStatusLine: String {
@@ -4401,9 +4400,11 @@ struct TranscriptedSettingsView: View {
 
     private var permissionsDetailLine: String {
         if missingRequiredPermissions.isEmpty {
-            return "Required permissions are on. Meeting permissions are optional."
+            return dictationShortcutsEnabled
+                ? "Dictation permissions are on. Meeting permissions are optional."
+                : "Meeting permissions are on. Paste-back is optional while shortcuts are off."
         }
-        return "Turn on \(missingRequiredPermissions.map(\.title).joined(separator: " and ")) to record and paste back."
+        return "Turn on \(missingRequiredPermissions.map(\.title).joined(separator: " and ")) to keep your current setup ready."
     }
 
     private var isUsingDefaultCaptureLibrary: Bool {
@@ -4600,6 +4601,14 @@ struct TranscriptedSettingsView: View {
 
     private func refreshPermissions() {
         permissionStates = PermissionSnapshot.current()
+        guard TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown else { return }
+        systemAudioPermissionRefreshTask?.cancel()
+        systemAudioPermissionRefreshTask = Task { @MainActor in
+            _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
+            guard !Task.isCancelled else { return }
+            permissionStates = PermissionSnapshot.current()
+            systemAudioPermissionRefreshTask = nil
+        }
     }
 
     private func refreshStoragePaths() {
@@ -4968,7 +4977,8 @@ struct TranscriptedSettingsView: View {
         if !isSameFolder, CaptureLibraryMigrationPlanner().libraryHasCaptures(at: currentLibrary) {
             pendingCaptureLibraryChoice = PendingCaptureLibraryChoice(
                 currentLibrary: currentLibrary,
-                newLibrary: url
+                newLibrary: url,
+                resetsToDefault: false
             )
             return
         }
@@ -4977,9 +4987,26 @@ struct TranscriptedSettingsView: View {
         applyCaptureLibraryChoice(url)
     }
 
+    private func resetCaptureLibraryToDefault() {
+        let currentLibrary = FileManager.default.transcriptedCaptureLibraryDir
+        let defaultLibrary = FileManager.default.transcriptedDefaultCaptureLibraryDir
+        let isSameFolder = currentLibrary.standardizedFileURL.path == defaultLibrary.standardizedFileURL.path
+        if !isSameFolder, CaptureLibraryMigrationPlanner().libraryHasCaptures(at: currentLibrary) {
+            pendingCaptureLibraryChoice = PendingCaptureLibraryChoice(
+                currentLibrary: currentLibrary,
+                newLibrary: defaultLibrary,
+                resetsToDefault: true
+            )
+            return
+        }
+
+        captureLibraryMigrationStatus = nil
+        applyDefaultCaptureLibraryChoice()
+    }
+
     private func switchLibraryWithoutCopying(_ choice: PendingCaptureLibraryChoice) {
         captureLibraryMigrationStatus = "Existing captures stayed in \(choice.currentLibrary.path)."
-        applyCaptureLibraryChoice(choice.newLibrary)
+        applyCaptureLibraryChoice(choice)
     }
 
     private func copyCapturesThenSwitchLibrary(_ choice: PendingCaptureLibraryChoice) {
@@ -4999,7 +5026,7 @@ struct TranscriptedSettingsView: View {
                 await MainActor.run {
                     captureLibraryMigrationInProgress = false
                     captureLibraryMigrationStatus = captureLibraryCopySummary(result)
-                    applyCaptureLibraryChoice(choice.newLibrary)
+                    applyCaptureLibraryChoice(choice)
                 }
             } catch {
                 await MainActor.run {
@@ -5031,6 +5058,31 @@ struct TranscriptedSettingsView: View {
             "settings_capture_library_changed",
             properties: [
                 "location_type": isUsingDefaultCaptureLibrary ? "default" : "custom",
+                "page_id": TranscriptedSettingsPage.storage.analyticsValue,
+            ]
+        )
+    }
+
+    private func applyCaptureLibraryChoice(_ choice: PendingCaptureLibraryChoice) {
+        if choice.resetsToDefault {
+            applyDefaultCaptureLibraryChoice()
+        } else {
+            applyCaptureLibraryChoice(choice.newLibrary)
+        }
+    }
+
+    private func applyDefaultCaptureLibraryChoice() {
+        guard TranscriptedStoragePreferences.setCaptureLibraryURL(nil) else {
+            refreshStoragePaths()
+            showCaptureLibrarySelectionError()
+            return
+        }
+        refreshStoragePaths()
+        CaptureLibraryChangeBroadcaster.shared.noteLibraryWideChange()
+        AnalyticsReporter.track(
+            "settings_capture_library_changed",
+            properties: [
+                "location_type": "default",
                 "page_id": TranscriptedSettingsPage.storage.analyticsValue,
             ]
         )
@@ -5281,6 +5333,15 @@ struct TranscriptedSettingsView: View {
 private struct PendingCaptureLibraryChoice: Equatable {
     let currentLibrary: URL
     let newLibrary: URL
+    let resetsToDefault: Bool
+
+    var copyButtonTitle: String {
+        resetsToDefault ? "Copy to Default Folder" : "Copy to New Folder"
+    }
+
+    var destinationName: String {
+        resetsToDefault ? "the default folder" : "the new folder"
+    }
 }
 
 // User-facing copy for the "we can't find this artifact on disk" failures that

--- a/Tests/OverlayScreenSharePrivacyTests.swift
+++ b/Tests/OverlayScreenSharePrivacyTests.swift
@@ -162,7 +162,7 @@ func testOverlayScreenSharePrivacy() async {
             to: "// Ad-hoc call detection:"
         )
         assertTrue(
-            promptRequest.contains("capturePillController.present(candidate: candidate)"),
+            promptRequest.contains("capturePillController.present(candidate: candidate, timeout:"),
             "detected meeting prompts should use the floating capture pill"
         )
         assertFalse(

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3459,6 +3459,85 @@ func testRepoCommandContract() {
             "settings should not immediately refresh after a fire-and-forget permission action"
         )
     }
+
+    runSuite("Repo command contract - audit prompt and onboarding UX guards") {
+        let appContents = readRepoTextFile("Sources/TranscriptedApp.swift")
+        let pillContents = readRepoTextFile("Sources/UI/Overlay/CapturePillController.swift")
+        let meetingOverlayContents = readRepoTextFile("Sources/UI/Overlay/MeetingOverlayController.swift")
+        let floatingOverlayContents = readRepoTextFile("Sources/UI/Overlay/FloatingOverlayController.swift")
+        let overlayDraftingContents = readRepoTextFile("Sources/UI/Overlay/OverlayDraftingView.swift")
+        let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        let onboardingContents = readRepoTextFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
+        let menuContents = readRepoTextFile("Sources/UI/MenuBar/MenuBarPanelController.swift")
+        let permissionAccessContents = readRepoTextFile("Sources/Support/TranscriptedPermissionAccess.swift")
+
+        assertTrue(
+            pillContents.contains("var onRemind")
+                && pillContents.contains("var onExpired")
+                && pillContents.contains("Remind me soon"),
+            "capture pill should keep Record, Not now, and Remind me soon outcomes"
+        )
+        assertTrue(
+            appContents.contains("MeetingPromptHeuristics.promptTimeoutSeconds")
+                && appContents.contains("capturePillController.onRemind")
+                && appContents.contains("capturePillController.onExpired"),
+            "capture pill prompts should use heuristic timeouts and route remind/expiry distinctly"
+        )
+        assertTrue(
+            pillContents.contains("event.window === panel || panel.isKeyWindow")
+                && !pillContents.contains("panel.makeKey()")
+                && pillContents.contains("NSMouseInRect(mouseLocation"),
+            "capture pill should not hijack app-wide keys or force primary-display placement"
+        )
+        assertTrue(
+            floatingOverlayContents.contains("func dismissError()")
+                && floatingOverlayContents.contains("onErrorDismiss:")
+                && overlayDraftingContents.contains("errorDismissButton"),
+            "actionable dictation errors should be explicitly dismissible"
+        )
+        let meetingErrorBlock = sourceSlice(
+            meetingOverlayContents,
+            from: "case .error(let message):\n            cancelRest()",
+            to: "pushToView()"
+        )
+        assertTrue(
+            meetingErrorBlock.contains("autoHideTask?.cancel()")
+                && !meetingErrorBlock.contains("scheduleAutoHide(after: 5)")
+                && meetingOverlayContents.contains("closeButton.attributedTitle = buttonTitle(\"Dismiss\""),
+            "meeting failures should stay visible until acknowledged"
+        )
+        assertTrue(
+            settingsContents.contains("requiredPermissionsForCurrentUsage")
+                && settingsContents.contains("return [.microphone, .systemAudioRecording]")
+                && menuContents.contains("HotkeyPreferences.dictationShortcutsEnabled() ? appState.contextCapture.hotkeyError : nil"),
+            "meetings-first users should not be nagged for Accessibility while System Audio Recording is the missing blocker"
+        )
+        assertTrue(
+            settingsContents.contains("resetCaptureLibraryToDefault()")
+                && settingsContents.contains("Copy to Default Folder")
+                && settingsContents.contains("applyDefaultCaptureLibraryChoice()"),
+            "resetting the capture library should confirm/copy/switch like choosing a folder"
+        )
+        assertTrue(
+            onboardingContents.contains("revalidateSystemAudioPermissionNow")
+                && settingsContents.contains("revalidateSystemAudioRecordingStatus()")
+                && permissionAccessContents.contains("static func revalidateSystemAudioRecordingStatus() async -> Bool"),
+            "onboarding and Settings should revalidate the System Audio Recording cache"
+        )
+        assertTrue(
+            sourceOrder(
+                in: permissionAccessContents,
+                needles: [
+                    "case .systemAudioRecording:",
+                    "if systemAudioRecordingStatus() == .granted",
+                    "let stillGranted = await revalidateSystemAudioRecordingStatus()",
+                    "return stillGranted",
+                    "let granted = await requestSystemAudioRecordingAccessIfNeeded()",
+                ]
+            ),
+            "the System Audio CTA should revalidate cached grants without opening Settings after a successful first-time grant"
+        )
+    }
 }
 
 private func repoRootURL() -> URL {

--- a/Tests/SyntheticMeetingPromptTests.swift
+++ b/Tests/SyntheticMeetingPromptTests.swift
@@ -556,6 +556,10 @@ func testSyntheticMeetingPrompts() {
             sessionState: .loadingModels,
             overlayState: .idle
         )
+        let transcribing = MeetingPromptPresentationSnapshot(
+            sessionState: .transcribing,
+            overlayState: .idle
+        )
         let overlayBusy = MeetingPromptPresentationSnapshot(
             sessionState: .ready,
             overlayState: .prompt
@@ -568,6 +572,7 @@ func testSyntheticMeetingPrompts() {
         assertTrue(MeetingPromptPresentationGate.allowsDetectedMeetingPrompt(idle), "ready + idle overlay should allow prompts")
         assertFalse(MeetingPromptPresentationGate.allowsDetectedMeetingPrompt(recording), "active recording should suppress detected prompts")
         assertFalse(MeetingPromptPresentationGate.allowsDetectedMeetingPrompt(loading), "model loading should suppress detected prompts")
+        assertTrue(MeetingPromptPresentationGate.allowsDetectedMeetingPrompt(transcribing), "background transcription should not hide back-to-back meeting prompts")
         assertFalse(MeetingPromptPresentationGate.allowsDetectedMeetingPrompt(overlayBusy), "an existing prompt should suppress another prompt")
         assertTrue(MeetingPromptPresentationGate.allowsDetectedMeetingPrompt(savedOverlay), "recent saved state may show a new prompt")
     }

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -283,4 +283,36 @@ func testTranscriptedPermissionAccess() async {
             "cached positive result should stay granted"
         )
     }
+
+    await runSuite("TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus — refreshes stale cache") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+        }
+
+        UserDefaults.standard.set(true, forKey: knownKey)
+        UserDefaults.standard.set(false, forKey: grantedKey)
+        let granted = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus {
+            true
+        }
+
+        assertTrue(granted, "revalidation should return the fresh requester result")
+        assertEqual(
+            TranscriptedPermissionAccess.systemAudioRecordingStatus(),
+            .granted,
+            "revalidation should replace stale denied cache with the fresh grant"
+        )
+
+        let denied = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus {
+            false
+        }
+        assertFalse(denied, "revalidation should also report revocations")
+        assertEqual(
+            TranscriptedPermissionAccess.systemAudioRecordingStatus(),
+            .denied,
+            "revalidation should replace stale granted cache after revocation"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- restores distinct Record / Not now / Remind me soon / expiry behavior for detected-meeting capture pills without stealing key focus
- allows safe detected-meeting prompts while transcription is finishing and keeps failed-meeting/actionable error overlays dismissible but durable
- tightens onboarding/settings permission UX: meetings-first requirements, System Audio revalidation, and reset-to-default capture-library confirmation

## Verification
- bash build-deps.sh --force
- bash run-tests.sh
- bash run-tests.sh --filter TranscriptedPermissionAccessTests
- bash run-tests.sh --filter RepoCommandContractTests
- TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 bash build.sh --no-open
- bash run-integration-smoke.sh
- codex review --base origin/main

## Known proof boundary
- Normal bash build.sh --no-open compiles/signs, then launch smoke fails locally with _LSOpenURLsWithCompletionHandler() error -10810. App launch/UI smoke remains unverified on this machine.

## Maestro lanes
- Codex: implemented, reviewed, built, tested, opened PR
- Claude: attempted, blocked because Claude CLI is not logged in
- Local: audit clustering and follow-up review attempted; outputs were low-quality/context-limited and not used as truth
- Windows: attempted, blocked because the Windows worker is not configured
