### PR TITLE
Fix live sidecar transcript scalability

### DIFF
--- a/Sources/Meeting/LiveMeetingCodexSession.swift
+++ b/Sources/Meeting/LiveMeetingCodexSession.swift
@@ -196,7 +196,7 @@ final class LiveMeetingCodexSession {
         }
 
         if !fileManager.fileExists(atPath: liveTranscriptURL.path) {
-            try writeTextIfChanged(idleTranscriptText(), to: liveTranscriptURL)
+            try writeTextIfChanged(knownText(at: liveTranscriptURL) ?? idleTranscriptText(), to: liveTranscriptURL)
         }
         if !fileManager.fileExists(atPath: watcherStateURL.path) {
             try writeTextIfChanged(initialWatcherStateText(), to: watcherStateURL)
@@ -204,7 +204,9 @@ final class LiveMeetingCodexSession {
         try rewriteLiveTranscriptStatus(state.status.rawValue)
 
         try syncHandoffWithState(fallbackDate: createdAt)
-        try writePreview(force: forcePreviewRewrite)
+        if forcePreviewRewrite || !fileManager.fileExists(atPath: previewURL.path) {
+            try writePreview(force: true)
+        }
     }
 
     private func ensurePreviewAuthTokenLocked() throws -> String {
@@ -255,13 +257,61 @@ final class LiveMeetingCodexSession {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return }
 
+            let previewExistedBeforeRepair = fileManager.fileExists(atPath: previewURL.path)
             try ensureWorkspaceFilesLocked(forcePreviewRewrite: false)
             let marker = entry.isFinal ? "" : " [partial]"
             let line = "**\(Self.timestamp(entry.timestampSeconds))** \(entry.source.markdownTag)\(marker) \(text)\n"
             try appendText(line, to: liveTranscriptURL)
             state.updatedAt = entry.createdAt
             try writeState()
-            try writePreview(force: false)
+            try writePreview(force: !previewExistedBeforeRepair)
+        }
+    }
+
+    func markAppendFailed(
+        consecutiveFailures: Int,
+        error: Error,
+        at date: Date = Date()
+    ) throws {
+        try withSessionLock {
+            try fileManager.createPrivateDirectory(at: workspaceRoot)
+            _ = try? ensurePreviewAuthTokenLocked()
+            loadStoredStateIfAvailable()
+            guard state.status == .recording else { return }
+
+            let countText = consecutiveFailures == 1 ? "1 append failure" : "\(consecutiveFailures) append failures"
+            let note = "Live sidecar stopped updating after \(countText): \(error.localizedDescription). The final Transcripted meeting Markdown still saves normally."
+            state.status = .recording
+            state.streamingBackendStatus = "live_sidecar_append_failed"
+            state.note = note
+            state.updatedAt = date
+
+            try writeState()
+            try syncHandoffWithState(fallbackDate: date)
+            try? rewriteLiveTranscriptStatus(state.status.rawValue)
+            try? appendText("\n\(note)\n", to: liveTranscriptURL)
+            try writePreview(force: true)
+        }
+    }
+
+    func markAppendRecovered(at date: Date = Date()) throws {
+        try withSessionLock {
+            try ensureWorkspaceFilesLocked(createdAt: date, forcePreviewRewrite: false)
+            guard state.streamingBackendStatus == "live_sidecar_append_failed" else {
+                return
+            }
+
+            let note = "Live sidecar is updating again. The final Transcripted meeting Markdown still saves normally."
+            state.status = .recording
+            state.streamingBackendStatus = "local_streaming_asr_running"
+            state.note = note
+            state.updatedAt = date
+
+            try rewriteLiveTranscriptStatus(state.status.rawValue)
+            try appendText("\n\(note)\n", to: liveTranscriptURL)
+            try writeState()
+            try syncHandoffWithState(fallbackDate: date)
+            try writePreview(force: true)
         }
     }
 
@@ -738,21 +788,25 @@ final class LiveMeetingCodexSession {
         let status = "\(state.status.rawValue) - \(state.streamingBackendStatus)"
         let escapedStatus = Self.htmlEscaped(status)
         let statusLine: String
-        switch state.status {
-        case .recording:
-            statusLine = "Recording locally"
-        case .transcriptSaved:
-            statusLine = "Transcript saved"
-        case .stopped:
-            statusLine = "Waiting for transcript"
-        case .cancelled:
-            statusLine = "Recording cancelled."
-        case .failed:
+        if state.streamingBackendStatus == "live_sidecar_append_failed" {
             statusLine = "Needs attention"
-        case .disabled:
-            statusLine = "Live sidecar disabled"
-        case .idle:
-            statusLine = "Not recording"
+        } else {
+            switch state.status {
+            case .recording:
+                statusLine = "Recording locally"
+            case .transcriptSaved:
+                statusLine = "Transcript saved"
+            case .stopped:
+                statusLine = "Waiting for transcript"
+            case .cancelled:
+                statusLine = "Recording cancelled."
+            case .failed:
+                statusLine = "Needs attention"
+            case .disabled:
+                statusLine = "Live sidecar disabled"
+            case .idle:
+                statusLine = "Not recording"
+            }
         }
         let escapedDisplayStatus = Self.htmlEscaped(statusLine)
         let escapedTitle = Self.htmlEscaped(state.title ?? "Live Meeting")
@@ -1139,6 +1193,10 @@ final class LiveMeetingCodexSession {
             function friendlyStatus(state) {
               if (!state || !state.status) {
                 return "Not recording";
+              }
+
+              if (state.streamingBackendStatus === "live_sidecar_append_failed") {
+                return "Needs attention";
               }
 
               if (state.status === "recording") {

--- a/Sources/Meeting/LiveMeetingTranscriber.swift
+++ b/Sources/Meeting/LiveMeetingTranscriber.swift
@@ -80,6 +80,8 @@ final class LiveMeetingTranscriber {
 
 @available(macOS 14.0, *)
 private final class LiveMeetingTranscriberChannel: @unchecked Sendable {
+    private static let sidecarAppendFailureThreshold = 3
+
     private let source: LiveMeetingCodexSource
     private let audioSource: AudioSource
     private let streamingSession: SlidingWindowAsrSession
@@ -96,6 +98,8 @@ private final class LiveMeetingTranscriberChannel: @unchecked Sendable {
     private var updateState = LiveMeetingStreamingUpdateState()
     private var lastFeedText = ""
     private var lastFeedWasFinal = false
+    private var consecutiveSidecarAppendFailures = 0
+    private var didSurfaceSidecarAppendFailure = false
 
     init(
         source: LiveMeetingCodexSource,
@@ -285,7 +289,71 @@ private final class LiveMeetingTranscriberChannel: @unchecked Sendable {
             updateState.lastAppendedWasFinal = update.isConfirmed
         }
 
-        try? codexSession.append(entry)
+        do {
+            try codexSession.append(entry)
+            let shouldRecoverSidecarFailure = lock.withLock {
+                let shouldRecover = didSurfaceSidecarAppendFailure
+                consecutiveSidecarAppendFailures = 0
+                didSurfaceSidecarAppendFailure = false
+                return shouldRecover
+            }
+            if shouldRecoverSidecarFailure {
+                try? codexSession.markAppendRecovered(at: now)
+                awaitFeedRecovery(note: sidecarAppendFailureNote)
+            }
+        } catch {
+            let failureState = lock.withLock { () -> (count: Int, shouldSurface: Bool) in
+                consecutiveSidecarAppendFailures += 1
+                let count = consecutiveSidecarAppendFailures
+                let shouldSurface = count >= Self.sidecarAppendFailureThreshold
+                    && !didSurfaceSidecarAppendFailure
+                if shouldSurface {
+                    didSurfaceSidecarAppendFailure = true
+                }
+                return (count, shouldSurface)
+            }
+            guard failureState.shouldSurface else { return }
+
+            let note = sidecarAppendFailureNote
+            try? codexSession.markAppendFailed(
+                consecutiveFailures: failureState.count,
+                error: error,
+                at: now
+            )
+            awaitFeedFailure(note)
+            let source = source.rawValue
+            let consecutiveFailures = "\(failureState.count)"
+            let errorDescription = error.localizedDescription
+            Task { @MainActor in
+                DiagnosticsTrail.record(
+                    level: .warning,
+                    engine: "meeting",
+                    event: "live_sidecar_append_failed",
+                    message: "Live meeting sidecar append failed repeatedly",
+                    context: [
+                        "source": source,
+                        "consecutive_failures": consecutiveFailures,
+                        "error": errorDescription
+                    ]
+                )
+            }
+        }
+    }
+
+    private func awaitFeedFailure(_ note: String) {
+        Task { @MainActor [weak feed] in
+            feed?.markFailed(note: note)
+        }
+    }
+
+    private var sidecarAppendFailureNote: String {
+        "\(source.displayName) live sidecar stopped updating. The final transcript still saves normally."
+    }
+
+    private func awaitFeedRecovery(note: String) {
+        Task { @MainActor [weak feed] in
+            feed?.recoverFromSidecarAppendFailure(note: note)
+        }
     }
 
     private static func copyPCMBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {

--- a/Sources/Meeting/LiveMeetingTranscriptFeed.swift
+++ b/Sources/Meeting/LiveMeetingTranscriptFeed.swift
@@ -53,6 +53,14 @@ final class LiveMeetingTranscriptFeed: ObservableObject {
         partialEntries = [:]
     }
 
+    func recoverFromSidecarAppendFailure(note: String) {
+        guard case .failed(let currentNote) = phase,
+              currentNote == note else {
+            return
+        }
+        phase = .live
+    }
+
     func ingest(_ entry: LiveMeetingCodexTranscriptEntry) {
         guard phase != .idle, phase != .stopped else { return }
 

--- a/Sources/UI/Overlay/MeetingLiveTranscriptDrawerView.swift
+++ b/Sources/UI/Overlay/MeetingLiveTranscriptDrawerView.swift
@@ -32,6 +32,8 @@ final class MeetingLiveTranscriptDrawerView: NSView {
     private var copyFeedbackTask: Task<Void, Never>?
     private var transientStatusTask: Task<Void, Never>?
     private var hoverTrackingArea: NSTrackingArea?
+    private var renderedFinalEntries: [LiveMeetingCodexTranscriptEntry] = []
+    private var renderedPartialRange: NSRange?
 
     var onOpenInBrowser: (() -> Void)?
     var onCopyTranscript: (() -> Void)?
@@ -188,7 +190,12 @@ final class MeetingLiveTranscriptDrawerView: NSView {
         }
     }
 
-    func update(transcript: NSAttributedString, statusText: String?, hasEntries: Bool) {
+    func update(
+        finals: [LiveMeetingCodexTranscriptEntry],
+        partials: [LiveMeetingCodexSource: LiveMeetingCodexTranscriptEntry],
+        statusText: String?,
+        hasEntries: Bool
+    ) {
         self.statusText = statusText
         self.hasEntries = hasEntries
         refreshStatusLabel()
@@ -200,11 +207,120 @@ final class MeetingLiveTranscriptDrawerView: NSView {
             let visible = scrollView.contentView.documentVisibleRect
             return visible.maxY >= documentView.frame.height - 28
         }()
-        textView.textStorage?.setAttributedString(transcript)
+        updateTranscriptStorage(finals: finals, partials: partials)
         if wasPinnedToBottom {
             textView.scrollToEndOfDocument(nil)
         }
         needsLayout = true
+    }
+
+    private func updateTranscriptStorage(
+        finals: [LiveMeetingCodexTranscriptEntry],
+        partials: [LiveMeetingCodexSource: LiveMeetingCodexTranscriptEntry]
+    ) {
+        guard let textStorage = textView.textStorage else { return }
+
+        if needsFullTranscriptRebuild(for: finals) {
+            textStorage.setAttributedString(makeTranscriptAttributedText(finals: finals, partials: partials))
+            renderedFinalEntries = finals
+            renderedPartialRange = partialRange(in: textStorage)
+            return
+        }
+
+        if let renderedPartialRange {
+            textStorage.replaceCharacters(in: renderedPartialRange, with: "")
+            self.renderedPartialRange = nil
+        }
+
+        if renderedFinalEntries.count < finals.count {
+            for entry in finals[renderedFinalEntries.count...] {
+                appendEntry(entry, isPartial: false, to: textStorage)
+            }
+            renderedFinalEntries = finals
+        }
+
+        let partialStart = textStorage.length
+        for source in [LiveMeetingCodexSource.microphone, .system] {
+            if let partial = partials[source] {
+                appendEntry(partial, isPartial: true, to: textStorage)
+            }
+        }
+        if textStorage.length > partialStart {
+            renderedPartialRange = NSRange(location: partialStart, length: textStorage.length - partialStart)
+        }
+    }
+
+    private func needsFullTranscriptRebuild(for finals: [LiveMeetingCodexTranscriptEntry]) -> Bool {
+        if renderedFinalEntries.count > finals.count {
+            return true
+        }
+        return Array(finals.prefix(renderedFinalEntries.count)) != renderedFinalEntries
+    }
+
+    private func makeTranscriptAttributedText(
+        finals: [LiveMeetingCodexTranscriptEntry],
+        partials: [LiveMeetingCodexSource: LiveMeetingCodexTranscriptEntry]
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for entry in finals {
+            appendEntry(entry, isPartial: false, to: result)
+        }
+        for source in [LiveMeetingCodexSource.microphone, .system] {
+            if let partial = partials[source] {
+                appendEntry(partial, isPartial: true, to: result)
+            }
+        }
+        return result
+    }
+
+    private func appendEntry(
+        _ entry: LiveMeetingCodexTranscriptEntry,
+        isPartial: Bool,
+        to result: NSMutableAttributedString
+    ) {
+        if result.length > 0 {
+            result.append(NSAttributedString(string: "\n"))
+        }
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineSpacing = 2
+        paragraph.paragraphSpacing = 7
+
+        let isMic = entry.source == .microphone
+        let tag = isMic ? "You" : "Them"
+        let tagColor = isMic
+            ? MeetingOverlayTokens.waveformMicTint
+            : MeetingOverlayTokens.waveformSystemTint
+        result.append(NSAttributedString(
+            string: "\(tag)  ",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+                .foregroundColor: isPartial ? tagColor.withAlphaComponent(0.55) : tagColor,
+                .paragraphStyle: paragraph,
+            ]
+        ))
+        result.append(NSAttributedString(
+            string: entry.text,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 12, weight: .regular),
+                .foregroundColor: isPartial
+                    ? MeetingOverlayTokens.textSecondary
+                    : MeetingOverlayTokens.textPrimary,
+                .paragraphStyle: paragraph,
+            ]
+        ))
+    }
+
+    private func partialRange(in textStorage: NSTextStorage) -> NSRange? {
+        let fullLength = textStorage.length
+        guard fullLength > 0 else { return nil }
+
+        let finalsOnly = NSMutableAttributedString()
+        for entry in renderedFinalEntries {
+            appendEntry(entry, isPartial: false, to: finalsOnly)
+        }
+        guard finalsOnly.length < fullLength else { return nil }
+        return NSRange(location: finalsOnly.length, length: fullLength - finalsOnly.length)
     }
 
     /// Called right before the drawer becomes visible so the latest lines

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -912,12 +912,14 @@ final class MeetingOverlayRootView: NSView {
     /// Separate push channel for live transcript content so per-entry updates
     /// do not re-run the full state update path.
     func updateLiveTranscript(
-        _ attributed: NSAttributedString,
+        finals: [LiveMeetingCodexTranscriptEntry],
+        partials: [LiveMeetingCodexSource: LiveMeetingCodexTranscriptEntry],
         statusText: String?,
         hasEntries: Bool
     ) {
         transcriptDrawer.update(
-            transcript: attributed,
+            finals: finals,
+            partials: partials,
             statusText: statusText,
             hasEntries: hasEntries
         )
@@ -1653,10 +1655,8 @@ final class MeetingOverlayController: NSObject {
 
         let hasEntries = !latestTranscriptFinals.isEmpty || !latestTranscriptPartials.isEmpty
         rootView?.updateLiveTranscript(
-            makeTranscriptAttributedText(
-                finals: latestTranscriptFinals,
-                partials: latestTranscriptPartials
-            ),
+            finals: latestTranscriptFinals,
+            partials: latestTranscriptPartials,
             statusText: MeetingLiveViewAffordancePolicy.drawerStatus(
                 phase: latestTranscriptPhase,
                 hasEntries: hasEntries
@@ -1668,55 +1668,6 @@ final class MeetingOverlayController: NSObject {
     private func flushPendingTranscriptIfNeeded() {
         guard transcriptPushPending else { return }
         pushTranscriptToView()
-    }
-
-    private func makeTranscriptAttributedText(
-        finals: [LiveMeetingCodexTranscriptEntry],
-        partials: [LiveMeetingCodexSource: LiveMeetingCodexTranscriptEntry]
-    ) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-        let paragraph = NSMutableParagraphStyle()
-        paragraph.lineSpacing = 2
-        paragraph.paragraphSpacing = 7
-
-        func append(_ entry: LiveMeetingCodexTranscriptEntry, isPartial: Bool) {
-            if result.length > 0 {
-                result.append(NSAttributedString(string: "\n"))
-            }
-            let isMic = entry.source == .microphone
-            let tag = isMic ? "You" : "Them"
-            let tagColor = isMic
-                ? MeetingOverlayTokens.waveformMicTint
-                : MeetingOverlayTokens.waveformSystemTint
-            result.append(NSAttributedString(
-                string: "\(tag)  ",
-                attributes: [
-                    .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-                    .foregroundColor: isPartial ? tagColor.withAlphaComponent(0.55) : tagColor,
-                    .paragraphStyle: paragraph,
-                ]
-            ))
-            result.append(NSAttributedString(
-                string: entry.text,
-                attributes: [
-                    .font: NSFont.systemFont(ofSize: 12, weight: .regular),
-                    .foregroundColor: isPartial
-                        ? MeetingOverlayTokens.textSecondary
-                        : MeetingOverlayTokens.textPrimary,
-                    .paragraphStyle: paragraph,
-                ]
-            ))
-        }
-
-        for entry in finals {
-            append(entry, isPartial: false)
-        }
-        for source in [LiveMeetingCodexSource.microphone, .system] {
-            if let partial = partials[source] {
-                append(partial, isPartial: true)
-            }
-        }
-        return result
     }
 
     private func applyAudioInactivityWarning(_ warning: MeetingAudioInactivityWarning?) {

--- a/Tests/LiveMeetingCodexSessionTests.swift
+++ b/Tests/LiveMeetingCodexSessionTests.swift
@@ -219,6 +219,229 @@ func testLiveMeetingCodexSession() {
         let watcherStateText = (try? String(contentsOf: reopenedSession.watcherStateURL, encoding: .utf8)) ?? ""
         assertTrue(watcherStateText.contains("already handled"), "reopened workspace should preserve agent watcher state")
     }
+
+    runSuite("LiveMeetingCodexSession preview - append repair uses cached transcript text") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedLiveMeetingCodex-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = LiveMeetingCodexSession(workspaceRoot: root)
+        try? session.start(
+            title: "Repair Meeting",
+            startedAt: Date(timeIntervalSince1970: 1_765_994_400)
+        )
+        try? session.append(
+            LiveMeetingCodexTranscriptEntry(
+                source: .microphone,
+                text: "first cached line",
+                timestampSeconds: 1,
+                createdAt: Date(timeIntervalSince1970: 1_765_994_401)
+            )
+        )
+        try? FileManager.default.removeItem(at: session.liveTranscriptURL)
+        try? session.append(
+            LiveMeetingCodexTranscriptEntry(
+                source: .system,
+                text: "second cached line",
+                timestampSeconds: 2,
+                createdAt: Date(timeIntervalSince1970: 1_765_994_402)
+            )
+        )
+
+        let liveText = (try? String(contentsOf: session.liveTranscriptURL, encoding: .utf8)) ?? ""
+        assertTrue(liveText.contains("first cached line"), "workspace repair should restore cached transcript text")
+        assertTrue(liveText.contains("second cached line"), "new append should be added after repair")
+
+        try? session.finish(
+            status: .stopped,
+            at: Date(timeIntervalSince1970: 1_765_994_430)
+        )
+        let previewText = (try? String(contentsOf: session.previewURL, encoding: .utf8)) ?? ""
+        assertTrue(previewText.contains("first cached line"), "preview should render from the cached transcript snapshot")
+        assertTrue(previewText.contains("second cached line"), "preview should include the latest append after lifecycle refresh")
+    }
+
+    runSuite("LiveMeetingCodexSession preview - append refreshes throttled file snapshot") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedLiveMeetingCodex-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = LiveMeetingCodexSession(workspaceRoot: root)
+        try? session.start(
+            title: "Preview Meeting",
+            startedAt: Date(timeIntervalSince1970: 1_765_994_400)
+        )
+        try? FileManager.default.removeItem(at: session.previewURL)
+        try? session.append(
+            LiveMeetingCodexTranscriptEntry(
+                source: .microphone,
+                text: "visible in direct preview",
+                timestampSeconds: 1,
+                createdAt: Date(timeIntervalSince1970: 1_765_994_401)
+            )
+        )
+
+        let previewText = (try? String(contentsOf: session.previewURL, encoding: .utf8)) ?? ""
+        assertTrue(previewText.contains("visible in direct preview"), "append should refresh direct preview.html snapshots")
+    }
+
+    runSuite("LiveMeetingCodexSession append failures - surface failed sidecar state") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedLiveMeetingCodex-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = LiveMeetingCodexSession(workspaceRoot: root)
+        try? session.start(
+            title: "Failure Meeting",
+            startedAt: Date(timeIntervalSince1970: 1_765_994_400)
+        )
+        let error = NSError(domain: "LiveSidecarAppendTest", code: 7, userInfo: [
+            NSLocalizedDescriptionKey: "simulated append failure"
+        ])
+        try? session.markAppendFailed(
+            consecutiveFailures: 3,
+            error: error,
+            at: Date(timeIntervalSince1970: 1_765_994_430)
+        )
+
+        let state = decodeLiveMeetingCodexState(at: session.stateURL)
+        assertEqual(state?.status, .recording, "append failures should keep the meeting recording state")
+        assertEqual(
+            state?.streamingBackendStatus,
+            "live_sidecar_append_failed",
+            "failed state should explain that the sidecar append path broke"
+        )
+        assertTrue(
+            state?.note.contains("simulated append failure") == true,
+            "state note should keep the append error visible"
+        )
+
+        let liveText = (try? String(contentsOf: session.liveTranscriptURL, encoding: .utf8)) ?? ""
+        assertTrue(liveText.contains("Status: recording"), "live transcript should keep the meeting recording status")
+        assertTrue(liveText.contains("simulated append failure"), "live transcript should include the failure note when writable")
+
+        let previewText = (try? String(contentsOf: session.previewURL, encoding: .utf8)) ?? ""
+        assertTrue(previewText.contains("Needs attention"), "preview should surface failed status")
+        assertTrue(previewText.contains("live_sidecar_append_failed"), "preview status title should expose append failure reason")
+    }
+
+    runSuite("LiveMeetingCodexSession append failures - state survives broken transcript path") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedLiveMeetingCodex-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = LiveMeetingCodexSession(workspaceRoot: root)
+        try? session.start(
+            title: "Broken Path Meeting",
+            startedAt: Date(timeIntervalSince1970: 1_765_994_400)
+        )
+        try? FileManager.default.removeItem(at: session.liveTranscriptURL)
+        try? FileManager.default.createDirectory(at: session.liveTranscriptURL, withIntermediateDirectories: false)
+
+        let entry = LiveMeetingCodexTranscriptEntry(
+            source: .microphone,
+            text: "this append should fail",
+            timestampSeconds: 1,
+            createdAt: Date(timeIntervalSince1970: 1_765_994_401)
+        )
+
+        do {
+            try session.append(entry)
+            assertTrue(false, "append should fail when live transcript path is not a file")
+        } catch {
+            try? session.markAppendFailed(
+                consecutiveFailures: 3,
+                error: error,
+                at: Date(timeIntervalSince1970: 1_765_994_430)
+            )
+        }
+
+        let state = decodeLiveMeetingCodexState(at: session.stateURL)
+        assertEqual(state?.status, .recording, "broken transcript path should not mark the whole meeting failed")
+        assertEqual(
+            state?.streamingBackendStatus,
+            "live_sidecar_append_failed",
+            "failed state should preserve the append failure reason"
+        )
+
+        let previewText = (try? String(contentsOf: session.previewURL, encoding: .utf8)) ?? ""
+        assertTrue(previewText.contains("Needs attention"), "preview should still render when live transcript path is broken")
+        assertTrue(previewText.contains("live_sidecar_append_failed"), "preview should expose the append failure status")
+    }
+
+    runSuite("LiveMeetingCodexSession append failures - recovered append clears failed state") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedLiveMeetingCodex-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = LiveMeetingCodexSession(workspaceRoot: root)
+        try? session.start(
+            title: "Recovery Meeting",
+            startedAt: Date(timeIntervalSince1970: 1_765_994_400)
+        )
+        let error = NSError(domain: "LiveSidecarAppendTest", code: 8, userInfo: [
+            NSLocalizedDescriptionKey: "temporary append failure"
+        ])
+        try? session.markAppendFailed(
+            consecutiveFailures: 3,
+            error: error,
+            at: Date(timeIntervalSince1970: 1_765_994_430)
+        )
+
+        try? session.append(
+            LiveMeetingCodexTranscriptEntry(
+                source: .microphone,
+                text: "append path recovered",
+                timestampSeconds: 31,
+                createdAt: Date(timeIntervalSince1970: 1_765_994_431)
+            )
+        )
+        try? session.markAppendRecovered(at: Date(timeIntervalSince1970: 1_765_994_432))
+
+        let state = decodeLiveMeetingCodexState(at: session.stateURL)
+        assertEqual(state?.status, .recording, "a recovered append should restore recording state")
+        assertEqual(
+            state?.streamingBackendStatus,
+            "local_streaming_asr_running",
+            "a recovered append should restore the running backend status"
+        )
+
+        let previewText = (try? String(contentsOf: session.previewURL, encoding: .utf8)) ?? ""
+        assertTrue(previewText.contains("recording - local_streaming_asr_running"), "preview should clear the failed append status")
+        assertTrue(previewText.contains("append path recovered"), "preview should include transcript text after recovery")
+    }
+
+    runSuite("LiveMeetingCodexSession append failures - late failure preserves terminal state") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedLiveMeetingCodex-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let session = LiveMeetingCodexSession(workspaceRoot: root)
+        try? session.start(
+            title: "Stopped Meeting",
+            startedAt: Date(timeIntervalSince1970: 1_765_994_400)
+        )
+        try? session.finish(
+            status: .stopped,
+            at: Date(timeIntervalSince1970: 1_765_994_430)
+        )
+        let error = NSError(domain: "LiveSidecarAppendTest", code: 9, userInfo: [
+            NSLocalizedDescriptionKey: "late append failure"
+        ])
+        try? session.markAppendFailed(
+            consecutiveFailures: 3,
+            error: error,
+            at: Date(timeIntervalSince1970: 1_765_994_431)
+        )
+
+        let state = decodeLiveMeetingCodexState(at: session.stateURL)
+        assertEqual(state?.status, .stopped, "late append failures should not reopen terminal sidecar state")
+        assertEqual(
+            state?.streamingBackendStatus,
+            "local_streaming_asr_stopped",
+            "late append failures should preserve the terminal backend status"
+        )
+    }
 }
 
 private func decodeLiveMeetingCodexState(at url: URL) -> LiveMeetingCodexState? {

--- a/Tests/LiveMeetingTranscriptFeedTests.swift
+++ b/Tests/LiveMeetingTranscriptFeedTests.swift
@@ -39,6 +39,24 @@ func testLiveMeetingTranscriptFeed() async {
         assertEqual(feed.phase, .failed("asr died"), "failure is terminal for this recording")
     }
 
+    runSuite("LiveMeetingTranscriptFeed — sidecar append recovery restores live phase") {
+        let feed = LiveMeetingTranscriptFeed()
+        feed.beginStarting()
+        feed.markLive()
+        let note = "Microphone live sidecar stopped updating. The final transcript still saves normally."
+        feed.markFailed(note: note)
+        feed.recoverFromSidecarAppendFailure(note: note)
+        assertEqual(feed.phase, .live, "append recovery should clear the drawer failure")
+
+        feed.markFailed(note: "Microphone live transcription stopped. The final transcript still saves normally.")
+        feed.recoverFromSidecarAppendFailure(note: note)
+        assertEqual(
+            feed.phase,
+            .failed("Microphone live transcription stopped. The final transcript still saves normally."),
+            "append recovery should not clear unrelated ASR failures"
+        )
+    }
+
     runSuite("LiveMeetingTranscriptFeed — partials replace per source, finals accumulate") {
         let feed = LiveMeetingTranscriptFeed()
         feed.beginStarting()


### PR DESCRIPTION
## Summary
- Make the in-overlay live transcript drawer update incrementally: append new finals, replace only the partial tail, and rebuild only when the capped feed drops/changes existing finals.
- Keep sidecar `preview.html` writes cached and throttled while preserving direct-file preview refreshes and avoiding per-append full rewrite/re-read churn.
- Surface repeated sidecar append failures as a degraded live-sidecar backend state, keep the main meeting state recording, recover cleanly after a successful append, and leave terminal states untouched.

## Verification
- `bash run-tests.sh --filter LiveMeetingCodexSessionTests` — 76 passed, 0 failed
- `bash run-tests.sh --filter LiveMeetingTranscriptFeedTests` — exit 0; prior visible run showed 24 passed, 0 failed
- `bash run-tests.sh` — passed during final Codex review
- `bash run-integration-smoke.sh` — passed earlier on this branch
- `TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 bash build.sh --no-open` — passed compile/sign/performance budget
- `bash build.sh --no-open` — compile/sign passed earlier, but launch smoke failed locally with LaunchServices `_LSOpenURLsWithCompletionHandler() failed with error -10810`; app launch remains manually unverified here
- `codex review --base origin/main` — final pass found no actionable bugs

## Maestro Lanes
- Codex: implemented, tested, reviewed, committed, pushed
- Claude: attempted via `/Users/redbars/.codex/maestro/runs/20260703T192946Z-transcripted-live-sidecar-architecture-review-claude`, returncode 1, no usable output
- Local: attempted via `/Users/redbars/.codex/maestro/runs/20260703T192946Z-transcripted-live-sidecar-scan-local` and `/Users/redbars/.codex/maestro/runs/20260703T204935Z-review-live-sidecar-local`, returncode 0 but low-signal output
- Windows: attempted via `/Users/redbars/.codex/maestro/runs/20260703T192945Z-transcripted-live-sidecar-first-pass-windows`, returncode 2, no usable output
