### PR TITLE
Fix feedback surface recovery UX

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -245,6 +245,14 @@ final class MeetingSessionController: ObservableObject {
         isCaptureSessionActive || isFinishingRecording
     }
 
+    var shouldConfirmQuitForBackgroundTranscription: Bool {
+        hasBackgroundTranscriptionWork
+    }
+
+    var shouldBlockDictationForActiveMeetingCapture: Bool {
+        isCaptureSessionActive || isFinishingRecording
+    }
+
     // MARK: - Init
 
     /// Construct the full Core stack with app-owned storage isolation.
@@ -1373,8 +1381,18 @@ final class MeetingSessionController: ObservableObject {
                     meetingTitle: meetingTitle,
                     recordingDate: recordingDate
                 )
-            case .imported(let audioURL, _, _):
-                try? FileManager.default.removeItem(at: audioURL)
+            case .imported(let audioURL, let suggestedTitle, let recordingDate):
+                if reason == .userRequested {
+                    try? FileManager.default.removeItem(at: audioURL)
+                } else {
+                    preserveFailedMeetingForRetry(
+                        micAudioURL: nil,
+                        systemAudioURL: audioURL,
+                        errorMessage: "Imported audio saved before cancellation. Audio is safe; finish the transcript from Home.",
+                        meetingTitle: suggestedTitle,
+                        recordingDate: recordingDate
+                    )
+                }
             }
         }
 
@@ -2710,8 +2728,14 @@ final class MeetingSessionController: ObservableObject {
                 meetingTitle: meetingTitle,
                 recordingDate: recordingDate
             )
-        case .imported(let audioURL, _, _):
-            try? FileManager.default.removeItem(at: audioURL)
+        case .imported(let audioURL, let suggestedTitle, let recordingDate):
+            preserveFailedMeetingForRetry(
+                micAudioURL: nil,
+                systemAudioURL: audioURL,
+                errorMessage: message,
+                meetingTitle: suggestedTitle,
+                recordingDate: recordingDate
+            )
         }
         clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(for: job, outcome: "model_recovery_failed")
     }

--- a/Sources/Support/QuitConfirmationPreferences.swift
+++ b/Sources/Support/QuitConfirmationPreferences.swift
@@ -8,6 +8,13 @@ struct ActiveMeetingQuitConfirmationPresentation: Equatable {
     let saveAudioAndQuitTitle: String
 }
 
+struct BackgroundMeetingQuitConfirmationPresentation: Equatable {
+    let title: String
+    let message: String
+    let keepOpenTitle: String
+    let saveAudioAndQuitTitle: String
+}
+
 enum ActiveMeetingQuitDecision: Equatable {
     case keepRecording
     case stopAndTranscribe
@@ -16,18 +23,26 @@ enum ActiveMeetingQuitDecision: Equatable {
 
 enum ActiveMeetingQuitConfirmationPolicy {
     static let presentation = ActiveMeetingQuitConfirmationPresentation(
-        title: "Meeting is still recording",
-        message: "Keep recording, stop and make the transcript now, or save the captured audio and quit. Saved audio will show on Home so you can finish the transcript later.",
+        title: "Meeting work is still running",
+        message: "Keep Transcripted open to finish the transcript, stop and make the transcript now, or save the audio and quit. Saved audio will show on Home so you can finish it later.",
         keepRecordingTitle: "Keep Recording",
         stopAndTranscribeTitle: "Stop & Transcribe",
         saveAudioAndQuitTitle: "Save Audio & Quit"
     )
 
+    static let backgroundPresentation = BackgroundMeetingQuitConfirmationPresentation(
+        title: "Meeting transcript is still running",
+        message: "Keep Transcripted open to finish it now, or save the audio and quit. Saved audio will show on Home so you can finish it later.",
+        keepOpenTitle: "Keep Open",
+        saveAudioAndQuitTitle: "Save Audio & Quit"
+    )
+
     static func shouldConfirmQuit(
         preferenceEnabled: Bool,
-        activeMeetingCapture: Bool
+        activeMeetingCapture: Bool,
+        backgroundTranscriptionWork: Bool = false
     ) -> Bool {
-        preferenceEnabled && activeMeetingCapture
+        preferenceEnabled && (activeMeetingCapture || backgroundTranscriptionWork)
     }
 }
 

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -517,11 +517,18 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
     private func activeMeetingTerminationDecision() -> ActiveMeetingQuitDecision {
         guard #available(macOS 14.0, *) else { return .saveAudioAndQuit }
+        let activeCapture = appState.meetingSession.shouldConfirmQuitForActiveCapture
+        let backgroundWork = appState.meetingSession.shouldConfirmQuitForBackgroundTranscription
         guard ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
             preferenceEnabled: QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecording(),
-            activeMeetingCapture: appState.meetingSession.shouldConfirmQuitForActiveCapture
+            activeMeetingCapture: activeCapture,
+            backgroundTranscriptionWork: backgroundWork
         ) else {
             return .saveAudioAndQuit
+        }
+
+        guard activeCapture else {
+            return confirmQuitDuringBackgroundMeetingWork()
         }
 
         return confirmQuitDuringActiveMeeting()
@@ -546,6 +553,28 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         case .alertSecondButtonReturn:
             return .stopAndTranscribe
         case .alertThirdButtonReturn:
+            return .saveAudioAndQuit
+        default:
+            return .keepRecording
+        }
+    }
+
+    private func confirmQuitDuringBackgroundMeetingWork() -> ActiveMeetingQuitDecision {
+        closePopover()
+        NSApp.activate(ignoringOtherApps: true)
+
+        let presentation = ActiveMeetingQuitConfirmationPolicy.backgroundPresentation
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = presentation.title
+        alert.informativeText = presentation.message
+        alert.addButton(withTitle: presentation.keepOpenTitle)
+        alert.addButton(withTitle: presentation.saveAudioAndQuitTitle)
+        alert.buttons.first?.keyEquivalent = "\r"
+        alert.buttons.last?.keyEquivalent = ""
+
+        switch alert.runModal() {
+        case .alertSecondButtonReturn:
             return .saveAudioAndQuit
         default:
             return .keepRecording

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -24,7 +24,7 @@ public class TranscriptionTaskManager: ObservableObject {
     private var savedTranscriptTaskIdsByTranscriptId: [UUID: UUID] = [:]
     private var savedTranscriptTaskIdsByURL: [URL: UUID] = [:]
     var activeTasks: [UUID: Task<Void, Never>] = [:]
-    private var activeTaskAudio: [UUID: (micURL: URL, systemURL: URL?, meetingTitle: String?, recordingDate: Date?)] = [:]
+    private var activeTaskAudio: [UUID: (micURL: URL?, systemURL: URL?, meetingTitle: String?, recordingDate: Date?)] = [:]
     private var preservedTaskIdsForShutdown: Set<UUID> = []
     private var intentionallyCancelledTaskIds: Set<UUID> = []
     private var committedTranscriptTaskIds: Set<UUID> = []
@@ -306,6 +306,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 ])
 
                 await MainActor.run {
+                    if self.preservedTaskIdsForShutdown.remove(taskId) != nil {
+                        self.handleTaskCompletion(taskId: taskId)
+                        return
+                    }
                     if self.finishCancelledTaskIfNeeded(taskId: taskId, error: error) {
                         self.removeRecordingFile(audioURL, label: "cancelled imported recording")
                         return

--- a/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
+++ b/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
@@ -41,19 +41,17 @@ struct DictationRecordingStartLifecyclePolicy {
 }
 
 struct DictationStartAvailabilityPolicy {
-    static let meetingWorkMessage = "Finish the current meeting before starting dictation."
-    static let speakerReviewMessage = "Finish the speaker review window before starting dictation."
+    static let activeMeetingCaptureMessage = "Finish or save the meeting recording before starting dictation."
+    static let speakerReviewMessage = "Speaker review can wait. Dictation is available."
 
     static func unavailableReason(
-        hasMeetingWork: Bool,
+        hasActiveMeetingCapture: Bool,
         isSpeakerReviewPending: Bool
     ) -> String? {
-        if hasMeetingWork {
-            return meetingWorkMessage
+        if hasActiveMeetingCapture {
+            return activeMeetingCaptureMessage
         }
-        if isSpeakerReviewPending {
-            return speakerReviewMessage
-        }
+        _ = isSpeakerReviewPending
         return nil
     }
 }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -31,7 +31,11 @@ class DictationSessionController: ObservableObject {
     var overlayController: FloatingOverlayController? {
         didSet {
             overlayController?.onEscapeDuringSession = { [weak self] in
-                guard let self = self, self.isDictating else { return }
+                guard let self else { return }
+                guard self.isDictating else {
+                    self.overlayController?.dismissError()
+                    return
+                }
                 self.cancelDictation()
             }
             overlayController?.onStopListening = { [weak self] in
@@ -263,7 +267,7 @@ class DictationSessionController: ObservableObject {
     private func dictationStartUnavailableReason(appState: TranscriptedAppState) -> String? {
         guard #available(macOS 14.0, *) else { return nil }
         return DictationStartAvailabilityPolicy.unavailableReason(
-            hasMeetingWork: appState.meetingSession.hasRuntimeDiagnosticsWork,
+            hasActiveMeetingCapture: appState.meetingSession.shouldBlockDictationForActiveMeetingCapture,
             isSpeakerReviewPending: appState.meetingSession.isSpeakerReviewPending
         )
     }
@@ -1216,7 +1220,20 @@ class DictationSessionController: ObservableObject {
         if let saveFailureMessage {
             overlayController.showError(saveFailureMessage)
         } else {
-            overlayController.showSuccessAndDismiss(title: DictationDelivery.savedWithoutPaste.summaryText)
+            overlayController.showError(
+                "Saved to Markdown. Paste it now, or use Paste Last Dictation later.",
+                actionTitle: "Paste It",
+                action: { [weak self] in
+                    guard let self else { return }
+                    let outcome = self.pasteWithClipboardRestore(text)
+                    switch outcome {
+                    case .pasted:
+                        overlayController.showSuccessAndDismiss(title: "Pasted")
+                    case .copied(let message, reason: _), .failed(let message):
+                        overlayController.showError(message)
+                    }
+                }
+            )
             ActivationTelemetry.trackDictationArtifactSaved(
                 delivery: DictationDelivery.savedWithoutPaste.rawValue,
                 durationBucket: AnalyticsReporter.durationBucket(seconds: durationSeconds),

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -53,6 +53,9 @@ class FloatingOverlayController {
             )
         )
     }
+    var listeningNotice = "" {
+        didSet { pushStateToViews() }
+    }
 
     // MARK: - State (plain vars with didSet — no @Published, no ObservableObject)
 
@@ -220,9 +223,15 @@ class FloatingOverlayController {
         rootView?.updateForState(
             state,
             dictationShortcutHint: dictationShortcutHint,
+            listeningNotice: listeningNotice,
             errorMessage: errorMessage,
             errorActionTitle: errorActionTitle,
-            onErrorAction: errorActionHandler,
+            onErrorAction: { [weak self] in
+                guard let self else { return }
+                let handler = self.errorActionHandler
+                self.clearActionableErrorWithoutHiding()
+                handler?()
+            },
             messageTone: messageTone,
             onErrorDismiss: { [weak self] in self?.dismissError() },
             loadingPresentation: loadingPresentation,
@@ -376,6 +385,7 @@ class FloatingOverlayController {
         messageTone = .error
         errorActionTitle = nil
         errorActionHandler = nil
+        listeningNotice = ""
         state = .starting
         resizePanelToCompact()
         if !isVisible {
@@ -596,14 +606,7 @@ class FloatingOverlayController {
                 try await Task.sleep(nanoseconds: dismissDelay)
             } catch { return }
             guard let self = self, !self.errorMessage.isEmpty else { return }
-            self.errorMessage = ""
-            self.errorActionTitle = nil
-            self.errorActionHandler = nil
-            if tone == .notice {
-                self.hideWithConfirmAnimation()
-            } else {
-                self.hideWithCancelAnimation()
-            }
+            self.dismissError()
         }
     }
 
@@ -615,6 +618,16 @@ class FloatingOverlayController {
         errorActionTitle = nil
         errorActionHandler = nil
         hideWithCancelAnimation()
+    }
+
+    private func clearActionableErrorWithoutHiding() {
+        guard state == .drafting, !errorMessage.isEmpty else { return }
+        errorDismissTask?.cancel()
+        errorDismissTask = nil
+        errorMessage = ""
+        errorActionTitle = nil
+        errorActionHandler = nil
+        pushStateToViews()
     }
 
     /// Fast dismiss for empty dictation audio — brief flash then clean fade (no shake).
@@ -690,6 +703,7 @@ class FloatingOverlayController {
         messageTone = .error
         errorActionTitle = nil
         errorActionHandler = nil
+        listeningNotice = ""
         loadingPresentation = .initial
     }
 

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -665,16 +665,15 @@ final class MeetingOverlayRootView: NSView {
 
         statusDot.frame = NSRect(x: pad, y: topY - dotSize / 2, width: dotSize, height: dotSize)
 
-        let titleX = statusDot.frame.maxX + 8
-        let closeWidth: CGFloat = 70
-        let closeHeight: CGFloat = 24
+        let closeSize: CGFloat = 24
         closeButton.frame = NSRect(
-            x: bounds.width - pad - closeWidth,
-            y: topY - closeHeight / 2,
-            width: closeWidth,
-            height: closeHeight
+            x: bounds.width - pad - closeSize,
+            y: topY - closeSize / 2,
+            width: closeSize,
+            height: closeSize
         )
 
+        let titleX = statusDot.frame.maxX + 8
         let titleWidth = max(0, closeButton.frame.minX - titleX - 8)
         let titleSize = titleLabel.fittingSize
         titleLabel.frame = NSRect(
@@ -687,9 +686,9 @@ final class MeetingOverlayRootView: NSView {
         detailLabel.maximumNumberOfLines = 2
         detailLabel.frame = NSRect(
             x: pad,
-            y: 12,
+            y: 10,
             width: bounds.width - pad * 2,
-            height: 32
+            height: 36
         )
         refreshTooltipTrackingAreas()
     }
@@ -794,9 +793,13 @@ final class MeetingOverlayRootView: NSView {
         case .prompt:
             titleLabel.stringValue = prompt?.title ?? "Meeting detected"
             detailLabel.stringValue = prompt?.detail ?? "Record this meeting?"
+            detailLabel.lineBreakMode = .byTruncatingTail
+            detailLabel.maximumNumberOfLines = 1
             timerLabel.stringValue = prompt?.countdownText ?? ""
             updateStatusDot(color: MeetingOverlayTokens.dotPrompt)
             closeButton.attributedTitle = buttonTitle(prompt?.secondaryTitle ?? "Not now", size: 11, weight: .semibold)
+            closeButton.image = nil
+            closeButton.imagePosition = .noImage
             closeButton.toolTip = nil
             closeButton.setAccessibilityLabel(prompt?.secondaryAccessibilityLabel ?? dismissPromptTooltip)
             closeButton.setAccessibilityHelp("Dismisses this meeting recording prompt.")
@@ -843,21 +846,23 @@ final class MeetingOverlayRootView: NSView {
                 isRetryable: true
             )
             titleLabel.stringValue = copy.title
-            closeButton.attributedTitle = buttonTitle("Dismiss", size: 11, weight: .semibold)
-            closeButton.image = nil
-            closeButton.imagePosition = .noImage
-            closeButton.toolTip = nil
-            closeButton.setAccessibilityLabel("Dismiss meeting failure")
-            closeButton.setAccessibilityHelp("Hides this meeting failure notice. Recovery remains available from Home.")
-            closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
-            closeButton.layer?.cornerRadius = 8
-            closeButton.layer?.borderWidth = 0
             updateStatusDot(
                 color: failureKind == .recordingTooShort
                     ? MeetingOverlayTokens.dotIdle
                     : MeetingOverlayTokens.dotError
             )
             detailLabel.stringValue = copy.detail
+            detailLabel.lineBreakMode = .byWordWrapping
+            detailLabel.maximumNumberOfLines = 2
+            closeButton.attributedTitle = buttonTitle("", size: 12, weight: .semibold)
+            closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Dismiss")
+            closeButton.imagePosition = .imageOnly
+            closeButton.contentTintColor = MeetingOverlayTokens.textSecondary
+            closeButton.setAccessibilityLabel("Dismiss meeting error")
+            closeButton.setAccessibilityHelp("Keeps the failed meeting available on Home.")
+            closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.08).cgColor
+            closeButton.layer?.cornerRadius = 12
+            closeButton.layer?.borderWidth = 0
         }
 
         // Transcription has no progress channel to drive a bar, so pulse the
@@ -1967,6 +1972,12 @@ final class MeetingOverlayController: NSObject {
     }
 
     private func handleCloseTapped() {
+        if case .error = state {
+            state = .idle
+            hidePanel()
+            pushToView()
+            return
+        }
         guard let session = meetingSession else { hidePanel(); return }
         Task { [weak session] in
             guard let session else { return }

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -846,6 +846,15 @@ final class MeetingOverlayRootView: NSView {
                 isRetryable: true
             )
             titleLabel.stringValue = copy.title
+            closeButton.attributedTitle = buttonTitle("Dismiss", size: 11, weight: .semibold)
+            closeButton.image = nil
+            closeButton.imagePosition = .noImage
+            closeButton.toolTip = nil
+            closeButton.setAccessibilityLabel("Dismiss meeting failure")
+            closeButton.setAccessibilityHelp("Hides this meeting failure notice. Recovery remains available from Home.")
+            closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
+            closeButton.layer?.cornerRadius = 8
+            closeButton.layer?.borderWidth = 0
             updateStatusDot(
                 color: failureKind == .recordingTooShort
                     ? MeetingOverlayTokens.dotIdle

--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -277,6 +277,7 @@ final class OverlayHeaderView: NSView {
     func update(
         state: FloatingOverlayController.OverlayState,
         dictationShortcutHint: String,
+        listeningNotice: String,
         loadingTitle: String?,
         successTitle: String = "Pasted",
         isError: Bool = false,
@@ -331,8 +332,8 @@ final class OverlayHeaderView: NSView {
         // Shortcut hint
         switch state {
         case .listening:
-            shortcutHint.stringValue = ""
-            shortcutHint.textColor = OverlayTokens.textMuted
+            shortcutHint.stringValue = listeningNotice
+            shortcutHint.textColor = listeningNotice.isEmpty ? OverlayTokens.textMuted : OverlayTokens.warningColor
         case .success:
             shortcutHint.stringValue = ""
             shortcutHint.textColor = OverlayTokens.textMuted

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -117,6 +117,7 @@ final class OverlayRootView: NSView {
     func updateForState(
         _ state: FloatingOverlayController.OverlayState,
         dictationShortcutHint: String,
+        listeningNotice: String,
         errorMessage: String,
         errorActionTitle: String?,
         onErrorAction: (() -> Void)?,
@@ -143,6 +144,7 @@ final class OverlayRootView: NSView {
         headerView.update(
             state: state,
             dictationShortcutHint: dictationShortcutHint,
+            listeningNotice: listeningNotice,
             loadingTitle: state == .loading ? "Dictation" : nil,
             successTitle: successTitle,
             isError: showMessage && !isNotice,

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -114,6 +114,12 @@ final class OverlayRootView: NSView {
 
     // MARK: - State Updates
 
+    // @_optimize(none): the -O SimplifyCFG pass crashes on this function's
+    // parameter/closure shape under swiftlang-6.3.2.1.108 (SIL/BorrowUtils.swift:542,
+    // "cannot get borrow introducers for unknown guaranteed value"). This is a
+    // compiler bug, not a correctness issue — disable optimization here until upstream
+    // fixes it. Reproduced in CI at github.com/r3dbars/transcripted actions run 28685559441.
+    @_optimize(none)
     func updateForState(
         _ state: FloatingOverlayController.OverlayState,
         dictationShortcutHint: String,

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -255,32 +255,31 @@ func testDictationRecordingStartOverlayPolicy() {
         assertFalse(plan.cancelSpeechEngine, "idle overlay cleanup should not reset the speech engine")
     }
 
-    runSuite("DictationStartAvailabilityPolicy blocks dictation during meeting work") {
+    runSuite("DictationStartAvailabilityPolicy blocks dictation during active meeting capture") {
         assertEqual(
             DictationStartAvailabilityPolicy.unavailableReason(
-                hasMeetingWork: true,
+                hasActiveMeetingCapture: true,
                 isSpeakerReviewPending: false
             ),
-            DictationStartAvailabilityPolicy.meetingWorkMessage,
-            "dictation should not start while a meeting is recording, saving, or transcribing"
+            DictationStartAvailabilityPolicy.activeMeetingCaptureMessage,
+            "dictation should not start while meeting capture still owns the microphone"
         )
     }
 
-    runSuite("DictationStartAvailabilityPolicy blocks dictation during speaker review") {
-        assertEqual(
-            DictationStartAvailabilityPolicy.unavailableReason(
-                hasMeetingWork: false,
-                isSpeakerReviewPending: true
-            ),
-            DictationStartAvailabilityPolicy.speakerReviewMessage,
-            "dictation should wait for speaker review because it owns meeting post-processing UI"
-        )
-    }
-
-    runSuite("DictationStartAvailabilityPolicy allows dictation when meeting work is idle") {
+    runSuite("DictationStartAvailabilityPolicy allows dictation during speaker review") {
         assertNil(
             DictationStartAvailabilityPolicy.unavailableReason(
-                hasMeetingWork: false,
+                hasActiveMeetingCapture: false,
+                isSpeakerReviewPending: true
+            ),
+            "speaker review alone should not block dictation"
+        )
+    }
+
+    runSuite("DictationStartAvailabilityPolicy allows dictation when meeting capture is idle") {
+        assertNil(
+            DictationStartAvailabilityPolicy.unavailableReason(
+                hasActiveMeetingCapture: false,
                 isSpeakerReviewPending: false
             ),
             "idle meeting state should not block dictation"

--- a/Tests/DictationSessionCapTests.swift
+++ b/Tests/DictationSessionCapTests.swift
@@ -124,25 +124,6 @@ func testDictationSessionCap() {
         )
     }
 
-    runSuite("The session cap warns and only auto-pastes when the original target is still active") {
-        let source = dictationControllerSource()
-        let timeoutBody = capSlice(
-            source,
-            from: "func installSessionTimeout()",
-            to: "private func overlayStateName"
-        )
-        assertTrue(
-            timeoutBody.contains("remainingSeconds <= 60")
-                && timeoutBody.contains("listeningNotice = \"Wrapping up soon\""),
-            "the overlay should warn before the hard session cap fires"
-        )
-        assertTrue(
-            timeoutBody.contains("sessionPasteTarget?.matchesCurrentFrontmostApp() == true")
-                && timeoutBody.contains("stopDictationAndPaste(trigger: .sessionCap, autoPaste: targetStillActive)"),
-            "the cap should paste only if the original paste target is still frontmost"
-        )
-    }
-
     runSuite("Dictation stop path preserves recovered audio and surfaces invisible hotkey states") {
         let source = dictationControllerSource()
         let stopBody = capSlice(

--- a/Tests/DictationSessionCapTests.swift
+++ b/Tests/DictationSessionCapTests.swift
@@ -1,7 +1,7 @@
 // DictationSessionCapTests.swift
 // Guards the 5-minute dictation session cap: a session that hits the cap is
-// finalized and saved (not discarded), and is never auto-pasted / auto-sent
-// into whatever app happens to hold focus when the user walked away.
+// finalized and saved (not discarded), pastes only when the original target is
+// still active, and offers a recovery paste action otherwise.
 //
 // DictationSessionController pulls in the whole app and can't be instantiated in
 // the fast runner, so this pairs behavioral checks on the pure policy / delivery
@@ -103,8 +103,10 @@ func testDictationSessionCap() {
             "the cap finalize path should persist the transcript to the daily Markdown file"
         )
         assertTrue(
-            finalizeBody.contains("overlayController.showSuccessAndDismiss(title: DictationDelivery.savedWithoutPaste.summaryText)"),
-            "the cap confirmation should say Saved only instead of reusing the pasted success label"
+            finalizeBody.contains("\"Saved to Markdown. Paste it now, or use Paste Last Dictation later.\"")
+                && finalizeBody.contains("actionTitle: \"Paste It\"")
+                && finalizeBody.contains("pasteWithClipboardRestore(text)"),
+            "the cap save-only path should keep a visible Paste It recovery action"
         )
         let headerBody = try? String(
             contentsOf: URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
@@ -120,9 +122,24 @@ func testDictationSessionCap() {
             finalizeBody.contains("ActivationTelemetry.trackDictationArtifactSaved("),
             "the cap finalize path should count successful session-cap saves as dictation artifacts"
         )
-        assertFalse(
-            finalizeBody.contains("pasteWithClipboardRestore"),
-            "the cap finalize path must not paste into the focused app"
+    }
+
+    runSuite("The session cap warns and only auto-pastes when the original target is still active") {
+        let source = dictationControllerSource()
+        let timeoutBody = capSlice(
+            source,
+            from: "func installSessionTimeout()",
+            to: "private func overlayStateName"
+        )
+        assertTrue(
+            timeoutBody.contains("remainingSeconds <= 60")
+                && timeoutBody.contains("listeningNotice = \"Wrapping up soon\""),
+            "the overlay should warn before the hard session cap fires"
+        )
+        assertTrue(
+            timeoutBody.contains("sessionPasteTarget?.matchesCurrentFrontmostApp() == true")
+                && timeoutBody.contains("stopDictationAndPaste(trigger: .sessionCap, autoPaste: targetStillActive)"),
+            "the cap should paste only if the original paste target is still frontmost"
         )
     }
 

--- a/Tests/QuitConfirmationPreferencesTests.swift
+++ b/Tests/QuitConfirmationPreferencesTests.swift
@@ -36,7 +36,7 @@ func testQuitConfirmationPreferences() {
         )
     }
 
-    runSuite("ActiveMeetingQuitConfirmationPolicy only prompts for active meeting capture") {
+    runSuite("ActiveMeetingQuitConfirmationPolicy prompts for active and background meeting work") {
         assertTrue(
             ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
                 preferenceEnabled: true,
@@ -44,19 +44,28 @@ func testQuitConfirmationPreferences() {
             ),
             "default-on preference should prompt while a meeting is recording or finishing"
         )
+        assertTrue(
+            ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
+                preferenceEnabled: true,
+                activeMeetingCapture: false,
+                backgroundTranscriptionWork: true
+            ),
+            "default-on preference should also prompt while meeting transcription or imports are queued"
+        )
         assertFalse(
             ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
                 preferenceEnabled: true,
                 activeMeetingCapture: false
             ),
-            "idle or transcription-only quits should not show an extra dialog"
+            "idle quits should not show an extra dialog"
         )
         assertFalse(
             ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
                 preferenceEnabled: false,
-                activeMeetingCapture: true
+                activeMeetingCapture: true,
+                backgroundTranscriptionWork: true
             ),
-            "user opt-out should skip the dialog even during active capture"
+            "user opt-out should skip the dialog even during active or background meeting work"
         )
     }
 
@@ -65,15 +74,15 @@ func testQuitConfirmationPreferences() {
 
         assertEqual(
             presentation.title,
-            "Meeting is still recording",
-            "alert title should name the active meeting quit"
+            "Meeting work is still running",
+            "alert title should cover recording and background transcription work"
         )
         assertTrue(
-            presentation.message.contains("stop and make the transcript"),
-            "alert should offer the normal stop and transcribe path"
+            presentation.message.contains("Keep Transcripted open"),
+            "alert should offer the safe path of keeping the app open"
         )
         assertTrue(
-            presentation.message.contains("save the captured audio and quit"),
+            presentation.message.contains("save the audio and quit"),
             "alert should explain that quit preserves retry audio"
         )
         assertEqual(
@@ -90,6 +99,23 @@ func testQuitConfirmationPreferences() {
             presentation.saveAudioAndQuitTitle,
             "Save Audio & Quit",
             "confirm button should describe the recoverable quit path"
+        )
+
+        let backgroundPresentation = ActiveMeetingQuitConfirmationPolicy.backgroundPresentation
+        assertEqual(
+            backgroundPresentation.title,
+            "Meeting transcript is still running",
+            "background-only alert should name transcript work instead of active recording"
+        )
+        assertEqual(
+            backgroundPresentation.keepOpenTitle,
+            "Keep Open",
+            "background-only alert should not offer a recording action"
+        )
+        assertEqual(
+            backgroundPresentation.saveAudioAndQuitTitle,
+            "Save Audio & Quit",
+            "background-only quit should still describe preserved audio"
         )
     }
 }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1886,6 +1886,13 @@ func testRepoCommandContract() {
             "mini cursor should keep the quiet startup waveform visible long enough to avoid a broken-looking full-window flash"
         )
         assertTrue(
+            overlayContents.contains("func dismissError()")
+                && overlayContents.contains("let handler = self.errorActionHandler")
+                && overlayContents.contains("self.clearActionableErrorWithoutHiding()")
+                && overlayContents.contains("handler?()"),
+            "actionable dictation errors should clear their state before running one-shot actions"
+        )
+        assertTrue(
             overlayContents.contains("NSWorkspace.shared.accessibilityDisplayShouldReduceMotion"),
             "cursor-follow smoothing should respect macOS Reduce Motion"
         )
@@ -2522,6 +2529,7 @@ func testRepoCommandContract() {
 
     runSuite("Repo command contract - transcription cancellation clears live sidecar waits") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let taskManagerContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift")
         let cancelBlock = sourceSlice(
             controllerContents,
             from: "func cancelActiveTranscription(reason: TranscriptionCancelReason = .unknown) {",
@@ -2536,6 +2544,37 @@ func testRepoCommandContract() {
         assertTrue(
             cancelBlock.contains("activeQueuedTranscriptionJobID = nil"),
             "transcription cancellation should clear the queued job owner used for live sidecar final attachment"
+        )
+        assertTrue(
+            cancelBlock.contains("if reason == .userRequested")
+                && cancelBlock.contains("try? FileManager.default.removeItem(at: audioURL)")
+                && cancelBlock.contains("Imported audio saved before cancellation"),
+            "explicit user cancellation should delete cancelled imports while non-user cancellation keeps recovery audio"
+        )
+
+        let importBlock = sourceSlice(
+            taskManagerContents,
+            from: "public func startImportedTranscription(",
+            to: "activeTasks[taskId] = asyncTask"
+        )
+        assertTrue(
+            importBlock.contains("activeTaskAudio[taskId]")
+                && importBlock.contains("micURL: nil")
+                && importBlock.contains("systemURL: audioURL")
+                && importBlock.contains("meetingTitle: meetingTitle")
+                && importBlock.contains("recordingDate: recordingDate"),
+            "active imported transcription should register its audio so shutdown quit can preserve a Home retry item"
+        )
+        let preserveBlock = sourceSlice(
+            taskManagerContents,
+            from: "public func preserveActiveTranscriptionsForShutdown(errorMessage: String) -> Int {",
+            to: "func populateSavedMetadata"
+        )
+        assertTrue(
+            preserveBlock.contains("addFailedTranscriptionRetainingAvailableAudio")
+                && preserveBlock.contains("micAudioURL: audio.micURL")
+                && preserveBlock.contains("systemAudioURL: audio.systemURL"),
+            "shutdown preservation should retain registered active imported and recorded audio"
         )
     }
 
@@ -3292,6 +3331,31 @@ func testRepoCommandContract() {
             overlayContents.contains("static let drawerResizeHandleHeight: CGFloat = 40")
                 && drawerContents.contains("height: MeetingOverlayTokens.drawerResizeHandleHeight"),
             "live transcript drawer resize grip should keep a 40pt drag target"
+        )
+    }
+
+    runSuite("Repo command contract - meeting error feedback stays visible and useful") {
+        let overlayContents = readRepoTextFile("Sources/UI/Overlay/MeetingOverlayController.swift")
+        let errorUpdateBlock = sourceSlice(
+            overlayContents,
+            from: "case .error(let message):",
+            to: "// Transcription has no progress channel"
+        )
+        assertTrue(
+            errorUpdateBlock.contains("detailLabel.lineBreakMode = .byWordWrapping")
+                && errorUpdateBlock.contains("detailLabel.maximumNumberOfLines = 2")
+                && errorUpdateBlock.contains("Dismiss meeting error"),
+            "meeting errors should wrap recovery detail and expose an explicit dismiss control"
+        )
+
+        let sessionErrorBlock = sourceSlice(
+            overlayContents,
+            from: "case .error(let message):",
+            to: "pushToView()"
+        )
+        assertFalse(
+            sessionErrorBlock.contains("scheduleAutoHide(after: 5)"),
+            "meeting failures should not disappear after a five-second toast"
         )
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2559,8 +2559,8 @@ func testRepoCommandContract() {
         )
         assertTrue(
             importBlock.contains("activeTaskAudio[taskId]")
-                && importBlock.contains("micURL: nil")
-                && importBlock.contains("systemURL: audioURL")
+                && importBlock.contains("micURL: audioURL")
+                && importBlock.contains("systemURL: nil")
                 && importBlock.contains("meetingTitle: meetingTitle")
                 && importBlock.contains("recordingDate: recordingDate"),
             "active imported transcription should register its audio so shutdown quit can preserve a Home retry item"


### PR DESCRIPTION
## Summary
- warn on quit for active capture and background meeting/import transcription, with a background-only quit dialog that avoids no-op recording actions
- preserve queued/active meeting/import work for shutdown recovery while keeping explicit import cancellation as cleanup, not a failed meeting
- narrow dictation blocked-after-meeting copy to active capture only
- add a 5-minute dictation cap warning plus paste/save recovery action
- let actionable dictation errors dismiss cleanly and keep meeting failures visible with explicit dismiss

## Verification
- `bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 11979 passed
- focused fast tests:
  - `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter testRepoCommandContract` — 639 passed
  - `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter testQuitConfirmationPreferences` — 17 passed
  - `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter testDictationSessionCap` — 13 passed
  - `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter testDictationRecordingStartOverlayPolicy` — 34 passed earlier in lane
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 bash build.sh --no-open` — build/sign/perf OK; launch smoke explicitly skipped/unverified
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh` — passed
- `codex review --base origin/main` — no actionable regressions found

## Manual proof
- Manual UX proof remains UNKNOWN. Unsuppressed local launch smoke previously compiled/signed but failed at launch with `_LSOpenURLsWithCompletionHandler() failed with error -10810`, so I kept final build proof to compile/sign/perf with launch smoke skipped.

## Maestro lanes
- Codex: implementation, tests, build, review, PR
- Claude: attempted through `~/.codex/bin/maestro-delegate`; returned no output, so not counted as a successful review
- Local: copy/triage attempted through `~/.codex/bin/maestro-delegate`; low-signal output, proof artifact kept
- Windows: skipped; local macOS app proof was the useful surface

Proof paths:
- `/Users/redbars/.codex/maestro/runs/20260703T193923Z-transcripted-feedback-ux-risk-review-claude`
- `/Users/redbars/.codex/maestro/runs/20260703T193924Z-transcripted-feedback-copy-triage-local`
