### PR TITLE
docs: mark roadmap #9 (write-error stop) as shipped

### DIFF
--- a/docs/FIX_ROADMAP.md
+++ b/docs/FIX_ROADMAP.md
@@ -4,7 +4,7 @@ _Last updated: 2026-06-20. Source: verified engineering audit of the current tre
 
 ## State of the product (honest)
 
-Transcripted works, but it leaks trust and quietly drops content at the edges. The core capture-and-transcribe loop is solid and the model now ships bundled (no first-run download race). The real problems are threefold: (1) **a serious privacy regression** — the live overlay and transcript drawer are screen-share-visible, so during a recorded call the other party's just-spoken words can get broadcast back onto the shared screen with no macOS warning; (2) **silent data loss** in a handful of paths — a system-audio tap that installs but never streams is marked "recording," a >5-minute dictation is discarded on timeout, and non-disk-full write stalls keep the duration timer ticking while audio dies; and (3) **activation gaps** — the meetings-first onboarding never records a real meeting, never teaches the default-on auto-detect, and there's no terminal event for the permission-bounce drop-off. The speaker-identity subsystem has two real-but-bounded accuracy holes (write-time voiceprint contamination, sub-naming-bar cluster fusion) that should ride behind the existing eval harness. Nothing here is a rewrite. Most of the highest-value fixes are small.
+Transcripted works, but it leaks trust and quietly drops content at the edges. The core capture-and-transcribe loop is solid and the model now ships bundled (no first-run download race). The real problems are threefold: (1) **a serious privacy regression** — the live overlay and transcript drawer are screen-share-visible, so during a recorded call the other party's just-spoken words can get broadcast back onto the shared screen with no macOS warning; (2) **silent data loss** in a handful of paths — a system-audio tap that installs but never streams is marked "recording," and a >5-minute dictation is discarded on timeout (non-disk-full write stalls are now fixed — see #9); and (3) **activation gaps** — the meetings-first onboarding never records a real meeting, never teaches the default-on auto-detect, and there's no terminal event for the permission-bounce drop-off. The speaker-identity subsystem has two real-but-bounded accuracy holes (write-time voiceprint contamination, sub-naming-bar cluster fusion) that should ride behind the existing eval harness. Nothing here is a rewrite. Most of the highest-value fixes are small.
 
 ---
 
@@ -73,11 +73,8 @@ Two distinct people each landing 0.70–0.92 against the same profile (and no ru
 - Separation guard: `SpeakerMatchingService.swift:106`
 - Fix: decouple a stricter link/merge floor from the looser per-utterance attach; add eval coverage.
 
-### 9. Disk-full / write errors silently kill audio while recording keeps "running"
-**Impact 5 · Effort S**
-After 10 consecutive write errors the writer drops every later buffer, but `isRecording` stays true and the duration timer keeps counting. The common case (full disk) is *already* handled by a 30s disk-space check; the residual gap is non-disk-full stalls (permission/sandbox loss, file deleted under the handle).
-- `AudioFileManager.swift:383`, `:399-405` (cap, no external consumer)
-- Fix: mirror the existing disk-full pattern (`:487-491`) — at the cap, hop to main, set `self.error`, call `stop()`.
+### 9. ~~Disk-full / write errors silently kill audio while recording keeps "running"~~ — SHIPPED
+**Status: done, verified on `main`.** Fixed via PR #1235 (`f484c462`, mic write-error path) and extended to the system-audio write path in `40cf3531`. Both `recordMicWriteFailure`/`recordSystemWriteFailure` now mirror the disk-full stop pattern at the write-error cap: hop to main, set `self.error`, call `stop()` (`surfaceWriteFailureAndStop`/`surfaceSystemWriteFailureAndStop` in `AudioFileManager.swift`). Covered by `testMicWriteErrorCapStopsRecordingAndSurfacesError` and `testMicWriteFailuresBelowCapKeepRecording` in `Tests/TranscriptedCoreTests/AudioInitializationTests.swift`. This entry's original line citations (`AudioFileManager.swift:383`, `:399-405`, `:487-491`) are stale — kept for audit-trail only. Don't re-implement.
 
 ### 10. Permission-bounce drop-off has no stage-attributed terminal event
 **Impact 5.5 · Effort S**


### PR DESCRIPTION
## Summary
- `docs/FIX_ROADMAP.md` item #9 ("Disk-full / write errors silently kill audio while recording keeps 'running'") asked to mirror the existing disk-full stop pattern for the write-error cap. That work is **already merged**: PR #1235 (`f484c462`) added `recordMicWriteFailure` → `surfaceWriteFailureAndStop` (hop to main, set `self.error`, call `stop()`) for the mic write path, and `40cf3531` extended the identical pattern to the system-audio write path (`recordSystemWriteFailure` → `surfaceSystemWriteFailureAndStop`).
- Coverage already exists: `testMicWriteErrorCapStopsRecordingAndSurfacesError` and `testMicWriteFailuresBelowCapKeepRecording` in `Tests/TranscriptedCoreTests/AudioInitializationTests.swift` assert the cap trips a stop + surfaces an error, and that failures below the cap don't.
- The roadmap's line citations (`AudioFileManager.swift:383`, `:399-405`, `:487-491`) predate the fix and no longer match the file, which risked someone re-implementing already-shipped work. This PR marks #9 done and points at the real implementation/tests instead of touching production code again.

## Test plan
- [x] Confirmed via `git log` that `f484c462` (PR #1235, merged) and `40cf3531` are ancestors of current `main`.
- [x] Read `AudioFileManager.swift` in full and confirmed `recordMicWriteFailure`/`recordSystemWriteFailure` mirror the disk-full stop pattern exactly (main-actor hop, `self.error`, `stop()`).
- [x] Confirmed existing tests in `AudioInitializationTests.swift` already cover a non-disk-full write-failure streak stopping the recording and surfacing an error.
- [ ] No source change in this PR (docs only) — CI's build-and-test job still runs per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)