### PR TITLE
Route local AI summary through OwnFileResolver

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1046,6 +1046,30 @@ struct TranscriptedSettingsView: View {
             )
             return
         }
+        // The recorded transcript URL can drift after scanning (restyle rename,
+        // preview rename) the same way copy/open/re-transcribe do, so resolve it
+        // through OwnFileResolver before handing it to the summarizer — otherwise
+        // a moved/renamed file surfaces a raw read error instead of the same
+        // friendly failure those other actions give.
+        guard let resolvedTranscriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [transcriptURL]) else {
+            trackLocalSummaryAbandoned(
+                reason: .unavailable,
+                stage: "start",
+                priorReadyState: selectedLocalSummaryProviderIsReady ? "ready" : "not_ready"
+            )
+            presentHomeActionFailure(
+                title: "Could not summarize meeting",
+                message: SettingsArtifactMessage.meetingTranscriptNotFound,
+                retry: {
+                    generateLocalSummary(
+                        transcriptURL: transcriptURL,
+                        title: title,
+                        hasExistingSummary: hasExistingSummary
+                    )
+                }
+            )
+            return
+        }
         trackSettingsAction("generate_local_meeting_summary", page: .home)
         let provider = localMeetingSummaryProvider
         let summaryAction = hasExistingSummary ? "regenerate" : "generate"
@@ -1077,12 +1101,12 @@ struct TranscriptedSettingsView: View {
             switch provider {
             case .gemmaMLX:
                 return try await LocalMeetingSummarizer().summarize(
-                    transcriptURL: transcriptURL,
+                    transcriptURL: resolvedTranscriptURL,
                     title: title
                 )
             case .appleFoundation:
                 return try await AppleFoundationMeetingSummarizer().summarize(
-                    transcriptURL: transcriptURL,
+                    transcriptURL: resolvedTranscriptURL,
                     title: title
                 )
             }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -396,6 +396,31 @@ func testUIAutomationSurfaceContract() {
             "copy-for-agent and re-transcribe should surface a failure alert when the own file is missing, instead of NSSound.beep()"
         )
 
+        // Local AI meeting summary must resolve the transcript before reading it,
+        // same as copy/open/re-transcribe (FIX_ROADMAP "Local AI summary path
+        // skips OwnFileResolver") — a raw scan-time URL surfaces an ugly read
+        // error instead of the friendly "Could not summarize meeting" alert when
+        // the file drifted (restyle/preview rename) since the row was scanned.
+        assertTrue(
+            contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("private func generateLocalSummary(")
+                && contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(
+                    "guard let resolvedTranscriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [transcriptURL])"
+                ),
+            "generateLocalSummary should resolve the transcript through OwnFileResolver before summarizing, not read the raw scan-time URL"
+        )
+        assertFalse(
+            contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(
+                "LocalMeetingSummarizer().summarize(\n                    transcriptURL: transcriptURL,"
+            ),
+            "the local summary provider dispatch must hand the OwnFileResolver-resolved URL to LocalMeetingSummarizer, not the raw unresolved transcriptURL"
+        )
+        assertFalse(
+            contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(
+                "AppleFoundationMeetingSummarizer().summarize(\n                    transcriptURL: transcriptURL,"
+            ),
+            "the local summary provider dispatch must hand the OwnFileResolver-resolved URL to AppleFoundationMeetingSummarizer, not the raw unresolved transcriptURL"
+        )
+
         // Retained-audio playback follows recompressed/moved files instead of going
         // silently Unavailable on a stale path.
         assertTrue(


### PR DESCRIPTION
## Summary

`FIX_ROADMAP.md` LATER item: "Local AI summary path skips OwnFileResolver" (Impact 3, Effort S).

- `generateLocalSummary` in `TranscriptedSettingsView.swift` read the raw scan-time `transcriptURL` and handed it straight to `LocalMeetingSummarizer`/`AppleFoundationMeetingSummarizer`, while copy/open/reveal/re-transcribe all resolve through `OwnFileResolver.resolveExistingFile` first.
- The broadcast→refresh loop keeps the recorded URL fresh sub-second in the common case, so this was a narrow race — but when the transcript moved/renamed (restyle rename, preview rename) between the summary trigger and the read, the raw `String(contentsOf:)` surfaced an ugly low-level read error instead of the friendly "Could not summarize meeting" alert the other actions give.
- Added a guard that resolves the transcript through `OwnFileResolver` before dispatching to either summarizer, mirroring the existing `handleCopyMeeting`/`handleRetranscribeMeeting` pattern (friendly title/message, retry closure). Job-tracking dictionaries (`homeLocalSummaryJobIDs`/`homeLocalSummaryTasks`/`homeLocalSummaryTaskTokens`) stay keyed by the original scan-time path since that's what `RecentMeetingItem.id` uses for the in-flight spinner lookup — only the URL actually handed to the summarizer is resolved.

## Test plan

- [x] Added a source-contract test in `Tests/UIAutomationSurfaceContractTests.swift` asserting `generateLocalSummary` routes through `OwnFileResolver.resolveExistingFile` and that neither summarizer call site is handed the raw unresolved `transcriptURL` — matching the existing wiring-guard pattern for copy/open/reveal/re-transcribe in that same file.
- Not added: a behavioral test simulating a rename mid-flight. `generateLocalSummary` is a private method on a SwiftUI `View` struct with no harness to inject a mid-flight file move, which is the same reason its sibling actions (`handleCopyMeeting`, `handleRetranscribeMeeting`) only have source-contract coverage today rather than behavioral coverage — resolver *behavior* itself (stem rematch, fallback) is covered by `OwnFileResolverTests.swift`.
- [x] `swiftc -parse` on both changed files (syntax-only, no local disk budget for a full build in this environment)
- [ ] CI (`swift-ci.yml`) — build + fast tests + core/tools package tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)