### PR TITLE
Teach auto-detect calls in onboarding instead of the manual path

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -250,12 +250,12 @@ struct PermissionsOnboardingView: View {
         case .meetingStart:
             SplitStage {
                 Kicker("Meetings first")
-                Headline(primary: "Start from Transcripted.", emphasis: "No shortcut needed.", size: 42, alignment: .leading)
-                BodyCopy("When a call starts, click Transcripted in the menu bar and choose Start Meeting. That's the whole path.")
+                Headline(primary: "Transcripted notices\nwhen a call starts.", emphasis: "Then it asks, once.", size: 42, alignment: .leading)
+                BodyCopy("Any app or browser tab using your mic counts — Zoom, Meet, whatever — no calendar invite required. Prefer to start it yourself? Click Transcripted in the menu bar and choose Start Meeting.")
                 BulletList([
                     leaveDictationShortcutsOff ? "Dictation shortcuts are off for this setup" : "Dictation shortcuts stay available",
-                    "Meeting recording starts from the app",
-                    "You can change this later in Settings"
+                    "Works with any call, calendar invite or not",
+                    "Turn auto-detect off anytime in Settings"
                 ])
             } right: {
                 MeetingStartPathCard(dictationShortcutsOff: leaveDictationShortcutsOff)
@@ -291,11 +291,11 @@ struct PermissionsOnboardingView: View {
         case .calendar:
             SplitStage {
                 Kicker("Calendar")
-                Headline(primary: "Want meeting\nreminders?", size: 42, alignment: .leading)
-                BodyCopy("Transcripted can look at your calendar and offer a quiet prompt when a call is about to start. Spontaneous calls — like a Google Meet with no invite — are detected automatically too, and you can turn that off anytime in Settings.")
+                Headline(primary: "Calendar adds\nan early nudge.", size: 42, alignment: .leading)
+                BodyCopy("Transcripted already notices when a call starts — any app or browser tab using your mic, no invite required — and asks once. Add calendar access and it can nudge you a few minutes before a scheduled meeting even begins.")
                 ToggleCard(
-                    title: "Meeting reminders",
-                    detail: "Use read-only calendar access to notice upcoming calls.",
+                    title: "Calendar reminders",
+                    detail: "Use read-only calendar access for a heads-up before scheduled calls.",
                     isOn: $meetingPromptsEnabled,
                     automationIdentifier: "transcripted.onboarding.calendar.meeting-reminders"
                 )

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -435,6 +435,25 @@ func testUIAutomationSurfaceContract() {
             assertTrue(contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains(requiredOnboardingHook), "\(requiredOnboardingHook) should stay in onboarding automation scope")
         }
 
+        // Auto-detect calls is default-on (AutoCallDetectionPreferences) but onboarding
+        // used to teach only the manual menu-bar path and frame detection as
+        // calendar-only. These guard the copy fix: the meetingStart step should prime
+        // users that Transcripted notices a call starting in any app/browser using the
+        // mic and asks once, and the calendar step should frame calendar access as an
+        // addition to that always-on detection rather than the only way calls get noticed.
+        assertTrue(
+            contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("Transcripted notices")
+                && contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("when a call starts.")
+                && contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("no calendar invite required")
+                && contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("Works with any call, calendar invite or not"),
+            "the meetingStart onboarding step should teach auto-detect calls instead of only the manual menu-bar path"
+        )
+        assertTrue(
+            contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("already notices when a call starts")
+                && contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("Calendar reminders"),
+            "the calendar onboarding step should frame calendar access as an addition to always-on call detection, not the only way calls get noticed"
+        )
+
         for identifier in [
             "transcripted.speaker-review.save-names",
             "transcripted.speaker-review.review-later",


### PR DESCRIPTION
## Summary
- Fix #7 from `docs/FIX_ROADMAP.md` (Impact 6, Effort S): auto-detect calls (`AutoCallDetectionPreferences`, default-on since 2026-06-14) is the strongest zero-effort capture lever, but onboarding never taught it — it only showed the manual "menu bar > Start Meeting" path and framed detection as calendar-only.
- `PermissionsOnboardingView`'s `.meetingStart` step now primes users that Transcripted already notices a call starting in any app or browser tab using the mic and asks once, with the manual menu-bar path kept as an explicit fallback for anyone who prefers it.
- The `.calendar` step's copy is reframed so calendar access reads as an addition on top of that always-on detection (an early heads-up before a scheduled call) rather than implying calendar is how call detection works.
- Copy-only change plus a renamed `ToggleCard` title ("Meeting reminders" → "Calendar reminders") for clarity; no changes to `AutoCallDetectionPreferences` wiring, gating, or the in-flight prompting redesign.

## Test plan
- [x] Added contract assertions in `Tests/UIAutomationSurfaceContractTests.swift` pinning the new copy so it can't silently regress back to manual-only/calendar-only framing.
- [x] `bash run-tests.sh` — full fast-test suite: 12163 tests, 12163 passed, 0 failed.
- [x] `swiftc -parse` sanity check on the edited view file (no compile toolchain/deps cache available locally to run the full `build.sh`; CI's `build-and-test` job covers the full app build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)