### PR TITLE
Salvage PR 1335 hardening slice

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,6 +94,34 @@ Practical implications for users:
 
 If a future version of the ML stack supports team-id-consistent signing for all
 embedded dylibs, the `disable-library-validation` entitlement will be removed.
+The shipped distribution entitlement profile currently shares this library
+validation exception for the same ML-loading reason; the mitigation is Developer
+ID signing and notarization of the full app bundle.
+
+## Permissions and TCC prompts
+
+Screen Recording (`NSScreenCaptureUsageDescription`) is requested only so
+meeting capture can capture system audio through ScreenCaptureKit. macOS uses
+the same TCC prompt for system-audio capture and screen capture, so the prompt
+mentions screen recording even though Transcripted does not read, store, or
+transmit screen pixels.
+
+## Companion MCP server trust model
+
+The companion MCP server (`Tools/TranscriptedMCP`) is a local, read-only stdio
+binary. It has no per-caller authentication: any local process that can launch
+it can read saved transcripts, dictations, and sidecars from the capture
+library. Treat adding it to an agent or editor as granting that client read
+access to your saved captures.
+
+## Update feed integrity
+
+Sparkle reads the appcast from a raw GitHub URL, but update integrity does not
+depend only on that hosting path. Each update is verified with Sparkle's EdDSA
+signature against the public key embedded in the app, so a tampered feed cannot
+install an unsigned or wrong-key build. Keep the signing key, GitHub account,
+and branch protections locked down because they are the trust roots for the
+published feed and artifacts.
 
 ## Supported Versions
 

--- a/Sources/Meeting/MeetingArtifactRenamer.swift
+++ b/Sources/Meeting/MeetingArtifactRenamer.swift
@@ -70,7 +70,9 @@ enum MeetingArtifactRenamer {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         let limited = String(collapsedWhitespace.prefix(80)).trimmingCharacters(in: .whitespacesAndNewlines)
-        return limited.isEmpty ? fallback : limited
+        let visibleStem = String(limited.drop(while: { $0 == "." }))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return visibleStem.isEmpty ? fallback : visibleStem
     }
 
     // MARK: - Artifact paths

--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -447,7 +447,11 @@ enum MeetingImportedAudioPreparer {
         let readHandle = try FileHandle(forReadingFrom: sourceURL)
         defer { try? readHandle.close() }
 
-        guard fileManager.createFile(atPath: destinationURL.path, contents: nil) else {
+        guard fileManager.createFile(
+            atPath: destinationURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
             throw MeetingImportedAudioPreparationError.copyFailed
         }
 

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -14,6 +14,12 @@ import UniformTypeIdentifiers
 struct TranscriptedApp: App {
     @NSApplicationDelegateAdaptor(TranscriptedAppDelegate.self) var appDelegate
 
+    init() {
+        // Set this before app startup creates logs, scratch files, or atomic-write
+        // temp files so new app-owned files default to owner-only permissions.
+        umask(0o077)
+    }
+
     var body: some Scene {
         Settings { EmptyView() }
             .commands {

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -3,6 +3,8 @@ import Foundation
 func testMeetingAudioArchiveResolver() {
     runSuite("MeetingAudioArchiveResolverTests") {
         testResolverUsesCanonicalMeetingArtifactAudioDirectory()
+        testMeetingArtifactRenamerStripsLeadingDots()
+        testMeetingArtifactRenamerFallsBackForAllDots()
         testResolverKeepsLiveMeetingAudioPairButUsesSinglePlaybackSource()
         testResolverFallsBackToMicrophonePlayback()
         testAttachmentPlaybackPrefersSystemForFailedMeetingAudio()
@@ -17,6 +19,22 @@ func testMeetingAudioArchiveResolver() {
         testRetranscriptionInputMapsLiveSplitStreams()
         testRetranscriptionInputMapsSingleRecording()
     }
+}
+
+private func testMeetingArtifactRenamerStripsLeadingDots() {
+    assertEqual(
+        MeetingArtifactRenamer.sanitizedTitleStem(for: "... Quarterly Planning", fallback: "Untitled Meeting"),
+        "Quarterly Planning",
+        "Meeting title fragments should not create hidden dot-prefixed artifact names"
+    )
+}
+
+private func testMeetingArtifactRenamerFallsBackForAllDots() {
+    assertEqual(
+        MeetingArtifactRenamer.sanitizedTitleStem(for: "...", fallback: "Untitled Meeting"),
+        "Untitled Meeting",
+        "All-dot meeting titles should fall back to a visible artifact name"
+    )
 }
 
 private func testResolverUsesCanonicalMeetingArtifactAudioDirectory() {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -310,6 +310,12 @@ func testRepoCommandContract() {
             buildDepsScript.contains("The SPM-path archive is contaminated with TranscriptedCore objects"),
             "build-deps.sh should fail with an actionable message when libExternalDeps.a contains Core symbols"
         )
+        assertTrue(
+            buildDepsScript.contains("assert_mlx_swift_lm_revision")
+                && buildDepsScript.contains("mlx-swift-lm revision mismatch")
+                && buildDepsScript.contains("\"$MLX_SWIFT_LM_REVISION\"*"),
+            "build-deps.sh should verify the resolved mlx-swift-lm checkout still matches the pinned revision"
+        )
     }
 
     runSuite("Repo command contract - fast test runner generation is per-process") {

--- a/scripts/entrypoints/build-deps.sh
+++ b/scripts/entrypoints/build-deps.sh
@@ -253,6 +253,51 @@ fetch_argmax_whisperkit_sources() {
     done
 }
 
+assert_mlx_swift_lm_revision() {
+    local resolved_file="Package.resolved"
+    local checkout="$DEPS_BUILD/.build/checkouts/mlx-swift-lm"
+    local resolved_revision=""
+    local source=""
+
+    if [ -f "$resolved_file" ]; then
+        resolved_revision="$(awk '
+            /mlx-swift-lm/ { in_pin = 1 }
+            in_pin && /"revision"[[:space:]]*:/ {
+                line = $0
+                sub(/.*"revision"[[:space:]]*:[[:space:]]*"/, "", line)
+                sub(/".*/, "", line)
+                print line
+                exit
+            }
+        ' "$resolved_file")"
+        [ -n "$resolved_revision" ] && source="$resolved_file"
+    fi
+
+    if [ -z "$resolved_revision" ] && [ -d "$checkout/.git" ]; then
+        resolved_revision="$(git -C "$checkout" rev-parse HEAD 2>/dev/null || true)"
+        [ -n "$resolved_revision" ] && source="git -C $checkout rev-parse HEAD"
+    fi
+
+    if [ -z "$resolved_revision" ]; then
+        echo "[build-deps] ERROR: could not determine resolved mlx-swift-lm revision"
+        echo "[build-deps]        checked Package.resolved and $checkout"
+        echo "[build-deps]        expected: $MLX_SWIFT_LM_REVISION"
+        exit 1
+    fi
+
+    case "$resolved_revision" in
+        "$MLX_SWIFT_LM_REVISION"*) ;;
+        *)
+            echo "[build-deps] ERROR: mlx-swift-lm revision mismatch (from $source)"
+            echo "[build-deps]   expected (pin): $MLX_SWIFT_LM_REVISION"
+            echo "[build-deps]   resolved:       $resolved_revision"
+            exit 1
+            ;;
+    esac
+
+    echo "[build-deps] Verified mlx-swift-lm resolved revision $resolved_revision matches pin $MLX_SWIFT_LM_REVISION (from $source)"
+}
+
 resolve_package_graph() {
     local resolve_cmd=("swift" "package" "resolve" "--disable-dependency-cache")
 
@@ -263,12 +308,14 @@ resolve_package_graph() {
     echo "  Argmax WhisperKit:  $ARGMAX_OSS_SWIFT_VERSION ($ARGMAX_OSS_SWIFT_REVISION)"
 
     if "${resolve_cmd[@]}"; then
+        assert_mlx_swift_lm_revision
         return 0
     fi
 
     echo "[build-deps] WARNING: initial resolve failed; retrying from a clean SwiftPM state"
     rm -rf .build Package.resolved
     "${resolve_cmd[@]}"
+    assert_mlx_swift_lm_revision
 }
 
 ensure_mlx_swift_submodules() {


### PR DESCRIPTION
## Summary

Salvages only the still-missing, current-compatible pieces from stale #1335 after checking live PR state:

- #1381 is merged and already covers the Sentry/support-diagnostics hardening.
- #1383 is merged and already covers capture Markdown read caps.
- #1397 is merged and already covers the pasteback/clipboard/Auto Enter hardening in a stronger current-main shape.

This PR keeps the remaining small slice:

- default app-created files to owner-only with `umask(077)` at app startup
- create imported-audio scratch copies as `0600`
- strip leading dots from meeting artifact title stems and fall back for all-dot names
- verify the resolved `mlx-swift-lm` checkout matches the pinned revision during `build-deps.sh`
- document the security model for distribution library validation, Screen Recording/system audio TCC, MCP local trust, and Sparkle feed integrity

## Drop recommendations for old #1335

Drop these instead of carrying them forward:

- Sentry/support diagnostics changes: superseded by #1381.
- Capture Markdown read cap changes: superseded by #1383.
- Paste target, clipboard, private-event-source, and Auto Enter changes: superseded by #1397.
- ESpeak/GPL offer text: stale now. `THIRD_PARTY_LICENSES.md` says FluidAudio >=0.15 no longer vendors ESpeakNG, and `build-deps.sh` skips that framework when absent.
- The old branch as a whole: it is stale against current `main`; carrying it wholesale would reintroduce already-replaced code paths.

## Verification

- `bash -n build-deps.sh && bash -n scripts/entrypoints/build-deps.sh`
- `bash run-tests.sh --filter MeetingAudioArchiveResolverTests` — 47 passed
- `bash run-tests.sh --filter RepoCommandContractTests` — 644 passed
- `bash build-deps.sh --force` — passed; verified `mlx-swift-lm` resolved revision `25b00d4e...` matches pin `25b00d4`
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 12,331 passed
- `bash run-integration-smoke.sh` — passed
- `codex review --base origin/main` — no findings; reviewer noted `bash run-tests.sh` passed locally

Note: one parallel `run-tests.sh` attempt failed while `build.sh` was compiling beside it because the custom runner shares build/temp state. The serial rerun passed cleanly.

## Lanes used

- Codex: live GitHub PR diffing, implementation, verification, independent review, push/PR
- Local: attempted via `maestro-delegate`; non-actionable output, proof paths under `~/.codex/maestro/runs/20260704T014508Z-transcripted-1335-salvage-triage-local` and `~/.codex/maestro/runs/20260704T022522Z-transcripted-1335-review-local`
- Claude: skipped; small current-compatible salvage after live refs and Codex review
- Windows: skipped; this needed local repo/build verification
