### PR TITLE
Salvage useful PR 1352 deltas

### DIFF
--- a/Sources/Meeting/MeetingQuickSummaryExtractor.swift
+++ b/Sources/Meeting/MeetingQuickSummaryExtractor.swift
@@ -53,7 +53,7 @@ enum MeetingQuickSummaryExtractor {
                 if matchesAny(decisionCues, in: normalized) {
                     append(sentence, to: &decisions)
                 } else if matchesAny(actionCues, in: normalized) {
-                    append(ownerPrefixed(sentence, owner: owner), to: &actionItems)
+                    append(actionBullet(sentence, owner: owner, normalized: normalized), to: &actionItems)
                 } else if isOpenQuestion(sentence, normalized: normalized) {
                     append(sentence, to: &openQuestions)
                 }
@@ -269,6 +269,36 @@ enum MeetingQuickSummaryExtractor {
     private static func ownerPrefixed(_ sentence: String, owner: String) -> String {
         let trimmed = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
         return "\(owner): \(trimmed)"
+    }
+
+    private static let dueCues: [(cue: String, due: String)] = [
+        ("by end of day", "end of day"),
+        ("by end of the day", "end of day"),
+        ("by eod", "end of day"),
+        ("by end of week", "end of week"),
+        ("by end of the week", "end of week"),
+        ("by eow", "end of week"),
+        ("by end of month", "end of month"),
+        ("by end of the month", "end of month"),
+        ("by tomorrow", "tomorrow"),
+        ("by tonight", "tonight"),
+        ("by next week", "next week"),
+        ("by next month", "next month"),
+        ("by monday", "Monday"),
+        ("by tuesday", "Tuesday"),
+        ("by wednesday", "Wednesday"),
+        ("by thursday", "Thursday"),
+        ("by friday", "Friday"),
+        ("by saturday", "Saturday"),
+        ("by sunday", "Sunday"),
+    ]
+
+    static func actionBullet(_ sentence: String, owner: String, normalized: String) -> String {
+        let bullet = ownerPrefixed(sentence, owner: owner)
+        guard let match = dueCues.first(where: { normalized.contains($0.cue) }) else {
+            return bullet
+        }
+        return "\(bullet) (due: \(match.due))"
     }
 
     private static func bulletList(_ items: [String]) -> String {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -34,6 +34,7 @@ class ParakeetEngine: ObservableObject {
     private nonisolated(unsafe) var audioStartReferenceTime: CFAbsoluteTime?
     private let pendingSamplesLock = NSLock()
     private var pendingSamples: [Float] = []
+    private var didReportPendingSampleTruncation = false
     private nonisolated(unsafe) var lastLevelUpdate: CFAbsoluteTime = 0
     private var isEnginePrewarmed = false
     private var wakeObserver: NSObjectProtocol?
@@ -1689,15 +1690,33 @@ class ParakeetEngine: ObservableObject {
                     }
                 }
 
-                self.pendingSamplesLock.withLock {
+                let truncatedSamples: Int = self.pendingSamplesLock.withLock {
                     self.pendingSamples.append(contentsOf: monoSamples)
                     let maxSamples = ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
                         sampleRate: effectiveSampleRate,
                         seconds: TranscriptedConstants.audioBufferCapacitySeconds
                     )
                     let overflowMargin = Int(effectiveSampleRate)
-                    if self.pendingSamples.count > maxSamples + overflowMargin {
-                        self.pendingSamples.removeFirst(self.pendingSamples.count - maxSamples)
+                    guard self.pendingSamples.count > maxSamples + overflowMargin else { return 0 }
+                    let dropped = self.pendingSamples.count - maxSamples
+                    self.pendingSamples.removeFirst(dropped)
+                    guard !self.didReportPendingSampleTruncation else { return 0 }
+                    self.didReportPendingSampleTruncation = true
+                    return dropped
+                }
+                if truncatedSamples > 0 {
+                    let droppedSeconds = Double(truncatedSamples) / effectiveSampleRate
+                    Task { @MainActor in
+                        EventReporter.shared.capture(
+                            level: .warning,
+                            engine: "parakeet",
+                            event: "audio_buffer_truncated",
+                            message: "Recording exceeded the audio buffer capacity; oldest audio was dropped",
+                            context: [
+                                "dropped_seconds": String(format: "%.1f", droppedSeconds),
+                                "capacity_seconds": "\(Int(TranscriptedConstants.audioBufferCapacitySeconds))",
+                            ]
+                        )
                     }
                 }
 
@@ -2172,6 +2191,7 @@ class ParakeetEngine: ObservableObject {
         }
         pendingSamplesLock.withLock {
             pendingSamples.removeAll(keepingCapacity: true)
+            didReportPendingSampleTruncation = false
         }
         sampleBuffer.removeAll(keepingCapacity: true)
         reserveNativeSampleBufferCapacity()
@@ -2531,6 +2551,7 @@ class ParakeetEngine: ObservableObject {
             }
             self.pendingSamplesLock.withLock {
                 self.pendingSamples.removeAll(keepingCapacity: true)
+                self.didReportPendingSampleTruncation = false
             }
             self.zombieRecoveryRestartPending = true
             self.isRecording = false

--- a/Sources/TranscriptedCore/Services/RecordingValidator.swift
+++ b/Sources/TranscriptedCore/Services/RecordingValidator.swift
@@ -4,8 +4,11 @@ import AVFoundation
 /// Validates system conditions before starting a recording to prevent data loss
 public enum RecordingValidator {
 
-    /// Minimum required disk space in bytes (100MB)
-    public static let minimumDiskSpace: Int64 = 100 * 1024 * 1024
+    /// Minimum free disk space required to start a recording.
+    ///
+    /// Meeting capture can write dual WAV streams fast enough that a 100MB
+    /// floor lets recordings begin with only a few minutes of runway.
+    public static let minimumDiskSpace: Int64 = 1024 * 1024 * 1024
 
     /// Result of validation check
     public enum ValidationResult {
@@ -70,7 +73,8 @@ public enum RecordingValidator {
 
             if Int64(availableCapacity) < minimumDiskSpace {
                 let availableMB = Int64(availableCapacity) / (1024 * 1024)
-                return .failure("Not enough disk space (\(availableMB)MB free, need 100MB). Free up space and try again.")
+                let requiredMB = minimumDiskSpace / (1024 * 1024)
+                return .failure("Not enough disk space (\(availableMB)MB free, need \(requiredMB)MB). Free up space and try again.")
             }
 
             return .success

--- a/Tests/MeetingQuickSummaryExtractorTests.swift
+++ b/Tests/MeetingQuickSummaryExtractorTests.swift
@@ -19,9 +19,30 @@ func testMeetingQuickSummaryExtractor() {
             sections.actionItems.contains("pricing deck"),
             "action item should preserve the concrete commitment"
         )
+        assertTrue(
+            sections.actionItems.contains("(due: Friday)"),
+            "deadline cue should produce a due marker, got: \(sections.actionItems)"
+        )
         assertFalse(
             sections.actionItems.lowercased().contains("sounds good"),
             "small talk should not become an action item"
+        )
+    }
+
+    runSuite("does not append a due marker when an action lacks a deadline cue") {
+        let transcript = """
+        **00:15**  [System/Maya]
+        I'll take care of the vendor follow-up.
+        """
+
+        let sections = MeetingQuickSummaryExtractor.sections(transcript: transcript)
+        assertTrue(
+            sections.actionItems.contains("vendor follow-up"),
+            "action without a deadline should still be extracted, got: \(sections.actionItems)"
+        )
+        assertFalse(
+            sections.actionItems.contains("(due:"),
+            "action without a deadline cue must not get a due marker"
         )
     }
 

--- a/Tests/TranscriptedCoreTests/PublicTranscriptedCoreAPITests.swift
+++ b/Tests/TranscriptedCoreTests/PublicTranscriptedCoreAPITests.swift
@@ -18,7 +18,7 @@ final class PublicTranscriptedCoreAPITests: XCTestCase {
         )
 
         XCTAssertEqual(paths.transcripts.lastPathComponent, "meetings")
-        XCTAssertEqual(RecordingValidator.minimumDiskSpace, 100 * 1024 * 1024)
+        XCTAssertEqual(RecordingValidator.minimumDiskSpace, 1024 * 1024 * 1024)
         XCTAssertTrue(RecordingValidator.validateSavePath(paths.transcripts).isValid)
     }
 

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift
@@ -8,10 +8,14 @@ public struct ParsedMeetingSummary: Equatable {
         /// to nil so rollups don't treat them as a person.
         public let owner: String?
         public let text: String
+        public let status: String?
+        public let due: String?
 
-        public init(owner: String?, text: String) {
+        public init(owner: String?, text: String, status: String? = nil, due: String? = nil) {
             self.owner = owner
             self.text = text
+            self.status = status
+            self.due = due
         }
     }
 
@@ -143,20 +147,60 @@ public enum CaptureSummaryParser {
     ]
 
     private static func actionItem(from text: String) -> ParsedMeetingSummary.ActionItem {
+        let (stripped, status, due) = extractTrailingMarkers(from: text)
         // The summarizer prompts action bullets as "<Owner if named: follow-up>".
         // Treat a short leading segment before the first ": " as the owner only
         // when it reads like a name/team — a Title-Case noun phrase. Sentence
         // fragments ("Discuss the new API: ...") carry lowercase function words,
         // so we keep them as plain text instead of shredding a fake owner out.
-        if let colon = text.range(of: ": ") {
-            let owner = String(text[..<colon.lowerBound]).trimmingCharacters(in: .whitespaces)
-            let rest = String(text[colon.upperBound...]).trimmingCharacters(in: .whitespaces)
+        if let colon = stripped.range(of: ": ") {
+            let owner = String(stripped[..<colon.lowerBound]).trimmingCharacters(in: .whitespaces)
+            let rest = String(stripped[colon.upperBound...]).trimmingCharacters(in: .whitespaces)
             if !rest.isEmpty, looksLikeOwner(owner) {
                 let normalized = placeholderOwners.contains(owner.lowercased()) ? nil : owner
-                return ParsedMeetingSummary.ActionItem(owner: normalized, text: rest)
+                return ParsedMeetingSummary.ActionItem(owner: normalized, text: rest, status: status, due: due)
             }
         }
-        return ParsedMeetingSummary.ActionItem(owner: nil, text: text)
+        return ParsedMeetingSummary.ActionItem(owner: nil, text: stripped, status: status, due: due)
+    }
+
+    private static let bareStatusTokens: Set<String> = [
+        "open", "done", "complete", "completed", "resolved", "closed",
+        "cancelled", "canceled",
+    ]
+
+    private static func extractTrailingMarkers(
+        from raw: String
+    ) -> (text: String, status: String?, due: String?) {
+        var text = raw.trimmingCharacters(in: .whitespaces)
+        var status: String?
+        var due: String?
+
+        for _ in 0..<2 {
+            guard text.hasSuffix(")"), let open = text.lastIndex(of: "(") else { break }
+            let inner = String(text[text.index(after: open)..<text.index(before: text.endIndex)])
+                .trimmingCharacters(in: .whitespaces)
+            let lowered = inner.lowercased()
+
+            let marker: (String) -> String? = { prefix in
+                guard lowered.hasPrefix(prefix) else { return nil }
+                let value = String(inner.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
+                return value.isEmpty ? nil : value
+            }
+
+            if status == nil, let value = marker("status:") {
+                status = value.lowercased()
+            } else if due == nil, let value = marker("due:") {
+                due = value
+            } else if status == nil, bareStatusTokens.contains(lowered) {
+                status = lowered
+            } else {
+                break
+            }
+            text = String(text[..<open]).trimmingCharacters(in: .whitespaces)
+        }
+
+        return (text, status, due)
     }
 
     private static func looksLikeOwner(_ candidate: String) -> Bool {

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureSummaryParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureSummaryParserTests.swift
@@ -76,6 +76,47 @@ final class CaptureSummaryParserTests: XCTestCase {
         XCTAssertEqual(summary.actionItems[1].text, "Follow up with legal")
     }
 
+    func testParsesTrailingDueAndStatusMarkers() throws {
+        let markdown = inlineMeeting(
+            actionItems: """
+            ### Action Items
+            - Jenny: send the revised spec (due: Friday)
+            - Nate: draft the launch email (status: done)
+            - Confirm the venue (done) (due: next week)
+            - Follow up with legal
+            """
+        )
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: markdown))
+        XCTAssertEqual(summary.actionItems.count, 4)
+
+        XCTAssertEqual(summary.actionItems[0].owner, "Jenny")
+        XCTAssertEqual(summary.actionItems[0].text, "send the revised spec")
+        XCTAssertNil(summary.actionItems[0].status)
+        XCTAssertEqual(summary.actionItems[0].due, "Friday")
+
+        XCTAssertEqual(summary.actionItems[1].owner, "Nate")
+        XCTAssertEqual(summary.actionItems[1].text, "draft the launch email")
+        XCTAssertEqual(summary.actionItems[1].status, "done")
+        XCTAssertNil(summary.actionItems[1].due)
+
+        XCTAssertEqual(summary.actionItems[2].text, "Confirm the venue")
+        XCTAssertEqual(summary.actionItems[2].status, "done")
+        XCTAssertEqual(summary.actionItems[2].due, "next week")
+
+        XCTAssertNil(summary.actionItems[3].status)
+        XCTAssertNil(summary.actionItems[3].due)
+    }
+
+    func testKeepsRealParentheticalsOutOfMarkers() throws {
+        let markdown = inlineMeeting(
+            actionItems: "### Action Items\n- Jenny: call the vendor (the new one)"
+        )
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: markdown))
+        XCTAssertEqual(summary.actionItems[0].text, "call the vendor (the new one)")
+        XCTAssertNil(summary.actionItems[0].status)
+        XCTAssertNil(summary.actionItems[0].due)
+    }
+
     func testDoesNotShredSentenceColonsIntoOwner() throws {
         let markdown = inlineMeeting(
             actionItems: "### Action Items\n- Discuss the new API: review the public endpoints and document them"

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
@@ -449,10 +449,7 @@ struct DictationDayPage: Codable {
 
 // MARK: - Summary-Fact Rollups (cross-meeting tools)
 
-/// Open/all filter for `list_action_items`.
-/// Current saved meeting summaries do not carry done/due metadata; the tool
-/// handler rejects "done" with an explicit error instead of returning a
-/// silent empty set.
+/// Open/done/all filter for `list_action_items`.
 enum ActionItemStatusFilter: String {
     case open
     case done

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -373,11 +373,11 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         ]),
                         "status": .object([
                             "type": .string("string"),
-                            "description": .string("Which items to return: 'open' (default) or 'all'. 'done' is not supported — saved summaries do not track completion state yet.")
+                            "description": .string("Which items to return: 'open' (default), 'done', or 'all'.")
                         ]),
                         "query": .object([
                             "type": .string("string"),
-                            "description": .string("Optional full-text filter on the action item text")
+                            "description": .string("Optional full-text filter on the action item text, owner, status, or due metadata")
                         ]),
                         "date_from": .object([
                             "type": .string("string"),
@@ -1076,7 +1076,9 @@ func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, meetingDir
             if let summary = TranscriptLoader.loadMeetingSummary(forTranscript: mdURL) {
                 title = summary.title ?? title
                 decisions = summary.decisions
-                actionItems = summary.actionItems.map { RecapActionItem(owner: $0.owner, text: $0.text) }
+                actionItems = summary.actionItems.map {
+                    RecapActionItem(owner: $0.owner, text: $0.text, status: $0.status, due: $0.due)
+                }
                 openQuestions = summary.openQuestions
                 let hasStructuredFacts = !decisions.isEmpty || !actionItems.isEmpty || !openQuestions.isEmpty
                 if hasStructuredFacts {
@@ -1380,6 +1382,15 @@ struct RecapEntry: Codable {
 struct RecapActionItem: Codable, Equatable {
     let owner: String?
     let text: String
+    let status: String?
+    let due: String?
+
+    init(owner: String?, text: String, status: String? = nil, due: String? = nil) {
+        self.owner = owner
+        self.text = text
+        self.status = status
+        self.due = due
+    }
 }
 
 struct RecapResult: Codable {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -363,7 +363,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "list_action_items",
-                description: "Roll up action items across every meeting. Filter by owner (supports name variants: Nate finds Nate Smith), by status ('open' by default, or 'all'), by a free-text query, or by date range. Use this for 'every open action item assigned to me' or 'what did we commit to last week'. Depends on the meeting summary index.",
+                description: "Roll up action items across every meeting. Filter by owner (supports name variants: Nate finds Nate Smith), by status ('open' by default, 'done', or 'all'), by a free-text query, or by date range. Use this for 'every open action item assigned to me' or 'what did we commit to last week'. Depends on the meeting summary index.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -1133,15 +1133,6 @@ func handleListActionItems(params: CallTool.Parameters, index: TranscriptIndex, 
     let dateFrom = params.arguments?["date_from"]?.stringValue
     let dateTo = params.arguments?["date_to"]?.stringValue
     let count = params.arguments?["count"]?.intValue ?? 50
-
-    // Saved summaries do not track completion state, so a done filter would
-    // always be a silent empty set — fail loudly instead.
-    if status == .done {
-        return textResult(
-            "Unsupported status filter: \"\(rawStatus ?? "done")\". Saved meeting summaries do not track done/completed state yet, so this filter would always return nothing. Use status \"open\" (the default) or \"all\".",
-            isError: true
-        )
-    }
 
     var result = try index.listActionItems(
         owner: owner, query: query, status: status,

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -64,8 +64,8 @@ final class TranscriptIndex: @unchecked Sendable {
     /// Bump when the derived index shape changes so existing on-disk indexes are
     /// rebuilt from disk on next open. v2 added `meeting_summary_items`; v3 added
     /// the meeting-summary FTS document used by general search; v4 adds action
-    /// item `status` and `due` metadata.
-    private static let schemaVersion: Int32 = 4
+    /// item `status` and `due` metadata; v5 makes that metadata searchable.
+    private static let schemaVersion: Int32 = 5
 
     /// An already-indexed meeting whose transcript mtime is unchanged is skipped
     /// by `reconcile`, so a schema addition (new table/column) would never
@@ -231,7 +231,7 @@ final class TranscriptIndex: @unchecked Sendable {
 
         exec("""
             CREATE VIRTUAL TABLE IF NOT EXISTS meeting_summary_items_fts USING fts5(
-                text, owner,
+                text, owner, status, due,
                 content='meeting_summary_items', content_rowid='rowid',
                 tokenize='porter unicode61'
             )
@@ -239,15 +239,15 @@ final class TranscriptIndex: @unchecked Sendable {
 
         exec("""
             CREATE TRIGGER IF NOT EXISTS meeting_summary_items_ai AFTER INSERT ON meeting_summary_items BEGIN
-                INSERT INTO meeting_summary_items_fts(rowid, text, owner)
-                VALUES (new.rowid, new.text, new.owner);
+                INSERT INTO meeting_summary_items_fts(rowid, text, owner, status, due)
+                VALUES (new.rowid, new.text, new.owner, new.status, new.due);
             END
         """)
 
         exec("""
             CREATE TRIGGER IF NOT EXISTS meeting_summary_items_ad AFTER DELETE ON meeting_summary_items BEGIN
-                INSERT INTO meeting_summary_items_fts(meeting_summary_items_fts, rowid, text, owner)
-                VALUES ('delete', old.rowid, old.text, old.owner);
+                INSERT INTO meeting_summary_items_fts(meeting_summary_items_fts, rowid, text, owner, status, due)
+                VALUES ('delete', old.rowid, old.text, old.owner, old.status, old.due);
             END
         """)
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -62,9 +62,10 @@ final class TranscriptIndex: @unchecked Sendable {
     }
 
     /// Bump when the derived index shape changes so existing on-disk indexes are
-    /// rebuilt from disk on next open. v2 added `meeting_summary_items`; v3 adds
-    /// the meeting-summary FTS document used by general search.
-    private static let schemaVersion: Int32 = 3
+    /// rebuilt from disk on next open. v2 added `meeting_summary_items`; v3 added
+    /// the meeting-summary FTS document used by general search; v4 adds action
+    /// item `status` and `due` metadata.
+    private static let schemaVersion: Int32 = 4
 
     /// An already-indexed meeting whose transcript mtime is unchanged is skipped
     /// by `reconcile`, so a schema addition (new table/column) would never
@@ -222,7 +223,9 @@ final class TranscriptIndex: @unchecked Sendable {
                 kind TEXT NOT NULL,
                 position INTEGER NOT NULL,
                 owner TEXT,
-                text TEXT NOT NULL
+                text TEXT NOT NULL,
+                status TEXT,
+                due TEXT
             )
         """)
 
@@ -473,10 +476,12 @@ final class TranscriptIndex: @unchecked Sendable {
         }
         for (position, item) in summary.actionItems.enumerated() {
             try bindExec(
-                "INSERT INTO meeting_summary_items (filename, kind, position, owner, text) VALUES (?,?,?,?,?)",
+                "INSERT INTO meeting_summary_items (filename, kind, position, owner, text, status, due) VALUES (?,?,?,?,?,?,?)",
                 bindings: [
                     .text(filename), .text(SummaryItemKind.actionItem), .int(position),
-                    item.owner.map { .text($0) } ?? .null, .text(item.text)
+                    item.owner.map { .text($0) } ?? .null, .text(item.text),
+                    item.status.map { .text($0) } ?? .null,
+                    item.due.map { .text($0) } ?? .null
                 ]
             )
         }
@@ -1559,7 +1564,7 @@ final class TranscriptIndex: @unchecked Sendable {
         try queue.sync {
             let limit = max(1, min(maxItems, 200))
             var sql = """
-                SELECT s.filename, s.text, s.owner, m.date, m.datetime
+                SELECT s.filename, s.text, s.owner, s.status, s.due, m.date, m.datetime
                 FROM meeting_summary_items s
                 JOIN meetings m ON m.filename = s.filename
                 WHERE s.kind = ?
@@ -1573,10 +1578,12 @@ final class TranscriptIndex: @unchecked Sendable {
             }
 
             switch status {
-            case .open, .all:
+            case .open:
+                sql += " AND (s.status IS NULL OR s.status = '' OR lower(s.status) NOT IN ('done', 'complete', 'completed', 'resolved', 'closed', 'cancelled', 'canceled'))"
+            case .all:
                 break
             case .done:
-                sql += " AND 1=0"
+                sql += " AND lower(s.status) IN ('done', 'complete', 'completed', 'resolved', 'closed', 'cancelled', 'canceled')"
             }
 
             if let dateFrom { sql += " AND m.date >= ?"; bindings.append(.text(dateFrom)) }
@@ -1603,12 +1610,12 @@ final class TranscriptIndex: @unchecked Sendable {
                 rows.append(ActionItemRecord(
                     filename: filename,
                     meetingTitle: filename,
-                    date: colText(stmt, 3),
-                    datetime: colText(stmt, 4),
+                    date: colText(stmt, 5),
+                    datetime: colText(stmt, 6),
                     text: colText(stmt, 1),
                     owner: colTextOptional(stmt, 2),
-                    status: nil,
-                    due: nil
+                    status: colTextOptional(stmt, 3),
+                    due: colTextOptional(stmt, 4)
                 ))
             }
 
@@ -1789,7 +1796,7 @@ final class TranscriptIndex: @unchecked Sendable {
     private func fetchActionSummaryItems(filenames: [String]) throws -> [String: [DigestActionItem]] {
         let placeholders = filenames.map { _ in "?" }.joined(separator: ", ")
         let sql = """
-            SELECT filename, text, owner FROM meeting_summary_items
+            SELECT filename, text, owner, status, due FROM meeting_summary_items
             WHERE kind = ? AND filename IN (\(placeholders))
             ORDER BY filename, position ASC
         """
@@ -1807,8 +1814,8 @@ final class TranscriptIndex: @unchecked Sendable {
             result[colText(stmt, 0), default: []].append(DigestActionItem(
                 text: colText(stmt, 1),
                 owner: colTextOptional(stmt, 2),
-                status: nil,
-                due: nil
+                status: colTextOptional(stmt, 3),
+                due: colTextOptional(stmt, 4)
             ))
         }
         return result

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryRollupTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryRollupTests.swift
@@ -111,6 +111,10 @@ final class SummaryRollupTests: XCTestCase {
         let all = try index.listActionItems(owner: nil, query: nil, status: .all, dateFrom: nil, dateTo: nil)
         XCTAssertEqual(all.count, 3)
 
+        let dueSearch = try index.listActionItems(owner: nil, query: "Friday", status: .all, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(dueSearch.items.map(\.text), ["Draft the launch email"])
+        XCTAssertEqual(dueSearch.items.first?.due, "Friday")
+
         let digest = try index.digest(dateFrom: "2026-05-01", dateTo: "2026-05-01")
         XCTAssertEqual(digest.actionItemCount, 3)
         XCTAssertEqual(digest.openActionItemCount, 1)

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryRollupTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryRollupTests.swift
@@ -80,6 +80,44 @@ final class SummaryRollupTests: XCTestCase {
         XCTAssertEqual(done.count, 0)
     }
 
+    func testDoneAndDueMarkersDriveStatusFilterAndDigestCounts() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                date: "2026-05-01",
+                time: "10:00:00",
+                decisions: [],
+                actionItems: [
+                    "Nate Smith: Draft the launch email (due: Friday)",
+                    "Jenny Wen: Confirm the venue (done)",
+                    "Send the recap (status: completed)",
+                ],
+                openQuestions: []
+            ),
+            filename: "Call_2026-05-01_10-00-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let open = try index.listActionItems(owner: nil, query: nil, status: .open, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(open.items.map(\.text), ["Draft the launch email"])
+        XCTAssertEqual(open.items.first?.due, "Friday")
+        XCTAssertNil(open.items.first?.status)
+
+        let done = try index.listActionItems(owner: nil, query: nil, status: .done, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(done.count, 2)
+        XCTAssertEqual(Set(done.items.map(\.text)), ["Confirm the venue", "Send the recap"])
+        XCTAssertEqual(Set(done.items.compactMap(\.status)), ["done", "completed"])
+
+        let all = try index.listActionItems(owner: nil, query: nil, status: .all, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(all.count, 3)
+
+        let digest = try index.digest(dateFrom: "2026-05-01", dateTo: "2026-05-01")
+        XCTAssertEqual(digest.actionItemCount, 3)
+        XCTAssertEqual(digest.openActionItemCount, 1)
+        let digestActions = try XCTUnwrap(digest.meetings.first?.actionItems)
+        XCTAssertEqual(digestActions.compactMap(\.due), ["Friday"])
+    }
+
     func testActionItemsDateWindowFilter() throws {
         try seedTwoMeetings()
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -526,17 +526,29 @@ final class ToolHandlersTests: XCTestCase {
         XCTAssertFalse(text.contains("total_entries"))
     }
 
-    func testListActionItemsDoneStatusReturnsExplicitError() throws {
+    func testListActionItemsDoneStatusReturnsStructuredEmptyResult() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                actionItems: ["Jenny: Confirm the venue (done)"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
         let result = try handleListActionItems(
             params: CallTool.Parameters(name: "list_action_items", arguments: ["status": .string("done")]),
             index: index,
             meetingDirs: [tempDir]
         )
 
-        XCTAssertEqual(result.isError, true)
+        XCTAssertNotEqual(result.isError, true)
         let text = try resultText(result)
-        XCTAssertTrue(text.contains("done"))
-        XCTAssertTrue(text.contains("\"all\""))
+        let decoded = try JSONDecoder().decode(ActionItemsResult.self, from: Data(text.utf8))
+        XCTAssertEqual(decoded.status, "done")
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.items.first?.text, "Confirm the venue")
+        XCTAssertEqual(decoded.items.first?.status, "done")
     }
 
     func testDecisionsToolReturnsStructuredReceipts() throws {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -144,7 +144,7 @@ final class ToolHandlersTests: XCTestCase {
                 date: "2026-04-18",
                 time: "09:15:00",
                 decisions: ["Ship the beta on Friday"],
-                actionItems: ["Jenny: send the revised spec"],
+                actionItems: ["Jenny: send the revised spec (due: Friday)"],
                 openQuestions: ["Do we need a migration window?"]
             ),
             filename: "Call_2026-04-18_09-15-00",
@@ -158,7 +158,9 @@ final class ToolHandlersTests: XCTestCase {
         XCTAssertEqual(meeting.title, "Beta launch sync")
         XCTAssertEqual(meeting.summarySource, "summary")
         XCTAssertEqual(meeting.decisions, ["Ship the beta on Friday"])
-        XCTAssertEqual(meeting.actionItems, [RecapActionItem(owner: "Jenny", text: "send the revised spec")])
+        XCTAssertEqual(meeting.actionItems, [
+            RecapActionItem(owner: "Jenny", text: "send the revised spec", due: "Friday")
+        ])
         XCTAssertEqual(meeting.openQuestions, ["Do we need a migration window?"])
         XCTAssertTrue(meeting.preview.contains("## Decisions"))
         XCTAssertFalse(meeting.preview.contains("[00:00]"), "recap should not leak raw dialogue when a summary exists")


### PR DESCRIPTION
## Summary
- Salvages the still-useful #1352 action item metadata slice: quick summaries can emit due hints, CaptureKit parses due/status markers, and MCP list/digest/recap keeps that metadata.
- Raises the pre-recording free-space guard from 100MB to 1GB.
- Adds one-shot Parakeet pending-buffer truncation telemetry when old samples are dropped.

## Live comparison / scope killed
- #1352 is closed and unmerged; this branch was rebuilt from current `main` instead of reviving it.
- #1375 already replaced the semantic/hybrid search, receipt/recent_context, and recap-preview parts. Keep those out of this PR.
- #1384 already replaced retained-audio maintenance telemetry and capture-library-size reporting. Keep those out of this PR.
- Leave the old route-recovery churn dead unless a fresh current-main repro proves it is still needed.

## Verification
- `codex review --base origin/main` clean after fixes. Earlier review found MCP due/status search + recap output gaps and stale schema copy; both were fixed.
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (12331 passed)
- `bash run-integration-smoke.sh`
- `bash run-e2e-smoke.sh`
- `swift test` (608 tests, 2 skipped)
- `swift test --package-path Tools/TranscriptedCaptureKit` (48 tests)
- `swift test --package-path Tools/TranscriptedCLI` (78 tests)
- `swift test --package-path Tools/TranscriptedMCP` (158 tests)
- `git diff --check`

lanes used: Codex=live GitHub compare, rebuild, tests, independent review, PR; Claude=skipped; Local=skipped; Windows=skipped
