### PR TITLE
docs: refresh CLAUDE.md for video meeting import support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ For day-to-day agent work, start with `AGENT_START.md` and treat `AGENTS.md` as 
 
 - dictation capture with paste-back into the focused editor
 - meeting capture (local mic + system audio) with local transcription
-- imported-audio transcription
+- imported-audio and imported-video transcription (video imports extract the audio track; see `MeetingImportedAudioPreparer`)
 - optional local-speaker review for people sharing the room mic
 - agent-readable Markdown output saved to disk
 
@@ -103,7 +103,7 @@ Subsystem boundaries (each has a local `CLAUDE.md`):
 | `Sources/Beta/` | beta-build configuration |
 | `Sources/Capture/` | physical dictation trigger capture, meeting hotkey routing, `ContextCaptureEngine` |
 | `Sources/Dictation/` | dictation transcript persistence, daily Markdown files, timeout helpers |
-| `Sources/Meeting/` | app-side bridge into `TranscriptedCore`; live capture, imported-audio, queued meeting transcription, `MeetingSTTAdapter` |
+| `Sources/Meeting/` | app-side bridge into `TranscriptedCore`; live capture, imported-audio/video prep, queued meeting transcription, `MeetingSTTAdapter` |
 | `Sources/Observability/` | events, debug log, Sentry, anonymous PostHog analytics, Sparkle updater, crash reporting |
 | `Sources/Reliability/` | wake/sleep recovery for hotkeys and active capture |
 | `Sources/Speech/` | local STT engines (`ParakeetEngine`), `STTRouter`, recorded-audio buffering, dictation audio recovery |


### PR DESCRIPTION
## Why

Audited `CLAUDE.md` against the current repo state (structure, scripts, `.agents/test-matrix.yml`, subsystem docs, storage paths, Sentry/PostHog config, legacy branch/tag references). It was already accurate and recently refreshed, with one drift: meeting import now accepts video files (MP4/MOV) and extracts the audio track via `MeetingImportedAudioPreparer`, but the doc still described imports as audio-only.

## Product Impact

- Affects: `docs only`
- Lane: `agent workflow`
- Why this matters: keeps the Claude-oriented orientation doc accurate so agents don't assume meeting import is audio-only.

## What changed

- `CLAUDE.md`: updated the product bullet list and the `Sources/Meeting/` subsystem-table row to mention imported-video handling.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed (docs-only path → preflight only)
- [ ] `bash build.sh --no-open` (not applicable, no source changes)
- [ ] `bash run-tests.sh` (not applicable, no source changes)
- [ ] Performance budget (not applicable)
- [ ] `bash run-integration-smoke.sh` (not applicable)
- [ ] `swift test` (not applicable)
- [x] Manual check: cross-referenced `Sources/Meeting/MeetingImportedAudioPreparer.swift`, `AGENTS.md`, `.agents/test-matrix.yml`, `docs/repo-layout.md`, README, and remote branch/tag list against the doc's claims.

## Risk Review

- [x] Privacy / local-first behavior reviewed (no change)
- [x] Storage path or migration impact reviewed (no change)
- [x] Public-facing copy stays concrete and matches current product scope
- [ ] Release/update impact reviewed (not applicable, docs only)
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence (no UI change)
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Everything else in `CLAUDE.md` (subsystem table, verification rules, build-system shape, storage layout, observability/privacy rules, release rules, legacy branch/tag pointers) matched current source and `.agents/test-matrix.yml`, so this PR is a small targeted fix rather than a rewrite.

## Agent handoff

`COORD_DONE: GREEN | this PR | updated CLAUDE.md's product description and Sources/Meeting row to note video-import audio extraction | none | none, doc is accurate and small | ran scripts/dev/agent-preflight.sh | cross-audited repo state vs CLAUDE.md claims | smallest next action: none, ready for human review`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MXi6XxAvqHhEBHMsL4W8D4)_