### PR TITLE
Dedupe Home failed-meeting retry copy against shared presentation helper

### DIFF
--- a/Sources/UI/Settings/FailedMeetingRecoveryPresentation.swift
+++ b/Sources/UI/Settings/FailedMeetingRecoveryPresentation.swift
@@ -45,7 +45,7 @@ struct FailedMeetingRecoveryPresentation: Equatable {
         )
     }
 
-    private static func retryDisabled(
+    static func retryDisabled(
         canRetry: Bool,
         isRetryable: Bool,
         isRetrying: Bool,
@@ -54,7 +54,7 @@ struct FailedMeetingRecoveryPresentation: Equatable {
         !canRetry || !isRetryable || !hasAudioFiles || isRetrying
     }
 
-    private static func retryHelp(
+    static func retryHelp(
         canRetry: Bool,
         retryUnavailableReason: String?,
         isRetryable: Bool,

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1624,26 +1624,22 @@ struct HomeFailedMeetingInlineRow: View {
     }
 
     private var retryDisabled: Bool {
-        !canRetry || !item.isRetryable || !item.hasAudioFiles || item.isRetrying
+        FailedMeetingRecoveryPresentation.retryDisabled(
+            canRetry: canRetry,
+            isRetryable: item.isRetryable,
+            isRetrying: item.isRetrying,
+            hasAudioFiles: item.hasAudioFiles
+        )
     }
 
     private var retryHelp: String {
-        if item.isRetrying {
-            return "Retry is already running."
-        }
-        if !item.hasAudioFiles {
-            return "This meeting does not have enough saved audio to retry."
-        }
-        if !item.isRetryable {
-            return "This meeting does not have enough saved audio to retry."
-        }
-        if let retryUnavailableReason {
-            return retryUnavailableReason
-        }
-        if !canRetry {
-            return "Wait for the current meeting work to finish before retrying."
-        }
-        return "Transcribe this saved audio again."
+        FailedMeetingRecoveryPresentation.retryHelp(
+            canRetry: canRetry,
+            retryUnavailableReason: retryUnavailableReason,
+            isRetryable: item.isRetryable,
+            isRetrying: item.isRetrying,
+            hasAudioFiles: item.hasAudioFiles
+        )
     }
 
     private var hasRetainedAudioFiles: Bool {

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -194,8 +194,18 @@ func testFailedMeetingPresentation() {
             "failed rows should keep Show Audio visible when any retained audio URL exists"
         )
         assertTrue(
-            homeSource.contains("private var retryDisabled: Bool {\n        !canRetry || !item.isRetryable || !item.hasAudioFiles || item.isRetrying"),
+            homeSource.contains("private var retryDisabled: Bool {\n        FailedMeetingRecoveryPresentation.retryDisabled(\n            canRetry: canRetry,\n            isRetryable: item.isRetryable,\n            isRetrying: item.isRetrying,\n            hasAudioFiles: item.hasAudioFiles\n        )"),
             "failed rows should keep retry readiness tied to complete retryable audio, not mere visibility"
+        )
+
+        let recoveryPresentationSource = (try? String(
+            contentsOf: repoFixtureURL("Sources/UI/Settings/FailedMeetingRecoveryPresentation.swift"),
+            encoding: .utf8
+        )) ?? ""
+
+        assertTrue(
+            recoveryPresentationSource.contains("!canRetry || !isRetryable || !hasAudioFiles || isRetrying"),
+            "the shared retry-readiness helper Home delegates to should still require complete retryable audio"
         )
         assertTrue(
             homeSource.contains("private var hasRetainedAudioFiles: Bool {\n        !item.audioURLs.isEmpty"),


### PR DESCRIPTION
## Why

The codebase has no literal TODO/FIXME comments (confirmed repo-wide), so per the task I audited `Sources/UI/` for a small, concrete, straightforward gap instead. `HomeFailedMeetingInlineRow` in `HomeView.swift` reimplemented the retry-disabled/retry-help copy logic that already lives in `FailedMeetingRecoveryPresentation` (used by the Settings-side failed-meeting row). The two copies matched today, but the shared helper was `private`, so nothing enforced the Home and Settings failed-meeting surfaces staying in sync on future copy changes.

## Product Impact

- Affects: `meetings` (failed-meeting recovery UI on Home and Settings)
- Lane: `meeting reliability`
- Why this matters: prevents the Home inline failed-meeting row and the Settings failed-meeting row from silently drifting apart on retry-availability copy/logic.

## What changed

- `Sources/UI/Settings/FailedMeetingRecoveryPresentation.swift`: made the `retryDisabled` / `retryHelp` static helpers internal instead of `private` so they can be reused.
- `Sources/UI/Settings/HomeView.swift`: `HomeFailedMeetingInlineRow.retryDisabled` / `.retryHelp` now delegate to `FailedMeetingRecoveryPresentation`'s shared helpers instead of duplicating the branch logic inline. Pure refactor — verified by hand that the collapsed `!hasAudioFiles || !isRetryable` branch is semantically identical to the two separate `if` checks it replaced.

## How I checked it

- [ ] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed (Sources/UI/** → build + run-tests)
- [ ] `bash build.sh --no-open`
- [ ] `bash run-tests.sh`
- [ ] Performance budget passed
- [ ] `bash run-integration-smoke.sh` (not touched: no `Sources/Meeting/` or `Sources/TranscriptedCore/` changes)
- [ ] `swift test` (not touched: no `Package.swift`/core seam changes)
- [x] Manual check: hand-traced both branches of the old vs. new logic for behavioral equivalence; confirmed existing `Tests/FailedMeetingRecoveryPresentationTests.swift` (already wired into `Tests/FastTests.manifest`) exercises the now-shared helper.

**Note:** this session's sandbox is Linux with no Swift toolchain (`swiftc`/`xcodebuild` unavailable), so I could not actually run `bash build.sh --no-open` or `bash run-tests.sh` as required by this repo's verification rules. Please run those before merging.

## Risk Review

- [x] Privacy / local-first behavior reviewed (no change — copy/logic only)
- [x] Storage path or migration impact reviewed (none)
- [x] Public-facing copy stays concrete and matches current product scope (copy text unchanged)
- [x] Release/update impact reviewed (none)
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence (no visual change — pure logic dedup, couldn't render screenshots in this sandbox anyway)
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Follow-up candidates from the same audit, not included in this PR:
- `FailedTranscription.audioFilesExist()` (requires both mic+system audio) can disagree with `FailedMeetingPresentation.audioURLs(for:)` (keeps whichever file survives) when only one of two audio files is lost — produces a contradictory failed-meeting row. Needs a `TranscriptedCore` model change, more invasive than this PR.
- `HomeFailedMeetingInlinePresentation` (Home) and `FailedMeetingRecoveryPresentation` (Settings) remain two separate view-model shapes for the same concept; `HomeFailedMeetingInlinePresentation` has no direct unit tests today.

## Agent handoff

`COORD_DONE: BRIEF | PR opened as draft | deduped Home vs Settings failed-meeting retry copy against shared FailedMeetingRecoveryPresentation helper | GitHub cleanup: none needed | decisions needed: none | tests/checks run: none (no Swift toolchain in this sandbox) — please run bash build.sh --no-open + bash run-tests.sh before merge | smallest next action: run build+tests, then merge if green`

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABa4jEtGp4hBuLTWM2GYkP)_