### PR TITLE
Fix code smells: dead code, duplicated logic, stringly-typed coupling

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -80,6 +80,12 @@ private enum PhysicalShortcutPhase {
 }
 
 private final class PhysicalShortcutDetector {
+    /// Shared with `ContextCaptureEngine.updateAccessibilityRetryMonitor()`,
+    /// which matches on this exact message to decide whether to poll for
+    /// Accessibility permission. Keep both call sites on this constant so a
+    /// wording change here can't silently break that retry.
+    static let accessibilityPermissionErrorMessage = "Shortcut trigger needs Accessibility permission"
+
     /// Cached binding snapshot, rebuilt by ContextCaptureEngine on
     /// .hotkeysDidChange. The event tap runs on a dedicated run loop so
     /// Transcripted main-thread work cannot delay global keyboard delivery.
@@ -137,7 +143,7 @@ private final class PhysicalShortcutDetector {
             resetState()
             return TranscriptedPermissionAccess.isGranted(.accessibility)
                 ? "Shortcut trigger failed to start"
-                : "Shortcut trigger needs Accessibility permission"
+                : Self.accessibilityPermissionErrorMessage
         }
 
         guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
@@ -631,7 +637,7 @@ class ContextCaptureEngine: ObservableObject {
     }
 
     private func updateAccessibilityRetryMonitor() {
-        guard physicalTriggerError == "Shortcut trigger needs Accessibility permission" else {
+        guard physicalTriggerError == PhysicalShortcutDetector.accessibilityPermissionErrorMessage else {
             accessibilityRetryTask?.cancel()
             accessibilityRetryTask = nil
             return

--- a/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
+++ b/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
@@ -181,7 +181,7 @@ enum DictationInputDeviceSelectionPolicy {
     }
 
     private static func isBluetoothHeadsetInput(_ device: DictationAudioDevice) -> Bool {
-        isBluetoothTransport(device.transport) || isBluetoothHeadsetName(normalize(device.name))
+        isBluetoothAudioDevice(device)
     }
 
     private static func isBluetoothAudioDevice(_ device: DictationAudioDevice) -> Bool {

--- a/Sources/Speech/NemotronEngine.swift
+++ b/Sources/Speech/NemotronEngine.swift
@@ -248,12 +248,3 @@ final class NemotronEngine: ObservableObject {
         return buffer
     }
 }
-
-private extension ParakeetModelState {
-    var isReady: Bool {
-        if case .ready = self {
-            return true
-        }
-        return false
-    }
-}

--- a/Sources/Speech/ParakeetAudioEngineSupport.swift
+++ b/Sources/Speech/ParakeetAudioEngineSupport.swift
@@ -66,6 +66,13 @@ extension ParakeetModelState {
         case .failed: return "failed"
         }
     }
+
+    var isReady: Bool {
+        if case .ready = self {
+            return true
+        }
+        return false
+    }
 }
 
 struct RecordedSpeechSamples {

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -202,70 +202,63 @@ class STTRouter: ObservableObject {
         case .parakeetTDTv3:
             return await parakeetEngine.transcribe()
         case .whisperLargeV3Turbo, .whisperLargeV3:
-            await initialize(model: model)
-            guard isModelLoaded(for: model) else {
-                EventReporter.shared.capture(
-                    level: .error,
-                    engine: model.engineName,
-                    event: "dictation_model_unavailable",
-                    message: "\(model.title) was selected but is not loaded",
-                    context: ["model": model.rawValue]
-                )
-                return nil
-            }
-
-            guard let recording = await parakeetEngine.drainRecordedSamplesForExternalTranscription(
-                engineName: model.engineName
-            ) else {
-                return nil
-            }
-
-            do {
-                defer {
-                    parakeetEngine.finishExternalTranscription()
-                }
-                let text = try await whisperEngine.transcribeSamples(
+            return await transcribeUsingExternalEngine(model: model) { [self] recording in
+                try await whisperEngine.transcribeSamples(
                     recording.samples16k,
                     source: .microphone,
                     model: model
                 )
-                return text.isEmpty ? nil : text
-            } catch {
-                print("❌ WHISPER | dictation failed: \(error.localizedDescription)")
-                return nil
             }
         case .nemotronStreaming:
-            await initialize(model: model)
-            guard isModelLoaded(for: model) else {
-                EventReporter.shared.capture(
-                    level: .error,
-                    engine: model.engineName,
-                    event: "dictation_model_unavailable",
-                    message: "\(model.title) was selected but is not loaded",
-                    context: ["model": model.rawValue]
-                )
-                return nil
-            }
-
-            guard let recording = await parakeetEngine.drainRecordedSamplesForExternalTranscription(
-                engineName: model.engineName
-            ) else {
-                return nil
-            }
-
-            do {
-                defer {
-                    parakeetEngine.finishExternalTranscription()
-                }
-                let text = try await nemotronEngine.transcribeSamples(
+            return await transcribeUsingExternalEngine(model: model) { [self] recording in
+                try await nemotronEngine.transcribeSamples(
                     recording.samples16k,
                     source: .microphone
                 )
-                return text.isEmpty ? nil : text
-            } catch {
-                print("❌ NEMOTRON | dictation failed: \(error.localizedDescription)")
-                return nil
             }
+        }
+    }
+
+    /// Shared drain/transcribe/report flow for the non-Parakeet dictation
+    /// engines (Whisper, Nemotron), which both transcribe already-recorded
+    /// Parakeet samples rather than owning the audio graph themselves.
+    private func transcribeUsingExternalEngine(
+        model: TranscriptionModelChoice,
+        transcribe: (RecordedSpeechSamples) async throws -> String
+    ) async -> String? {
+        await initialize(model: model)
+        guard isModelLoaded(for: model) else {
+            EventReporter.shared.capture(
+                level: .error,
+                engine: model.engineName,
+                event: "dictation_model_unavailable",
+                message: "\(model.title) was selected but is not loaded",
+                context: ["model": model.rawValue]
+            )
+            return nil
+        }
+
+        guard let recording = await parakeetEngine.drainRecordedSamplesForExternalTranscription(
+            engineName: model.engineName
+        ) else {
+            return nil
+        }
+
+        do {
+            defer {
+                parakeetEngine.finishExternalTranscription()
+            }
+            let text = try await transcribe(recording)
+            return text.isEmpty ? nil : text
+        } catch {
+            EventReporter.shared.capture(
+                level: .error,
+                engine: model.engineName,
+                event: "dictation_transcription_failed",
+                message: error.localizedDescription,
+                context: ["model": model.rawValue]
+            )
+            return nil
         }
     }
 

--- a/Sources/Speech/WhisperEngine.swift
+++ b/Sources/Speech/WhisperEngine.swift
@@ -256,12 +256,3 @@ final class WhisperEngine: ObservableObject {
         }
     }
 }
-
-private extension ParakeetModelState {
-    var isReady: Bool {
-        if case .ready = self {
-            return true
-        }
-        return false
-    }
-}

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -2834,7 +2834,7 @@ private struct HomeMeetingSpeakerPill: View {
     }
 }
 
-private enum HomeMeetingSpeakerColor {
+enum HomeMeetingSpeakerColor {
     static func color(for speaker: String) -> Color {
         let palette: [NSColor] = [
             .systemBlue,

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -1515,21 +1515,7 @@ private struct SpeakerAvatarView: View {
 
     private var color: Color {
         guard let name, !name.isEmpty else { return .secondary }
-        let palette: [NSColor] = [
-            .systemBlue,
-            .systemGreen,
-            .systemPurple,
-            .systemOrange,
-            .systemPink,
-            .systemTeal,
-            .systemRed,
-            .systemIndigo,
-        ]
-        let normalized = name.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        let value = normalized.unicodeScalars.reduce(UInt32(0)) { partial, scalar in
-            partial &+ scalar.value
-        }
-        return Color(nsColor: palette[Int(value % UInt32(palette.count))])
+        return HomeMeetingSpeakerColor.color(for: name)
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -4465,17 +4465,6 @@ struct TranscriptedSettingsView: View {
         return "PostHog is not configured in this build. Usage stats stay off."
     }
 
-    private func homeModelDetail(from modelCard: FirstRunModelCardState) -> String {
-        switch modelCard.tone {
-        case .ready:
-            return "\(effectiveTranscriptionModel.title) is ready on this Mac."
-        case .working:
-            return modelCard.title
-        case .failed:
-            return modelCard.detail
-        }
-    }
-
     private func tone(for tone: FirstRunModelCardState.Tone) -> SettingsStatusCard.Tone {
         switch tone {
         case .ready:
@@ -5338,19 +5327,6 @@ struct TranscriptedSettingsView: View {
             return .readyToInstall
         }
     }
-
-    private func formattedRecentDate(_ date: Date) -> String {
-        Self.recentCaptureDateFormatter.string(from: date)
-    }
-
-    private static let recentCaptureDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = .current
-        formatter.doesRelativeDateFormatting = true
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        return formatter
-    }()
 }
 
 private struct PendingCaptureLibraryChoice: Equatable {


### PR DESCRIPTION
## Why

Requested code-smell sweep of the app. I fanned out 4 research agents across `Sources/Meeting+TranscriptedCore`, `Sources/UI`, `Sources/Support+Observability+Speech`, and the smaller directories to surface concrete findings, then picked a bounded, low-risk subset to actually fix (skipping God-object splits, the Meeting/Core pipeline decomposition, and anything touching real-time CoreAudio callbacks or the slow-pasteback-timing path — those need a human call, not a drive-by).

## Product Impact

- Affects: `dictation` / `agent artifacts` — no user-facing behavior change intended, this is internal cleanup
- Lane: `dictation reliability`
- Why this matters: removes dead code and duplicated logic that had already drifted apart in wording/behavior once (see the shared Accessibility-permission string), and tightens one inconsistent error-reporting path in the dictation STT router.

## What changed

- **Dead code removal** — `TranscriptedSettingsView.swift`: `homeModelDetail(from:)` and `formattedRecentDate(_:)` (plus its backing `DateFormatter`) were defined but never called anywhere in the tree.
- **Deduped speaker-color hashing** — `SpeakerPeopleSettingsSection`'s `SpeakerAvatarView` reimplemented the exact 8-color palette + name-hash logic that `HomeView`'s `HomeMeetingSpeakerColor` already had (delegating to the existing Foundation-pure `HomeMeetingSpeakerPalette.slotIndex`). Made `HomeMeetingSpeakerColor` internal and had the settings view call it instead of carrying its own copy.
- **Shared Accessibility-permission error constant** — `ContextCaptureEngine.swift` produced `"Shortcut trigger needs Accessibility permission"` in one place and matched on that exact literal in another (`updateAccessibilityRetryMonitor()`); a future wording tweak in one spot would have silently broken the retry poll. Backed both by one `static let`.
- **Deduped `ParakeetModelState.isReady`** — `WhisperEngine.swift` and `NemotronEngine.swift` each carried a private, byte-identical extension. Moved onto the existing internal `ParakeetModelState` extension in `ParakeetAudioEngineSupport.swift` and deleted both copies.
- **Deduped Bluetooth-device check** — `DictationInputDeviceSelectionPolicy.isBluetoothHeadsetInput` and `isBluetoothAudioDevice` had identical bodies; the former now delegates to the latter (kept both names since they read differently at their two call sites).
- **`STTRouter.transcribe()`** — the Whisper and Nemotron branches repeated the same initialize → check-loaded → drain → transcribe → report flow almost verbatim. Extracted into `transcribeUsingExternalEngine(model:transcribe:)`. While there, replaced the two bare `print()` failure logs (the only two spots in this function that didn't report through `EventReporter`, unlike every sibling failure path) with an `EventReporter.capture` call matching the existing pattern elsewhere in the same function.

Deliberately **not** touched (flagged for a follow-up, not fixed here, given risk/verification cost):
- `MeetingSessionController.swift` (3.5k-line God object) and other 200+ line functions in `Sources/Meeting/`+`TranscriptedCore/` — real but requires careful, reviewed decomposition, not a drive-by.
- `LiveMeetingCodexSession.streamingBackendStatus` stringly-typed status (8+ string literals mirrored into an embedded JS template) — worth an enum, but touching it means keeping Swift/JS in lockstep; wanted a human sign-off first.
- `ClipboardRestoringTextPaster`'s two scheduling helpers — similar shape but not literally identical, and this file sits on the dedicated slow-pasteback-timing smoke path; not worth the risk for a cosmetic dedupe.
- `ParakeetEngine.swift` (3.3k lines, no `// MARK:` sections) — reorg-only, but 3.3k lines is a lot of surface to touch without being able to compile locally in this session.

## How I checked it

- [ ] `scripts/dev/agent-preflight.sh`
- [ ] Selected checks from `.agents/test-matrix.yml` for the files changed
- [ ] `bash build.sh --no-open`
- [ ] `bash run-tests.sh`
- [ ] Performance budget passed
- [ ] `bash run-integration-smoke.sh` if I touched `Sources/Meeting/` or `Sources/TranscriptedCore/` — N/A, didn't touch those
- [ ] `swift test` — N/A, didn't touch `Package.swift`/`TranscriptedCore`
- [x] Manual check: this sandbox is Linux with no Swift toolchain (no `swift`, `xcodebuild`, or `ditto`), so none of the build/test commands above could actually be run here. I instead manually traced every changed call site and signature by hand (types, property names, closure signatures) against the surrounding code to check for compile errors. **This has not been build-verified — please run `bash build.sh --no-open && bash run-tests.sh` before merging.**

## Risk Review

- [x] Privacy / local-first behavior reviewed — no new off-device data; the one new `EventReporter.capture` call reuses the exact shape (`level`, `engine`, `event`, `message`, `context: ["model": ...]`) already used by the adjacent branch in the same function.
- [x] Storage path or migration impact reviewed — none.
- [x] Public-facing copy stays concrete and matches current product scope — no user-facing copy changed.
- [ ] Agent PRs link the issue/workpad and stay draft until human review — no linked issue, this was a direct ask; left as draft.
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — no visual UI change (only an internal color-computation dedupe with identical output).
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included.

## Notes

Full agent-survey findings (including the items intentionally left unfixed above) are summarized in the commit message and this description; happy to open follow-up issues for the larger God-object/decomposition items if useful.

## Agent handoff

`COORD_DONE: BRIEF | this PR | dead-code removal + 5 dedup fixes across UI/Capture/Speech | none | build.sh/run-tests.sh could not be run in this sandbox (no Swift toolchain) — please run before merge | smallest next action: run bash build.sh --no-open && bash run-tests.sh, then review the God-object/streamingBackendStatus follow-up candidates noted above`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxoV6GHMu7KHwTsbf2BPvn)_