### PR TITLE
Fix core reliability bugs: audio capture race, speaker un-merge data integrity, failed-transcription reconciliation

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2583,23 +2583,28 @@ class ParakeetEngine: ObservableObject {
                 EventReporter.shared.capture(level: .error, engine: "parakeet", event: "zombie_engine_recovery_failed",
                     message: "Audio engine could not recover after reset",
                     context: ["audio_device": self.inputDeviceName])
-                self.interruptRecordingAndClearRecoveredTimeline()
+                self.interruptRecordingPreservingRecoveredTimeline()
             }
         }
     }
 
     func stopRecording() async {
         guard isRecording else {
-            // A zombie reset marks recording idle while it waits to retry. Treat a
-            // user stop in that window as cancellation of the pending restart.
+            // Genuinely preserved/recovered audio (e.g. real pre-sleep audio held
+            // across a wake-recovery gap) must win over a merely-pending zombie
+            // restart — checking this first ensures a stop during an in-flight
+            // zombie retry drains real audio instead of discarding it.
+            if preservingRecordingAcrossRecovery || !recoveredRecordingTimeline.isEmpty {
+                cancelPendingRecordingRecovery()
+                return
+            }
+            // A zombie reset marks recording idle while it waits to retry, with
+            // nothing preserved worth keeping. Treat a user stop in that window
+            // as cancellation of the pending restart.
             if zombieRecoveryRestartPending {
                 audioGraphGeneration += 1
                 cancelAudioWatchdog()
                 clearRecoveredRecordingTimeline(keepingCapacity: true)
-                return
-            }
-            if preservingRecordingAcrossRecovery || !recoveredRecordingTimeline.isEmpty {
-                cancelPendingRecordingRecovery()
                 return
             }
             if audioStartInProgress {

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -58,6 +58,16 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     private var isWaitingForTimedOutStopCallback = false
     private var recoveryAttempts = 0
     private var isRecovering = false
+    // Guards `_isCapturing`, `recoveryAttempts`, and `isRecovering` so the
+    // buffer-stall watchdog (`checkWatchdog`, on `watchdogQueue`), the
+    // `SCStreamDelegate` callback (on ScreenCaptureKit's delegate queue), and
+    // the recovery block they spawn (on a `.userInitiated` global queue)
+    // cannot race each other's guard-check-then-set of these fields — e.g.
+    // both a buffer-stall and a `didStopWithError` callback observing
+    // "not yet recovering" and both kicking off a recovery attempt.
+    // NOTE: this does not yet give full cross-file coordination with
+    // `Audio.swift`'s stop path — see the recovery block below.
+    private let captureStateLock = NSLock()
     private static let callbackTimeoutSeconds = 8
     private static let permissionPromptCallbackTimeoutSeconds = 120
     private static let callbackTimeout: DispatchTimeInterval = .seconds(callbackTimeoutSeconds)
@@ -173,7 +183,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             AppLogger.audioSystem.warning("SCKAudioCapture: refusing to start stream while previous stop is still pending")
             throw SCKCaptureTimeoutError(operation: "previous stop cleanup")
         }
-        guard !_isCapturing else {
+        guard !isCurrentlyCapturing() else {
             AppLogger.audioSystem.warning("SCKAudioCapture: refusing to start stream because capture is already active")
             throw "SCKAudioCapture: capture already active"
         }
@@ -187,9 +197,11 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
 
         self.bufferCallback = bufferCallback
         resetBufferWatchdogState()
+        captureStateLock.lock()
         if !isRecovering {
             recoveryAttempts = 0
         }
+        captureStateLock.unlock()
         publishErrorMessage(nil)
 
         // Output handler converts CMSampleBuffer → AVAudioPCMBuffer
@@ -227,7 +239,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             guard currentGeneration() == startGeneration, self.stream === stream else {
                 throw AudioCaptureStaleSessionError()
             }
-            _isCapturing = true
+            setCapturing(true)
             startWatchdog(generation: startGeneration)
             AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
         } catch {
@@ -246,12 +258,11 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     func stop() {
         guard let stream = stream else { return }
         let stopGeneration = currentGeneration()
-        guard _isCapturing else {
+        guard transitionToStopped() else {
             cleanupIfCurrent(generation: stopGeneration, stream: stream)
             return
         }
 
-        _isCapturing = false
         stopWatchdog()
         stream.stopCapture { [weak self, stream] error in
             if let error = error {
@@ -268,12 +279,11 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             return
         }
         let stopGeneration = currentGeneration()
-        guard _isCapturing else {
+        guard transitionToStopped() else {
             cleanupIfCurrent(generation: stopGeneration, stream: stream)
             return
         }
 
-        _isCapturing = false
         stopWatchdog()
         if stopStreamSynchronously(stream, cleanupAfterLateCallback: { [weak self, stream] in
             self?.cleanupIfCurrent(generation: stopGeneration, stream: stream)
@@ -319,6 +329,29 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         }
     }
 
+    private func isCurrentlyCapturing() -> Bool {
+        captureStateLock.lock()
+        defer { captureStateLock.unlock() }
+        return _isCapturing
+    }
+
+    private func setCapturing(_ value: Bool) {
+        captureStateLock.lock()
+        _isCapturing = value
+        captureStateLock.unlock()
+    }
+
+    /// Atomically checks that capture is currently active and flips it to
+    /// inactive. Returns false (leaving state unchanged) if capture was
+    /// already inactive.
+    private func transitionToStopped() -> Bool {
+        captureStateLock.lock()
+        defer { captureStateLock.unlock() }
+        guard _isCapturing else { return false }
+        _isCapturing = false
+        return true
+    }
+
     private func cleanupIfCurrent(generation: UInt64, stream expectedStream: SCStream) {
         guard currentGeneration() == generation,
               let currentStream = stream,
@@ -355,7 +388,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             return
         }
 
-        _isCapturing = true
+        setCapturing(true)
         isWaitingForTimedOutStopCallback = true
         startWatchdog(generation: currentGeneration())
         AppLogger.audioSystem.warning("SCKAudioCapture: keeping stream reference after stop timeout")
@@ -410,7 +443,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     private func cleanup() {
         AppLogger.audioSystem.info("SCKAudioCapture: cleanup")
         logStats()
-        _isCapturing = false
+        setCapturing(false)
         isWaitingForTimedOutStopCallback = false
         stopWatchdog()
         stream = nil
@@ -497,7 +530,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     }
 
     private func checkWatchdog(generation: UInt64) {
-        guard currentGeneration() == generation, _isCapturing else { return }
+        guard currentGeneration() == generation, isCurrentlyCapturing() else { return }
         watchdogLock.lock()
         let hasReceivedFirstBuffer = _hasReceivedFirstBuffer
         let elapsed = CACurrentMediaTime() - _lastBufferTime
@@ -519,20 +552,38 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         generation: UInt64,
         attemptRestart: Bool
     ) {
-        guard currentGeneration() == generation, _isCapturing else { return }
+        guard currentGeneration() == generation, isCurrentlyCapturing() else { return }
         publishErrorMessage(message)
-        guard attemptRestart,
-              recoveryAttempts < Self.maxRecoveryAttempts,
-              !isRecovering,
-              let callback = bufferCallback else {
+        guard attemptRestart, let callback = bufferCallback else { return }
+
+        // Atomically check-and-set the recovery guards under one lock so two
+        // concurrent triggers (the buffer-stall watchdog and
+        // `didStopWithError`) cannot both observe "not yet recovering" and
+        // both kick off a recovery attempt.
+        captureStateLock.lock()
+        guard recoveryAttempts < Self.maxRecoveryAttempts, !isRecovering else {
+            captureStateLock.unlock()
             return
         }
-
         recoveryAttempts += 1
         isRecovering = true
+        captureStateLock.unlock()
+
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
-            defer { self.isRecovering = false }
+            defer {
+                self.captureStateLock.lock()
+                self.isRecovering = false
+                self.captureStateLock.unlock()
+            }
+            // NOTE: this only prevents two recovery attempts from racing each
+            // other (above). It does not yet fully coordinate with an
+            // official stop initiated from Audio.swift's stop()/stopSync()
+            // path — if such a stop completes while this recovery is between
+            // its own stopSync()/prepare()/start() calls, the recovery can
+            // still restart capture after the caller believed capture had
+            // stopped. Full cross-file coordination with Audio.swift's stop
+            // path is a larger follow-up.
             do {
                 AppLogger.audioSystem.info("SCKAudioCapture: attempting stream recovery", [
                     "attempt": "\(self.recoveryAttempts)"

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -185,7 +185,23 @@ public class FailedTranscriptionManager: ObservableObject {
         }
 
         if hasUnavailableAudio {
-            return (entry, didHeal, true)
+            // Return the already-healed micURL/systemURL (e.g. a merge-heal that
+            // repointed micURL to `<stem>_merged.wav`) rather than the stale
+            // original `entry`, so a later retry doesn't see a no-longer-existing
+            // audio path and wrongly delete a recoverable entry. `hasUnavailableAudio`
+            // still tells the caller not to persist this reconciliation to disk.
+            guard didHeal else { return (entry, false, true) }
+            return (FailedTranscription(
+                id: entry.id,
+                timestamp: entry.timestamp,
+                recordingDate: entry.recordingDate,
+                micAudioURL: micURL,
+                systemAudioURL: systemURL,
+                errorMessage: entry.errorMessage,
+                meetingTitle: entry.meetingTitle,
+                retryCount: entry.retryCount,
+                lastRetryDate: entry.lastRetryDate
+            ), true, true)
         }
 
         // Audio preserved during a quit that interrupted finalization can have

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -10,14 +10,14 @@ extension TranscriptSaver {
     /// Thread-safe: serialized via fileUpdateQueue to prevent concurrent file corruption.
     /// Satisfies the `TranscriptStorage` protocol — uses `defaultSaveDirectory`.
     public static func retroactivelyUpdateSpeaker(dbId: UUID, newName: String) {
-        fileUpdateQueue.sync {
+        serializeTranscriptFileUpdate {
             _retroactivelyUpdateSpeakerImpl(dbId: dbId, newName: newName, directory: defaultSaveDirectory)
         }
     }
 
     /// Internal overload for tests — scans a specific directory instead of `defaultSaveDirectory`.
     static func retroactivelyUpdateSpeaker(dbId: UUID, newName: String, in directory: URL) {
-        fileUpdateQueue.sync {
+        serializeTranscriptFileUpdate {
             _retroactivelyUpdateSpeakerImpl(dbId: dbId, newName: newName, directory: directory)
         }
     }
@@ -36,7 +36,7 @@ extension TranscriptSaver {
         channel: UtteranceChannel,
         newName: String
     ) -> Bool {
-        fileUpdateQueue.sync {
+        serializeTranscriptFileUpdate {
             _updateDeferredSpeakerNameImpl(
                 transcriptURL: transcriptURL,
                 dbId: dbId,
@@ -50,7 +50,7 @@ extension TranscriptSaver {
     /// After Settings merges two people, rewrite old source profile references to the
     /// kept profile id so future renames of the kept person still reach older transcripts.
     public static func retroactivelyMergeSpeaker(sourceDbId: UUID, targetDbId: UUID, targetName: String) {
-        fileUpdateQueue.sync {
+        serializeTranscriptFileUpdate {
             _retroactivelyMergeSpeakerImpl(
                 sourceDbId: sourceDbId,
                 targetDbId: targetDbId,
@@ -62,7 +62,7 @@ extension TranscriptSaver {
 
     /// Internal overload for tests — scans a specific directory instead of `defaultSaveDirectory`.
     static func retroactivelyMergeSpeaker(sourceDbId: UUID, targetDbId: UUID, targetName: String, in directory: URL) {
-        fileUpdateQueue.sync {
+        serializeTranscriptFileUpdate {
             _retroactivelyMergeSpeakerImpl(
                 sourceDbId: sourceDbId,
                 targetDbId: targetDbId,
@@ -446,7 +446,7 @@ extension TranscriptSaver {
     ) -> Bool {
         guard !entries.isEmpty else { return true }
 
-        return fileUpdateQueue.sync {
+        return serializeTranscriptFileUpdate {
             guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
                 AppLogger.pipeline.error("Failed to read transcript for deferred speaker review", ["path": transcriptURL.path])
                 return false
@@ -493,7 +493,7 @@ extension TranscriptSaver {
     ) -> Bool {
         guard !updates.isEmpty else { return true }
 
-        return fileUpdateQueue.sync {
+        return serializeTranscriptFileUpdate {
             guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
                 AppLogger.pipeline.error("Failed to read transcript for name update (generic)", ["path": transcriptURL.path])
                 return false
@@ -544,7 +544,7 @@ extension TranscriptSaver {
     ) -> Bool {
         guard !updates.isEmpty else { return true }
 
-        return fileUpdateQueue.sync {
+        return serializeTranscriptFileUpdate {
             guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
                 AppLogger.pipeline.error("Failed to read transcript for name update", ["path": transcriptURL.path])
                 return false
@@ -672,7 +672,7 @@ extension TranscriptSaver {
     ) -> Bool {
         guard !collapsedUpdates.isEmpty else { return true }
 
-        return fileUpdateQueue.sync {
+        return serializeTranscriptFileUpdate {
             guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
                 AppLogger.pipeline.error("Failed to read transcript for mic collapse", ["path": transcriptURL.path])
                 return false
@@ -740,7 +740,7 @@ extension TranscriptSaver {
     ) -> Bool {
         guard !discardedUpdates.isEmpty else { return true }
 
-        return fileUpdateQueue.sync {
+        return serializeTranscriptFileUpdate {
             guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
                 AppLogger.pipeline.error("Failed to read transcript for speaker discard", ["path": transcriptURL.path])
                 return false

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
@@ -588,16 +588,24 @@ extension SpeakerDatabase {
         return row
     }
 
+    /// LIFO safety check for un-merge: true if either (a) a newer non-undone merge
+    /// still targets `targetId` (restoring the older snapshot would drop it), or
+    /// (b) `targetId` was itself later absorbed as the *source* of a newer
+    /// non-undone merge (its contributions were already re-pointed onward, so
+    /// resurrecting it here would leave a stale, orphaned profile row — the
+    /// merge that consumed it must be undone first).
     private func hasNewerUndoneMergeImpl(targetId: UUID, afterRowid rowid: Int64) -> Bool {
         let sql = """
         SELECT COUNT(*) FROM speaker_merge_events
-        WHERE target_id = ? AND undone_at IS NULL AND rowid > ?;
+        WHERE undone_at IS NULL AND rowid > ?
+          AND (target_id = ? OR source_id = ?);
         """
         var statement: OpaquePointer?
         var count: Int32 = 0
         if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-            sqlite3_bind_text(statement, 1, (targetId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_int64(statement, 2, rowid)
+            sqlite3_bind_int64(statement, 1, rowid)
+            sqlite3_bind_text(statement, 2, (targetId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 3, (targetId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
             if sqlite3_step(statement) == SQLITE_ROW {
                 count = sqlite3_column_int(statement, 0)
             }

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -256,8 +256,10 @@ public class TranscriptSaver {
             formatOptions: formatOptions
         )
 
-        // Serialize file writes to prevent concurrent corruption with retroactive speaker updates
-        let savedURL: URL? = fileUpdateQueue.sync {
+        // Serialize file writes to prevent concurrent corruption with retroactive speaker updates.
+        // Uses the reentrancy-safe wrapper (not a raw `.sync`) so this cannot deadlock if it is
+        // ever invoked while already running inside a `serializeTranscriptFileUpdate` block.
+        let savedURL: URL? = serializeTranscriptFileUpdate {
             do {
                 try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
                 FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)


### PR DESCRIPTION
## Why

Found by an automated adversarial code review of the last 7 days of `main` (not tied to any one person or PR). Five confirmed reliability/data-integrity bugs in already-merged core code, all fixed here.

**Unverified by compilation — this environment (Linux container) cannot run `swift build` or the Swift test suite.** Please verify with `bash build.sh --no-open` and `bash run-tests.sh` (and `swift test` for `TranscriptedCoreTests`) before merging.

## Product Impact

- Affects: `meetings` (audio capture reliability, speaker un-merge, failed-transcription recovery) / `dictation` (zombie-recovery audio loss)
- Lane: `meeting reliability` / `dictation reliability`
- Why this matters: each of these is a real data-loss or data-integrity bug — silently restarted system-audio capture after a user stop, a resurrected zombie speaker profile after un-merge, a wrongly-deleted recoverable failed meeting, and (most seriously) permanently discarded real pre-sleep dictation audio.

## What changed

1. **`Sources/TranscriptedCore/Audio/SCKAudioCapture.swift`** (HIGH — race condition)
   - Bug: `_isCapturing`, `recoveryAttempts`, and `isRecovering` were read/written with no lock from three different execution contexts: the buffer-stall watchdog (`checkWatchdog`, on `watchdogQueue`), the `SCStreamDelegate.stream(_:didStopWithError:)` callback (ScreenCaptureKit's own delegate queue), and the recovery block they spawn (`DispatchQueue.global(qos: .userInitiated)`). Two concurrent failure triggers (a stalled-buffer watchdog firing at the same time as a `didStopWithError` callback) could both pass the `recoveryAttempts < max && !isRecovering` guard before either wrote back, kicking off two overlapping recovery attempts.
   - Fix: added a dedicated `captureStateLock` (`NSLock`, matching the file's existing lock style) guarding `_isCapturing`/`recoveryAttempts`/`isRecovering`, and made the guard-check-then-increment in `handleMidRecordingFailure` a single atomic critical section.
   - **Known remaining gap (documented in code comment):** this does not yet give full cross-file coordination with `Audio.swift`'s `stop()`/`stopSync()` path. If a real user-initiated stop completes while a recovery is between its own `stopSync()`/`prepare()`/`start()` calls, the recovery can in theory still restart capture after the caller believed capture had stopped. Fixing that fully requires touching `Audio.swift`'s stop coordination too, which felt too risky to do blind in this environment — flagging it here as a larger follow-up.

2. **`Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift`** (HIGH — data integrity)
   - Bug: `hasNewerUndoneMergeImpl` (the LIFO safety check gating un-merge) only checked `WHERE target_id = ? AND undone_at IS NULL AND rowid > ?`. Scenario: merge A→B, then merge B→C (B's row deleted, contributions re-pointed to C), then undo A→B — this resurrects a stale/orphaned B row, since B's contributions already moved to C and `rederiveProfileFromContributionsImpl` becomes a no-op for it.
   - Fix: the query now also blocks undo when there's a later, still-active merge event where `source_id` matches the target being restored — i.e. the target was itself later merged away as a source.
   - **Skipped (documented, lower priority per the review):** the separate "preserve post-merge rename/dispute/confidence across undo" enhancement (`reinsertProfileSnapshotImpl` restores the full pre-merge snapshot including `displayName`/`nameSource`/`confidence`/`disputeCount`, discarding any rename/dispute change made after the merge). This needs product judgment calls about which post-merge field changes count as "higher provenance" than the snapshot, which isn't safe to guess correctly without being able to compile/test. The LIFO fix above is the more serious data-integrity bug and is the one addressed here.

3. **`Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift`** (HIGH — data loss)
   - Bug: in `reconcileAudioReferences`, when `hasUnavailableAudio` was set (system-audio root unreachable), the function returned the *original* unmodified `entry` parameter — discarding any mic-side heal already applied earlier in the same call (e.g. a merge-heal that repointed a local `micURL` to `<stem>_merged.wav`). `retryFailedTranscription` would then see a stale, no-longer-existing `micAudioURL` and wrongly delete a recoverable failed-meeting entry.
   - Fix: the `hasUnavailableAudio` branch now constructs and returns an entry using the already-healed `micURL`/`systemURL` (mirroring the same construction pattern used by the normal heal-and-return path just below it), while still setting the unavailable flag so the caller does not persist this reconciliation to disk.

4. **`Sources/TranscriptedCore/Storage/TranscriptSaver.swift`** / **`Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift`** (MEDIUM — latent deadlock hardening)
   - Bug: `serializeTranscriptFileUpdate` uses a `DispatchSpecificKey` to detect reentrancy on `fileUpdateQueue` and skip a redundant `.sync`, but `saveTranscript`'s own write and every method in `RetroactiveSpeakerUpdater.swift` still did a raw `fileUpdateQueue.sync` without that check — a latent deadlock trap if ever nested inside a `serializeTranscriptFileUpdate` block. Not currently triggered by any call site, but cheap to harden.
   - Fix: `saveTranscript`'s write and all 10 raw `fileUpdateQueue.sync` call sites in `RetroactiveSpeakerUpdater.swift` now go through the reentrancy-safe `serializeTranscriptFileUpdate` wrapper instead.

5. **`Sources/Speech/ParakeetEngine.swift`** (HIGH — real user audio data loss, most safety-critical fix in this batch)
   - Bug A: `stopRecording()`'s early-return guard checked `zombieRecoveryRestartPending` *before* checking `preservingRecordingAcrossRecovery`/whether `recoveredRecordingTimeline` held real content. If the user stopped dictation while a post-wake zombie-engine retry was in flight and `recoveredRecordingTimeline` already held real pre-sleep audio, the code took the zombie branch and called `clearRecoveredRecordingTimeline(keepingCapacity: true)` — permanently discarding legitimately recorded pre-sleep audio instead of draining it for transcription.
   - Bug B: when the zombie retry itself failed, it called the unconditional-clear `interruptRecordingAndClearRecoveredTimeline()` instead of the preserve-semantics `interruptRecordingPreservingRecoveredTimeline()` used by `handleSystemWake()`.
   - Fix: reordered the guard so the preserving/non-empty-timeline check runs first (falling through to `cancelPendingRecordingRecovery()`, which also cancels the audio watchdog and resets `zombieRecoveryRestartPending` as a side effect via `cancelAudioWatchdog()` — so this doesn't leave the pending zombie retry able to restart capture behind the user's back), and changed the zombie-retry-failure path to call `interruptRecordingPreservingRecoveredTimeline()`, matching `handleSystemWake()`'s existing preserve semantics.

## How I checked it

- [ ] `scripts/dev/agent-preflight.sh`
- [ ] Selected checks from `.agents/test-matrix.yml` for the files changed
- [ ] `bash build.sh --no-open`
- [ ] `bash run-tests.sh`
- [ ] Performance budget passed
- [ ] `bash run-integration-smoke.sh` (touched `Sources/TranscriptedCore/`)
- [ ] `swift test` (touched `Sources/TranscriptedCore/`)
- [x] Manual check: read every changed function in full from the current source (not from stale line numbers), traced the exact race/bug scenario by hand for each fix, reviewed the full diff against `origin/main`, and confirmed brace/syntax balance by inspection. **None of this was compiled or run** — see the verification checklist above, which still needs to happen before merge.

This PR was authored in a Linux container with no Swift toolchain, so none of the boxes above could actually be run here — please treat them as a pre-merge checklist for the reviewer, not as completed by this PR.

## Risk Review

- [x] Privacy / local-first behavior reviewed — no changes to what data is persisted or transmitted; only locking/ordering/return-value fixes.
- [ ] Storage path or migration impact reviewed — n/a, no schema or path changes.
- [ ] Public-facing copy stays concrete and matches current product scope — n/a.
- [ ] Release/update impact reviewed — n/a.
- [x] Agent PRs link the issue/workpad and stay draft until human review — this PR stays draft; no source issue/workpad, this was requested directly.
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a, no UI changes.
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included.

## Notes

- Two items intentionally left as follow-ups rather than risked as blind fixes in this batch:
  1. Full cross-file coordination between `SCKAudioCapture`'s internal recovery locking and `Audio.swift`'s stop path (see fix #1 above).
  2. Preserving post-merge rename/dispute/confidence learning across a speaker un-merge (see fix #2 above).
- All five fixes are intentionally scoped and conservative — no refactoring beyond what each bug required.

## Agent handoff

`COORD_DONE: BRIEF | PR: (this PR) | changes made: 5 reliability/data-integrity fixes across SCKAudioCapture.swift, SpeakerProfileProvenance.swift, FailedTranscriptionManager.swift, TranscriptSaver.swift + RetroactiveSpeakerUpdater.swift, ParakeetEngine.swift | GitHub cleanup recommendations: none | decisions needed: whether to pursue the two follow-ups noted above as separate PRs | tests/checks run: none (Linux container, no Swift toolchain) — run `bash build.sh --no-open`, `bash run-tests.sh`, `swift test` before merge | smallest next action: run the build/test suite on macOS and review the diff`


---
_Generated by [Claude Code](https://claude.ai/code/session_01AeWxy6dtwosF4NyVSZMB7Z)_