### PR TITLE
Separate release health by build identity

### DIFF
--- a/Tests/Fixtures/posthog-dashboard-query-results.json
+++ b/Tests/Fixtures/posthog-dashboard-query-results.json
@@ -174,9 +174,36 @@
       ]
     },
     {
-      "id": "release_health.version_event_counts",
+      "id": "release_health.installed_build_outcomes",
       "rows": [
-        {"event": "app_launched", "events": 82, "devices": 41, "first_seen": "2026-06-18T00:10:00Z", "last_seen": "2026-06-19T12:00:00Z"}
+        {
+          "app_version": "1.1.48",
+          "build_version": "536174328",
+          "build_channel": "release",
+          "build_revision": "releaseabc",
+          "launch_events": 82,
+          "launch_devices": 41,
+          "success_events": 37,
+          "success_devices": 22,
+          "failure_events": 3,
+          "failure_devices": 3,
+          "first_seen": "2026-06-18T00:10:00Z",
+          "last_seen": "2026-06-19T12:00:00Z"
+        },
+        {
+          "app_version": "1.1.49",
+          "build_version": "main-20260704",
+          "build_channel": "local",
+          "build_revision": "localmain",
+          "launch_events": 6,
+          "launch_devices": 2,
+          "success_events": 1,
+          "success_devices": 1,
+          "failure_events": 2,
+          "failure_devices": 1,
+          "first_seen": "2026-07-04T15:00:00Z",
+          "last_seen": "2026-07-04T15:30:00Z"
+        }
       ]
     },
     {

--- a/Tests/Fixtures/posthog-product-dashboard-summary.json
+++ b/Tests/Fixtures/posthog-product-dashboard-summary.json
@@ -192,18 +192,41 @@
     "release_breakdown": [
       {
         "app_version": "1.1.48",
+        "build_channel": "release",
+        "build_revision": "releaseabc",
+        "build_version": "536174328",
         "failure_devices": 5,
         "failure_events": 7,
         "last_seen": "2026-06-19T00:00:00",
+        "launch_events": 52,
         "launch_devices": 34,
+        "success_events": 18,
         "success_devices": 14
       },
       {
+        "app_version": "1.1.49",
+        "build_channel": "local",
+        "build_revision": "localmain",
+        "build_version": "main-20260704",
+        "failure_devices": 2,
+        "failure_events": 3,
+        "last_seen": "2026-07-04T15:30:00",
+        "launch_events": 4,
+        "launch_devices": 2,
+        "success_events": 1,
+        "success_devices": 1
+      },
+      {
         "app_version": "1.1.47",
+        "build_channel": "release",
+        "build_revision": "oldrelease",
+        "build_version": "534000111",
         "failure_devices": 0,
         "failure_events": 0,
         "last_seen": "2026-06-18T00:00:00",
+        "launch_events": 11,
         "launch_devices": 8,
+        "success_events": 7,
         "success_devices": 5
       }
     ],

--- a/docs/posthog-100-wau-dashboard.md
+++ b/docs/posthog-100-wau-dashboard.md
@@ -42,7 +42,7 @@ Do not collapse launch, proxy activation, and strict activation into one number.
 | Meeting reliability funnel | Do meeting captures start, retain audio, transcribe, and save? | `meeting_prompt_shown`, `meeting_prompt_record_selected`, `meeting_prompt_dismissed`, `meeting_prompt_suppressed`, `meeting_recording_started`, `meeting_recording_start_failed`, `meeting_recording_stopped`, `meeting_capture_health_snapshot`, `meeting_transcript_saved`, `meeting_transcript_failed`, `meeting_transcript_skipped`, `meeting_saved_audio_retranscription_requested`, `meeting_mic_boost_prompt_shown`, `meeting_mic_boost_prompt_actioned`, `meeting_file_imported`, `meeting_file_import_failed`, `meeting_speaker_finalization_failed` | `meeting_opened_after_save` if Home/open behavior needs stricter proof than artifact-action clicks |
 | Local summary beta funnel | Are beta summaries discoverable, prepared, run, and useful? | `settings_page_viewed`, `settings_action_clicked`, `settings_toggle_changed`, `activation_artifact_action_clicked` with `action_kind = 'local_summary'`, plus `local_meeting_summary_started`, `local_meeting_summary_completed`, and `local_meeting_summary_failed` | None for the current beta loop; keep model/provider/status/failure as enums only |
 | Agent/Markdown value loop | Does saved Markdown become sourced agent use and later return? | `activation_first_artifact_saved`, `activation_second_artifact_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_habit_loop_actioned`, `activation_return_proxy_observed`, `agent_capture_query_observed` grouped by `query_kind`, `artifact_kind`, `source_count_bucket`, `capture_age_bucket`, and `return_window_bucket`, `meeting_transcript_saved`, `dictation_completed` | maybe `agent_answer_returned_observed` only if implemented through local MCP/tool invocation metadata, never content |
-| Release health by app version | Did a release improve activation without hurting reliability? | All dashboard events grouped by default `app_version` and `build_version`; update events: `update_check_finished`, `update_download_started`, `update_download_finished`, `update_ready_to_install`, `update_relaunching`, `update_installed`; runtime events: `app_unclean_shutdown_detected`, `app_session_stall_detected` | None for the first dashboard. Add only coarse release-readiness enums if Sentry/PostHog release reviews need a stable join key later |
+| Release health by installed build | Did a shipped release improve activation without hurting reliability, and are local/current-main builds staying out of shipped proof? | Workflow events grouped by default `app_version`, `build_version`, `build_channel`, and `build_revision`; update events: `update_check_finished`, `update_download_started`, `update_download_finished`, `update_ready_to_install`, `update_relaunching`, `update_installed`; runtime events: `app_unclean_shutdown_detected`, `app_session_stall_detected` | None for the first dashboard. Add only coarse release-readiness enums if Sentry/PostHog release reviews need a stable join key later |
 
 ## PostHog Objects
 
@@ -97,10 +97,14 @@ Create these as saved PostHog insights, then collect them into one dashboard.
    - Label setup/prompt clicks as proxy evidence; even agent-query rows prove a
      saved-capture read/search, not answer quality.
 
-7. **Release health by app version**
+7. **Release health by installed build**
    - Compare launch WAU, value WAU, activation conversion, dictation completion,
      meeting save rate, update success, unclean shutdowns, and stalls by
-     `app_version`.
+     `app_version`, `build_version`, `build_channel`, and `build_revision`.
+   - Treat `build_channel = local`, `dev`, `main`, `nightly`, or `unknown` as
+     current-main/local telemetry, not shipped-release proof.
+   - Keep update events separate: they describe the update target `version`,
+     not necessarily the installed `app_version`.
    - Keep Sentry crash triage separate, but use this dashboard to decide if a
      release changed usage or reliability.
 

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -350,7 +350,11 @@ diagnosis.
 
 ### Release Health By App Version
 
-- active devices by `app_version`
+- launch, success, and failure rows by `app_version`, `build_version`,
+  `build_channel`, and `build_revision`
+- shipped-release reads must not merge `build_channel = release` rows with
+  local/current-main rows such as `local`, `dev`, `main`, `nightly`, or
+  `unknown`
 - first successful `dictation_artifact_saved`
 - useful dictation completion volume via `dictation_completed`
 - first successful `meeting_transcript_saved`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,7 +55,7 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
 - `scripts/ops/health-probe.sh` — run health checks for observability lanes (Sentry, PostHog, GitHub, Cloudflare)
   - Usage: `bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|all>`
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
-- `scripts/ops/release-health-card.py` — print a compact release-health card for one app version by combining local release metadata, GitHub downloads, live public release surfaces, and PostHog update/workflow counts when credentials are present
+- `scripts/ops/release-health-card.py` — print a compact release-health card for one app version by combining local release metadata, GitHub downloads, live public release surfaces, and PostHog update/workflow counts when credentials are present; installed workflow rows are grouped by `app_version`, `build_version`, `build_channel`, and `build_revision` so local/current-main builds cannot be counted as shipped-release proof
   - Usage: `python3 scripts/ops/release-health-card.py --version 1.1.47`
 - `scripts/ops/retention-cohort-report.py` — print a privacy-safe PostHog retention cohort report for first/second artifact, next-day and 7-day return, repeat dictation/meeting/agent/summary use, 3-days-this-week, version adoption, and first-run drop-off
   - Usage: `python3 scripts/ops/retention-cohort-report.py`
@@ -72,13 +72,13 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Writes local Markdown and JSON under `/tmp/transcripted-posthog-product-context/<run-id>/`
   - Missing PostHog credentials produce explicit `UNKNOWN` states unless `--strict` is passed
   - Self-test: `python3 scripts/ops/posthog-product-context-pack.py --self-test`
-- `scripts/ops/posthog-dashboard-queries.py` — reusable PostHog aggregate query catalog for the 100 WAU, activation, reliability, feature-adoption, and release-health dashboard families
+- `scripts/ops/posthog-dashboard-queries.py` — reusable PostHog aggregate query catalog for the 100 WAU, activation, reliability, feature-adoption, and release-health dashboard families; release-health keeps installed build outcomes separate from update target-version outcomes
   - Dry-run specs: `python3 scripts/ops/posthog-dashboard-queries.py --dry-run`
   - One family: `python3 scripts/ops/posthog-dashboard-queries.py --family activation --dry-run`
   - Live aggregate query: `python3 scripts/ops/posthog-dashboard-queries.py --family 100_wau --days 30`
   - CI/offline proof: `python3 scripts/ops/posthog-dashboard-queries.py --self-test`
   - Machine output for health agents: `python3 scripts/ops/posthog-dashboard-queries.py --family all --json-only`
-- `scripts/ops/posthog-product-dashboard-summary.py` — turn the five PostHog product-learning dashboard families into ranked product tasks
+- `scripts/ops/posthog-product-dashboard-summary.py` — turn the five PostHog product-learning dashboard families into ranked product tasks, with release-regression watch rows grouped by full build identity
   - Usage: `python3 scripts/ops/posthog-product-dashboard-summary.py --days 30`
   - Fixture usage: `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json`
   - Writes local Markdown and JSON under `/tmp/transcripted-posthog-product-tasks/<run-id>/`

--- a/scripts/ops/posthog-dashboard-queries.py
+++ b/scripts/ops/posthog-dashboard-queries.py
@@ -174,6 +174,15 @@ RELEASE_EVENTS = (
     "update_installed",
 )
 
+RELEASE_WORKFLOW_EVENTS = (
+    "app_launched",
+    "dictation_started",
+    "dictation_completed",
+    "meeting_recording_started",
+    "meeting_transcript_saved",
+    "meeting_transcript_failed",
+)
+
 DISALLOWED_OUTPUT_FRAGMENTS = (
     "distinct_id",
     "person",
@@ -908,27 +917,51 @@ LIMIT 50
 """,
         ),
         QuerySpec(
-            id="release_health.version_event_counts",
+            id="release_health.installed_build_outcomes",
             family="release_health",
-            title="Release event counts",
-            description="Counts workflow and update events for a release-scoped health card.",
-            columns=("event", "events", "devices", "first_seen", "last_seen"),
+            title="Installed build launch and outcome counts",
+            description="Groups launch, success, and failure events by installed app/build identity so shipped and local/current-main rows stay separate.",
+            columns=(
+                "app_version",
+                "build_version",
+                "build_channel",
+                "build_revision",
+                "launch_events",
+                "launch_devices",
+                "success_events",
+                "success_devices",
+                "failure_events",
+                "failure_devices",
+                "first_seen",
+                "last_seen",
+            ),
             sql=f"""
 SELECT
-  event,
-  count() AS events,
-  uniq(distinct_id) AS devices,
+  properties['app_version'] AS app_version,
+  properties['build_version'] AS build_version,
+  properties['build_channel'] AS build_channel,
+  properties['build_revision'] AS build_revision,
+  countIf(event = 'app_launched') AS launch_events,
+  uniqIf(distinct_id, event = 'app_launched') AS launch_devices,
+  countIf(event IN ('dictation_completed', 'meeting_transcript_saved')) AS success_events,
+  uniqIf(distinct_id, event IN ('dictation_completed', 'meeting_transcript_saved')) AS success_devices,
+  countIf(event = 'meeting_transcript_failed') AS failure_events,
+  uniqIf(distinct_id, event = 'meeting_transcript_failed') AS failure_devices,
   min(timestamp) AS first_seen,
   max(timestamp) AS last_seen
 FROM events
 WHERE timestamp >= now() - INTERVAL {days} DAY
-  AND {event_filter(RELEASE_EVENTS)}
-  {version_or_app_version_filter(app_version)}
-GROUP BY event
-ORDER BY event ASC
+  AND {event_filter(RELEASE_WORKFLOW_EVENTS)}
+  AND properties['app_version'] IS NOT NULL
+  {app_version_filter(app_version)}
+GROUP BY app_version, build_version, build_channel, build_revision
+ORDER BY launch_devices DESC, launch_events DESC, app_version ASC, build_channel ASC
 LIMIT 100
 """,
-            notes=("Pass --app-version for a specific release. Update events use properties['version']; workflow events use app_version.",),
+            notes=(
+                "This is installed build health only. Rows with build_channel local/dev/main/nightly are current-main proof, not shipped-release proof.",
+                "Use update_results for Sparkle target-version health; update events use properties['version'], not installed app_version.",
+            ),
         ),
         QuerySpec(
             id="release_health.update_results",
@@ -953,6 +986,7 @@ GROUP BY event, result, state, failure_kind, version
 ORDER BY events DESC
 LIMIT 80
 """,
+            notes=("Pass --app-version to filter update target `version`. Keep this separate from installed build health rows.",),
         ),
     ]
 
@@ -1210,7 +1244,7 @@ def run_self_test() -> int:
         "retry_recovery.failure_rates",
         "onboarding_friction.step_friction",
         "timeline_dayflow.dayflow_events",
-        "release_health.version_event_counts",
+        "release_health.installed_build_outcomes",
     )
     for query_id in required:
         if query_id not in rendered:

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -334,7 +334,12 @@ def release_breakdown_query(days: int) -> str:
     return f"""
 SELECT
   properties['app_version'] AS app_version,
+  properties['build_version'] AS build_version,
+  properties['build_channel'] AS build_channel,
+  properties['build_revision'] AS build_revision,
+  countIf(event = 'app_launched') AS launch_events,
   uniqIf(distinct_id, event = 'app_launched') AS launch_devices,
+  countIf(event IN ('dictation_completed', 'meeting_transcript_saved', 'activation_first_artifact_saved')) AS success_events,
   uniqIf(distinct_id, event IN ('dictation_completed', 'meeting_transcript_saved', 'activation_first_artifact_saved')) AS success_devices,
   countIf(event IN ('dictation_start_failed', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped')) AS failure_events,
   uniqIf(distinct_id, event IN ('dictation_start_failed', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped')) AS failure_devices,
@@ -342,8 +347,9 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ({sql_list(CORE_EVENTS)})
-GROUP BY app_version
-ORDER BY last_seen DESC
+  AND properties['app_version'] IS NOT NULL
+GROUP BY app_version, build_version, build_channel, build_revision
+ORDER BY launch_devices DESC, launch_events DESC, last_seen DESC
 LIMIT 20
 """
 
@@ -729,15 +735,20 @@ def build_release_watch(data: dict[str, Any]) -> Finding:
     successes = as_int(watched.get("success_devices"))
     failures = as_int(watched.get("failure_events"))
     version = watched.get("app_version")
+    build_version = watched.get("build_version") or "unknown"
+    build_channel = watched.get("build_channel") or "unknown"
+    build_revision = watched.get("build_revision") or "unknown"
     if launches and successes == 0:
         recommendation = "Watch this version for install/update friction: launch exists but no first success signal yet."
     elif failures:
         recommendation = "Compare this version against Sentry and recent PRs before calling the release clean."
     else:
         recommendation = "No release regression from aggregate PostHog counts; keep watching Sentry for sparse fatals."
+    if str(build_channel).lower() in {"local", "dev", "debug", "main", "nightly"}:
+        recommendation = "Treat this as current-main/local telemetry, not shipped-release proof. Keep it separate from shipped app_version rows."
     return Finding(
         "Release regression watch",
-        f"{version}: launches={launches}, success_devices={successes}, failure_events={failures}.",
+        f"{version} ({build_version}, {build_channel}, {build_revision}): launches={launches}, success_devices={successes}, failure_events={failures}.",
         recommendation,
         "medium" if launches < 10 or failures else "high",
         (failures / max(launches, 1)) * 1000 + max(0, launches - successes),
@@ -945,6 +956,18 @@ def run_self_test() -> int:
         if "SELECT *" in query.upper():
             print("self-test failed: query uses SELECT *", file=sys.stderr)
             return 1
+    release_query = release_breakdown_query(30)
+    if "GROUP BY app_version, build_version, build_channel, build_revision" not in release_query:
+        print("self-test failed: release breakdown must group by full build identity", file=sys.stderr)
+        return 1
+    release_rows = data["results"].get("release_breakdown", [])
+    if not any(row.get("build_channel") == "release" for row in release_rows) or not any(row.get("build_channel") == "local" for row in release_rows):
+        print("self-test failed: release fixture must include shipped and local/current-main build rows", file=sys.stderr)
+        return 1
+    release_metric = findings["release"].metric
+    if "localmain" not in release_metric:
+        print("self-test failed: release watch must print selected build revision/channel", file=sys.stderr)
+        return 1
     print("self-test passed")
     return 0
 

--- a/scripts/ops/release-health-card.py
+++ b/scripts/ops/release-health-card.py
@@ -49,6 +49,7 @@ POSTHOG_UPDATE_TARGET_EVENTS = (
     "update_relaunching",
     "update_installed",
 )
+POSTHOG_LOCAL_BUILD_CHANNELS = ("local", "dev", "debug", "main", "nightly", "unknown")
 POSTHOG_FAILURE_EVENTS = (
     "app_unclean_shutdown_detected",
     "app_session_stall_detected",
@@ -216,6 +217,7 @@ def posthog_release_health(version: str, hours: int) -> dict[str, Any]:
         for event in POSTHOG_ACTIVE_EVENTS
         if event not in POSTHOG_UPDATE_TARGET_EVENTS
     )
+    local_channels = ", ".join(sql_quote(channel) for channel in POSTHOG_LOCAL_BUILD_CHANNELS)
     query = (
         "SELECT event, count() AS events, uniq(distinct_id) AS devices, "
         "min(timestamp) AS first_seen, max(timestamp) AS last_seen "
@@ -223,7 +225,8 @@ def posthog_release_health(version: str, hours: int) -> dict[str, Any]:
         f"WHERE timestamp >= now() - INTERVAL {int(hours)} HOUR "
         f"AND event IN ({events}) "
         "AND ("
-        f"(event IN ({workflow_events}) AND properties['app_version'] = {sql_quote(version)}) "
+        f"(event IN ({workflow_events}) AND properties['app_version'] = {sql_quote(version)} "
+        f"AND coalesce(properties['build_channel'], 'unknown') NOT IN ({local_channels})) "
         f"OR (event IN ({update_events}) AND properties['version'] = {sql_quote(version)})"
         ") "
         "GROUP BY event ORDER BY event ASC LIMIT 100"
@@ -281,6 +284,8 @@ def posthog_version_health(hours: int, limit: int) -> dict[str, Any]:
         "SELECT "
         "properties['app_version'] AS app_version, "
         "properties['build_version'] AS build_version, "
+        "properties['build_channel'] AS build_channel, "
+        "properties['build_revision'] AS build_revision, "
         "countIf(event = 'app_launched') AS launches, "
         "uniqIf(distinct_id, event = 'app_launched') AS launch_devices, "
         "countIf(event = 'activation_first_artifact_saved') AS first_artifacts, "
@@ -305,8 +310,8 @@ def posthog_version_health(hours: int, limit: int) -> dict[str, Any]:
         "FROM events "
         f"WHERE timestamp >= now() - INTERVAL {int(hours)} HOUR "
         f"AND event IN ({events}) "
-        "GROUP BY app_version, build_version "
-        "ORDER BY launch_devices DESC, launches DESC "
+        "GROUP BY app_version, build_version, build_channel, build_revision "
+        "ORDER BY launch_devices DESC, launches DESC, app_version ASC, build_channel ASC "
         f"LIMIT {int(limit)}"
     )
     payload = {
@@ -343,6 +348,8 @@ def version_health_row(row: list[Any]) -> dict[str, Any]:
     fields = (
         "app_version",
         "build_version",
+        "build_channel",
+        "build_revision",
         "launches",
         "launch_devices",
         "first_artifacts",
@@ -368,7 +375,9 @@ def version_health_row(row: list[Any]) -> dict[str, Any]:
     item = dict(zip(fields, row))
     item["app_version"] = str(item.get("app_version") or "unknown")
     item["build_version"] = str(item.get("build_version") or "unknown")
-    for field in fields[2:-1]:
+    item["build_channel"] = str(item.get("build_channel") or "unknown")
+    item["build_revision"] = str(item.get("build_revision") or "unknown")
+    for field in fields[4:-1]:
         item[field] = int(item.get(field) or 0)
     return item
 
@@ -398,16 +407,31 @@ def shipped_scope_label(app_version: str, target_version: str, gh_release: dict[
     return "other installed version"
 
 
+def build_scope_label(row: dict[str, Any], target_version: str, gh_release: dict[str, Any], surfaces: dict[str, Any]) -> str:
+    app_scope = shipped_scope_label(str(row["app_version"]), target_version, gh_release, surfaces)
+    channel = str(row.get("build_channel") or "unknown").lower()
+    revision = str(row.get("build_revision") or "unknown")
+    if channel in POSTHOG_LOCAL_BUILD_CHANNELS:
+        return f"source/local target; not shipped proof ({channel})"
+    if app_scope == "shipped/live target" and channel in {"release", "stable", "appstore"}:
+        return "shipped/live target"
+    if app_scope == "shipped/live target":
+        return f"{app_scope}; verify build_channel={channel}"
+    if revision not in {"", "unknown"}:
+        return f"source/local target; not shipped proof ({channel})"
+    return app_scope
+
+
 def version_health_line(row: dict[str, Any], target_version: str, gh_release: dict[str, Any], surfaces: dict[str, Any]) -> str:
     launches = int(row["launches"])
     failures = int(row["failures"])
-    scope = shipped_scope_label(str(row["app_version"]), target_version, gh_release, surfaces)
+    scope = build_scope_label(row, target_version, gh_release, surfaces)
     updates = (
         f"checks {row['update_checks']}, available {row['update_available']}, "
         f"ready {row['update_ready_to_install']}, installed {row['update_installed']}, failed {row['update_check_failures'] + row['update_download_failed']}"
     )
     return (
-        f"{row['app_version']} ({row['build_version']}, {scope}): "
+        f"{row['app_version']} ({row['build_version']}, {row['build_channel']}, {row['build_revision']}, {scope}): "
         f"launches {launches} / {row['launch_devices']} devices; "
         f"first_artifact {row['first_artifacts']}; "
         f"dictations {row['dictation_completions']}; "
@@ -421,6 +445,8 @@ def run_self_test() -> int:
     sample = version_health_row([
         "1.2.3",
         "456",
+        "release",
+        "release123",
         10,
         4,
         3,
@@ -455,9 +481,52 @@ def run_self_test() -> int:
     if "failures 2 (20.0% of launches)" not in line:
         print("self-test failed: missing failure rate", file=sys.stderr)
         return 1
-    query_guard = posthog_version_health.__code__.co_consts
+    local_sample = version_health_row([
+        "1.2.3",
+        "456",
+        "local",
+        "main123",
+        2,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        "2026-06-19T00:00:00",
+    ])
+    local_line = version_health_line(
+        local_sample,
+        "1.2.3",
+        {"available": True},
+        {"appcast_matches": True, "download_matches": True},
+    )
+    if "not shipped proof" not in local_line:
+        print("self-test failed: local build row should not be shipped proof", file=sys.stderr)
+        return 1
+    query_guard = posthog_version_health.__code__.co_consts + posthog_release_health.__code__.co_consts
     if any(isinstance(value, str) and "SELECT *" in value.upper() for value in query_guard):
         print("self-test failed: query uses SELECT *", file=sys.stderr)
+        return 1
+    query_text = " ".join(value for value in query_guard if isinstance(value, str))
+    if "GROUP BY app_version, build_version, build_channel, build_revision" not in query_text:
+        print("self-test failed: version health query must group by full build identity", file=sys.stderr)
+        return 1
+    if "coalesce(properties['build_channel'], 'unknown') NOT IN" not in query_text:
+        print("self-test failed: release health query must exclude local/unknown workflow channels", file=sys.stderr)
         return 1
     print("self-test passed")
     return 0


### PR DESCRIPTION
## Summary
- split release-health dashboard workflow outcomes by app_version, build_version, build_channel, and build_revision
- keep installed build health separate from Sparkle update target-version health
- add fixtures covering shipped 1.1.48 release rows and local/current-main 1.1.49 rows so they cannot collapse into one release read
- update operator docs for shipped vs local/current-main proof boundaries

## Verification
- python3 -m py_compile scripts/ops/release-health-card.py scripts/ops/posthog-dashboard-queries.py scripts/ops/posthog-product-dashboard-summary.py
- python3 scripts/ops/release-health-card.py --self-test
- python3 scripts/ops/posthog-dashboard-queries.py --self-test
- python3 scripts/ops/posthog-product-dashboard-summary.py --self-test
- python3 scripts/ops/posthog-dashboard-queries.py --family release_health --fixture Tests/Fixtures/posthog-dashboard-query-results.json --json-only > /tmp/transcripted-release-health-dashboard-fixture.json
- python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only > /tmp/transcripted-release-health-product-summary.json
- python3 -m json.tool /tmp/transcripted-release-health-dashboard-fixture.json >/dev/null
- python3 -m json.tool /tmp/transcripted-release-health-product-summary.json >/dev/null
- git diff --check

## Maestro lanes
lanes used: Codex=implemented, verified, committed, pushed, opened PR; Claude=read-only release-health dashboard separation audit (/Users/redbars/.codex/maestro/runs/20260704T114945Z-transcripted-release-health-version-audit-claude); Local=skipped LM Studio unavailable in smoke; Windows=skipped worker not configured in smoke.

No release.