### PR TITLE
Add PostHog observed taxonomy self-test

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -154,11 +154,13 @@ rules:
   - paths:
       - "scripts/ops/posthog-dashboard-queries.py"
       - "Tests/Fixtures/posthog-dashboard-query-results.json"
+      - "Tests/Fixtures/posthog-observed-event-taxonomy.json"
       - "docs/posthog-dashboard-query-helpers.md"
     checks:
       - "scripts/dev/agent-preflight.sh"
       - "python3 -m py_compile scripts/ops/posthog-dashboard-queries.py"
       - "python3 scripts/ops/posthog-dashboard-queries.py --self-test"
+      - "python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --observed-fixture Tests/Fixtures/posthog-observed-event-taxonomy.json --json-only"
 
   - paths:
       - "scripts/ops/nightly-security-check.py"

--- a/Tests/Fixtures/posthog-dashboard-query-results.json
+++ b/Tests/Fixtures/posthog-dashboard-query-results.json
@@ -164,13 +164,13 @@
     {
       "id": "timeline_dayflow.dayflow_events",
       "rows": [
-        {"event": "timeline_viewed", "provider": "localFoundation", "mode": "day", "result": "shown", "events": 7, "devices": 3, "first_seen": "2026-06-18T00:10:00Z", "last_seen": "2026-06-19T12:00:00Z"}
+        {"event": "timeline_card_opened", "provider_kind": null, "surface": "home", "card_kind": "daily_digest", "result": "success", "events": 7, "devices": 3, "first_seen": "2026-06-18T00:10:00Z", "last_seen": "2026-06-19T12:00:00Z"}
       ]
     },
     {
       "id": "timeline_dayflow.data_quality",
       "rows": [
-        {"event": "timeline_batch_completed", "provider": "localFoundation", "failure_kind": null, "events": 5, "devices": 3}
+        {"event": "timeline_card_generated", "provider_kind": "local_foundation", "permission_state": null, "card_kind": "daily_digest", "result": "success", "events": 5, "devices": 3}
       ]
     },
     {

--- a/Tests/Fixtures/posthog-observed-event-taxonomy.json
+++ b/Tests/Fixtures/posthog-observed-event-taxonomy.json
@@ -1,0 +1,144 @@
+{
+  "observed_events": [
+    {
+      "event": "activation_first_artifact_saved",
+      "events": 41,
+      "devices": 29,
+      "first_seen": "2026-06-20T09:12:00Z",
+      "last_seen": "2026-06-28T18:42:00Z"
+    },
+    {
+      "event": "activation_second_artifact_saved",
+      "events": 19,
+      "devices": 13,
+      "first_seen": "2026-06-20T12:10:00Z",
+      "last_seen": "2026-06-28T19:02:00Z"
+    },
+    {
+      "event": "dictation_artifact_saved",
+      "events": 52,
+      "devices": 31,
+      "first_seen": "2026-06-20T09:14:00Z",
+      "last_seen": "2026-06-28T18:43:00Z"
+    },
+    {
+      "event": "activation_artifact_action_clicked",
+      "events": 27,
+      "devices": 17,
+      "first_seen": "2026-06-21T10:22:00Z",
+      "last_seen": "2026-06-28T17:10:00Z"
+    },
+    {
+      "event": "workflow_recovery_attempted",
+      "events": 8,
+      "devices": 6,
+      "first_seen": "2026-06-22T15:20:00Z",
+      "last_seen": "2026-06-28T16:02:00Z"
+    },
+    {
+      "event": "workflow_recovery_finished",
+      "events": 7,
+      "devices": 5,
+      "first_seen": "2026-06-22T15:21:00Z",
+      "last_seen": "2026-06-28T16:04:00Z"
+    },
+    {
+      "event": "activation_agent_prompt_action_clicked",
+      "events": 22,
+      "devices": 14,
+      "first_seen": "2026-06-21T11:00:00Z",
+      "last_seen": "2026-06-28T19:10:00Z"
+    },
+    {
+      "event": "activation_agent_setup_cta_clicked",
+      "events": 11,
+      "devices": 8,
+      "first_seen": "2026-06-21T11:03:00Z",
+      "last_seen": "2026-06-28T13:05:00Z"
+    },
+    {
+      "event": "agent_capture_query_observed",
+      "events": 15,
+      "devices": 9,
+      "first_seen": "2026-06-22T12:33:00Z",
+      "last_seen": "2026-06-28T20:25:00Z"
+    },
+    {
+      "event": "activation_habit_loop_actioned",
+      "events": 16,
+      "devices": 10,
+      "first_seen": "2026-06-23T08:15:00Z",
+      "last_seen": "2026-06-28T08:40:00Z"
+    },
+    {
+      "event": "activation_return_proxy_observed",
+      "events": 24,
+      "devices": 15,
+      "first_seen": "2026-06-22T08:11:00Z",
+      "last_seen": "2026-06-28T08:55:00Z"
+    },
+    {
+      "event": "meeting_prompt_shown",
+      "events": 33,
+      "devices": 20,
+      "first_seen": "2026-06-20T17:15:00Z",
+      "last_seen": "2026-06-28T18:05:00Z"
+    },
+    {
+      "event": "meeting_prompt_choice_made",
+      "events": 18,
+      "devices": 12,
+      "first_seen": "2026-06-20T17:16:00Z",
+      "last_seen": "2026-06-28T18:06:00Z"
+    },
+    {
+      "event": "meeting_prompt_record_selected",
+      "events": 14,
+      "devices": 10,
+      "first_seen": "2026-06-20T17:16:10Z",
+      "last_seen": "2026-06-28T18:06:15Z"
+    },
+    {
+      "event": "meeting_prompt_outcome_recorded",
+      "events": 12,
+      "devices": 9,
+      "first_seen": "2026-06-20T17:20:00Z",
+      "last_seen": "2026-06-28T18:30:00Z"
+    },
+    {
+      "event": "meeting_prompt_dismissed",
+      "events": 9,
+      "devices": 7,
+      "first_seen": "2026-06-20T18:10:00Z",
+      "last_seen": "2026-06-28T19:01:00Z"
+    },
+    {
+      "event": "meeting_prompt_suppressed",
+      "events": 6,
+      "devices": 5,
+      "first_seen": "2026-06-21T09:10:00Z",
+      "last_seen": "2026-06-28T10:22:00Z"
+    },
+    {
+      "event": "onboarding_completed",
+      "events": 28,
+      "devices": 28,
+      "first_seen": "2026-06-20T09:00:00Z",
+      "last_seen": "2026-06-28T21:00:00Z"
+    },
+    {
+      "event": "product_friction_observed",
+      "events": 10,
+      "devices": 8,
+      "first_seen": "2026-06-21T14:00:00Z",
+      "last_seen": "2026-06-28T15:00:00Z"
+    },
+    {
+      "event": "workflow_abandoned",
+      "events": 7,
+      "devices": 6,
+      "first_seen": "2026-06-21T14:10:00Z",
+      "last_seen": "2026-06-28T15:10:00Z"
+    }
+  ]
+}

--- a/docs/posthog-dashboard-query-helpers.md
+++ b/docs/posthog-dashboard-query-helpers.md
@@ -13,7 +13,7 @@ It covers ten dashboard families:
 - `speaker_trust` - speaker review, auto-recognition, corrections, deferrals, and finalization failures
 - `retry_recovery` - workflow retry/recovery, failure kinds, and dictation latency buckets
 - `onboarding_friction` - first-run steps, permission readiness, dismissals, abandonment, and product friction
-- `timeline_dayflow` - planned timeline/dayflow adoption and data-quality rows when those events ship
+- `timeline_dayflow` - shipped timeline/dayflow adoption and data-quality rows from the allowlisted timeline taxonomy
 - `release_health` - release-scoped workflow and Sparkle update health
 
 All query outputs are aggregate, bucketed, and privacy-safe. The helpers do not
@@ -56,6 +56,19 @@ Run the offline CI/self-test path:
 
 ```bash
 python3 scripts/ops/posthog-dashboard-queries.py --self-test
+```
+
+Compare observed/live event names against the checked-in allowlist without
+exporting user rows:
+
+```bash
+python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --days 30
+```
+
+Run the same event-name check against a synthetic aggregate fixture:
+
+```bash
+python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --observed-fixture Tests/Fixtures/posthog-observed-event-taxonomy.json --json-only
 ```
 
 Render synthetic fixture rows without credentials:
@@ -127,6 +140,11 @@ The JSON shape is stable:
 Health checks should treat missing live credentials as an environment gap, not
 as a product analytics failure. Use `--dry-run` or `--fixture` in CI.
 
+For taxonomy checks, the JSON shape includes `unknown_events`,
+`required_taxonomy_events`, `observed_required_taxonomy_events`, and
+`observed_events`. `observed_events` is aggregate-only: event name, count,
+anonymous device count, and first/last seen timestamps.
+
 ## Dashboard Family Notes
 
 `100_wau` uses active workflow and first-value events, not launch alone. That
@@ -166,9 +184,9 @@ raw error strings, device names, app names, or audio details.
 `onboarding_friction` tracks step, permission, abandonment, and product-friction
 buckets only.
 
-`timeline_dayflow` is intentionally separate because timeline analytics may be
-empty until that surface ships. It must not export screen text, screenshots, app
-names, file paths, or raw timeline rows.
+`timeline_dayflow` is intentionally separate because timeline analytics can be
+sparse. It must not export screen text, screenshots, app names, file paths, or
+raw timeline rows.
 
 `release_health` accepts `--app-version`. Workflow events use `app_version`;
 update events use `version`, so the helper filters both.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,6 +76,8 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Dry-run specs: `python3 scripts/ops/posthog-dashboard-queries.py --dry-run`
   - One family: `python3 scripts/ops/posthog-dashboard-queries.py --family activation --dry-run`
   - Live aggregate query: `python3 scripts/ops/posthog-dashboard-queries.py --family 100_wau --days 30`
+  - Live taxonomy check: `python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --days 30`
+  - Fixture taxonomy check: `python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --observed-fixture Tests/Fixtures/posthog-observed-event-taxonomy.json --json-only`
   - CI/offline proof: `python3 scripts/ops/posthog-dashboard-queries.py --self-test`
   - Machine output for health agents: `python3 scripts/ops/posthog-dashboard-queries.py --family all --json-only`
 - `scripts/ops/posthog-product-dashboard-summary.py` — turn the five PostHog product-learning dashboard families into ranked product tasks

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -191,10 +191,11 @@ if [ -n "$changed_paths" ]; then
             add_command "python3 scripts/ops/posthog-product-context-pack.py --fixture Tests/Fixtures/posthog-product-context-pack-fixture.json --write-dir build/posthog-product-context-sample"
         fi
 
-        if matches_any "$path" "scripts/ops/posthog-dashboard-queries.py" "Tests/Fixtures/posthog-dashboard-query-results.json" "docs/posthog-dashboard-query-helpers.md"; then
+        if matches_any "$path" "scripts/ops/posthog-dashboard-queries.py" "Tests/Fixtures/posthog-dashboard-query-results.json" "Tests/Fixtures/posthog-observed-event-taxonomy.json" "docs/posthog-dashboard-query-helpers.md"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "python3 -m py_compile scripts/ops/posthog-dashboard-queries.py"
             add_command "python3 scripts/ops/posthog-dashboard-queries.py --self-test"
+            add_command "python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --observed-fixture Tests/Fixtures/posthog-observed-event-taxonomy.json --json-only"
         fi
 
         if matches_any "$path" "scripts/ops/nightly-security-check.py"; then

--- a/scripts/ops/posthog-dashboard-queries.py
+++ b/scripts/ops/posthog-dashboard-queries.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -149,14 +150,15 @@ ONBOARDING_FRICTION_EVENTS = (
 )
 
 TIMELINE_DAYFLOW_EVENTS = (
-    "timeline_onboarding_completed",
-    "timeline_viewed",
-    "timeline_mode_changed",
+    "timeline_enabled",
+    "timeline_screen_permission_ready",
+    "timeline_screen_permission_denied",
+    "timeline_capture_paused",
+    "timeline_capture_resumed",
+    "timeline_card_generated",
     "timeline_card_opened",
-    "timeline_provider_selected",
-    "timeline_chat_question_asked",
-    "timeline_batch_completed",
-    "timeline_batch_failed",
+    "timeline_daily_markdown_written",
+    "timeline_used_again",
 )
 
 RELEASE_EVENTS = (
@@ -190,6 +192,34 @@ DISALLOWED_OUTPUT_FRAGMENTS = (
 )
 
 FIXTURE_PATH = Path("Tests/Fixtures/posthog-dashboard-query-results.json")
+OBSERVED_FIXTURE_PATH = Path("Tests/Fixtures/posthog-observed-event-taxonomy.json")
+ANALYTICS_EVENTS_PATH = Path("Resources/analytics-events.psv")
+
+EVENT_LITERAL_RE = re.compile(r"\b(?:event|e\.event)\s*=\s*'([a-z][a-z0-9_]+)'|\b(?:event|e\.event)\s+IN\s*\(([^)]*)\)")
+STRING_LITERAL_RE = re.compile(r"'([^']+)'")
+
+REQUIRED_TAXONOMY_EVENTS = (
+    "activation_first_artifact_saved",
+    "activation_second_artifact_saved",
+    "dictation_artifact_saved",
+    "activation_artifact_action_clicked",
+    "workflow_recovery_attempted",
+    "workflow_recovery_finished",
+    "activation_agent_prompt_action_clicked",
+    "activation_agent_setup_cta_clicked",
+    "agent_capture_query_observed",
+    "activation_habit_loop_actioned",
+    "activation_return_proxy_observed",
+    "meeting_prompt_shown",
+    "meeting_prompt_choice_made",
+    "meeting_prompt_record_selected",
+    "meeting_prompt_outcome_recorded",
+    "meeting_prompt_dismissed",
+    "meeting_prompt_suppressed",
+    "onboarding_completed",
+    "product_friction_observed",
+    "workflow_abandoned",
+)
 
 
 @dataclass(frozen=True)
@@ -863,13 +893,14 @@ LIMIT 80
             id="timeline_dayflow.dayflow_events",
             family="timeline_dayflow",
             title="Timeline Dayflow adoption",
-            description="Queries planned timeline/dayflow analytics by coarse timeline action buckets when those events are present.",
-            columns=("event", "provider", "mode", "result", "events", "devices", "first_seen", "last_seen"),
+            description="Queries shipped timeline/dayflow analytics by coarse provider, surface, card, and result buckets when those events are present.",
+            columns=("event", "provider_kind", "surface", "card_kind", "result", "events", "devices", "first_seen", "last_seen"),
             sql=f"""
 SELECT
   event,
-  properties['provider'] AS provider,
-  properties['mode'] AS mode,
+  properties['provider_kind'] AS provider_kind,
+  properties['surface'] AS surface,
+  properties['card_kind'] AS card_kind,
   properties['result'] AS result,
   count() AS events,
   uniq(distinct_id) AS devices,
@@ -879,30 +910,32 @@ FROM events
 WHERE timestamp >= now() - INTERVAL {days} DAY
   AND {event_filter(TIMELINE_DAYFLOW_EVENTS)}
   {app_version_filter(app_version)}
-GROUP BY event, provider, mode, result
+GROUP BY event, provider_kind, surface, card_kind, result
 ORDER BY events DESC
 LIMIT 80
 """,
-            notes=("These rows may be empty until timeline analytics ship; keep this family separate from shipped release health.",),
+            notes=("Keep this family separate from shipped release health; Dayflow rows can be sparse by design.",),
         ),
         QuerySpec(
             id="timeline_dayflow.data_quality",
             family="timeline_dayflow",
             title="Timeline Dayflow data quality",
-            description="Counts timeline batch completions/failures by provider/result without screen text, screenshots, app names, or paths.",
-            columns=("event", "provider", "failure_kind", "events", "devices"),
+            description="Counts timeline enablement, screen permission, card generation, and markdown write outcomes without screen text, screenshots, app names, or paths.",
+            columns=("event", "provider_kind", "permission_state", "card_kind", "result", "events", "devices"),
             sql=f"""
 SELECT
   event,
-  properties['provider'] AS provider,
-  properties['failure_kind'] AS failure_kind,
+  properties['provider_kind'] AS provider_kind,
+  properties['permission_state'] AS permission_state,
+  properties['card_kind'] AS card_kind,
+  properties['result'] AS result,
   count() AS events,
   uniq(distinct_id) AS devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {days} DAY
-  AND event IN ('timeline_batch_completed', 'timeline_batch_failed')
+  AND event IN ('timeline_enabled', 'timeline_screen_permission_ready', 'timeline_screen_permission_denied', 'timeline_card_generated', 'timeline_daily_markdown_written')
   {app_version_filter(app_version)}
-GROUP BY event, provider, failure_kind
+GROUP BY event, provider_kind, permission_state, card_kind, result
 ORDER BY events DESC
 LIMIT 50
 """,
@@ -992,6 +1025,58 @@ def unsafe_columns(columns: list[str] | tuple[str, ...]) -> list[str]:
     ]
 
 
+def load_allowed_events(path: Path = ANALYTICS_EVENTS_PATH) -> set[str]:
+    if not path.is_absolute():
+        path = Path(__file__).resolve().parents[2] / path
+    allowed: set[str] = set()
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        event_name = line.split("|", 1)[0].strip()
+        if event_name:
+            allowed.add(event_name)
+    return allowed
+
+
+def sql_event_literals(sql: str) -> set[str]:
+    events: set[str] = set()
+    for match in EVENT_LITERAL_RE.finditer(sql):
+        single, in_list = match.groups()
+        if single:
+            events.add(single)
+        if in_list:
+            events.update(STRING_LITERAL_RE.findall(in_list))
+    return events
+
+
+def referenced_events(specs: list[QuerySpec]) -> set[str]:
+    events: set[str] = set()
+    for spec in specs:
+        events.update(sql_event_literals(spec.sql))
+    return events
+
+
+def event_taxonomy_errors(
+    specs: list[QuerySpec],
+    allowed_events: set[str],
+    require_required_coverage: bool,
+) -> list[str]:
+    errors: list[str] = []
+    referenced = referenced_events(specs)
+    missing = sorted(referenced - allowed_events)
+    if missing:
+        errors.append("query catalog references event(s) outside analytics-events.psv: " + ", ".join(missing))
+    missing_required = sorted(event for event in REQUIRED_TAXONOMY_EVENTS if event not in allowed_events)
+    if missing_required:
+        errors.append("required product-learning event(s) missing from analytics-events.psv: " + ", ".join(missing_required))
+    if require_required_coverage:
+        unqueried_required = sorted(event for event in REQUIRED_TAXONOMY_EVENTS if event not in referenced)
+        if unqueried_required:
+            errors.append("required product-learning event(s) missing from dashboard query catalog: " + ", ".join(unqueried_required))
+    return errors
+
+
 def spec_payload(specs: list[QuerySpec], days: int, app_version: str | None) -> dict[str, Any]:
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -1046,6 +1131,83 @@ def execute_payload(specs: list[QuerySpec], days: int, app_version: str | None) 
         "families": sorted({spec.family for spec in specs}),
         "queries": queries,
     }
+
+
+def observed_events_query(days: int, app_version: str | None) -> str:
+    return f"""
+SELECT
+  event,
+  count() AS events,
+  uniq(distinct_id) AS devices,
+  min(timestamp) AS first_seen,
+  max(timestamp) AS last_seen
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  {app_version_filter(app_version)}
+GROUP BY event
+ORDER BY event ASC
+LIMIT 1000
+"""
+
+
+def observed_event_rows_from_response(response: dict[str, Any]) -> list[dict[str, Any]]:
+    return posthog.rows_as_dicts(
+        response,
+        DISALLOWED_OUTPUT_FRAGMENTS,
+        PostHogDashboardError,
+        declared_columns=("event", "events", "devices", "first_seen", "last_seen"),
+    )
+
+
+def observed_event_rows_from_fixture(path: Path) -> list[dict[str, Any]]:
+    fixture = load_fixture(path)
+    rows = fixture.get("observed_events")
+    if rows is None:
+        rows = fixture.get("events")
+    if not isinstance(rows, list):
+        raise PostHogDashboardError(f"observed-event fixture must contain an observed_events array: {path}")
+    for row in rows:
+        if not isinstance(row, dict) or not row.get("event"):
+            raise PostHogDashboardError(f"observed-event fixture row is missing event: {row!r}")
+    return rows
+
+
+def observed_taxonomy_payload(
+    rows: list[dict[str, Any]],
+    days: int,
+    app_version: str | None,
+    mode: str,
+) -> dict[str, Any]:
+    allowed_events = load_allowed_events()
+    unknown = sorted({str(row.get("event")) for row in rows if str(row.get("event")) not in allowed_events})
+    required_present = sorted(event for event in REQUIRED_TAXONOMY_EVENTS if event in allowed_events)
+    observed_required = sorted(event for event in required_present if any(row.get("event") == event for row in rows))
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "mode": mode,
+        "window_days": days,
+        "app_version": app_version,
+        "source": {
+            "kind": "fixture_observed_event_aggregates" if mode == "fixture" else "posthog_hogql_event_name_aggregates",
+        },
+        "privacy": "Observed-event taxonomy checks use aggregate event-name rows only: event name, event count, anonymous device count, and first/last seen timestamps. They never request people rows, distinct IDs, transcripts, audio references, titles, paths, URLs, emails, or tokens.",
+        "allowed_event_count": len(allowed_events),
+        "observed_event_count": len({str(row.get("event")) for row in rows}),
+        "unknown_events": unknown,
+        "required_taxonomy_events": required_present,
+        "observed_required_taxonomy_events": observed_required,
+        "observed_events": rows,
+    }
+
+
+def execute_taxonomy_payload(days: int, app_version: str | None) -> dict[str, Any]:
+    load_env()
+    host, project_id, token = posthog_config()
+    response = run_hogql(host, project_id, token, observed_events_query(days, app_version))
+    payload = observed_taxonomy_payload(observed_event_rows_from_response(response), days, app_version, "live")
+    payload["source"]["host"] = host
+    payload["source"]["project"] = "configured PostHog project"
+    return payload
 
 
 def clean_sql(sql: str) -> str:
@@ -1117,6 +1279,58 @@ def render_markdown(payload: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def render_taxonomy_markdown(payload: dict[str, Any]) -> str:
+    unknown = payload.get("unknown_events") or []
+    rows = payload.get("observed_events") or []
+    required_observed = set(payload.get("observed_required_taxonomy_events") or [])
+    required_rows = [
+        [
+            event,
+            "observed" if event in required_observed else "not observed",
+        ]
+        for event in payload.get("required_taxonomy_events") or []
+    ]
+    event_rows = [
+        [
+            row.get("event"),
+            row.get("events"),
+            row.get("devices"),
+            row.get("first_seen"),
+            row.get("last_seen"),
+        ]
+        for row in rows[:80]
+    ]
+    lines = [
+        "# Transcripted PostHog Observed Event Taxonomy Check",
+        "",
+        f"Generated: {payload['generated_at']}",
+        f"Mode: {payload['mode']}",
+        f"Window: last {payload['window_days']} days",
+        f"App version: {payload.get('app_version') or 'all app versions'}",
+        "",
+        payload["privacy"],
+        "",
+        f"Allowed events: {payload['allowed_event_count']}",
+        f"Observed events: {payload['observed_event_count']}",
+        f"Unknown observed events: {len(unknown)}",
+        "",
+    ]
+    if unknown:
+        lines.extend(["## Unknown Observed Events", "", md_table(["event"], [[event] for event in unknown]), ""])
+    else:
+        lines.extend(["No unknown observed event names.", ""])
+    lines.extend(["## Recently Merged Product-Learning Events", "", md_table(["event", "fixture/live status"], required_rows), ""])
+    if event_rows:
+        lines.extend(["## Observed Event Aggregates", "", md_table(["event", "events", "devices", "first_seen", "last_seen"], event_rows), ""])
+    return "\n".join(lines)
+
+
+def render_payload(payload: dict[str, Any]) -> str:
+    if "unknown_events" in payload:
+        return render_taxonomy_markdown(payload)
+    return render_markdown(payload)
+
+
 def write_outputs(payload: dict[str, Any], markdown: str, write_dir: Path | None) -> tuple[Path, Path]:
     output_dir = write_dir or Path("/tmp/transcripted-posthog-dashboard-queries") / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1163,6 +1377,7 @@ def fixture_payload(path: Path, family: str, days: int, app_version: str | None)
 
 def validate_specs(specs: list[QuerySpec], require_all_families: bool = False) -> list[str]:
     errors: list[str] = []
+    allowed_events = load_allowed_events()
     seen: set[str] = set()
     for spec in specs:
         if spec.id in seen:
@@ -1180,6 +1395,7 @@ def validate_specs(specs: list[QuerySpec], require_all_families: bool = False) -
         missing = sorted(set(FAMILIES) - {spec.family for spec in specs})
         if missing:
             errors.append("missing family specs: " + ", ".join(missing))
+    errors.extend(event_taxonomy_errors(specs, allowed_events, require_required_coverage=require_all_families))
     return errors
 
 
@@ -1191,6 +1407,23 @@ def run_self_test() -> int:
     except PostHogDashboardError as exc:
         errors.append(str(exc))
         payload = {"queries": []}
+    try:
+        taxonomy_payload = observed_taxonomy_payload(
+            observed_event_rows_from_fixture(OBSERVED_FIXTURE_PATH),
+            30,
+            "1.1.48",
+            "fixture",
+        )
+        if taxonomy_payload["unknown_events"]:
+            errors.append("observed-event fixture contains event(s) outside analytics-events.psv: " + ", ".join(taxonomy_payload["unknown_events"]))
+        if "agent_capture_query_observed" not in taxonomy_payload["observed_required_taxonomy_events"]:
+            errors.append("observed-event fixture should include agent_capture_query_observed")
+        if "workflow_recovery_finished" not in taxonomy_payload["observed_required_taxonomy_events"]:
+            errors.append("observed-event fixture should include workflow_recovery_finished")
+        if "meeting_prompt_outcome_recorded" not in taxonomy_payload["observed_required_taxonomy_events"]:
+            errors.append("observed-event fixture should include meeting_prompt_outcome_recorded")
+    except PostHogDashboardError as exc:
+        errors.append(str(exc))
     fallback_rows = posthog.rows_as_dicts(
         {"results": [["2026-06-18", 24]]},
         DISALLOWED_OUTPUT_FRAGMENTS,
@@ -1236,6 +1469,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--app-version", help="Optional app_version/version filter, e.g. 1.1.48.")
     parser.add_argument("--dry-run", action="store_true", help="Print query specs without requiring PostHog credentials.")
     parser.add_argument("--fixture", type=Path, help="Render synthetic fixture rows instead of querying PostHog.")
+    parser.add_argument("--taxonomy-check", action="store_true", help="Compare observed PostHog event names against Resources/analytics-events.psv.")
+    parser.add_argument("--observed-fixture", type=Path, help="Run --taxonomy-check against a synthetic observed-event aggregate fixture.")
     parser.add_argument("--json-only", action="store_true", help="Print JSON instead of Markdown.")
     parser.add_argument("--write-dir", type=Path, help="Directory for posthog-dashboard-queries.md/json outputs.")
     parser.add_argument("--self-test", action="store_true", help="Run offline fixture/spec/privacy checks.")
@@ -1250,26 +1485,39 @@ def main() -> int:
         print("ERROR: --days must be positive", file=sys.stderr)
         return 2
 
-    specs = selected_specs(args.family, args.days, args.app_version)
-    if not specs:
-        print("ERROR: no query specs selected", file=sys.stderr)
-        return 2
-
     try:
-        spec_errors = validate_specs(specs)
-        if spec_errors:
-            raise PostHogDashboardError("; ".join(spec_errors))
-        if args.fixture:
-            payload = fixture_payload(args.fixture, args.family, args.days, args.app_version)
-        elif args.dry_run:
-            payload = spec_payload(specs, args.days, args.app_version)
+        if args.taxonomy_check:
+            if args.observed_fixture:
+                payload = observed_taxonomy_payload(
+                    observed_event_rows_from_fixture(args.observed_fixture),
+                    args.days,
+                    args.app_version,
+                    "fixture",
+                )
+            else:
+                payload = execute_taxonomy_payload(args.days, args.app_version)
+            if payload["unknown_events"]:
+                raise PostHogDashboardError("observed event(s) outside analytics-events.psv: " + ", ".join(payload["unknown_events"]))
         else:
-            payload = execute_payload(specs, args.days, args.app_version)
+            specs = selected_specs(args.family, args.days, args.app_version)
+            if not specs:
+                print("ERROR: no query specs selected", file=sys.stderr)
+                return 2
+
+            spec_errors = validate_specs(specs)
+            if spec_errors:
+                raise PostHogDashboardError("; ".join(spec_errors))
+            if args.fixture:
+                payload = fixture_payload(args.fixture, args.family, args.days, args.app_version)
+            elif args.dry_run:
+                payload = spec_payload(specs, args.days, args.app_version)
+            else:
+                payload = execute_payload(specs, args.days, args.app_version)
     except PostHogDashboardError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 3
 
-    markdown = render_markdown(payload)
+    markdown = render_payload(payload)
     if args.write_dir:
         markdown_path, json_path = write_outputs(payload, markdown, args.write_dir)
     else:


### PR DESCRIPTION
## Summary
- add an observed-event taxonomy mode to `posthog-dashboard-queries.py` that compares aggregate PostHog event names against `Resources/analytics-events.psv`
- add a synthetic observed-event fixture covering artifact usefulness, recovery outcome, agent payoff, habit loop, meeting prompt quality, and onboarding friction/exit surfaces
- align the timeline dashboard query family with the current allowlisted timeline taxonomy and document the new live/fixture checks

## Verification
- `scripts/dev/agent-preflight.sh`
- `python3 -m py_compile scripts/ops/posthog-dashboard-queries.py`
- `python3 scripts/ops/posthog-dashboard-queries.py --self-test`
- `python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --observed-fixture Tests/Fixtures/posthog-observed-event-taxonomy.json --json-only` -> unknown_events=[]
- `python3 scripts/ops/posthog-dashboard-queries.py --family 100_wau --dry-run --json-only`
- live `python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --days 30 --json-only` -> observed_event_count=64, unknown_events=[]
- independent review: Claude via maestro-delegate, no findings, MAESTRO_PROOF=/Users/redbars/.codex/maestro/runs/20260704T115953Z-posthog-taxonomy-selftest-review-claude

## Notes
- Focused `bash run-tests.sh --filter AnalyticsEventPolicyTests.swift` did not complete; it hung at "Compiling tests..." for several minutes and was interrupted. No Swift source changed in this PR.

lanes used: Codex=implemented, tested, live PostHog aggregate taxonomy check, committed/pushed/opened PR; Claude=independent diff review via maestro-delegate proof path above; Local=skipped unavailable; Windows=skipped unavailable