### PR TITLE
Validate meeting prompt telemetry paths

### DIFF
--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -1530,6 +1530,46 @@ func testAnalyticsEventPolicy() {
         assertNil(privatePromptFields["transcript_text"], "transcript text must not be sent")
     }
 
+    runSuite("AnalyticsEventPolicy pins meeting prompt telemetry firing paths") {
+        let appSource = readAnalyticsPolicyRepoTextFile("Sources/TranscriptedApp.swift")
+        let meetingSessionSource = readAnalyticsPolicyRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+
+        assertEqual(
+            analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_shown\"", in: appSource),
+            1,
+            "shown telemetry should fire once, only after the detected prompt is actually presented"
+        )
+        assertEqual(
+            analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_record_selected\"", in: appSource),
+            1,
+            "selected telemetry should fire once on the explicit record choice"
+        )
+        assertEqual(
+            analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_suppressed\"", in: appSource),
+            1,
+            "suppression telemetry should fire once from the detector suppression hook"
+        )
+        assertEqual(
+            analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_choice_made\"", in: appSource),
+            4,
+            "choice telemetry should cover record, dismiss, remind-later, and expiry actions without counting shown inventory"
+        )
+        assertEqual(
+            analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_outcome_recorded\"", in: appSource),
+            2,
+            "app-level outcomes should cover ignored expiry and pre-prompt suppression only"
+        )
+        assertEqual(
+            analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_outcome_recorded\"", in: meetingSessionSource),
+            2,
+            "session-level outcomes should stay centralized for start/save/fail terminal recording results"
+        )
+        assertTrue(
+            meetingSessionSource.contains("guard let properties = promptProperties else { return }"),
+            "manual and hotkey meetings must not inherit stale detected-prompt properties"
+        )
+    }
+
     runSuite("AnalyticsEventPolicy keeps mic boost prompt events narrow") {
         let shown = AnalyticsEventPolicy.policy(forEvent: "meeting_mic_boost_prompt_shown")
         let actioned = AnalyticsEventPolicy.policy(forEvent: "meeting_mic_boost_prompt_actioned")
@@ -1564,6 +1604,17 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["trigger"], "hotkey", "trigger enum should survive sanitization")
         assertNil(sanitized["app_name"], "unallowlisted properties must be dropped")
     }
+}
+
+private func analyticsPolicyOccurrenceCount(of needle: String, in haystack: String) -> Int {
+    guard !needle.isEmpty else { return 0 }
+    var count = 0
+    var searchRange = haystack.startIndex..<haystack.endIndex
+    while let range = haystack.range(of: needle, range: searchRange) {
+        count += 1
+        searchRange = range.upperBound..<haystack.endIndex
+    }
+    return count
 }
 
 private func readAnalyticsPolicyRepoTextFile(_ relativePath: String) -> String {

--- a/Tests/Fixtures/posthog-dashboard-query-results.json
+++ b/Tests/Fixtures/posthog-dashboard-query-results.json
@@ -55,8 +55,8 @@
     {
       "id": "meeting_prompt_quality.prompt_outcomes",
       "rows": [
-        {"provider": "zoom", "source": "active_call", "prompt_reason": "call_detected", "route_ready": true, "choice_kind": null, "outcome_kind": null, "elapsed_bucket": null, "shown_events": 12, "choice_events": 0, "record_selected_events": 5, "outcome_events": 0, "dismissed_events": 3, "suppressed_events": 1, "missed_call_nudges": 2, "devices": 9},
-        {"provider": "zoom", "source": "runtime_app", "prompt_reason": "call_detected", "route_ready": "true", "choice_kind": "record", "outcome_kind": "transcript_saved", "elapsed_bucket": "10_29s", "shown_events": 0, "choice_events": 8, "record_selected_events": 0, "outcome_events": 6, "dismissed_events": 0, "suppressed_events": 0, "missed_call_nudges": 0, "devices": 5}
+        {"provider": "zoom", "source": "runtime_app", "prompt_reason": "mic_input", "route_ready": "true", "choice_kind": null, "outcome_kind": null, "elapsed_bucket": null, "shown_events": 12, "choice_events": 0, "record_selected_events": 5, "outcome_events": 0, "dismissed_events": 3, "suppressed_events": 1, "missed_call_nudges": 2, "devices": 9},
+        {"provider": "zoom", "source": "runtime_app", "prompt_reason": "mic_input", "route_ready": "true", "choice_kind": "record", "outcome_kind": "transcript_saved", "elapsed_bucket": "10_29s", "shown_events": 0, "choice_events": 8, "record_selected_events": 0, "outcome_events": 6, "dismissed_events": 0, "suppressed_events": 0, "missed_call_nudges": 0, "devices": 5}
       ]
     },
     {

--- a/Tests/Fixtures/posthog-product-dashboard-summary.json
+++ b/Tests/Fixtures/posthog-product-dashboard-summary.json
@@ -225,15 +225,20 @@
     ],
     "meeting_prompt_quality": [
       {
+        "choice_events": 3,
+        "choice_kind": "record",
         "devices": 4,
         "dismissed_events": 2,
+        "elapsed_bucket": "10_29s",
         "missed_call_nudges": 1,
-        "prompt_reason": "call_detected",
+        "outcome_events": 2,
+        "outcome_kind": "transcript_saved",
+        "prompt_reason": "mic_input",
         "provider": "zoom",
         "record_selected_events": 3,
-        "route_ready": true,
+        "route_ready": "true",
         "shown_events": 6,
-        "source": "active_call",
+        "source": "runtime_app",
         "suppressed_events": 1
       }
     ],

--- a/scripts/ops/posthog-activation-funnel.py
+++ b/scripts/ops/posthog-activation-funnel.py
@@ -431,17 +431,22 @@ SELECT
   properties['source'] AS source,
   properties['prompt_reason'] AS prompt_reason,
   properties['route_ready'] AS route_ready,
+  properties['choice_kind'] AS choice_kind,
+  properties['outcome_kind'] AS outcome_kind,
+  properties['elapsed_bucket'] AS elapsed_bucket,
   countIf(event = 'meeting_prompt_shown') AS shown_events,
+  countIf(event = 'meeting_prompt_choice_made') AS choice_events,
   countIf(event = 'meeting_prompt_record_selected') AS record_selected_events,
+  countIf(event = 'meeting_prompt_outcome_recorded') AS outcome_events,
   countIf(event = 'meeting_prompt_dismissed') AS dismissed_events,
   countIf(event = 'meeting_prompt_suppressed') AS suppressed_events,
   countIf(event = 'meeting_missed_call_nudge') AS missed_call_nudges,
   uniq(distinct_id) AS devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
-  AND event IN ('meeting_prompt_shown', 'meeting_prompt_record_selected', 'meeting_prompt_dismissed', 'meeting_prompt_suppressed', 'meeting_missed_call_nudge')
+  AND event IN ('meeting_prompt_shown', 'meeting_prompt_choice_made', 'meeting_prompt_record_selected', 'meeting_prompt_outcome_recorded', 'meeting_prompt_dismissed', 'meeting_prompt_suppressed', 'meeting_missed_call_nudge')
   {app_version_filter(app_version)}
-GROUP BY provider, source, prompt_reason, route_ready
+GROUP BY provider, source, prompt_reason, route_ready, choice_kind, outcome_kind, elapsed_bucket
 ORDER BY shown_events DESC, devices DESC
 LIMIT 40
 """
@@ -798,7 +803,7 @@ def render_report(data: dict[str, Any]) -> str:
         render_top_rows(
             "Meeting Prompt Quality",
             data["results"].get("meeting_prompt_quality", []),
-            ["provider", "source", "prompt_reason", "route_ready", "shown_events", "record_selected_events", "dismissed_events", "suppressed_events", "missed_call_nudges", "devices"],
+            ["provider", "source", "prompt_reason", "route_ready", "choice_kind", "outcome_kind", "elapsed_bucket", "shown_events", "choice_events", "record_selected_events", "outcome_events", "dismissed_events", "suppressed_events", "missed_call_nudges", "devices"],
         ),
         render_top_rows(
             "Speaker Trust",

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -253,17 +253,22 @@ SELECT
   properties['source'] AS source,
   properties['prompt_reason'] AS prompt_reason,
   properties['route_ready'] AS route_ready,
+  properties['choice_kind'] AS choice_kind,
+  properties['outcome_kind'] AS outcome_kind,
+  properties['elapsed_bucket'] AS elapsed_bucket,
   countIf(event = 'meeting_prompt_shown') AS shown_events,
+  countIf(event = 'meeting_prompt_choice_made') AS choice_events,
   countIf(event = 'meeting_prompt_record_selected') AS record_selected_events,
+  countIf(event = 'meeting_prompt_outcome_recorded') AS outcome_events,
   countIf(event = 'meeting_prompt_dismissed') AS dismissed_events,
   countIf(event = 'meeting_prompt_suppressed') AS suppressed_events,
   countIf(event = 'meeting_missed_call_nudge') AS missed_call_nudges,
   uniq(distinct_id) AS devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
-  AND event IN ('meeting_prompt_shown', 'meeting_prompt_record_selected', 'meeting_prompt_dismissed', 'meeting_prompt_suppressed', 'meeting_missed_call_nudge')
+  AND event IN ('meeting_prompt_shown', 'meeting_prompt_choice_made', 'meeting_prompt_record_selected', 'meeting_prompt_outcome_recorded', 'meeting_prompt_dismissed', 'meeting_prompt_suppressed', 'meeting_missed_call_nudge')
   {app_version_filter(app_version)}
-GROUP BY provider, source, prompt_reason, route_ready
+GROUP BY provider, source, prompt_reason, route_ready, choice_kind, outcome_kind, elapsed_bucket
 ORDER BY shown_events DESC, devices DESC
 LIMIT 50
 """
@@ -617,7 +622,14 @@ def build_under_discovered_feature(data: dict[str, Any]) -> Finding:
 def build_prompt_quality(data: dict[str, Any]) -> Finding:
     rows = data["results"].get("meeting_prompt_quality", [])
     shown = sum(as_int(row.get("shown_events")) for row in rows)
-    accepted = sum(as_int(row.get("record_selected_events")) for row in rows)
+    record_selected = sum(as_int(row.get("record_selected_events")) for row in rows)
+    record_choices = sum(
+        as_int(row.get("choice_events"))
+        for row in rows
+        if row.get("choice_kind") == "record"
+    )
+    accepted = max(record_selected, record_choices)
+    terminal = sum(as_int(row.get("outcome_events")) for row in rows)
     dismissed = sum(as_int(row.get("dismissed_events")) for row in rows)
     suppressed = sum(as_int(row.get("suppressed_events")) for row in rows)
     if shown <= 0 and accepted <= 0:
@@ -631,7 +643,7 @@ def build_prompt_quality(data: dict[str, Any]) -> Finding:
     friction = dismissed + suppressed
     return Finding(
         "Meeting prompt quality",
-        f"shown={shown}, accepted={accepted}, dismissed_or_suppressed={friction}, acceptance={pct(accepted, shown)}.",
+        f"shown={shown}, accepted_or_choice={accepted}, terminal_outcomes={terminal}, dismissed_or_suppressed={friction}, acceptance={pct(accepted, shown)}.",
         "If dismissal/suppression beats acceptance, inspect route-ready and missing-permission buckets before changing prompt copy.",
         "high" if shown >= 10 else "medium",
         float(friction - accepted),
@@ -930,6 +942,15 @@ def run_self_test() -> int:
     mismatch_metric = build_reliability_leak(mismatch_data).metric
     if "Meeting transcript failure" not in mismatch_metric or "meeting_transcript_failed" not in mismatch_metric or "dictation_no_speech" in mismatch_metric:
         print("self-test failed: reliability breakdown did not stay tied to selected leak", file=sys.stderr)
+        return 1
+    split_prompt_data = json.loads(json.dumps(data))
+    split_prompt_data["results"]["meeting_prompt_quality"] = [
+        {"shown_events": 10, "record_selected_events": 4, "choice_events": 0, "dismissed_events": 0, "suppressed_events": 0},
+        {"shown_events": 0, "record_selected_events": 0, "choice_events": 4, "choice_kind": "record", "dismissed_events": 0, "suppressed_events": 0},
+    ]
+    split_prompt_metric = build_prompt_quality(split_prompt_data).metric
+    if "accepted_or_choice=4" not in split_prompt_metric:
+        print("self-test failed: prompt quality double-counted split record choice/selected rows", file=sys.stderr)
         return 1
     for query in (
         event_counts_query(30, None),


### PR DESCRIPTION
## Summary
- add a deterministic analytics policy regression pinning meeting prompt shown/choice/selected/outcome/dismissed/suppressed firing paths
- include choice/outcome/elapsed fields in PostHog meeting prompt quality helper queries and rendered rows
- update dashboard fixtures to current coarse enum shapes and prevent record choice/selected double-counting in the product summary helper

## Proof
- bash run-tests.sh --filter MeetingPromptTelemetry: 52 passed
- bash run-tests.sh --filter AnalyticsEventPolicy: 5936 passed
- bash run-tests.sh --filter AnalyticsPayloadSanitizer: 136 passed
- bash run-tests.sh --filter MeetingPromptDetector: 85 passed
- bash run-tests.sh --filter MeetingPromptHeuristics: 104 passed
- bash run-tests.sh --filter SyntheticMeetingPrompt: 108 passed
- bash run-tests.sh --filter AnalyticsReporter: 111 passed
- bash run-tests.sh --filter Observability: 164 passed
- python3 -m py_compile scripts/ops/posthog-activation-funnel.py scripts/ops/posthog-dashboard-queries.py scripts/ops/posthog-product-dashboard-summary.py
- python3 scripts/ops/posthog-activation-funnel.py --self-test
- python3 scripts/ops/posthog-dashboard-queries.py --self-test
- python3 scripts/ops/posthog-product-dashboard-summary.py --self-test
- python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only
- bash scripts/dev/agent-preflight.sh
- git diff --check

Note: after a Python-only helper math tweak, a redundant second AnalyticsEventPolicy rerun stalled in swift-driver behind other local compile jobs and was killed. The prior AnalyticsEventPolicy run passed after the Swift test change.