### PR TITLE
Add Home meeting import CTA

### DIFF
--- a/Sources/UI/Settings/HomePresentation.swift
+++ b/Sources/UI/Settings/HomePresentation.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Empty-state copy for the Home capture lists. Foundation-pure constants so the
 /// strings can be pinned by fast tests; `HomeView` reads them directly.
 enum HomeCaptureListCopy {
-    static let emptyMeetings = "No recent meetings. Record one or transcribe an audio file from General."
+    static let emptyMeetings = "No recent meetings. Record one or transcribe an existing audio file."
     static let emptyDictations = "No recent dictations."
     static let noMeetingMatches = "No meetings match your search. Older meetings load with Show more."
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1846,6 +1846,9 @@ struct HomeListEmptyState {
     let actionTitle: String
     let automationIdentifier: String
     let action: () -> Void
+    var secondaryActionTitle: String? = nil
+    var secondaryAutomationIdentifier: String? = nil
+    var secondaryAction: (() -> Void)? = nil
 }
 
 private struct HomeEmptyStateView: View {
@@ -1870,13 +1873,26 @@ private struct HomeEmptyStateView: View {
                     .frame(maxWidth: 360)
             }
 
-            Button(action: state.action) {
-                Text(state.actionTitle)
+            HStack(spacing: 8) {
+                Button(action: state.action) {
+                    Text(state.actionTitle)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .accessibilityIdentifier(state.automationIdentifier)
+
+                if let secondaryTitle = state.secondaryActionTitle,
+                   let secondaryAutomationIdentifier = state.secondaryAutomationIdentifier,
+                   let secondaryAction = state.secondaryAction {
+                    Button(action: secondaryAction) {
+                        Text(secondaryTitle)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .accessibilityIdentifier(secondaryAutomationIdentifier)
+                }
             }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
             .padding(.top, 2)
-            .accessibilityIdentifier(state.automationIdentifier)
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 40)

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -700,12 +700,18 @@ struct TranscriptedSettingsView: View {
             emptyState: isSearchingMeetings ? nil : HomeListEmptyState(
                 symbolName: "waveform",
                 title: "No meetings yet",
-                message: "Record a meeting and Transcripted transcribes it, labels each speaker, and saves the transcript here. You can also transcribe an existing audio file from General.",
+                message: "Record a meeting or transcribe an existing audio file. Transcripted labels each speaker and saves the transcript here.",
                 actionTitle: "Start a meeting",
                 automationIdentifier: "transcripted.home.meetings.empty.start",
                 action: {
                     trackSettingsAction("empty_start_meeting", page: .home)
                     actions.startMeeting()
+                },
+                secondaryActionTitle: "Transcribe audio file",
+                secondaryAutomationIdentifier: "transcripted.home.meetings.empty.import-audio",
+                secondaryAction: {
+                    trackSettingsAction("empty_import_audio", page: .home)
+                    actions.importAudioFile()
                 }
             ),
             isLoading: homeViewModel.isLoading,

--- a/Tests/HomeImportAudioActionTests.swift
+++ b/Tests/HomeImportAudioActionTests.swift
@@ -29,13 +29,21 @@ func testHomeImportAudioAction() {
             "general settings should keep imported-audio help simple"
         )
         assertTrue(
-            !homeSource.contains("HomeMeetingImportActionRow")
-                && !homeSource.contains("onImportAudio"),
-            "meetings tab should not carry the imported-audio action"
+            settingsSource.contains("secondaryActionTitle: \"Transcribe audio file\"")
+                && settingsSource.contains("secondaryAutomationIdentifier: \"transcripted.home.meetings.empty.import-audio\"")
+                && settingsSource.contains("trackSettingsAction(\"empty_import_audio\", page: .home)")
+                && settingsSource.contains("actions.importAudioFile()"),
+            "Home meetings empty state should expose a visible imported-audio route"
         )
         assertTrue(
-            HomeCaptureListCopy.emptyMeetings.contains("transcribe an audio file from General"),
-            "home meeting empty state should point users back to the import location"
+            homeSource.contains("secondaryActionTitle")
+                && homeSource.contains("secondaryAutomationIdentifier")
+                && homeSource.contains("secondaryAction"),
+            "Home empty states should render the optional secondary action route"
+        )
+        assertTrue(
+            HomeCaptureListCopy.emptyMeetings.contains("transcribe an existing audio file"),
+            "Home meeting empty copy should name imported-audio transcription directly"
         )
     }
 }

--- a/Tests/HomePresentationTests.swift
+++ b/Tests/HomePresentationTests.swift
@@ -86,7 +86,7 @@ func testHomePresentation() {
     runSuite("HomeCaptureListCopy — pinned empty-state strings") {
         assertEqual(
             HomeCaptureListCopy.emptyMeetings,
-            "No recent meetings. Record one or transcribe an audio file from General."
+            "No recent meetings. Record one or transcribe an existing audio file."
         )
         assertEqual(HomeCaptureListCopy.emptyDictations, "No recent dictations.")
     }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -224,6 +224,8 @@ func testUIAutomationSurfaceContract() {
         for requiredSourceHook in [
             "title: \"Transcribe audio file\"",
             "actions.importAudioFile()",
+            "secondaryAutomationIdentifier: \"transcripted.home.meetings.empty.import-audio\"",
+            "trackSettingsAction(\"empty_import_audio\", page: .home)",
             "title: \"AI meeting summaries\"",
             "title: \"Live meeting sidecar\"",
             "trackSettingsToggle(\"local_ai_meeting_summaries\"",


### PR DESCRIPTION
## Summary
- Adds a visible `Transcribe audio file` secondary action to Home's empty meetings state.
- Routes that Home action through the existing imported-audio flow (`actions.importAudioFile()`), while keeping the General settings row and app command menu route intact.
- Updates Home/UI contract tests so imported-audio discoverability is pinned to Home instead of pointing users back to General.

## Product behavior impact
Users who land on Home with no meetings now see two direct choices: start a live meeting or transcribe an existing audio file. This should reduce the hidden-path problem behind PostHog's `Meeting import = 0 devices` signal without changing transcription/import internals.

## Verification
- `bash scripts/dev/agent-preflight.sh` -> suggested `bash build.sh --no-open`, `bash run-tests.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter HomeImportAudioActionTests` -> 7 passed, 0 failed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` -> 12566 passed, 0 failed
- `git diff --check` -> passed
- Claude second-pass audit -> clean, no findings; proof: `/Users/redbars/.codex/maestro/runs/20260704T115104Z-transcripted-home-import-audit-claude`

## Build note
- `bash build.sh --no-open` is currently blocked in this fresh worktree because dependency artifacts are stale for `TranscriptedCore` (`current: adfa05b...`, copied stamp: `7fb6ed...`).
- Attempted `bash build-deps.sh --force`; first attempt reached release build then hit the script's built-in retry path, second attempt became stuck in SwiftPM resolving/cloning FluidAudio while many other Transcripted dependency builds were running locally. I stopped that process and did not mark the app build green.

## Lanes used
Codex=implemented, tested, committed, pushed, opened PR; Claude=second-pass diff audit; Local=skipped, LM Studio unavailable in smoke; Windows=skipped, worker unavailable in smoke.
