### PR TITLE
Preserve failed meeting system audio on finalization

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -674,7 +674,7 @@ public class TranscriptionTaskManager: ObservableObject {
         micAudioURL: URL,
         systemAudioURL: URL?
     ) -> Bool {
-        guard failedTranscriptionManager.failedTranscriptions.contains(where: { $0.id == id }) else {
+        guard let existingFailure = failedTranscriptionManager.failedTranscriptions.first(where: { $0.id == id }) else {
             AppLogger.pipeline.warning("Failed transcription audio promotion skipped because entry was missing", [
                 "id": id.uuidString
             ])
@@ -682,16 +682,17 @@ public class TranscriptionTaskManager: ObservableObject {
         }
 
         let retryIsUsingOriginalAudio = activeTasks[id] != nil
+        let promotedSystemAudioURL = systemAudioURL ?? existingFailure.systemAudioURL
         let didPersist = failedTranscriptionManager.updateFailedTranscriptionAudio(
             id: id,
             micAudioURL: micAudioURL,
-            systemAudioURL: systemAudioURL
+            systemAudioURL: promotedSystemAudioURL
         )
         guard didPersist else { return false }
 
         scheduleFailedRecordingAudioArchive(
             micURL: micAudioURL,
-            systemURL: systemAudioURL,
+            systemURL: promotedSystemAudioURL,
             taskId: id,
             removeOriginalsAfterArchive: !retryIsUsingOriginalAudio,
             originalMicCleanupLabel: "finalized failed mic scratch",

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -2283,6 +2283,34 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(failed.errorMessage, "Retry failed: Parakeet inference failed")
     }
 
+    func testFinalizedFailedAudioPromotionPreservesExistingSystemAudioWhenCallbackHasOnlyMic() throws {
+        let manager = makeManager()
+        let failedId = UUID()
+        let originalMicURL = tempDirectory.appendingPathComponent("audio/timeout-mic.wav")
+        let finalizedMicURL = tempDirectory.appendingPathComponent("audio/timeout-mic-final.wav")
+        let existingSystemURL = tempDirectory.appendingPathComponent("audio/timeout-system.wav")
+        FileManager.default.createFile(atPath: originalMicURL.path, contents: Data("mic".utf8))
+        FileManager.default.createFile(atPath: finalizedMicURL.path, contents: Data("final-mic".utf8))
+        FileManager.default.createFile(atPath: existingSystemURL.path, contents: Data("system".utf8))
+
+        XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
+            id: failedId,
+            micAudioURL: originalMicURL,
+            systemAudioURL: existingSystemURL,
+            errorMessage: "Recording stop timed out before audio files were finalized."
+        ))
+
+        XCTAssertTrue(manager.promoteFinalizedFailedTranscriptionAudio(
+            id: failedId,
+            micAudioURL: finalizedMicURL,
+            systemAudioURL: nil
+        ))
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(failed.micAudioURL, finalizedMicURL)
+        XCTAssertEqual(failed.systemAudioURL, existingSystemURL)
+    }
+
     private func makeManager(
         speechToText: (any SpeechToTextEngine)? = nil,
         diarization: (any DiarizationEngine)? = nil,


### PR DESCRIPTION
## Summary
- preserve an existing failed-queue system audio URL when late stop-timeout finalization only reports a finalized mic URL
- archive/promote the merged mic plus the already-retained system audio together
- add deterministic core coverage for the mic-only callback reconciliation case

## Proof
- bash build-deps.sh --force
- swift test --filter TranscriptionTaskManagerMetadataTests/testFinalizedFailedAudioPromotionPreservesExistingSystemAudioWhenCallbackHasOnlyMic
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- git diff --check
- codex review --base origin/main: clean, no actionable regression

## Notes
- No release work performed.
- Claude audit also flagged a separate failed-queue persistence rollback hygiene issue in FailedTranscriptionManager; left for follow-up because this PR stays scoped to failed-save audio reconciliation.