### PR TITLE
Surface meeting no-speech recovery

### DIFF
--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -30,12 +30,12 @@ struct MeetingFailureCopy: Equatable {
         case .emptyAudio:
             return MeetingFailureCopy(
                 title: "No audio was captured",
-                detail: "Transcripted kept the recording, but there was not enough audio signal to transcribe."
+                detail: "Transcripted kept the recording. Open Home to retry the saved audio, or record again with mic and system audio on."
             )
         case .noSpeechDetected:
             return MeetingFailureCopy(
                 title: "No speech found",
-                detail: "Transcripted found audio, but not enough spoken words to write a transcript."
+                detail: "Transcripted found audio, but not enough spoken words to write a transcript. Open Home to retry, or record again with clearer voices."
             )
         case .saveFailed:
             return MeetingFailureCopy(

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2985,6 +2985,8 @@ final class MeetingSessionController: ObservableObject {
                     failureKind: failureKind.rawValue,
                     modelState: state.diagnosticName
                 )
+                lastTerminalTranscriptionOutcome = .failed(diagnosticMessage)
+                state = .error(diagnosticMessage)
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: failureKind.rawValue)
                 handleBackgroundTranscriptionWorkChanged()

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -68,6 +68,33 @@ func testFailedMeetingPresentation() {
         assertEqual(copy.detail, "Could not write transcript to meetings", "save failures should preserve the short write error")
     }
 
+    runSuite("FailedMeetingPresentation no-speech failures point to Home recovery") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "No speech detected",
+            shortErrorMessage: "No speech detected",
+            isRetryable: true
+        )
+
+        assertEqual(copy.title, "No speech found", "no-speech outcomes should be named plainly")
+        assertEqual(
+            copy.detail,
+            "Transcripted found audio, but not enough spoken words to write a transcript. Open Home to retry, or record again with clearer voices.",
+            "no-speech outcomes should point to a visible recovery path"
+        )
+    }
+
+    runSuite("MeetingSessionController surfaces skipped no-speech outcomes visibly") {
+        let source = (try? String(
+            contentsOf: repoFixtureURL("Sources/Meeting/MeetingSessionController.swift"),
+            encoding: .utf8
+        )) ?? ""
+
+        assertTrue(
+            source.contains("lastTerminalTranscriptionOutcome = .failed(diagnosticMessage)\n                state = .error(diagnosticMessage)"),
+            "skipped no-speech transcripts should still publish a visible recovery notice"
+        )
+    }
+
     runSuite("HomeFailedMeetingInlinePresentation shows details for non-retryable failures") {
         let presentation = HomeFailedMeetingInlinePresentation.make(
             isRetryable: false,


### PR DESCRIPTION
## Summary
- Surface expected meeting no-speech/empty-audio outcomes as visible recovery notices instead of silent skipped-transcript terminal states.
- Update failed-meeting copy so retained audio points users to Home retry or a clearer re-recording.
- Add fast coverage for no-speech recovery copy and the skipped-transcript state handoff.

## Observability checked
- PostHog 30d aggregate: `meeting_transcript_skipped` included `no_speech_detected` from menu/hotkey/detected prompt and `empty_audio` from menu/detected prompt; menu start/recent-meeting actions are active.
- Sentry 30d simple searches for `no_speech_detected` and `"no speech detected"`: no matching issues found in `r3dbars/apple-macos`.

## Tests / proof
- `bash run-tests.sh --filter FailedMeetingPresentationTests` - passed, 39 tests.
- `bash run-tests.sh --filter MeetingFailureKindTests` - passed, 33 tests.
- `bash run-tests.sh --filter ReliabilityPacketRecorderTests` - passed, 78 tests.
- `swift test --filter TranscriptionTaskManagerMetadataTests/testStartImportedTranscriptionSurfacesNoSpeechWhenNoUtterances` - passed, deterministic quiet-audio no-speech fixture.
- `codex review --base origin/main` - no findings.

## Incomplete proof
- `bash build-deps.sh --force` did not complete locally: first release build attempt failed, then the built-in retry stalled while many other Transcripted worktrees were concurrently cloning/building FluidAudio deps on this Mac. I interrupted the retry after several minutes of no progress.
- `bash build.sh --no-open` is blocked until deps are rebuilt for this exact `origin/main` dependency digest.
- `bash run-integration-smoke.sh` was not run for the same missing/stale deps reason.

## Manual proof still needed
- Live meeting no-speech UX on a built app: record a meeting with audio but no speech, confirm the overlay shows the no-speech recovery notice and Home keeps the failed row retry path.

## Lanes used
- Codex: implementation, PostHog/Sentry read-only checks, deterministic tests, review, PR.
- Claude: read-only code/telemetry scout via `~/.codex/bin/maestro-delegate`, proof path `/Users/redbars/.codex/maestro/runs/20260704T114625Z-transcripted-no-speech-scout-claude`.
- Local: skipped, LM Studio not reachable.
- Windows: skipped, worker not configured.
