### PR TITLE
Keep failed retry state transactional

### DIFF
--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -464,6 +464,9 @@ public class FailedTranscriptionManager: ObservableObject {
         )
 
         let didPersist = saveFailedTranscriptions()
+        if !didPersist {
+            failedTranscriptions[index] = existing
+        }
         AppLogger.pipeline.info("Updated failed transcription error", [
             "id": "\(id)",
             "persisted": "\(didPersist)"

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -233,6 +233,28 @@ func testFailedMeetingPresentation() {
             "failed meeting metadata should label retained WAVs as raw audio"
         )
     }
+
+    runSuite("FailedMeetingPresentation exposes queued retry state in row metadata") {
+        let source = (try? String(
+            contentsOf: repoFixtureURL("Sources/Meeting/FailedMeetingPresentation.swift"),
+            encoding: .utf8
+        )) ?? ""
+
+        assertTrue(
+            source.contains("title(for: failed, fallback: copy.title)"),
+            "failed meeting rows should keep the queued meeting title when one exists"
+        )
+        assertTrue(
+            source.contains("if failed.retryCount > 0")
+                && source.contains("failed.retryCount == 1 ? \"1 retry\" : \"\\(failed.retryCount) retries\""),
+            "retry attempts should stay visible in failed meeting metadata"
+        )
+        assertTrue(
+            source.contains("if isRetrying")
+                && source.contains("parts.append(\"Retrying now\")"),
+            "active retry progress should stay visible in failed meeting metadata"
+        )
+    }
 }
 
 private func makeFailedMeetingPresentationTestDirectory() -> URL {

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -273,6 +273,38 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(persisted.first?.meetingTitle, "Design review")
     }
 
+    func testUpdateFailedTranscriptionErrorRollsBackMemoryWhenPersistenceFails() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let micURL = paths.audioCaptures.appendingPathComponent("safe-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+
+        let manager = FailedTranscriptionManager(paths: paths)
+        let failedId = UUID()
+        XCTAssertTrue(manager.addFailedTranscription(
+            id: failedId,
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Temporary transcription failure",
+            meetingTitle: "Queue retry"
+        ))
+        let original = try XCTUnwrap(manager.failedTranscriptions.first)
+
+        try FileManager.default.removeItem(at: paths.failedQueue)
+        try FileManager.default.createDirectory(at: paths.failedQueue, withIntermediateDirectories: true)
+
+        XCTAssertFalse(manager.updateFailedTranscriptionError(
+            id: failedId,
+            errorMessage: "Retry failed: model not ready"
+        ))
+        XCTAssertEqual(
+            manager.failedTranscriptions.first,
+            original,
+            "the visible failed queue should not drift from durable storage when retry-state persistence fails"
+        )
+    }
+
     func testUpdateFailedTranscriptionAudioPreservesRetryMetadata() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)


### PR DESCRIPTION
## Summary
- Roll back failed-transcription error updates when queue persistence fails, so the visible failed queue cannot drift away from durable storage after a retry/finalization error update.
- Add deterministic coverage for failed queue rollback when the retained-audio retry row cannot be persisted.
- Add fast presentation coverage that queued failed meetings keep title, retry count, and active retry state visible in row metadata.

## Behavior fixed
If `updateFailedTranscriptionError(id:errorMessage:)` updated memory but `failedTranscriptions.json` could not be saved, Home/Settings could show a new retry failure message that was never durably queued. The manager now restores the previous in-memory failed row when persistence fails and returns `false`.

## Tests
- PASS: `git diff --check`
- PASS: `bash run-tests.sh --filter FailedMeetingPresentation` (39 passed)
- PASS: `bash run-tests.sh` (12566 passed)
- PASS: `codex review --base origin/main` (no discrete regression found)
- BLOCKED: `swift test --filter FailedTranscriptionManagerTests` fails before tests run with `Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift:4:8: error: no such module 'FluidAudio'`.
- BLOCKED: `bash build-deps.sh --force` attempted; the first release build failed and the retry was interrupted after local machine contention from sibling Transcripted dependency builds. Exit code 130.
- NOT RUN: `bash build.sh --no-open`, `bash run-integration-smoke.sh`, and full `swift test` because the local dependency bootstrap did not complete and `FluidAudio` is unavailable in this worktree.

## Lanes used
- Codex: audited, implemented, tested, reviewed, pushed, opened PR.
- Local: attempted via `~/.codex/bin/maestro-delegate`; proof path `/Users/redbars/.codex/maestro/runs/20260704T114644Z-transcripted-failed-queue-retry-audit-local`; exited 7 with no useful output.
- Claude: skipped; scoped bugfix did not need paid reasoning lane.
- Windows: skipped; local isolated worktree plus deterministic tests were sufficient.

No release actions.
