### PR TITLE
Guard dictation mic start recovery cooldown

### DIFF
--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -530,6 +530,7 @@ class DictationSessionController: ObservableObject {
                     return
                 }
 
+                readinessRefreshes = 0
                 if readinessRefresher.start(appState: appState) {
                     readinessRefreshes += 1
                 }

--- a/Tests/DictationReadinessWaitPolicyTests.swift
+++ b/Tests/DictationReadinessWaitPolicyTests.swift
@@ -261,6 +261,20 @@ func testDictationReadinessWaitPolicy() {
         assertEqual(action, .refreshInputReadiness, "after one recovery start attempt the loop should refresh until a hard recovery is attempted")
     }
 
+    runSuite("DictationReadinessWaitPolicy — failed recovery start requires fresh cooldown refreshes") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: 1,
+            forcedRecoveryAttempts: 0,
+            forcedRecoveryRefreshThreshold: 5,
+            maxForcedRecoveryAttempts: 2,
+            recoveryStartAttempts: 1
+        )
+
+        assertEqual(action, .refreshInputReadiness, "after a guarded recovery-start retry fails, one fresh refresh should not immediately force hard recovery")
+    }
+
     runSuite("DictationReadinessWaitPolicy — second recovery start is bounded") {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1987,6 +1987,18 @@ func testRepoCommandContract() {
             contents.contains("hasStartupTask: startupTask != nil"),
             "mini cursor model warmup should remain cancellable before the delayed loading reveal"
         )
+        let recoveryStartFailedBlock = sourceSlice(
+            contents,
+            from: "case .startRecoveryRecording:",
+            to: "case .startRecording:"
+        )
+        assertTrue(
+            recoveryStartFailedBlock.contains("if started {")
+                && recoveryStartFailedBlock.contains("return")
+                && recoveryStartFailedBlock.contains("readinessRefreshes = 0")
+                && recoveryStartFailedBlock.contains("if readinessRefresher.start(appState: appState)"),
+            "failed recovery-start attempts should reset stale refresh counters before the next cooldown refresh"
+        )
         let lifecycleContents = readRepoTextFile("Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift")
         assertTrue(
             lifecycleContents.contains("hasStartupTask || hasRecordingStartTask"),


### PR DESCRIPTION
## Summary
- reset stale readiness refresh counters after a guarded recovery-start attempt fails
- add deterministic cooldown coverage for the microphone-start timeout wait policy
- pin the AppKit/CoreAudio controller reset with a source contract test

## Verification
- `bash run-tests.sh --filter DictationReadinessWaitPolicyTests.swift` — 31 passed
- `bash run-tests.sh --filter DictationRecordingStartOverlayPolicyTests.swift` — 34 passed
- `bash run-tests.sh --filter ParakeetStartRecordingFailurePolicyTests.swift` — 122 passed
- `bash run-tests.sh --filter ReliabilityPacketRecorderTests.swift` — 78 passed
- `bash run-tests.sh --filter RepoCommandContractTests.swift` — 651 passed
- `bash run-tests.sh` — 12565 passed
- `bash build-deps.sh --force` — passed after built-in retry; third-party warnings only
- `bash build.sh --no-open` — passed, signed app, launch smoke, performance budget OK

## Notes
- Sentry CLI could not fetch `APPLE-MACOS-14` by short-code query (`issues list --query 'APPLE-MACOS-14'` returned no issues), so code inspection used the repo’s `dictation.microphone_start_timeout` path and existing Sentry event policy hooks.\n- No hardware/audio proof was run; this is deterministic policy and build proof only.\n\nlanes used: Codex=implemented diff, tests, build, PR; Local=attempted via maestro-delegate but endpoint returned code 7 and produced no output, not counted; Claude=skipped; Windows=skipped.\n\nCOORD_DONE