### PR TITLE
Retain failed meeting audio before retry queue

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -204,25 +204,32 @@ public class TranscriptionTaskManager: ObservableObject {
             } catch {
                 AppLogger.pipeline.error("Transcription task failed", ["taskId": "\(task.id)", "error": "\(error.localizedDescription)"])
 
-                await MainActor.run {
+                let shouldPreserveFailedAudio = await MainActor.run { () -> Bool in
                     if self.preservedTaskIdsForShutdown.remove(task.id) != nil {
                         self.handleTaskCompletion(taskId: task.id)
-                        return
+                        return false
                     }
-                    guard !self.finishCancelledTaskIfNeeded(taskId: task.id, error: error) else { return }
+                    guard !self.finishCancelledTaskIfNeeded(taskId: task.id, error: error) else { return false }
 
                     self.publishFailure(
                         displayMessage: "Transcription failed",
                         diagnosticMessage: Self.safeFailureDiagnosticMessage(for: error)
                     )
-                    self.addFailedTranscriptionRetainingAvailableAudio(
-                        micAudioURL: micURL,
-                        systemAudioURL: systemURL,
-                        errorMessage: error.localizedDescription,
-                        taskId: task.id,
-                        meetingTitle: task.meetingTitle,
-                        recordingDate: task.recordingDate
-                    )
+                    return true
+                }
+
+                guard shouldPreserveFailedAudio else { return }
+
+                _ = await self.addFailedTranscriptionRetainingAvailableAudioAfterArchive(
+                    micAudioURL: micURL,
+                    systemAudioURL: systemURL,
+                    errorMessage: error.localizedDescription,
+                    taskId: task.id,
+                    meetingTitle: task.meetingTitle,
+                    recordingDate: task.recordingDate
+                )
+
+                await MainActor.run {
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: task.id)
                 }
@@ -230,6 +237,69 @@ public class TranscriptionTaskManager: ObservableObject {
         }
 
         activeTasks[task.id] = asyncTask
+    }
+
+    /// Retains failed audio before writing the durable failed-queue row, without
+    /// doing large file copies on the main actor. This is for async failure paths
+    /// where losing the process mid-copy can still fall back to the recording
+    /// journal / scratch audio recovery on next launch.
+    @discardableResult
+    public func addFailedTranscriptionRetainingAvailableAudioAfterArchive(
+        micAudioURL: URL?,
+        systemAudioURL: URL?,
+        errorMessage: String,
+        taskId: UUID = UUID(),
+        meetingTitle: String? = nil,
+        recordingDate: Date? = nil,
+        archiveAudio: Bool = true
+    ) async -> Bool {
+        guard micAudioURL != nil || systemAudioURL != nil else {
+            AppLogger.pipeline.error("No audio files available to retain for failed transcription", [
+                "taskId": taskId.uuidString
+            ])
+            return false
+        }
+
+        if archiveAudio,
+           let retainedAudioDirectory = resolvedRetainedAudioDirectory() {
+            let failedStem = "Failed_\(DateFormattingHelper.formatFilename(Date()))_\(String(taskId.uuidString.prefix(8)))"
+            let placeholderTranscriptURL = retainedAudioDirectory
+                .appendingPathComponent(failedStem)
+                .appendingPathExtension("md")
+
+            let retainedAudio = await Task.detached(priority: .utility) {
+                Self.archiveFailedRecordingAudio(
+                    micURL: micAudioURL,
+                    systemURL: systemAudioURL,
+                    taskId: taskId,
+                    transcriptURL: placeholderTranscriptURL,
+                    archiveRoot: retainedAudioDirectory
+                )
+            }.value
+
+            if let retainedAudio {
+                return enqueueFailedTranscriptionAfterRetainingAudio(
+                    taskId: taskId,
+                    retainedAudio: retainedAudio,
+                    originalMicURL: micAudioURL,
+                    originalSystemURL: systemAudioURL,
+                    errorMessage: errorMessage,
+                    meetingTitle: meetingTitle,
+                    recordingDate: recordingDate,
+                    removeOriginalsAfterArchive: true
+                )
+            }
+        }
+
+        return addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micAudioURL,
+            systemAudioURL: systemAudioURL,
+            errorMessage: errorMessage,
+            taskId: taskId,
+            meetingTitle: meetingTitle,
+            recordingDate: recordingDate,
+            archiveAudio: archiveAudio
+        )
     }
 
     /// Start a new transcription task for an imported audio file.
@@ -844,7 +914,7 @@ public class TranscriptionTaskManager: ObservableObject {
                     "reason": reason
                 ])
             case .recover(let micURL, let systemURL, let startedAt):
-                let didPersist = addFailedTranscriptionRetainingAvailableAudio(
+                let didPersist = await addFailedTranscriptionRetainingAvailableAudioAfterArchive(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: "Recording was interrupted before it could be saved. The recovered audio is ready to transcribe.",

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -601,6 +601,38 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should be removed after archive")
     }
 
+    func testAsyncFailedQueueArchivesBeforePersistingFailedRow() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        let micURL = scratchDirectory.appendingPathComponent("mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        let didQueue = await manager.addFailedTranscriptionRetainingAvailableAudioAfterArchive(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Transcription inference failed",
+            taskId: UUID(uuidString: "00000000-0000-0000-0000-000000000149")!,
+            meetingTitle: "Recovery Check",
+            recordingDate: Date(timeIntervalSince1970: 1_797_000_000)
+        )
+
+        XCTAssertTrue(didQueue)
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(failed.meetingTitle, "Recovery Check")
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.systemAudioURL?.path ?? ""))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "scratch mic audio should be removed after retained archive is persisted")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should be removed after retained archive is persisted")
+    }
+
     func testManualFailedQueueRemovesRetainedAudioWhenQueuePersistenceFails() throws {
         let retainedAudioDirectory = tempDirectory
             .appendingPathComponent("transcripts", isDirectory: true)


### PR DESCRIPTION
## Summary
- Preserve failed meeting audio in retained storage before writing the retry queue row on async transcription failure and orphan recovery paths
- Keep large retained-audio copies off the main actor while preserving existing fallback behavior
- Add focused coverage proving async failed-queue rows point at retained audio and remove scratch only after persistence

## Live signal
- Sentry issue APPLE-MACOS-1H is unresolved/ongoing, latest seen 2026-07-03, current release transcripted@1.1.48
- Recent events classify primarily as transcription_inference_failed for menu/detected_prompt triggers across parakeet and whisper-large-v3
- PostHog schema includes meeting_transcript_failed with failure_kind/trigger/audio diagnostic properties; recent 1.1.48 aggregate shows transcription_inference_failed events

## Verification
- bash build-deps.sh --force
- swift test --filter TranscriptionTaskManagerMetadataTests
- codex review --base origin/main
- bash build.sh --no-open
- bash run-integration-smoke.sh
- bash run-tests.sh
- swift test
- git diff --check

## Release scope
No release, tag, notarization, appcast, or Homebrew work included.