### PR TITLE
Ease meetings-first onboarding permission gate

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -45,7 +45,7 @@ struct PermissionsOnboardingView: View {
     @State private var navigationDirection: OnboardingNavigationDirection = .forward
     @State private var micGranted = false
     @State private var accessibilityGranted = false
-    @State private var screenRecordingGranted = false
+    @State private var systemAudioGranted = false
     @State private var calendarGranted = false
     @State private var meetingPromptsEnabled = true
     @State private var selectedUseCase: OnboardingUseCase = .meetings
@@ -80,9 +80,14 @@ struct PermissionsOnboardingView: View {
     private var hasRequiredPermissions: Bool {
         switch selectedUseCase {
         case .meetings:
-            return micGranted && screenRecordingGranted
+            return FirstRunExperience.hasRequiredMeetingSetup(
+                microphoneGranted: micGranted
+            )
         case .dictation:
-            return micGranted && accessibilityGranted
+            return FirstRunExperience.hasRequiredDictationSetup(
+                microphoneGranted: micGranted,
+                accessibilityGranted: accessibilityGranted
+            )
         }
     }
 
@@ -281,10 +286,10 @@ struct PermissionsOnboardingView: View {
                 Headline(primary: "Record meetings.\nGet the transcript.", size: 42, alignment: .leading)
                 BodyCopy("Transcripted needs two audio streams to write the whole conversation: your microphone for you, and system audio for everyone else.")
                 BulletList(["macOS calls this Screen Recording", "Used only to hear meeting audio", "Everything stays on your Mac"])
-                Button(screenRecordingGranted ? "System audio enabled" : "Enable system audio") {
+                Button(systemAudioGranted ? "System audio enabled" : "Enable system audio") {
                     requestPermission(.systemAudioRecording, required: false)
                 }
-                .buttonStyle(InkButtonStyle(isSubtle: screenRecordingGranted))
+                .buttonStyle(InkButtonStyle(isSubtle: systemAudioGranted))
                 .padding(.top, 12)
                 .accessibilityIdentifier("transcripted.onboarding.system-audio.enable")
                 Text("You can skip this now, but meeting transcripts need it to include the other side of the call.")
@@ -292,14 +297,18 @@ struct PermissionsOnboardingView: View {
                     .foregroundStyle(OnboardingTheme.muted)
                     .fixedSize(horizontal: false, vertical: true)
             } right: {
-                DualStreamVisual(systemReady: screenRecordingGranted)
+                DualStreamVisual(systemReady: systemAudioGranted)
             }
         case .meeting:
             SplitStage {
                 Kicker("After the call")
                 Headline(primary: "A transcript you can actually use.", size: 42, alignment: .leading)
-                BodyCopy("Every recorded meeting becomes a local Markdown file with timestamps and speaker labels.")
-                BulletList(["Find decisions later", "Copy exact quotes", "Give your agent the right context"])
+                BodyCopy(systemAudioGranted
+                    ? "Every recorded meeting becomes a local Markdown file with timestamps and speaker labels."
+                    : "Once System Audio is on, recorded meetings become local Markdown with both sides of the conversation.")
+                BulletList(systemAudioGranted
+                    ? ["Find decisions later", "Copy exact quotes", "Give your agent the right context"]
+                    : ["Meeting prompts are ready now", "System Audio adds everyone else's voice", "Turn it on from the app when you are ready"])
             } right: {
                 MeetingDemoCard()
             }
@@ -392,9 +401,7 @@ struct PermissionsOnboardingView: View {
                     size: 52
                 )
                 Lede(
-                    selectedUseCase == .meetings
-                        ? "Start meetings from Transcripted. Dictation can stay off until you want it."
-                        : "Three actions to remember: use your voice anywhere, capture meetings, then ask your agent what happened.",
+                    doneStepLede,
                     maxWidth: 560
                 )
                 ThreeActionsRecap(useCase: selectedUseCase)
@@ -423,11 +430,11 @@ struct PermissionsOnboardingView: View {
                     title: "System Audio",
                     reason: "For everyone else on the call.",
                     icon: "speaker.wave.2.fill",
-                    granted: screenRecordingGranted,
+                    granted: systemAudioGranted,
                     actionTitle: "Allow",
                     automationIdentifier: "transcripted.onboarding.permissions.system-audio"
                 ) {
-                    requestPermission(.systemAudioRecording, required: true)
+                    requestPermission(.systemAudioRecording, required: false)
                 }
             case .dictation:
                 PermissionGrantRow(
@@ -447,13 +454,24 @@ struct PermissionsOnboardingView: View {
     private var requiredPermissionsStatusText: String {
         if hasRequiredPermissions {
             return selectedUseCase == .meetings
-                ? "Meeting recording is ready."
+                ? (systemAudioGranted ? "Meeting recording is ready." : "Meeting prompts are ready. System Audio can be set up next.")
                 : "Dictation is ready."
         }
 
         return selectedUseCase == .meetings
-            ? "Allow Microphone and System Audio to continue."
+            ? "Allow Microphone to continue. System Audio is next for full meeting transcripts."
             : "Allow Microphone and Accessibility to continue."
+    }
+
+    private var doneStepLede: String {
+        switch selectedUseCase {
+        case .meetings:
+            return systemAudioGranted
+                ? "Start meetings from Transcripted. Dictation can stay off until you want it."
+                : "Transcripted can spot calls now. Turn on System Audio from the app before recording a full meeting transcript."
+        case .dictation:
+            return "Three actions to remember: use your voice anywhere, capture meetings, then ask your agent what happened."
+        }
     }
 
     private func goBack() {
@@ -579,7 +597,7 @@ struct PermissionsOnboardingView: View {
 
         micGranted = TranscriptedPermissionAccess.isGranted(.microphone)
         accessibilityGranted = TranscriptedPermissionAccess.isGranted(.accessibility)
-        screenRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
+        systemAudioGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
         calendarGranted = TranscriptedPermissionAccess.isGranted(.calendar)
         revalidateSystemAudioPermissionForStatusSurfaces()
 
@@ -595,7 +613,7 @@ struct PermissionsOnboardingView: View {
         guard TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown else { return }
         permissionRevalidationTask = Task { @MainActor in
             _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
-            screenRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
+            systemAudioGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
             permissionRevalidationTask = nil
         }
     }
@@ -653,7 +671,7 @@ struct PermissionsOnboardingView: View {
             "onboarding_completed",
             properties: FirstRunExperience.onboardingCompletionAnalyticsProperties(
                 completionPath: selectedUseCase.completionPath,
-                systemAudioGranted: screenRecordingGranted,
+                systemAudioGranted: systemAudioGranted,
                 calendarGranted: calendarGranted,
                 meetingPromptsEnabled: meetingPromptsEnabled,
                 firstDictationSaved: PermissionsOnboardingPreferences.hasTrackedFirstDictationSaved(),
@@ -768,7 +786,7 @@ struct PermissionsOnboardingView: View {
         [
             .microphone: micGranted ? "granted" : "not_granted",
             .accessibility: accessibilityGranted ? "granted" : "not_granted",
-            .systemAudioRecording: screenRecordingGranted ? "granted" : "not_granted",
+            .systemAudioRecording: systemAudioGranted ? "granted" : "not_granted",
             .screenRecording: TranscriptedPermissionAccess.isGranted(.screenRecording) ? "granted" : "not_granted",
             .calendar: calendarGranted ? "granted" : "not_granted",
         ]
@@ -787,6 +805,7 @@ struct PermissionsOnboardingView: View {
                 .init(kind: .useCase),
                 .init(kind: .permissions),
                 .init(kind: .meetingStart),
+                .init(kind: .systemAudio, canSkip: true),
                 .init(kind: .meeting),
                 .init(kind: .calendar, canSkip: true),
                 .init(kind: .memory),

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -160,6 +160,12 @@ enum FirstRunExperience {
         microphoneGranted && accessibilityGranted
     }
 
+    static func hasRequiredMeetingSetup(
+        microphoneGranted: Bool
+    ) -> Bool {
+        microphoneGranted
+    }
+
     static func onboardingAction(
         for step: FirstRunOnboardingStep,
         microphoneGranted: Bool,
@@ -242,6 +248,17 @@ enum FirstRunExperience {
 
     static func onboardingRequiredPermissions() -> [TranscriptedPermissionKind] {
         [.microphone, .accessibility]
+    }
+
+    static func onboardingRequiredPermissions(
+        completionPath: FirstRunCompletionPath
+    ) -> [TranscriptedPermissionKind] {
+        switch completionPath {
+        case .meetings:
+            return [.microphone]
+        case .dictation:
+            return [.microphone, .accessibility]
+        }
     }
 
     static func onboardingOptionalPermissions() -> [TranscriptedPermissionKind] {

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -120,6 +120,27 @@ func testFirstRunExperience() {
         )
     }
 
+    runSuite("FirstRunExperience.onboardingPermissions — meetings-first setup does not hard-block on System Audio") {
+        assertTrue(
+            FirstRunExperience.hasRequiredMeetingSetup(microphoneGranted: true),
+            "meetings-first onboarding should let users continue after Microphone so System Audio can be explained in context"
+        )
+        assertFalse(
+            FirstRunExperience.hasRequiredMeetingSetup(microphoneGranted: false),
+            "meetings-first onboarding still needs Microphone before call detection or recording can work"
+        )
+        assertEqual(
+            FirstRunExperience.onboardingRequiredPermissions(completionPath: .meetings),
+            [.microphone],
+            "meetings-first onboarding should not trap users on System Audio before showing the meeting value path"
+        )
+        assertEqual(
+            FirstRunExperience.onboardingRequiredPermissions(completionPath: .dictation),
+            [.microphone, .accessibility],
+            "dictation onboarding should still require paste-back readiness"
+        )
+    }
+
     runSuite("FirstRunExperience.onboardingCompletionAnalyticsProperties — keeps completion payload coarse") {
         let properties = FirstRunExperience.onboardingCompletionAnalyticsProperties(
             completionPath: .meetings,

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -460,6 +460,13 @@ func testUIAutomationSurfaceContract() {
             assertTrue(contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains(requiredOnboardingHook), "\(requiredOnboardingHook) should stay in onboarding automation scope")
         }
 
+        assertTrue(
+            contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains(".init(kind: .meetingStart),\n                .init(kind: .systemAudio, canSkip: true),\n                .init(kind: .meeting)")
+                && contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("requestPermission(.systemAudioRecording, required: false)")
+                && contractSource("Sources/UI/Settings/PermissionsOnboardingView.swift").contains("Meeting prompts are ready. System Audio can be set up next."),
+            "meetings-first onboarding should not hard-block permission progress on System Audio; it should continue after Microphone, then explain optional System Audio before meeting value"
+        )
+
         // Auto-detect calls is default-on (AutoCallDetectionPreferences) but onboarding
         // used to teach only the manual menu-bar path and frame detection as
         // calendar-only. These guard the copy fix: the meetingStart step should prime


### PR DESCRIPTION
## Summary
- Let meetings-first onboarding continue after Microphone is granted instead of hard-blocking on System Audio Recording.
- Move System Audio into the next skippable setup step for meetings-first users, while keeping copy honest when full meeting recording is not ready yet.
- Add policy and UI contract coverage so the lower-friction permission path stays intentional and privacy-safe analytics keep using coarse readiness booleans.

## Proof
- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force` (initial release build retried once through repo-owned recovery; final deps build completed)
- `bash build.sh --no-open`
- `bash run-tests.sh` -> 12568 passed, 0 failed

## Lane Proof
- Codex: implementation, build, tests, commit, PR
- Claude: audit/adversarial review via `/Users/redbars/.codex/maestro/runs/20260704T114751Z-transcripted-onboarding-permission-audit-claude`
- Local: skipped, LM Studio unavailable in smoke
- Windows: skipped, worker unavailable in smoke

No release. Manual TCC deny/regrant behavior is not claimed proven by this PR.