### PR TITLE
Classify audio engine start timeouts

### DIFF
--- a/Sources/Observability/ReliabilityPacketRecorder.swift
+++ b/Sources/Observability/ReliabilityPacketRecorder.swift
@@ -273,6 +273,7 @@ enum ReliabilityPacketRecorder {
              ("parakeet", "device_change_recovery_timeout"):
             return .init(feature: "dictation", stage: "device_change", defaultOutcome: "failed_retryable")
         case ("parakeet", "audio_engine_start_failed"),
+             ("parakeet", "audio_engine_start_timeout"),
              ("parakeet", "mic_not_authorized"),
              ("dictation", "microphone_start_timeout"):
             return .init(feature: "dictation", stage: "start", defaultOutcome: "failed_retryable")

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2349,7 +2349,7 @@ class ParakeetEngine: ObservableObject {
                 }
             } catch {
                 let operationTimedOut = error is ParakeetAudioEngineWorkError
-                let context = audioStartContext(
+                var context = audioStartContext(
                     attempt: attempt,
                     isRecoveryAttempt: isRecoveryAttempt,
                     engineWasRunning: snapshot.engineWasRunning,
@@ -2358,8 +2358,10 @@ class ParakeetEngine: ObservableObject {
                     error: error
                 )
                 let failureReason = operationTimedOut
-                    ? ParakeetStartRecordingFailureReason.audioEngineStartFailed
+                    ? ParakeetStartRecordingFailureReason.audioEngineStartTimedOut
                     : ParakeetAudioFormatReadinessPolicy.startFailureReason(for: error as NSError)
+                context["failure_kind"] = operationTimedOut ? "audio_engine_start_timeout" : "audio_engine_start_failed"
+                context["sample_flow_started"] = "\(didReceiveAudioSamples)"
                 let shouldRetry = !operationTimedOut
                     && failureReason == .audioEngineStartFailed
                     && ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(
@@ -2420,7 +2422,7 @@ class ParakeetEngine: ObservableObject {
                         context: context
                     )
                     let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
-                        for: .audioEngineStartFailed,
+                        for: .audioEngineStartTimedOut,
                         isRecoveryAttempt: isRecoveryAttempt
                     )
                     if startFailureAction.markFormatUnready {

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -4,6 +4,7 @@ enum ParakeetStartRecordingFailureReason: Equatable {
     case invalidAudioFormat
     case audioRouteNotSettled
     case audioEngineStartFailed
+    case audioEngineStartTimedOut
 }
 
 struct ParakeetStartRecordingFailureAction: Equatable {
@@ -40,7 +41,7 @@ enum ParakeetStartRecordingFailurePolicy {
     ) -> ParakeetStartRecordingFailureAction {
         let shouldScheduleRetry: Bool
         switch reason {
-        case .invalidAudioFormat, .audioRouteNotSettled, .audioEngineStartFailed:
+        case .invalidAudioFormat, .audioRouteNotSettled, .audioEngineStartFailed, .audioEngineStartTimedOut:
             shouldScheduleRetry = !isRecoveryAttempt
         }
 

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -71,6 +71,28 @@ func testParakeetStartRecordingFailurePolicy() {
         assertTrue(action.rebuildAudioEngine, "engine start failure should rebuild the stale audio engine")
     }
 
+    runSuite("ParakeetStartRecordingFailurePolicy engine start timeout stays explicit and retryable") {
+        let action = ParakeetStartRecordingFailurePolicy.action(
+            for: .audioEngineStartTimedOut,
+            isRecoveryAttempt: false
+        )
+
+        assertTrue(action.markFormatUnready, "timed-out engine starts should hold new starts until recovery refreshes readiness")
+        assertTrue(action.schedulePrewarmRetry, "a timed-out first start should still schedule readiness recovery for Try Again")
+        assertTrue(action.rebuildAudioEngine, "timed-out starts should keep using the graph recovery action")
+    }
+
+    runSuite("ParakeetStartRecordingFailurePolicy engine start timeout on recovery does not chain retries") {
+        let action = ParakeetStartRecordingFailurePolicy.action(
+            for: .audioEngineStartTimedOut,
+            isRecoveryAttempt: true
+        )
+
+        assertTrue(action.markFormatUnready, "recovery timeout should keep input marked unready")
+        assertFalse(action.schedulePrewarmRetry, "recovery timeout should not recursively schedule more recovery starts")
+        assertTrue(action.rebuildAudioEngine, "recovery timeout should keep graph recovery enabled")
+    }
+
     runSuite("ParakeetStartRecordingFailurePolicy route-not-settled schedules prewarm") {
         let action = ParakeetStartRecordingFailurePolicy.action(
             for: .audioRouteNotSettled,

--- a/Tests/ReliabilityPacketRecorderTests.swift
+++ b/Tests/ReliabilityPacketRecorderTests.swift
@@ -170,6 +170,45 @@ func testReliabilityPacketRecorder() {
         assertNil(packet?.context["transcript_text"], "transcript text should not be copied into reliability packets")
     }
 
+    runSuite("ReliabilityPacketRecorder maps Parakeet audio engine start timeout as retryable startup failure") {
+        let event = ObservabilityEvent(
+            timestamp: "2026-07-04T11:58:00.000Z",
+            level: "error",
+            engine: "parakeet",
+            event: "audio_engine_start_timeout",
+            message: "Audio engine start timed out; abandoned blocked microphone graph",
+            context: [
+                "audio_device": "Private AirPods",
+                "default_input_class": "bluetooth",
+                "default_output_class": "bluetooth",
+                "failure_kind": "audio_engine_start_timeout",
+                "format_ready": "false",
+                "input_device_class": "built_in",
+                "output_device_class": "bluetooth",
+                "sample_flow_started": "false",
+                "selected_input_class": "built_in",
+                "selection_overrode_default": "true",
+                "selection_reason": "preferredBuiltInForBluetoothHeadset",
+                "status_domain": "private raw domain",
+                "transcript_text": "private words",
+            ],
+            appVersion: "1.1.49",
+            osVersion: "Version 26.5.0"
+        )
+
+        let packet = ReliabilityPacketRecorder.packet(from: event)
+
+        assertNotNil(packet, "Parakeet audio start timeout should produce a reliability packet")
+        assertEqual(packet?.feature, "dictation", "packet feature should classify dictation startup")
+        assertEqual(packet?.stage, "start", "packet stage should classify startup")
+        assertEqual(packet?.outcome, "failed_retryable", "audio engine start timeout should be retryable")
+        assertEqual(packet?.context["failure_kind"], "audio_engine_start_timeout", "timeout kind should stay queryable")
+        assertEqual(packet?.context["sample_flow_started"], "false", "sample-flow state should stay queryable")
+        assertNil(packet?.context["audio_device"], "raw device names should not be copied into reliability packets")
+        assertNil(packet?.context["status_domain"], "raw status details should not be copied into reliability packets")
+        assertNil(packet?.context["transcript_text"], "transcript text should not be copied into reliability packets")
+    }
+
     runSuite("ReliabilityPacketRecorder preserves coarse runtime shutdown duration") {
         let event = ObservabilityEvent(
             timestamp: "2026-05-03T01:15:11.605Z",


### PR DESCRIPTION
## Summary
- Treat Parakeet audio-engine start timeouts as an explicit startup failure reason instead of folding them into generic start failures.
- Add `failure_kind=audio_engine_start_timeout` and `sample_flow_started` context to timeout captures before the blocked graph is abandoned.
- Map `parakeet.audio_engine_start_timeout` into local reliability packets as a retryable dictation startup failure.

## Sentry
- Confirmed `APPLE-MACOS-21` in `r3dbars/apple-macos`: `parakeet.audio_engine_start_timeout`, high priority, 2 events, first/last seen 2026-07-03.

## Tests / proof
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter ParakeetStartRecordingFailurePolicyTests`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter ReliabilityPacketRecorderTests`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter SentryEventPolicyTests`
- `bash build-deps.sh --force` (first release build attempt retried via repo script; retry completed)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (12,578 passed)
- `codex review --base origin/main`: no actionable bugs found

## Manual / hardware proof
- Not run. No real microphone, Bluetooth, route switching, sleep/wake, or live dictation hardware proof is claimed.

## Lanes used
- Codex: implementation, Sentry read-only query, build/test/review/PR.
- Local: attempted via `~/.codex/bin/maestro-delegate`; failed with return code 7, proof at `/Users/redbars/.codex/maestro/runs/20260704T114745Z-transcripted-audio-timeout-triage-local`.
- Claude: skipped; focused deterministic policy fix after Sentry confirmation.
- Windows: skipped; local deterministic proof was cheaper and enough for this slice.