### PR TITLE
Fix post-save habit loop telemetry outcomes

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -555,15 +555,16 @@ struct TranscriptedSettingsView: View {
                     action: activity.transcriptURL.map { transcriptURL in
                         {
                             trackSettingsAction("open_current_activity", page: .home)
-                            ActivationTelemetry.trackArtifactAction(
-                                artifactKind: .meeting,
-                                actionKind: .openMarkdown,
-                                surface: .homeCurrentActivity
-                            )
                             let didOpen = openOwnFile(
                                 candidateURLs: [transcriptURL],
                                 failureTitle: "Could not open transcript",
                                 failureMessage: "Transcripted couldn't find this meeting's transcript on disk yet. If the recording is still finishing, try again in a moment."
+                            )
+                            ActivationTelemetry.trackArtifactAction(
+                                artifactKind: .meeting,
+                                actionKind: .openMarkdown,
+                                surface: .homeCurrentActivity,
+                                result: didOpen ? .success : .failed
                             )
                             ActivationTelemetry.trackHabitLoopAction(
                                 actionKind: .openRecentMeeting,
@@ -789,16 +790,17 @@ struct TranscriptedSettingsView: View {
                 isCopied: homeCopiedRowID == entry.id,
                 onOpen: {
                     trackSettingsAction("open_recent_dictation", page: navigation.selectedPage)
-                    ActivationTelemetry.trackArtifactAction(
-                        artifactKind: .dictation,
-                        actionKind: .openMarkdown,
-                        surface: .homeRow,
-                        artifactDate: entry.createdAt
-                    )
                     let didOpen = openOwnFile(
                         candidateURLs: [entry.url],
                         failureTitle: "Could not open dictation",
                         failureMessage: SettingsArtifactMessage.dictationFileNotFound
+                    )
+                    ActivationTelemetry.trackArtifactAction(
+                        artifactKind: .dictation,
+                        actionKind: .openMarkdown,
+                        surface: .homeRow,
+                        artifactDate: entry.createdAt,
+                        result: didOpen ? .success : .failed
                     )
                     ActivationTelemetry.trackHabitLoopAction(
                         actionKind: .reviewYesterday,
@@ -889,19 +891,6 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeeting(_ item: RecentMeetingItem) {
         trackSettingsAction("copy_meeting", page: .home)
-        ActivationTelemetry.trackHabitLoopAction(
-            actionKind: .whatDidIPromise,
-            surface: .homeRow,
-            artifactKind: .meeting,
-            artifactDate: item.date
-        )
-        ActivationTelemetry.trackAgentPromptAction(
-            promptKind: .meetingBundle,
-            actionKind: .copied,
-            agentTarget: .localAgent,
-            surface: .homeRow,
-            artifactKind: .meeting
-        )
         // Resolve the transcript first so a row whose path drifted (restyle/
         // rename after scanning) still copies, and a genuinely missing file
         // surfaces an error instead of silently no-op'ing on the empty clipboard.
@@ -987,12 +976,6 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeetingPreview(_ preview: HomeMeetingPreview) {
         trackSettingsAction("copy_meeting_preview", page: .home)
-        ActivationTelemetry.trackHabitLoopAction(
-            actionKind: .whatDidIPromise,
-            surface: .homePreview,
-            artifactKind: .meeting,
-            artifactDate: preview.date
-        )
         let bundle = AgentConnectionGuide.portableMeetingBundle(
             title: preview.title,
             date: preview.date,
@@ -1396,18 +1379,6 @@ struct TranscriptedSettingsView: View {
 
     private func presentHomeMeetingPreview(_ item: RecentMeetingItem) {
         trackSettingsAction("preview_recent_meeting", page: .home)
-        ActivationTelemetry.trackArtifactAction(
-            artifactKind: .meeting,
-            actionKind: .preview,
-            surface: .homeRow,
-            artifactDate: item.date
-        )
-        ActivationTelemetry.trackHabitLoopAction(
-            actionKind: .openRecentMeeting,
-            surface: .homeRow,
-            artifactKind: .meeting,
-            artifactDate: item.date
-        )
         homeMeetingPreviewLoadTask?.cancel()
         homeMeetingPreviewLoadTask = Task { @MainActor in
             let readResult = await Self.readMeetingMarkdown(at: item.transcriptURL)
@@ -1423,6 +1394,13 @@ struct TranscriptedSettingsView: View {
                         isEnabled: localMeetingSummariesEnabled
                     )
                 )
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .meeting,
+                    actionKind: .preview,
+                    surface: .homeRow,
+                    artifactDate: item.date,
+                    result: .success
+                )
                 ActivationTelemetry.trackHabitLoopAction(
                     actionKind: .openRecentMeeting,
                     surface: .homeRow,
@@ -1434,6 +1412,13 @@ struct TranscriptedSettingsView: View {
                     item: item,
                     markdown: "",
                     readError: message
+                )
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .meeting,
+                    actionKind: .preview,
+                    surface: .homeRow,
+                    artifactDate: item.date,
+                    result: .failed
                 )
                 ActivationTelemetry.trackHabitLoopAction(
                     actionKind: .openRecentMeeting,
@@ -1510,16 +1495,17 @@ struct TranscriptedSettingsView: View {
         [
             HomeRowMenuItem(title: "Open Markdown", symbolName: "doc.text") {
                 trackSettingsAction("open_recent_dictation_file", page: .home)
-                ActivationTelemetry.trackArtifactAction(
-                    artifactKind: .dictation,
-                    actionKind: .openMarkdown,
-                    surface: .homeMenu,
-                    artifactDate: entry.createdAt
-                )
                 let didOpen = openOwnFile(
                     candidateURLs: [entry.url],
                     failureTitle: "Could not open dictation",
                     failureMessage: SettingsArtifactMessage.dictationFileNotFound
+                )
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .dictation,
+                    actionKind: .openMarkdown,
+                    surface: .homeMenu,
+                    artifactDate: entry.createdAt,
+                    result: didOpen ? .success : .failed
                 )
                 ActivationTelemetry.trackHabitLoopAction(
                     actionKind: .reviewYesterday,
@@ -1535,16 +1521,17 @@ struct TranscriptedSettingsView: View {
             },
             HomeRowMenuItem(title: "Reveal in Finder", symbolName: "folder") {
                 trackSettingsAction("reveal_dictation_in_finder", page: .home)
+                let didReveal = revealOwnFile(
+                    candidateURLs: [entry.url],
+                    failureTitle: "Could not show dictation",
+                    failureMessage: SettingsArtifactMessage.dictationFileNotFound
+                )
                 ActivationTelemetry.trackArtifactAction(
                     artifactKind: .dictation,
                     actionKind: .revealFolder,
                     surface: .homeMenu,
-                    artifactDate: entry.createdAt
-                )
-                revealOwnFile(
-                    candidateURLs: [entry.url],
-                    failureTitle: "Could not show dictation",
-                    failureMessage: SettingsArtifactMessage.dictationFileNotFound
+                    artifactDate: entry.createdAt,
+                    result: didReveal ? .success : .failed
                 )
             },
             HomeRowMenuItem(title: "Delete dictation", symbolName: "trash", isDestructive: true) {
@@ -1618,16 +1605,17 @@ struct TranscriptedSettingsView: View {
             },
             HomeRowMenuItem(title: "Show transcript in Finder", symbolName: "doc.text") {
                 trackSettingsAction("reveal_meeting_in_finder", page: .home)
-                ActivationTelemetry.trackArtifactAction(
-                    artifactKind: .meeting,
-                    actionKind: .revealFolder,
-                    surface: .homeMenu,
-                    artifactDate: item.date
-                )
                 let didReveal = revealOwnFile(
                     candidateURLs: HomeMeetingRowActionTargets.transcriptRevealURLs(for: item),
                     failureTitle: "Could not show transcript",
                     failureMessage: SettingsArtifactMessage.meetingTranscriptNotFound
+                )
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .meeting,
+                    actionKind: .revealFolder,
+                    surface: .homeMenu,
+                    artifactDate: item.date,
+                    result: didReveal ? .success : .failed
                 )
                 ActivationTelemetry.trackHabitLoopAction(
                     actionKind: .openRecentMeeting,

--- a/Tests/Fixtures/posthog-dashboard-query-results.json
+++ b/Tests/Fixtures/posthog-dashboard-query-results.json
@@ -117,6 +117,7 @@
       "id": "activation.habit_loop_actions",
       "rows": [
         {"action_kind": "open_recent_meeting", "artifact_kind": "meeting", "return_window_bucket": "18_36h", "surface": "home_row", "result": "success", "events": 7, "devices": 5},
+        {"action_kind": "open_recent_meeting", "artifact_kind": "meeting", "return_window_bucket": "18_36h", "surface": "home_row", "result": "failed", "events": 2, "devices": 2},
         {"action_kind": "review_yesterday", "artifact_kind": "dictation", "return_window_bucket": "3_7d", "surface": "home_menu", "result": "success", "events": 4, "devices": 3}
       ]
     },

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -366,6 +366,61 @@ func testUIAutomationSurfaceContract() {
             "Home reveal/open should route through OwnFileResolver helpers, surfacing presentHomeActionFailure on .unavailable instead of a dead click"
         )
 
+        let settingsSource = contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        let copyMeetingBlock = sourceBlock(
+            named: "private func handleCopyMeeting(_ item: RecentMeetingItem)",
+            endingBefore: "    private func handleCopyMeetingPreview(",
+            in: settingsSource
+        )
+        assertFalse(
+            copyMeetingBlock.contains(
+                "trackSettingsAction(\"copy_meeting\", page: .home)\n        ActivationTelemetry.trackHabitLoopAction"
+            ),
+            "copy-for-agent telemetry must not emit habit-loop success before the transcript resolves"
+        )
+        assertEqual(
+            countOccurrences(of: "ActivationTelemetry.trackHabitLoopAction(", in: copyMeetingBlock),
+            3,
+            "copy-for-agent should track habit-loop exactly on missing-file failure, read failure, or success"
+        )
+
+        let copyPreviewBlock = sourceBlock(
+            named: "private func handleCopyMeetingPreview(_ preview: HomeMeetingPreview)",
+            endingBefore: "    private func handleRetranscribeMeeting(",
+            in: settingsSource
+        )
+        assertFalse(
+            copyPreviewBlock.contains(
+                "trackSettingsAction(\"copy_meeting_preview\", page: .home)\n        ActivationTelemetry.trackHabitLoopAction"
+            ),
+            "preview copy telemetry must not emit habit-loop success before bundle/markdown text exists"
+        )
+        assertEqual(
+            countOccurrences(of: "ActivationTelemetry.trackHabitLoopAction(", in: copyPreviewBlock),
+            2,
+            "preview copy should track habit-loop exactly on no-text failure or success"
+        )
+
+        let previewBlock = sourceBlock(
+            named: "private func presentHomeMeetingPreview(_ item: RecentMeetingItem)",
+            endingBefore: "    private static func readMeetingMarkdown(",
+            in: settingsSource
+        )
+        assertFalse(
+            previewBlock.contains(
+                "trackSettingsAction(\"preview_recent_meeting\", page: .home)\n        ActivationTelemetry.trackArtifactAction"
+            )
+                || previewBlock.contains(
+                    "trackSettingsAction(\"preview_recent_meeting\", page: .home)\n        ActivationTelemetry.trackHabitLoopAction"
+                ),
+            "meeting preview telemetry must wait for the async Markdown read to succeed or fail"
+        )
+        assertEqual(
+            countOccurrences(of: "ActivationTelemetry.trackHabitLoopAction(", in: previewBlock),
+            2,
+            "meeting preview should track habit-loop once in the success branch and once in the failure branch"
+        )
+
         // No control may pass a possibly-stale row/preview/notice URL straight to
         // NSWorkspace — those silently no-op when the file moved after scanning.
         for staleRawCall in [
@@ -776,6 +831,19 @@ func testUIAutomationSurfaceContract() {
             "QA bench should keep a callable ui mode with local JSON evidence"
         )
     }
+}
+
+private func sourceBlock(named startMarker: String, endingBefore endMarker: String, in source: String) -> String {
+    guard let start = source.range(of: startMarker)?.lowerBound,
+          let end = source[start...].range(of: endMarker)?.lowerBound else {
+        return ""
+    }
+    return String(source[start..<end])
+}
+
+private func countOccurrences(of needle: String, in haystack: String) -> Int {
+    guard !needle.isEmpty else { return 0 }
+    return haystack.components(separatedBy: needle).count - 1
 }
 
 private func readUIAutomationContractFile(_ relativePath: String) -> String {

--- a/scripts/ops/posthog-dashboard-queries.py
+++ b/scripts/ops/posthog-dashboard-queries.py
@@ -468,16 +468,19 @@ SELECT
   uniqIf(distinct_id, event = 'agent_capture_query_observed') AS agent_payoff_devices,
   uniqIf(distinct_id, event = 'activation_return_proxy_observed' AND properties['return_window_bucket'] = '18_36h') AS next_day_return_devices,
   uniqIf(distinct_id, event = 'activation_return_proxy_observed' AND properties['return_window_bucket'] IN ('36_72h', '3_7d')) AS seven_day_return_devices,
-  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] = 'review_yesterday') AS review_yesterday_devices,
-  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] = 'what_did_i_promise') AS promise_review_devices,
-  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] = 'open_recent_meeting') AS open_recent_meeting_devices,
-  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] IN ('daily_digest_viewed', 'daily_digest_exported')) AS daily_digest_devices
+  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] = 'review_yesterday' AND properties['result'] IN ('success', 'fallback')) AS review_yesterday_devices,
+  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] = 'what_did_i_promise' AND properties['result'] IN ('success', 'fallback')) AS promise_review_devices,
+  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] = 'open_recent_meeting' AND properties['result'] IN ('success', 'fallback')) AS open_recent_meeting_devices,
+  uniqIf(distinct_id, event = 'activation_habit_loop_actioned' AND properties['action_kind'] IN ('daily_digest_viewed', 'daily_digest_exported') AND properties['result'] IN ('success', 'fallback')) AS daily_digest_devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {days} DAY
   AND event IN ('activation_first_artifact_saved', 'activation_second_artifact_saved', 'agent_capture_query_observed', 'activation_return_proxy_observed', 'activation_habit_loop_actioned')
   {app_version_filter(app_version)}
 """,
-            notes=("Daily digest rows stay zero until a UI seam calls ActivationTelemetry.trackHabitLoopAction for viewed/exported.",),
+            notes=(
+                "Daily digest rows stay zero until a UI seam calls ActivationTelemetry.trackHabitLoopAction for viewed/exported.",
+                "The summary counts only success/fallback habit-loop outcomes; failed attempts remain visible in activation.habit_loop_actions.",
+            ),
         ),
         QuerySpec(
             id="activation.habit_loop_actions",
@@ -1215,6 +1218,13 @@ def run_self_test() -> int:
     for query_id in required:
         if query_id not in rendered:
             errors.append(f"fixture render missing {query_id}")
+    habit_summary = next((spec for spec in specs if spec.id == "activation.habit_loop_summary"), None)
+    if habit_summary and "properties['result'] IN ('success', 'fallback')" not in habit_summary.sql:
+        errors.append("habit-loop summary must exclude failed outcomes from success shortcut counts")
+    habit_actions = next((query for query in payload.get("queries", []) if query.get("id") == "activation.habit_loop_actions"), None)
+    action_rows = habit_actions.get("rows", []) if isinstance(habit_actions, dict) else []
+    if not any(row.get("result") == "failed" for row in action_rows):
+        errors.append("fixture must include a failed habit-loop action row so result breakdown stays exercised")
     forbidden_output = ("transcript_text", "audio_path", "meeting_title", "raw_url", "email", "token")
     lowered = rendered.lower()
     leaked = [fragment for fragment in forbidden_output if fragment in lowered]


### PR DESCRIPTION
## Summary
- Move post-save open/reveal/preview/copy telemetry so result-bearing events fire after success/failure is known.
- Remove eager habit-loop success tracking that double-counted meeting preview and copy-for-agent flows.
- Tighten PostHog habit-loop summary counts to success/fallback outcomes while preserving failed rows in the detailed action breakdown.
- Add source-contract regressions and a failed fixture row for dashboard helper self-tests.

## Proof
- Claude audit: `/Users/redbars/.codex/maestro/runs/20260704T114824Z-transcripted-post-save-telemetry-audit-claude`
- codex review --base origin/main: no actionable bugs found
- scripts/dev/agent-preflight.sh
- git diff --check
- python3 -m py_compile scripts/ops/posthog-dashboard-queries.py
- python3 scripts/ops/posthog-dashboard-queries.py --self-test
- python3 scripts/ops/posthog-dashboard-queries.py --fixture Tests/Fixtures/posthog-dashboard-query-results.json --json-only
- python3 -m py_compile scripts/ops/posthog-product-dashboard-summary.py
- python3 scripts/ops/posthog-product-dashboard-summary.py --self-test
- python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only
- bash run-tests.sh --filter UIAutomationSurfaceContractTests.swift
- bash run-tests.sh --filter AnalyticsEventPolicyTests.swift
- bash run-tests.sh --filter AnalyticsPayloadSanitizerTests.swift
- bash run-tests.sh: 12,569 passed
- bash build-deps.sh --force
- bash build.sh --no-open

## Lanes
lanes used: Codex=implementation, verification, review, PR; Claude=read-only telemetry audit; Local=attempted review but LM response was not useful; Windows=skipped unavailable/not configured

No release.
