### PR TITLE
Fix speaker finalization rename chains

### DIFF
--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -1142,36 +1142,20 @@ extension TranscriptSaver {
             replacementPlans.append((prefix: prefix, oldName: update.oldName, newName: update.newName))
         }
 
-        guard !hasCascadingScopedNameReplacement(in: replacementPlans) else {
-            return false
-        }
-
-        for plan in replacementPlans {
+        var deferredReplacements: [(token: String, newName: String)] = []
+        for (index, plan) in replacementPlans.enumerated() {
+            let token = scopedReplacementToken(kind: "transcript", index: index)
             let replaced = replaceTranscriptSpeakerLabels(
                 in: &content,
                 prefix: plan.prefix,
                 oldName: plan.oldName,
-                newName: plan.newName
+                newName: token
             )
             guard replaced > 0 else { return false }
+            deferredReplacements.append((token: token, newName: plan.newName))
         }
+        applyDeferredScopedReplacements(in: &content, replacements: deferredReplacements)
         return true
-    }
-
-    private static func hasCascadingScopedNameReplacement(
-        in plans: [(prefix: String, oldName: String, newName: String)]
-    ) -> Bool {
-        for plan in plans {
-            guard plan.oldName != plan.newName else { continue }
-            if plans.contains(where: {
-                $0.prefix == plan.prefix
-                    && $0.oldName != $0.newName
-                    && $0.oldName == plan.newName
-            }) {
-                return true
-            }
-        }
-        return false
     }
 
     private static func applyScopedBreakdownNameReplacements(
@@ -1207,12 +1191,6 @@ extension TranscriptSaver {
             replacementPlans.append((prefix: prefix, oldName: update.oldName, newName: update.newName, channel: target.channel))
         }
 
-        guard !hasCascadingScopedNameReplacement(in: replacementPlans.map {
-            (prefix: $0.prefix, oldName: $0.oldName, newName: $0.newName)
-        }) else {
-            return false
-        }
-
         for plan in replacementPlans {
             guard countSpeakerBreakdownRows(
                 in: content,
@@ -1223,16 +1201,33 @@ extension TranscriptSaver {
             }
         }
 
-        for plan in replacementPlans {
+        var deferredReplacements: [(token: String, newName: String)] = []
+        for (index, plan) in replacementPlans.enumerated() {
+            let token = scopedReplacementToken(kind: "breakdown", index: index)
             let replaced = replaceSpeakerBreakdownName(
                 in: &content,
                 oldName: plan.oldName,
-                newName: plan.newName,
+                newName: token,
                 channel: plan.channel
             )
             guard replaced == 1 else { return false }
+            deferredReplacements.append((token: token, newName: plan.newName))
         }
+        applyDeferredScopedReplacements(in: &content, replacements: deferredReplacements)
         return true
+    }
+
+    private static func scopedReplacementToken(kind: String, index: Int) -> String {
+        "__TRANSCRIPTED_SCOPED_\(kind.uppercased())_\(index)_\(UUID().uuidString)__"
+    }
+
+    private static func applyDeferredScopedReplacements(
+        in content: inout String,
+        replacements: [(token: String, newName: String)]
+    ) {
+        for replacement in replacements {
+            content = content.replacingOccurrences(of: replacement.token, with: replacement.newName)
+        }
     }
 
     private static func channelAndDiarizerID(forSpeakerKey key: String) -> (channel: UtteranceChannel, diarizerSpeakerId: Int)? {

--- a/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
@@ -1653,7 +1653,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         XCTAssertEqual(markdown, originalMarkdown)
     }
 
-    func testUpdateSpeakerNamesFallbackFailsClosedForOverlappingRenames() throws {
+    func testUpdateSpeakerNamesFallbackAppliesOverlappingRenamesSimultaneously() throws {
         let firstId = UUID()
         let secondId = UUID()
         let transcriptURL = tempDirectory.appendingPathComponent("overlapping-renames.md")
@@ -1696,12 +1696,16 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             transcriptionResult: driftedResult
         )
 
-        XCTAssertFalse(didUpdate)
+        XCTAssertTrue(didUpdate)
         let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
-        XCTAssertEqual(markdown, originalMarkdown)
+        XCTAssertTrue(markdown.contains("[00:01] [System/Sarah] First speaker."), markdown)
+        XCTAssertTrue(markdown.contains("[00:05] [System/Jamie] Second speaker."), markdown)
+        XCTAssertFalse(markdown.contains("[00:01] [System/Jamie] First speaker."), markdown)
+        XCTAssertTrue(markdown.contains(#"name: "Sarah""#), markdown)
+        XCTAssertTrue(markdown.contains(#"name: "Jamie""#), markdown)
     }
 
-    func testUpdateSpeakerNamesBreakdownFallbackFailsClosedForOverlappingRenames() throws {
+    func testUpdateSpeakerNamesBreakdownFallbackAppliesOverlappingRenamesSimultaneously() throws {
         let firstId = UUID()
         let secondId = UUID()
         let transcriptURL = tempDirectory.appendingPathComponent("overlapping-breakdown-renames.md")
@@ -1757,9 +1761,12 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             transcriptionResult: result
         )
 
-        XCTAssertFalse(didUpdate)
+        XCTAssertTrue(didUpdate)
         let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
-        XCTAssertEqual(markdown, originalMarkdown)
+        XCTAssertTrue(markdown.contains("- **Sarah:** 1 utterances, ~2 words, 00:03"), markdown)
+        XCTAssertTrue(markdown.contains("- **Jamie:** 1 utterances, ~2 words, 00:03"), markdown)
+        XCTAssertFalse(markdown.contains("- **Matt:**"), markdown)
+        XCTAssertFalse(markdown.contains("- **Sarah:** 2 utterances"), markdown)
     }
 
     func testUpdateSpeakerNamesBreakdownFallbackFailsClosedWhenRowsCollide() throws {

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -399,6 +399,133 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleNamingCompleteFinalizesScopedRenameChain() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let firstSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.51, count: 256),
+            existingId: nil
+        ).id
+        let secondSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.52, count: 256),
+            existingId: nil
+        ).id
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("Scoped_Rename_Chain.md")
+        let micURL = harness.paths.audioCaptures.appendingPathComponent("rename-chain-mic.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("rename-chain-system.wav")
+        let firstClipURL = harness.paths.speakerClips.appendingPathComponent("rename-chain-1.wav")
+        let secondClipURL = harness.paths.speakerClips.appendingPathComponent("rename-chain-2.wav")
+        let speakers = [
+            MarkdownSpeaker(id: "1", persistentSpeakerId: firstSpeakerId, name: "Speaker 1", confidence: "unknown", source: "db_pending"),
+            MarkdownSpeaker(id: "2", persistentSpeakerId: secondSpeakerId, name: "Speaker 2", confidence: "unknown", source: "db_pending"),
+        ]
+        let utterances = [
+            MarkdownUtterance(timestamp: "00:01", source: "System", label: "Speaker 1", text: "First voice.", diarizerSpeakerId: 1),
+            MarkdownUtterance(timestamp: "00:05", source: "System", label: "Speaker 2", text: "Second voice.", diarizerSpeakerId: 2),
+        ]
+        let transcript = """
+        ---
+        transcript_id: "\(transcriptId.uuidString)"
+        date: 2026-04-10
+        time: 15:01:23
+        sources: [mic, system_audio]
+        speakers:
+          - id: "1"
+            channel: system
+            db_id: "\(firstSpeakerId.uuidString)"
+            name: "Speaker 1"
+            confidence: unknown
+            source: db_pending
+          - id: "2"
+            channel: system
+            db_id: "\(secondSpeakerId.uuidString)"
+            name: "Speaker 2"
+            confidence: unknown
+            source: db_pending
+        ---
+
+        # Meeting Recording - Apr 10, 2026 at 3:01 PM
+
+        ## Channel & Speaker Analytics
+
+        ### Meeting Audio (Remote Participants)
+        - **Utterances:** 2
+        - **Words:** ~4
+        - **Speaking Time:** 00:06
+        - **Speakers Detected:** 2
+
+        #### Remote Speaker Breakdown
+
+        - **Speaker 1:** 1 utterances, ~2 words, 00:03
+        - **Speaker 2:** 1 utterances, ~2 words, 00:03
+
+        ## Conversation
+
+        [00:01] [System/Speaker 1] First voice.
+
+        [00:05] [System/Speaker 2] Second voice.
+        """
+
+        try transcript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+        try Data().write(to: firstClipURL)
+        try Data().write(to: secondClipURL)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: firstSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Speaker 2",
+                    previousName: "Speaker 1",
+                    action: .named
+                ),
+                SpeakerNameUpdate(
+                    persistentSpeakerId: secondSpeakerId,
+                    diarizerSpeakerId: "2",
+                    newName: "Jordan Lee",
+                    previousName: "Speaker 2",
+                    action: .named
+                ),
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(id: firstSpeakerId, diarizerSpeakerId: "1", clipURL: firstClipURL, sampleText: "First voice.", currentName: nil, matchSimilarity: nil, needsNaming: true, needsConfirmation: false, sessionEmbedding: [Float](repeating: 0.51, count: 256)),
+                SpeakerNamingEntry(id: secondSpeakerId, diarizerSpeakerId: "2", clipURL: secondClipURL, sampleText: "Second voice.", currentName: nil, matchSimilarity: nil, needsNaming: true, needsConfirmation: false, sessionEmbedding: [Float](repeating: 0.52, count: 256)),
+            ]
+        )
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+                && harness.manager.displayStatus == .transcriptSaved
+        }
+
+        let savedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(savedTranscript.contains("[00:01] [System/Speaker 2] First voice."), savedTranscript)
+        XCTAssertTrue(savedTranscript.contains("[00:05] [System/Jordan Lee] Second voice."), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains("[00:05] [System/Speaker 2] Second voice."), savedTranscript)
+        XCTAssertTrue(savedTranscript.contains(#"name: "Speaker 2""#), savedTranscript)
+        XCTAssertTrue(savedTranscript.contains(#"name: "Jordan Lee""#), savedTranscript)
+        XCTAssertEqual(harness.speakerDB.getSpeaker(id: firstSpeakerId)?.displayName, "Speaker 2")
+        XCTAssertEqual(harness.speakerDB.getSpeaker(id: secondSpeakerId)?.displayName, "Jordan Lee")
+    }
+
+    @MainActor
     func testHandleNamingCompleteAppleMacOS1RCoalescesSplitRowsAndSkipsNoDialogSpeaker() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()


### PR DESCRIPTION
## Summary
- Fix scoped fallback speaker-name finalization for overlapping rename chains like `Speaker 1 -> Speaker 2` and `Speaker 2 -> Jordan Lee`.
- Apply scoped transcript and speaker-breakdown replacements through temporary tokens so changes are simultaneous instead of cascading or failing closed.
- Add deterministic regression coverage for coordinator finalization plus transcript/breakdown fallback paths.

## Sentry
- Issue: APPLE-MACOS-1R (`meeting.speaker_finalization_failed`)
- Sentry 30d sample showed 7 production events; newest event ID `ccefe185dd57482898a5c0921e3f6781` at `2026-07-03T15:56:07Z`.

## Verification
- `~/.codex/bin/maestro-smoke.sh` (Codex/Claude reachable; Local LM Studio unavailable; Windows not configured)
- `~/.codex/bin/maestro-delegate claude --label speaker-finalization-review -- ...`
  - Proof: `/Users/redbars/.codex/maestro/runs/20260704T114848Z-speaker-finalization-review-claude`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` → 12563 passed, 0 failed
- `bash run-integration-smoke.sh` → core smoke, wake smoke, MicRecordingFileMergerTests green
- `swift test` → 677 tests, 2 skipped, 0 failures
- `codex review --base origin/main` → no actionable bugs; targeted tests green

## Lanes used
- Codex=implementation, Sentry inspection, dependency refresh, tests, build, review, PR
- Claude=independent root-cause review via maestro proof path above
- Local=skipped; LM Studio was not reachable on localhost:1234
- Windows=skipped; worker endpoint not configured/reachable
