### PR TITLE
Bound meeting model readiness waits

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -408,7 +408,11 @@ final class MeetingSessionController: ObservableObject {
         )
         let task = Task<Result<Void, Error>, Never> { [downloader] in
             do {
-                try await downloader.ensureModelsReady()
+                try await TranscriptedConstants.withDetachedTimeout(
+                    seconds: TranscriptedConstants.modelLoadWaitBudget
+                ) {
+                    try await downloader.ensureModelsReady()
+                }
                 return .success(())
             } catch {
                 return .failure(error)
@@ -2671,7 +2675,11 @@ final class MeetingSessionController: ObservableObject {
         )
 
         do {
-            try await downloader.ensureModelsReady(sttModel: job.sttModel)
+            try await TranscriptedConstants.withDetachedTimeout(
+                seconds: TranscriptedConstants.modelLoadWaitBudget
+            ) {
+                try await self.downloader.ensureModelsReady(sttModel: job.sttModel)
+            }
             sttAdapter.selectPreparedModel(job.sttModel)
         } catch {
             DiagnosticsTrail.record(

--- a/Sources/Meeting/MeetingWarmupStatusPolicy.swift
+++ b/Sources/Meeting/MeetingWarmupStatusPolicy.swift
@@ -84,12 +84,13 @@ enum MeetingWarmupStatusPolicy {
 
         switch dictationState {
         case .downloading(let progress):
+            let percentage = clampedDownloadPercentage(progress)
             return MeetingWarmupStatus(
                 title: "Getting Transcripted ready",
                 subtitle: "Downloading local dictation model",
                 detail: "One-time local model download. Keep Transcripted open; future app updates should reuse the cached model.",
                 progress: max(0.08, min(0.62, 0.08 + progress * 0.54)),
-                dictationStatus: progress > 0 ? "Downloading \(Int(progress * 100))%" : "Downloading",
+                dictationStatus: percentage > 0 ? "Downloading \(percentage)%" : "Downloading",
                 meetingsStatus: "Waiting"
             )
         case .loading:
@@ -128,6 +129,10 @@ enum MeetingWarmupStatusPolicy {
         case .notLoaded:
             return .modelsOnDemand
         }
+    }
+
+    private static func clampedDownloadPercentage(_ progress: Double) -> Int {
+        max(0, min(100, Int(progress * 100)))
     }
 
     private static func meetingStatus(

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -279,4 +279,87 @@ enum TranscriptedConstants {
             return result
         }
     }
+
+    /// Run an async operation with a deadline and return as soon as the deadline
+    /// wins, even if the underlying operation does not cooperatively unwind.
+    static func withDetachedTimeout<T: Sendable>(
+        seconds: Double,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        let operationTask = Task { try await operation() }
+        let timeoutTask = Task<T, Error> {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            throw CancellationError()
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let race = TimeoutRaceState<T>()
+
+            Task {
+                do {
+                    race.resume(
+                        with: .success(try await operationTask.value),
+                        continuation: continuation,
+                        operationTask: operationTask,
+                        timeoutTask: timeoutTask
+                    )
+                } catch {
+                    race.resume(
+                        with: .failure(error),
+                        continuation: continuation,
+                        operationTask: operationTask,
+                        timeoutTask: timeoutTask
+                    )
+                }
+            }
+
+            Task {
+                do {
+                    race.resume(
+                        with: .success(try await timeoutTask.value),
+                        continuation: continuation,
+                        operationTask: operationTask,
+                        timeoutTask: timeoutTask
+                    )
+                } catch {
+                    race.resume(
+                        with: .failure(error),
+                        continuation: continuation,
+                        operationTask: operationTask,
+                        timeoutTask: timeoutTask
+                    )
+                }
+            }
+        }
+    }
+}
+
+private final class TimeoutRaceState<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didResume = false
+
+    func resume(
+        with result: Result<T, Error>,
+        continuation: CheckedContinuation<T, Error>,
+        operationTask: Task<T, Error>,
+        timeoutTask: Task<T, Error>
+    ) {
+        lock.lock()
+        guard !didResume else {
+            lock.unlock()
+            return
+        }
+        didResume = true
+        lock.unlock()
+
+        operationTask.cancel()
+        timeoutTask.cancel()
+
+        switch result {
+        case .success(let value):
+            continuation.resume(returning: value)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
+    }
 }

--- a/Tests/MeetingWarmupStatusPolicyTests.swift
+++ b/Tests/MeetingWarmupStatusPolicyTests.swift
@@ -111,6 +111,18 @@ func testMeetingWarmupStatusPolicy() {
         )
     }
 
+    runSuite("MeetingWarmupStatusPolicy.status — clamps over-complete download copy") {
+        let status = MeetingWarmupStatusPolicy.status(
+            dictationState: .downloading(progress: 1.35),
+            meetingState: .notLoaded,
+            isMeetingWarmupInFlight: false,
+            shouldSurfaceMeetingWarmupFailure: false
+        )
+
+        assertEqual(status.dictationStatus, "Downloading 100%", "first-run download copy should never show impossible percentages")
+        assertTrue(status.progress <= 0.62, "download progress bar should stay in the bounded warmup range")
+    }
+
     runSuite("MeetingWarmupStatusPolicy.status — shows cached dictation files without fake readiness") {
         let status = MeetingWarmupStatusPolicy.status(
             dictationState: .cached,
@@ -125,6 +137,25 @@ func testMeetingWarmupStatusPolicy() {
             status.detail.contains("load them into memory on first use"),
             "cached copy should not claim the speech model is already loaded"
         )
+    }
+
+    runSuite("MeetingWarmupStatusPolicy.status — transitions from cached files to active loading copy") {
+        let cached = MeetingWarmupStatusPolicy.status(
+            dictationState: .cached,
+            meetingState: .notLoaded,
+            isMeetingWarmupInFlight: false,
+            shouldSurfaceMeetingWarmupFailure: false
+        )
+        let loading = MeetingWarmupStatusPolicy.status(
+            dictationState: .loading,
+            meetingState: .notLoaded,
+            isMeetingWarmupInFlight: false,
+            shouldSurfaceMeetingWarmupFailure: false
+        )
+
+        assertEqual(cached.dictationStatus, "Cached", "cached model files should stay distinct from a resident model")
+        assertEqual(loading.dictationStatus, "Loading", "active first-use loading should surface as loading")
+        assertFalse(loading.isReadyForMenuHeader, "active model loading should not be treated as ready")
     }
 
     runSuite("MeetingWarmupStatusPolicy.status — dictation failures still take priority") {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2162,6 +2162,28 @@ func testRepoCommandContract() {
             controllerContents.contains("downloader.ensureModelsReady(sttModel: job.sttModel)"),
             "queued meeting jobs should reload the STT model selected when the audio was queued"
         )
+        let visibleWarmupBlock = sourceSlice(
+            controllerContents,
+            from: "let task = Task<Result<Void, Error>, Never> { [downloader] in",
+            to: "modelPreparationTask = task"
+        )
+        assertTrue(
+            visibleWarmupBlock.contains("TranscriptedConstants.withDetachedTimeout")
+                && visibleWarmupBlock.contains("TranscriptedConstants.modelLoadWaitBudget")
+                && visibleWarmupBlock.contains("downloader.ensureModelsReady()"),
+            "visible meeting model warmup should fail through the existing model-load budget instead of staying stuck in loadingModels"
+        )
+        let queuedRecoveryBlock = sourceSlice(
+            controllerContents,
+            from: "private func ensureModelsReadyForQueuedTranscription(_ job: QueuedTranscriptionJob) async -> Bool {",
+            to: "let ready = sttAdapter.isReady && diarization.isReady"
+        )
+        assertTrue(
+            queuedRecoveryBlock.contains("TranscriptedConstants.withDetachedTimeout")
+                && queuedRecoveryBlock.contains("TranscriptedConstants.modelLoadWaitBudget")
+                && queuedRecoveryBlock.contains("downloader.ensureModelsReady(sttModel: job.sttModel)"),
+            "queued meeting model recovery should use the same bounded readiness wait as visible first-run warmup"
+        )
         assertTrue(
             controllerContents.contains("preparingQueuedTranscriptionJob")
                 && controllerContents.contains("isPreparingQueuedTranscriptionStart")

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -131,4 +131,26 @@ func testTranscriptedConstants() async {
 
         assertNil(result, "timeout should return through the throwing path instead of hanging")
     }
+
+    await runSuite("TranscriptedConstants.withDetachedTimeout — returns completed work before deadline") {
+        let result = try? await TranscriptedConstants.withDetachedTimeout(seconds: 1) {
+            "ok"
+        }
+
+        assertEqual(result, "ok", "detached timeout should return completed async work")
+    }
+
+    await runSuite("TranscriptedConstants.withDetachedTimeout — returns even when work ignores cancellation") {
+        let startedAt = Date()
+        let result = try? await TranscriptedConstants.withDetachedTimeout(seconds: 0.01) {
+            for _ in 0..<1_000 {
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+            return "late"
+        }
+        let elapsed = Date().timeIntervalSince(startedAt)
+
+        assertNil(result, "detached timeout should throw on deadline")
+        assertTrue(elapsed < 0.5, "detached timeout should not wait for non-cooperative model work to unwind")
+    }
 }


### PR DESCRIPTION
## Summary
- bound meeting model warmup and queued transcription model recovery with the existing model-load wait budget
- added a non-cooperative timeout helper so stuck model initialization cannot leave first-run UI loading forever
- clamped first-run download percentage copy and added deterministic readiness/loading contract tests

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter testTranscriptedConstants
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- git diff --check
- codex review --base origin/main: no actionable bugs; review-owned fast tests and build also passed

## Lanes used
- Codex: implemented, built, tested, reviewed, committed, pushed
- Claude: first-pass audit found stuck loading risk; proof /Users/redbars/.codex/maestro/runs/20260704T114741Z-transcripted-model-ready-audit-claude
- Local: smoke/local lane unavailable initially; later local review proof path produced non-file-aware output and was not treated as proof: /Users/redbars/.codex/maestro/runs/20260704T131638Z-transcripted-1149-review-local
- Windows: skipped, not configured/reachable

No release.