### PR TITLE
Gate dictation saved telemetry on artifact proof

### DIFF
--- a/Sources/Dictation/DictationStopFinalizationPolicy.swift
+++ b/Sources/Dictation/DictationStopFinalizationPolicy.swift
@@ -25,35 +25,35 @@ enum DictationStopFinalizationPolicy {
     static let order: DictationStopFinalizationOrder = .saveBeforeAutoEnter
 }
 
-struct DictationStopFinalizationResult<AutoEnterOutcome, SaveFailure> {
+struct DictationStopFinalizationResult<AutoEnterOutcome, SaveResult> {
     let autoEnterOutcome: AutoEnterOutcome
-    let saveFailure: SaveFailure?
+    let saveResult: SaveResult
 }
 
 enum DictationStopFinalizer {
     @MainActor
-    static func finalize<SaveValue, AutoEnterOutcome, SaveFailure>(
+    static func finalize<SaveResult, AutoEnterOutcome>(
         order: DictationStopFinalizationOrder,
-        startSaving: () -> Task<Result<SaveValue, Error>, Never>,
-        finishSaving: (Task<Result<SaveValue, Error>, Never>) async -> SaveFailure?,
-        saveSynchronously: () -> SaveFailure?,
+        startSaving: () -> Task<SaveResult, Never>,
+        finishSaving: (Task<SaveResult, Never>) async -> SaveResult,
+        saveSynchronously: () -> SaveResult,
         performAutoEnter: () async -> AutoEnterOutcome
-    ) async -> DictationStopFinalizationResult<AutoEnterOutcome, SaveFailure> {
+    ) async -> DictationStopFinalizationResult<AutoEnterOutcome, SaveResult> {
         switch order {
         case .saveAfterAutoEnter:
             let autoEnterOutcome = await performAutoEnter()
-            let saveFailure = saveSynchronously()
+            let saveResult = saveSynchronously()
             return DictationStopFinalizationResult(
                 autoEnterOutcome: autoEnterOutcome,
-                saveFailure: saveFailure
+                saveResult: saveResult
             )
         case .saveBeforeAutoEnter:
             let saveTask = startSaving()
             let autoEnterOutcome = await performAutoEnter()
-            let saveFailure = await finishSaving(saveTask)
+            let saveResult = await finishSaving(saveTask)
             return DictationStopFinalizationResult(
                 autoEnterOutcome: autoEnterOutcome,
-                saveFailure: saveFailure
+                saveResult: saveResult
             )
         }
     }

--- a/Sources/Observability/ActivationTelemetry.swift
+++ b/Sources/Observability/ActivationTelemetry.swift
@@ -303,13 +303,17 @@ enum ActivationTelemetry {
         ]
     }
 
+    @discardableResult
     static func trackDictationArtifactSaved(
+        saved: SavedDictationTranscript,
         delivery: String,
         durationBucket: String,
         surface: Surface = .dictationSave,
         trigger: String,
         wordCountBucket: String
-    ) {
+    ) -> Bool {
+        guard savedDictationArtifactExists(saved) else { return false }
+
         AnalyticsReporter.track(
             "dictation_artifact_saved",
             properties: dictationArtifactSavedProperties(
@@ -321,6 +325,23 @@ enum ActivationTelemetry {
                 wordCountBucket: wordCountBucket
             )
         )
+        return true
+    }
+
+    static func savedDictationArtifactExists(
+        _ saved: SavedDictationTranscript,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard saved.url.pathExtension.lowercased() == "md" else { return false }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: saved.url.path, isDirectory: &isDirectory),
+              !isDirectory.boolValue,
+              let attributes = try? fileManager.attributesOfItem(atPath: saved.url.path),
+              let fileSize = attributes[.size] as? NSNumber else {
+            return false
+        }
+        return fileSize.intValue > 0
     }
 
     static func trackAgentPromptAction(

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1067,7 +1067,8 @@ class DictationSessionController: ObservableObject {
                 }
             )
             let autoSendOutcome = finalization.autoEnterOutcome
-            let saveFailureMessage = finalization.saveFailure
+            let saveResult = finalization.saveResult
+            let saveFailureMessage = saveResult.failureMessage
             let wordCount = text.split(whereSeparator: \.isWhitespace).count
             stopTiming.completedAt = CFAbsoluteTimeGetCurrent()
             let deliveryLevel: EventLevel = pasteOutcome.delivery == .pasted ? .info : .warning
@@ -1152,8 +1153,9 @@ class DictationSessionController: ObservableObject {
                     ]
                 )
             )
-            if saveFailureMessage == nil {
+            if let saved = saveResult.saved {
                 ActivationTelemetry.trackDictationArtifactSaved(
+                    saved: saved,
                     delivery: pasteOutcome.delivery.rawValue,
                     durationBucket: AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime),
                     trigger: currentDictationTrigger.rawValue,
@@ -1185,7 +1187,8 @@ class DictationSessionController: ObservableObject {
         sessionID: UUID
     ) {
         lastCompletedText = text
-        let saveFailureMessage = persistDictationTranscript(text: text, delivery: .savedWithoutPaste)
+        let saveResult = persistDictationTranscript(text: text, delivery: .savedWithoutPaste)
+        let saveFailureMessage = saveResult.failureMessage
         let wordCount = text.split(whereSeparator: \.isWhitespace).count
         let durationSeconds = CFAbsoluteTimeGetCurrent() - sessionStartTime
         appState.logger.log("DICTATION | session cap reached, saved \(text.count) chars without pasting")
@@ -1237,12 +1240,15 @@ class DictationSessionController: ObservableObject {
                     }
                 }
             )
-            ActivationTelemetry.trackDictationArtifactSaved(
-                delivery: DictationDelivery.savedWithoutPaste.rawValue,
-                durationBucket: AnalyticsReporter.durationBucket(seconds: durationSeconds),
-                trigger: currentDictationTrigger.rawValue,
-                wordCountBucket: AnalyticsReporter.wordCountBucket(wordCount)
-            )
+            if let saved = saveResult.saved {
+                ActivationTelemetry.trackDictationArtifactSaved(
+                    saved: saved,
+                    delivery: DictationDelivery.savedWithoutPaste.rawValue,
+                    durationBucket: AnalyticsReporter.durationBucket(seconds: durationSeconds),
+                    trigger: currentDictationTrigger.rawValue,
+                    wordCountBucket: AnalyticsReporter.wordCountBucket(wordCount)
+                )
+            }
             ActivationTelemetry.trackFirstArtifactSavedIfNeeded(
                 artifactKind: .dictation,
                 surface: .dictationSave,
@@ -1748,8 +1754,26 @@ class DictationSessionController: ObservableObject {
         return autoSender.send(DictationAutoSendPreferences.sendKey(), target: sessionPasteTarget)
     }
 
+    private struct DictationTranscriptPersistenceResult {
+        let saved: SavedDictationTranscript?
+        let failureMessage: String?
+        let failureError: Error?
+
+        static func success(_ saved: SavedDictationTranscript) -> Self {
+            Self(saved: saved, failureMessage: nil, failureError: nil)
+        }
+
+        static func failure(_ message: String) -> Self {
+            Self(saved: nil, failureMessage: message, failureError: nil)
+        }
+
+        static func failure(_ error: Error) -> Self {
+            Self(saved: nil, failureMessage: nil, failureError: error)
+        }
+    }
+
     @discardableResult
-    private func persistDictationTranscript(text: String, delivery: DictationDelivery) -> String? {
+    private func persistDictationTranscript(text: String, delivery: DictationDelivery) -> DictationTranscriptPersistenceResult {
         do {
             let saved = try DictationTranscriptStore.save(
                 text: text,
@@ -1757,43 +1781,49 @@ class DictationSessionController: ObservableObject {
                 delivery: delivery
             )
             recordDictationTranscriptSaved(saved, delivery: delivery)
-            return nil
+            return .success(saved)
         } catch {
-            return recordDictationTranscriptSaveFailed(error)
+            return .failure(recordDictationTranscriptSaveFailed(error))
         }
     }
 
     private func startPersistingDictationTranscript(
         text: String,
         delivery: DictationDelivery
-    ) -> Task<Result<SavedDictationTranscript, Error>, Never> {
+    ) -> Task<DictationTranscriptPersistenceResult, Never> {
         let sourceAppName = sessionSourceApp?.localizedName ?? "Unknown"
         let sourceBundleID = sessionSourceApp?.bundleIdentifier
 
         return Task.detached(priority: .utility) {
-            Result {
-                try DictationTranscriptWriter.save(
+            do {
+                let saved = try DictationTranscriptWriter.save(
                     text: text,
                     sourceAppName: sourceAppName,
                     sourceBundleID: sourceBundleID,
                     delivery: delivery
                 )
+                return .success(saved)
+            } catch {
+                return .failure(error)
             }
         }
     }
 
     private func finishPersistingDictationTranscript(
-        _ task: Task<Result<SavedDictationTranscript, Error>, Never>,
+        _ task: Task<DictationTranscriptPersistenceResult, Never>,
         delivery: DictationDelivery
-    ) async -> String? {
-        switch await task.value {
-        case .success(let saved):
+    ) async -> DictationTranscriptPersistenceResult {
+        let result = await task.value
+        if let saved = result.saved {
             NotificationCenter.default.post(name: .dictationTranscriptDidSave, object: saved.url)
             recordDictationTranscriptSaved(saved, delivery: delivery)
-            return nil
-        case .failure(let error):
-            return recordDictationTranscriptSaveFailed(error)
+            return result
         }
+
+        if let error = result.failureError {
+            return .failure(recordDictationTranscriptSaveFailed(error))
+        }
+        return result
     }
 
     private func recordDictationTranscriptSaved(

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -362,6 +362,42 @@ func testAnalyticsEventPolicy() {
             "dictation artifact save telemetry should not include raw text, paths, filenames, app names, titles, or counts"
         )
         assertEqual(dictationProperties["surface"], "dictation_save", "saved dictation surface should stay coarse")
+
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory.appendingPathComponent(
+            "ActivationTelemetryTests.saved-dictation.\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
+        try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempRoot) }
+
+        let saved = try? DictationTranscriptStore.save(
+            text: "saved artifact proof",
+            sourceApp: nil,
+            delivery: .pasted,
+            createdAt: Date(timeIntervalSince1970: 1_800_000_000),
+            directory: outputDir
+        )
+        assertEqual(
+            saved.map { ActivationTelemetry.savedDictationArtifactExists($0) },
+            true,
+            "dictation_artifact_saved may fire only after a regular Markdown file exists on disk"
+        )
+
+        if let saved {
+            try? fm.removeItem(at: saved.url)
+            assertFalse(
+                ActivationTelemetry.trackDictationArtifactSaved(
+                    saved: saved,
+                    delivery: "pasted",
+                    durationBucket: "10_29s",
+                    trigger: "hotkey",
+                    wordCountBucket: "10_49"
+                ),
+                "missing saved Markdown must block dictation_artifact_saved even if a stale save result exists"
+            )
+        }
     }
 
     runSuite("ActivationTelemetry tracks first and second artifact saves once per install") {

--- a/Tests/DictationStopFinalizationPolicyTests.swift
+++ b/Tests/DictationStopFinalizationPolicyTests.swift
@@ -48,17 +48,17 @@ func testDictationStopFinalizationPolicy() async {
 
     await runSuite("DictationStopFinalizer.finalize - default starts save before Auto Enter and finishes after") {
         var events: [String] = []
-        let result: DictationStopFinalizationResult<String, String> = await DictationStopFinalizer.finalize(
+        let result: DictationStopFinalizationResult<String, String?> = await DictationStopFinalizer.finalize(
             order: .saveBeforeAutoEnter,
             startSaving: {
                 events.append("start_save")
-                return Task { .success("saved") }
+                return Task { nil }
             },
             finishSaving: { task in
                 events.append("finish_save_started")
-                _ = await task.value
+                let result = await task.value
                 events.append("finish_save_finished")
-                return nil
+                return result
             },
             saveSynchronously: {
                 events.append("save_synchronously")
@@ -81,21 +81,20 @@ func testDictationStopFinalizationPolicy() async {
             "save-before finalization should start saving, send Auto Enter, then await the save result"
         )
         assertEqual(result.autoEnterOutcome, "sent", "finalizer should preserve the Auto Enter result")
-        assertNil(result.saveFailure, "successful save should report no failure")
+        assertNil(result.saveResult, "successful save should report no failure")
     }
 
     await runSuite("DictationStopFinalizer.finalize - legacy order keeps save after Auto Enter") {
         var events: [String] = []
-        let result: DictationStopFinalizationResult<String, String> = await DictationStopFinalizer.finalize(
+        let result: DictationStopFinalizationResult<String, String?> = await DictationStopFinalizer.finalize(
             order: .saveAfterAutoEnter,
             startSaving: {
                 events.append("start_save")
-                return Task { .success("saved") }
+                return Task { nil }
             },
             finishSaving: { task in
                 events.append("finish_save")
-                _ = await task.value
-                return nil
+                return await task.value
             },
             saveSynchronously: {
                 events.append("save_synchronously")
@@ -116,6 +115,6 @@ func testDictationStopFinalizationPolicy() async {
             "save-after finalization should preserve the legacy Auto Enter first order"
         )
         assertEqual(result.autoEnterOutcome, "sent", "finalizer should preserve the Auto Enter result")
-        assertEqual(result.saveFailure, "disk full", "finalizer should preserve synchronous save failures")
+        assertEqual(result.saveResult, "disk full", "finalizer should preserve synchronous save failures")
     }
 }

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -212,12 +212,14 @@ aggregate reliability sizing and should not be expanded to raw device names.
   now covers sourced local-memory rollups, but PostHog still cannot judge
   whether the sourced answer was useful.
 - General dictation saved-Markdown writes now have `dictation_artifact_saved`;
-  keep `dictation_completed` as completion-volume context, not strict saved-artifact proof.
+  it fires only after the daily Markdown file is confirmed on disk. Keep
+  `dictation_completed` as completion-volume context, not strict saved-artifact proof.
 - `agent_capture_query_observed` proves successful saved-capture reads,
   searches, and summary-memory rollups through MCP, but it still cannot judge
   answer quality.
-- General dictation saved-Markdown writes still rely on `dictation_completed`
-  as a proxy, while onboarding dictation and meeting saves have stricter events.
+- General dictation completion volume can be larger than saved-artifact volume;
+  investigate any sustained gap between `dictation_completed` and
+  `dictation_artifact_saved` as a save-proof or telemetry-delivery problem.
 - Settings/action tracking is broad enough to show discovery, but it does not
   always connect settings changes to later workflow success.
 - Local summary beta behavior now has artifact-action, start, completion,
@@ -238,7 +240,7 @@ Prefer a small number of lifecycle events over broad click tracking.
 | `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures or sourced local summary memory | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
 | `activation_second_artifact_saved` | A device saves its second artifact | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `activation_habit_loop_actioned` | A user takes a post-save or daily-return action like Review yesterday, What did I promise, open recent meeting, daily digest viewed/exported, or return after first/second artifact | `action_kind`, `artifact_kind`, `artifact_count_bucket`, `return_window_bucket`, `surface`, `result` |
-| `dictation_artifact_saved` | Any normal dictation Markdown is durably saved | `delivery`, `duration_bucket`, `save_outcome`, `surface`, `trigger`, `word_count_bucket` |
+| `dictation_artifact_saved` | Any normal dictation Markdown is durably saved and confirmed as an on-disk `.md` artifact | `delivery`, `duration_bucket`, `save_outcome`, `surface`, `trigger`, `word_count_bucket` |
 | `dictation_retry_started` | User retries after a failed or empty dictation | `failure_kind`, `retry_source`, `route_shape`, `trigger` |
 | `meeting_speaker_auto_recognized` | A returning speaker was silently recognized without review; `graduated` marks a profile's first-ever auto-recognition | `similarity_bucket`, `margin_bucket`, `call_count_bucket`, `channel`, `graduated`, `surface` |
 | `meeting_speaker_match_reviewed` | One review verdict joining match confidence to the user's answer (confirmed = right, corrected = wrong) | `review_action`, `similarity_bucket`, `margin_bucket`, `call_count_bucket`, `channel`, `had_suggestion`, `surface` |

--- a/scripts/ops/posthog-activation-funnel.py
+++ b/scripts/ops/posthog-activation-funnel.py
@@ -682,7 +682,7 @@ def render_report(data: dict[str, Any]) -> str:
     limitations = [
         "`permission ready` uses `onboarding_completed` as a proxy. The app guards completion on required dictation permissions, but this does not count users who became ready outside onboarding.",
         "`strict saved Markdown` counts `activation_first_artifact_saved`, emitted once per install from successful dictation, live meeting, and imported meeting Markdown save paths.",
-        "`dictation_artifact_saved`, `dictation_completed`, `onboarding_first_dictation_saved`, and `meeting_transcript_saved` are included only in the broader proxy row for dictation volume and legacy continuity.",
+        "`dictation_artifact_saved`, `onboarding_first_dictation_saved`, and `meeting_transcript_saved` are broader saved-artifact proof signals; `dictation_completed` is included only for completion-volume continuity.",
         "Agent setup and prompt-copy events prove intent. They do not prove the user asked an agent a sourced question or got a useful answer.",
         "`activation_second_artifact_saved` proves a second durable artifact save on the same anonymous device, but does not inspect artifact content or join identity.",
         "`agent_capture_query_observed` is the strongest current true-agent-use signal. Its query/source/age buckets prove saved local capture use, not answer quality.",


### PR DESCRIPTION
Replaces dirty PR #1471 with a fresh branch from current main.\n\nWhat changed:\n- Carries the saved dictation persistence result through stop finalization.\n- Emits dictation_artifact_saved only when the saved Markdown file exists and is non-empty.\n- Keeps activation_first_artifact_saved tied to the successful saved artifact path.\n\nChecks run:\n- scripts/dev/agent-preflight.sh\n- git diff --cached --check\n- bash run-tests.sh --filter AnalyticsEventPolicy\n- bash run-tests.sh --filter DictationStopFinalizationPolicy\n\nBlocked check:\n- bash build.sh --no-open first required build-deps. bash build-deps.sh --force then failed inside temp SwiftPM dependency compilation with a disk I/O / temp rename error and could not recover its temp cwd. This did not reach app Swift compilation. Run build-deps/build/run-tests before merge.