### PR TITLE
Harden dictation Bluetooth recovery

### DIFF
--- a/Sources/Speech/ParakeetAudioDeviceLookup.swift
+++ b/Sources/Speech/ParakeetAudioDeviceLookup.swift
@@ -9,9 +9,21 @@ extension NSLock {
     }
 }
 
-private enum InputDeviceLookupError: Error {
+private enum InputDeviceLookupError: LocalizedError {
     case propertyReadFailed(OSStatus)
+    case propertyWriteFailed(OSStatus)
     case unknownDevice
+
+    var errorDescription: String? {
+        switch self {
+        case .propertyReadFailed(let status):
+            return "CoreAudio property read failed with status \(status)"
+        case .propertyWriteFailed(let status):
+            return "CoreAudio property write failed with status \(status)"
+        case .unknownDevice:
+            return "CoreAudio returned an unknown device"
+        }
+    }
 }
 
 enum ParakeetAudioEngineWorkError: LocalizedError {
@@ -48,6 +60,31 @@ enum CoreAudioInputDeviceLookup {
             availableInputs: availableInputs,
             allowsBuiltInBluetoothFallback: allowsBuiltInBluetoothFallback
         )
+    }
+
+    static func setDefaultInputDeviceID(_ deviceID: AudioDeviceID) throws {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var mutableDeviceID = deviceID
+        let dataSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectSetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            dataSize,
+            &mutableDeviceID
+        )
+        guard status == noErr else {
+            throw InputDeviceLookupError.propertyWriteFailed(status)
+        }
+    }
+
+    static func currentDefaultInputDeviceID() throws -> AudioDeviceID {
+        try defaultInputDeviceID()
     }
 
     private static func allInputDevices() throws -> [DictationAudioDevice] {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -3129,6 +3129,7 @@ class ParakeetEngine: ObservableObject {
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "transcription_failed",
                 message: error.localizedDescription,
                 context: ["samples": "\(nativeCount)", "elapsed": String(format: "%.2f", elapsed)])
+            lastEmptyTranscriptionReason = .modelFailure
             finishTranscription()
             return nil
         }

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -92,6 +92,8 @@ class ParakeetEngine: ObservableObject {
     private var pureSampleTranscriptionActivityCount = 0
     private var asrManagerReady = false
     private nonisolated(unsafe) var didReceiveAudioSamples = false
+    private nonisolated(unsafe) var didReceiveNonZeroAudioSamples = false
+    private var recordingStartedOnLikelyBluetoothHandsFreeRoute = false
     private var cachedInputDeviceName = "Unknown"
     /// Last known dictation input selection, refreshed on start, prewarm,
     /// route/device-change notifications, and background refreshes. Serves
@@ -698,6 +700,7 @@ class ParakeetEngine: ObservableObject {
     // MARK: - Input readiness
 
     func prewarm() async {
+        guard !Task.isCancelled else { return }
         guard !isShuttingDown else { return }
         guard !isRecording else { return }
         guard !audioStartInProgress else { return }
@@ -705,6 +708,7 @@ class ParakeetEngine: ObservableObject {
         scheduleInputDeviceNameRefresh()
 
         await releaseIdleAudioHardware(removeTap: false)
+        guard !Task.isCancelled else { return }
         let prewarmGeneration = audioGraphGeneration
         guard canContinuePrewarm(generation: prewarmGeneration) else { return }
 
@@ -821,6 +825,7 @@ class ParakeetEngine: ObservableObject {
     }
 
     func forceInputReadinessRecovery(reason: String) async {
+        guard !Task.isCancelled else { return }
         guard !isShuttingDown else { return }
         guard !isRecording, !audioStartInProgress else { return }
 
@@ -843,7 +848,12 @@ class ParakeetEngine: ObservableObject {
 
         abandonBlockedAudioEngine(reason: reason)
         markFormatUnreadyAndPublish()
-        try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+        do {
+            try await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+        } catch {
+            return
+        }
+        guard !Task.isCancelled else { return }
         await prewarm()
     }
 
@@ -1481,6 +1491,7 @@ class ParakeetEngine: ObservableObject {
                 outputDeviceClass: defaultOutputClass
             ),
             "sample_flow_started": "\(didReceiveAudioSamples)",
+            "sample_signal_started": "\(didReceiveNonZeroAudioSamples)",
             "selection_overrode_default": "\(selection?.didOverrideDefault ?? false)",
             "selection_reason": selection?.reason.rawValue ?? "unknown",
             "selected_input_class": selectedClass,
@@ -1656,6 +1667,10 @@ class ParakeetEngine: ObservableObject {
                     bufferSampleRate: bufferFormat.sampleRate
                 )
                 self.nativeSampleRate = effectiveSampleRate
+                let hasNonZeroSignal = ParakeetSampleSignalPolicy.hasNonZeroSignal(monoSamples)
+                if hasNonZeroSignal {
+                    self.didReceiveNonZeroAudioSamples = true
+                }
 
                 if !self.didReceiveAudioSamples && frameLength > 0 {
                     self.didReceiveAudioSamples = true
@@ -1666,7 +1681,8 @@ class ParakeetEngine: ObservableObject {
                         var context = [
                             "sample_rate": "\(effectiveSampleRate)",
                             "channels": "\(bufferFormat.channelCount)",
-                            "frames": "\(frameLength)"
+                            "frames": "\(frameLength)",
+                            "sample_signal_started": "\(hasNonZeroSignal)"
                         ]
                         if let startToFirstSampleMs {
                             context["start_to_first_sample_ms"] = "\(startToFirstSampleMs)"
@@ -1815,6 +1831,8 @@ class ParakeetEngine: ObservableObject {
         isRecording = false
         audioLevel = 0
         didReceiveAudioSamples = false
+        didReceiveNonZeroAudioSamples = false
+        recordingStartedOnLikelyBluetoothHandsFreeRoute = false
 
         if rebuildEngine {
             await rebuildAudioEngine(reason: reason)
@@ -1872,6 +1890,8 @@ class ParakeetEngine: ObservableObject {
         inputTapInstalled = false
         isEnginePrewarmed = false
         didReceiveAudioSamples = false
+        didReceiveNonZeroAudioSamples = false
+        recordingStartedOnLikelyBluetoothHandsFreeRoute = false
         if !isShuttingDown {
             installAudioEngineConfigObserverIfNeeded()
         }
@@ -1900,6 +1920,8 @@ class ParakeetEngine: ObservableObject {
         inputTapInstalled = false
         isEnginePrewarmed = false
         didReceiveAudioSamples = false
+        didReceiveNonZeroAudioSamples = false
+        recordingStartedOnLikelyBluetoothHandsFreeRoute = false
         if !isShuttingDown {
             installAudioEngineConfigObserverIfNeeded()
         }
@@ -2188,6 +2210,8 @@ class ParakeetEngine: ObservableObject {
 
         recordingInterrupted = false
         didReceiveAudioSamples = false
+        didReceiveNonZeroAudioSamples = false
+        recordingStartedOnLikelyBluetoothHandsFreeRoute = false
         cancelAudioWatchdog()
         if !isRecoveryAttempt && !preservingRecordingAcrossRecovery {
             recoveredRecordingTimeline.removeAll(keepingCapacity: true)
@@ -2300,6 +2324,12 @@ class ParakeetEngine: ObservableObject {
             }
 
             updateNativeSampleRate(snapshot.outputFormat.sampleRate)
+            recordingStartedOnLikelyBluetoothHandsFreeRoute = ParakeetRouteDiagnosticsPolicy.isLikelyBluetoothHandsFreeProfile(
+                inputClass: selectedInputClass(for: snapshot.selection),
+                outputDeviceClass: defaultOutputClass(for: snapshot.selection),
+                inputRate: snapshot.hwFormat.sampleRate,
+                outputRate: snapshot.outputFormat.sampleRate
+            )
             reserveNativeSampleBufferCapacity()
 
             do {
@@ -2361,8 +2391,13 @@ class ParakeetEngine: ObservableObject {
                 let failureReason = operationTimedOut
                     ? ParakeetStartRecordingFailureReason.audioEngineStartTimedOut
                     : ParakeetAudioFormatReadinessPolicy.startFailureReason(for: error as NSError)
+                let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
+                    for: failureReason,
+                    isRecoveryAttempt: isRecoveryAttempt
+                )
                 context["failure_kind"] = operationTimedOut ? "audio_engine_start_timeout" : "audio_engine_start_failed"
                 context["sample_flow_started"] = "\(didReceiveAudioSamples)"
+                context["sample_signal_started"] = "\(didReceiveNonZeroAudioSamples)"
                 let shouldRetry = !operationTimedOut
                     && failureReason == .audioEngineStartFailed
                     && ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(
@@ -2374,7 +2409,7 @@ class ParakeetEngine: ObservableObject {
                 } else {
                     await resetAudioGraphAfterStartFailure(
                         reason: failureReason == .audioRouteNotSettled ? "audio_route_not_settled" : "audio_engine_start_failed",
-                        rebuildEngine: true
+                        rebuildEngine: startFailureAction.rebuildAudioEngine
                     )
                 }
 
@@ -2400,10 +2435,6 @@ class ParakeetEngine: ObservableObject {
                         message: "Audio route format was not ready while starting dictation",
                         context: context
                     )
-                    let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
-                        for: failureReason,
-                        isRecoveryAttempt: isRecoveryAttempt
-                    )
                     if startFailureAction.markFormatUnready {
                         markStartFailedAndPublish()
                     }
@@ -2422,10 +2453,6 @@ class ParakeetEngine: ObservableObject {
                         message: "Audio engine start timed out; abandoned blocked microphone graph",
                         context: context
                     )
-                    let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
-                        for: .audioEngineStartTimedOut,
-                        isRecoveryAttempt: isRecoveryAttempt
-                    )
                     if startFailureAction.markFormatUnready {
                         markStartFailedAndPublish()
                     }
@@ -2437,10 +2464,6 @@ class ParakeetEngine: ObservableObject {
 
                 print("❌ PARAKEET | audio engine failed after \(attempt) attempt(s): \(error.localizedDescription)")
                 reportAudioStartFailureIfNeeded(message: error.localizedDescription, context: context)
-                let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
-                    for: .audioEngineStartFailed,
-                    isRecoveryAttempt: isRecoveryAttempt
-                )
                 if startFailureAction.markFormatUnready {
                     markStartFailedAndPublish()
                 }
@@ -2482,7 +2505,7 @@ class ParakeetEngine: ObservableObject {
         }
         print("🎤 PARAKEET | recording started (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
 
-        // Watchdog: detect zombie audio engine (running but no samples flowing after sleep/wake).
+        // Watchdog: detect zombie audio engine (running but no usable signal after sleep/wake).
         // Only on first attempt — recovery attempt doesn't re-watchdog to prevent infinite loops.
         if !isRecoveryAttempt {
             startAudioWatchdog()
@@ -2528,7 +2551,7 @@ class ParakeetEngine: ObservableObject {
         return monoSamples
     }
 
-    /// Watchdog that detects zombie audio engines — running but producing no samples.
+    /// Watchdog that detects zombie audio engines — running but producing no usable signal.
     /// After sleep/wake, CoreAudio may report the engine as running but the hardware graph
     /// is disconnected. If no samples arrive within 2 seconds, tear down and retry once.
     /// If the user stops dictation during the recovery delay, the pending retry is cleared
@@ -2545,11 +2568,23 @@ class ParakeetEngine: ObservableObject {
             }
             guard sampleCount >= 0 else { return }
 
-            guard sampleCount == 0 else { return }  // Audio is flowing — all good
+            let shouldReset = ParakeetSampleSignalPolicy.shouldResetStartupAudio(
+                sampleCount: sampleCount,
+                hasNonZeroSignal: self.didReceiveNonZeroAudioSamples,
+                isLikelyBluetoothHandsFreeRoute: self.recordingStartedOnLikelyBluetoothHandsFreeRoute
+            )
+            guard shouldReset else { return }
 
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "zombie_engine_detected",
-                message: "No audio samples received after recording start — resetting engine",
-                context: ["audio_device": self.inputDeviceName])
+                message: sampleCount == 0
+                    ? "No audio samples received after recording start — resetting engine"
+                    : "Only silent audio samples received after recording start — resetting engine",
+                context: [
+                    "audio_device": self.inputDeviceName,
+                    "hfp_suspected": "\(self.recordingStartedOnLikelyBluetoothHandsFreeRoute)",
+                    "sample_count": "\(sampleCount)",
+                    "sample_signal_started": "\(self.didReceiveNonZeroAudioSamples)",
+                ])
 
             self.streamingSamplesLock.withLock {
                 self.streamingSampleBuffer.removeAll(keepingCapacity: true)
@@ -3211,6 +3246,8 @@ class ParakeetEngine: ObservableObject {
         isTranscribing = false
         audioLevel = 0
         didReceiveAudioSamples = false
+        didReceiveNonZeroAudioSamples = false
+        recordingStartedOnLikelyBluetoothHandsFreeRoute = false
         sampleBuffer.removeAll(keepingCapacity: true)
         clearRecoveredRecordingTimeline(keepingCapacity: true)
         liveTranscript = ""
@@ -3245,6 +3282,8 @@ class ParakeetEngine: ObservableObject {
         audioStartInProgress = false
         audioLevel = 0
         didReceiveAudioSamples = false
+        didReceiveNonZeroAudioSamples = false
+        recordingStartedOnLikelyBluetoothHandsFreeRoute = false
         sampleBuffer.removeAll(keepingCapacity: true)
         clearRecoveredRecordingTimeline(keepingCapacity: true)
         liveTranscript = ""

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -102,6 +102,7 @@ class ParakeetEngine: ObservableObject {
     private var lastAudioStartFailureReportAt: TimeInterval?
     private var lastInputSelectionReportKey: String?
     private var ignoreInputSelectionConfigChangesUntil: CFAbsoluteTime = 0
+    private var pendingSystemInputRestore: (temporaryInput: AudioDeviceID, previousInput: AudioDeviceID)?
 
     var isModelLoaded: Bool { asrManagerReady }
     var inputDeviceName: String { cachedInputDeviceName }
@@ -155,6 +156,39 @@ class ParakeetEngine: ObservableObject {
             )
         } catch {
             return nil
+        }
+    }
+
+    nonisolated private static func applyPreferredSystemInputDevice(
+        for selection: DictationInputDeviceSelection?
+    ) -> String? {
+        guard let selection,
+              selection.didOverrideDefault,
+              selection.reason == .preferredBuiltInForBluetoothHeadset else {
+            return nil
+        }
+
+        do {
+            try CoreAudioInputDeviceLookup.setDefaultInputDeviceID(selection.selectedInput.id)
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    nonisolated private static func restoreSystemInputDeviceIfStillTemporary(
+        temporaryInput: AudioDeviceID,
+        previousInput: AudioDeviceID
+    ) -> String? {
+        do {
+            let currentInput = try CoreAudioInputDeviceLookup.currentDefaultInputDeviceID()
+            guard currentInput == temporaryInput else {
+                return nil
+            }
+            try CoreAudioInputDeviceLookup.setDefaultInputDeviceID(previousInput)
+            return nil
+        } catch {
+            return error.localizedDescription
         }
     }
 
@@ -1514,6 +1548,70 @@ class ParakeetEngine: ObservableObject {
         return context
     }
 
+    private func restoreSystemInputIfStillTemporary(
+        temporaryInput: AudioDeviceID,
+        previousInput: AudioDeviceID,
+        operation: String
+    ) async {
+        ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent()
+            + TranscriptedConstants.selfInducedConfigChangeIgnoreWindow
+        let restoreError = await Task.detached(priority: .utility) {
+            Self.restoreSystemInputDeviceIfStillTemporary(
+                temporaryInput: temporaryInput,
+                previousInput: previousInput
+            )
+        }.value
+        if let restoreError {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "dictation_system_input_restore_failed",
+                message: "Failed to restore system input after dictation route override",
+                context: [
+                    "operation": operation,
+                    "error": restoreError,
+                ]
+            )
+        }
+    }
+
+    private func restorePendingSystemInputAfterRecording(operation: String) async {
+        guard let restoreTarget = pendingSystemInputRestore else { return }
+        pendingSystemInputRestore = nil
+        await restoreSystemInputIfStillTemporary(
+            temporaryInput: restoreTarget.temporaryInput,
+            previousInput: restoreTarget.previousInput,
+            operation: operation
+        )
+    }
+
+    private func schedulePendingSystemInputRestore(operation: String) {
+        guard let restoreTarget = pendingSystemInputRestore else { return }
+        pendingSystemInputRestore = nil
+        ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent()
+            + TranscriptedConstants.selfInducedConfigChangeIgnoreWindow
+        Task.detached(priority: .utility) {
+            let restoreError = Self.restoreSystemInputDeviceIfStillTemporary(
+                temporaryInput: restoreTarget.temporaryInput,
+                previousInput: restoreTarget.previousInput
+            )
+            if let restoreError {
+                await MainActor.run {
+                    EventReporter.shared.capture(
+                        level: .warning,
+                        engine: "parakeet",
+                        event: "dictation_system_input_restore_failed",
+                        message: "Failed to restore system input after dictation route override",
+                        context: [
+                            "operation": operation,
+                            "error": restoreError,
+                        ]
+                    )
+                }
+            }
+        }
+    }
+
     private func audioInputSnapshot(
         operation: String,
         recoveryGeneration: UInt64? = nil,
@@ -1536,20 +1634,88 @@ class ParakeetEngine: ObservableObject {
             ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent()
                 + TranscriptedConstants.selfInducedConfigChangeIgnoreWindow
         }
+        let shouldRestoreSystemInputOnStop = operation == "start_recording"
+        let systemInputOverrideStartedAt = CFAbsoluteTimeGetCurrent()
+        let systemInputOverrideError = await Task.detached(priority: .utility) {
+            Self.applyPreferredSystemInputDevice(for: selection)
+        }.value
+        var systemInputRestoreTarget: (temporaryInput: AudioDeviceID, previousInput: AudioDeviceID)?
+        stageTimings["audio_input_system_override_ms"] = Self.elapsedMilliseconds(since: systemInputOverrideStartedAt)
+        if let selection, selection.didOverrideDefault {
+            var context = inputSelectionContext(selection, operation: "\(operation)_system_input")
+            if let systemInputOverrideError {
+                pendingSystemInputRestore = nil
+                context["error"] = systemInputOverrideError
+                EventReporter.shared.capture(
+                    level: .warning,
+                    engine: "parakeet",
+                    event: "dictation_system_input_override_failed",
+                    message: "Failed to move system input away from Bluetooth headset microphone",
+                    context: context
+                )
+            } else if selection.reason == .preferredBuiltInForBluetoothHeadset {
+                let restoreTarget = (
+                    temporaryInput: selection.selectedInput.id,
+                    previousInput: selection.defaultInput.id
+                )
+                if shouldRestoreSystemInputOnStop {
+                    pendingSystemInputRestore = restoreTarget
+                }
+                systemInputRestoreTarget = restoreTarget
+                EventReporter.shared.capture(
+                    level: .info,
+                    engine: "parakeet",
+                    event: "dictation_system_input_auto_selected",
+                    message: "System input moved away from Bluetooth headset microphone",
+                    context: context
+                )
+            }
+        }
 
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
+            if !shouldRestoreSystemInputOnStop, let systemInputRestoreTarget {
+                await restoreSystemInputIfStillTemporary(
+                    temporaryInput: systemInputRestoreTarget.temporaryInput,
+                    previousInput: systemInputRestoreTarget.previousInput,
+                    operation: "\(operation)_system_input_stale_recovery"
+                )
+            }
             throw CancellationError()
         }
         let snapshotGraphGeneration = audioGraphGeneration
         let snapshotReadStartedAt = CFAbsoluteTimeGetCurrent()
-        let snapshotResult = try await runTimedAudioEngineWork(operation: "\(operation)_snapshot") { audioEngine in
-            let inputNode = audioEngine.inputNode
-            let selectionApplication = Self.applyPreferredDictationInputDevice(selection, to: inputNode)
-            return (
-                outputFormat: Self.audioFormatSummary(inputNode.outputFormat(forBus: 0)),
-                hwFormat: Self.audioFormatSummary(inputNode.inputFormat(forBus: 0)),
-                selectionApplication: selectionApplication,
-                engineWasRunning: audioEngine.isRunning
+        let snapshotResult: (
+            outputFormat: ParakeetAudioFormatSummary,
+            hwFormat: ParakeetAudioFormatSummary,
+            selectionApplication: ParakeetInputDeviceApplication?,
+            engineWasRunning: Bool
+        )
+        do {
+            snapshotResult = try await runTimedAudioEngineWork(operation: "\(operation)_snapshot") { audioEngine in
+                let inputNode = audioEngine.inputNode
+                let selectionApplication = Self.applyPreferredDictationInputDevice(selection, to: inputNode)
+                return (
+                    outputFormat: Self.audioFormatSummary(inputNode.outputFormat(forBus: 0)),
+                    hwFormat: Self.audioFormatSummary(inputNode.inputFormat(forBus: 0)),
+                    selectionApplication: selectionApplication,
+                    engineWasRunning: audioEngine.isRunning
+                )
+            }
+        } catch {
+            if !shouldRestoreSystemInputOnStop, let systemInputRestoreTarget {
+                await restoreSystemInputIfStillTemporary(
+                    temporaryInput: systemInputRestoreTarget.temporaryInput,
+                    previousInput: systemInputRestoreTarget.previousInput,
+                    operation: "\(operation)_system_input_failed"
+                )
+            }
+            throw error
+        }
+        if !shouldRestoreSystemInputOnStop, let systemInputRestoreTarget {
+            await restoreSystemInputIfStillTemporary(
+                temporaryInput: systemInputRestoreTarget.temporaryInput,
+                previousInput: systemInputRestoreTarget.previousInput,
+                operation: "\(operation)_system_input"
             )
         }
         stageTimings["audio_input_snapshot_read_ms"] = Self.elapsedMilliseconds(since: snapshotReadStartedAt)
@@ -2180,13 +2346,17 @@ class ParakeetEngine: ObservableObject {
         defer {
             audioStartInProgress = false
         }
+        func failAudioStart(_ operation: String) async -> Bool {
+            await restorePendingSystemInputAfterRecording(operation: operation)
+            return false
+        }
 
         scheduleInputDeviceNameRefresh()
         let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         guard micStatus == .authorized else {
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "mic_not_authorized",
                 message: "Microphone permission status: \(micStatus.rawValue)")
-            return false
+            return await failAudioStart("start_recording_mic_not_authorized")
         }
 
         installAudioObserversIfNeeded()
@@ -2205,7 +2375,7 @@ class ParakeetEngine: ObservableObject {
             if !recoveryState.isRecovering {
                 schedulePrewarmRetry()
             }
-            return false
+            return await failAudioStart("start_recording_recovering")
         }
 
         recordingInterrupted = false
@@ -2233,7 +2403,7 @@ class ParakeetEngine: ObservableObject {
                     message: "Audio start aborted because the audio graph changed before startup finished",
                     context: ["audio_graph_generation": "\(audioGraphGeneration)"]
                 )
-                return false
+                return await failAudioStart("start_recording_generation_changed_before_snapshot")
             }
 
             let snapshot: ParakeetAudioInputSnapshot
@@ -2264,7 +2434,7 @@ class ParakeetEngine: ObservableObject {
                 }
                 markFormatUnreadyAndPublish()
                 schedulePrewarmRetry()
-                return false
+                return await failAudioStart("start_recording_format_read_failed")
             }
             guard startGeneration == audioGraphGeneration else {
                 EventReporter.shared.capture(
@@ -2274,7 +2444,7 @@ class ParakeetEngine: ObservableObject {
                     message: "Audio start aborted because the audio graph changed while reading input format",
                     context: ["audio_graph_generation": "\(audioGraphGeneration)"]
                 )
-                return false
+                return await failAudioStart("start_recording_generation_changed_after_snapshot")
             }
 
             let readiness = audioFormatReadiness(
@@ -2320,7 +2490,7 @@ class ParakeetEngine: ObservableObject {
                 if startFailureAction.schedulePrewarmRetry {
                     schedulePrewarmRetry()
                 }
-                return false
+                return await failAudioStart("start_recording_format_unavailable")
             }
 
             updateNativeSampleRate(snapshot.outputFormat.sampleRate)
@@ -2344,7 +2514,7 @@ class ParakeetEngine: ObservableObject {
                         message: "Audio start aborted because the audio graph changed while starting",
                         context: ["audio_graph_generation": "\(audioGraphGeneration)"]
                     )
-                    return false
+                    return await failAudioStart("start_recording_generation_changed_after_start")
                 }
                 inputTapInstalled = true
                 isEnginePrewarmed = true
@@ -2441,7 +2611,7 @@ class ParakeetEngine: ObservableObject {
                     if startFailureAction.schedulePrewarmRetry {
                         schedulePrewarmRetry()
                     }
-                    return false
+                    return await failAudioStart("start_recording_route_not_settled")
                 }
 
                 if operationTimedOut {
@@ -2459,7 +2629,7 @@ class ParakeetEngine: ObservableObject {
                     if startFailureAction.schedulePrewarmRetry {
                         schedulePrewarmRetry()
                     }
-                    return false
+                    return await failAudioStart("start_recording_engine_start_timeout")
                 }
 
                 print("❌ PARAKEET | audio engine failed after \(attempt) attempt(s): \(error.localizedDescription)")
@@ -2470,7 +2640,7 @@ class ParakeetEngine: ObservableObject {
                 if startFailureAction.schedulePrewarmRetry {
                     schedulePrewarmRetry()
                 }
-                return false
+                return await failAudioStart("start_recording_engine_start_failed")
             }
 
             if attempt > 1 {
@@ -2634,6 +2804,7 @@ class ParakeetEngine: ObservableObject {
             // zombie retry drains real audio instead of discarding it.
             if preservingRecordingAcrossRecovery || !recoveredRecordingTimeline.isEmpty {
                 cancelPendingRecordingRecovery()
+                await restorePendingSystemInputAfterRecording(operation: "stop_recording_preserved_recovery")
                 return
             }
             // A zombie reset marks recording idle while it waits to retry, with
@@ -2643,6 +2814,7 @@ class ParakeetEngine: ObservableObject {
                 audioGraphGeneration += 1
                 cancelAudioWatchdog()
                 clearRecoveredRecordingTimeline(keepingCapacity: true)
+                await restorePendingSystemInputAfterRecording(operation: "stop_recording_zombie_restart")
                 return
             }
             if audioStartInProgress {
@@ -2650,6 +2822,7 @@ class ParakeetEngine: ObservableObject {
             } else {
                 clearRecoveredRecordingTimeline(keepingCapacity: true)
             }
+            await restorePendingSystemInputAfterRecording(operation: "stop_recording_idle")
             return
         }
         audioGraphGeneration += 1
@@ -2670,6 +2843,7 @@ class ParakeetEngine: ObservableObject {
         }
         await removeRecordingTap()
         await stopAudioEngine()
+        await restorePendingSystemInputAfterRecording(operation: "stop_recording")
         isEnginePrewarmed = false
         drainPendingSamplesIntoSampleBuffer()
         isRecording = false
@@ -3256,6 +3430,7 @@ class ParakeetEngine: ObservableObject {
         audioGraphGeneration += 1
         let cleanupGeneration = audioGraphGeneration
         await releaseIdleAudioHardware(removeTap: true, expectedGeneration: cleanupGeneration)
+        await restorePendingSystemInputAfterRecording(operation: "reset_after_failed_recording_start")
     }
 
     func abandonBlockedRecordingStart(reason: String) {
@@ -3289,6 +3464,7 @@ class ParakeetEngine: ObservableObject {
         clearRecoveredRecordingTimeline(keepingCapacity: true)
         liveTranscript = ""
         committedStreamText = ""
+        schedulePendingSystemInputRestore(operation: "abandon_blocked_recording_start")
         abandonBlockedAudioEngine(reason: reason)
     }
 
@@ -3319,6 +3495,7 @@ class ParakeetEngine: ObservableObject {
         }
         audioGraphGeneration += 1
         let cleanupGeneration = audioGraphGeneration
+        schedulePendingSystemInputRestore(operation: "cancel")
         Task { @MainActor [weak self] in
             await self?.releaseIdleAudioHardware(removeTap: true, expectedGeneration: cleanupGeneration)
         }
@@ -3370,6 +3547,7 @@ class ParakeetEngine: ObservableObject {
         cancelConfigRecoveryTimeout()
         audioGraphGeneration += 1
         let cleanupGeneration = audioGraphGeneration
+        schedulePendingSystemInputRestore(operation: "cleanup")
         Task { @MainActor [weak self] in
             await self?.releaseIdleAudioHardware(removeTap: true, expectedGeneration: cleanupGeneration)
         }

--- a/Sources/Speech/ParakeetShortAudioGate.swift
+++ b/Sources/Speech/ParakeetShortAudioGate.swift
@@ -17,6 +17,7 @@ struct ParakeetTranscriptionDecision: Equatable {
 enum DictationEmptyTranscriptionReason: String {
     case noSpeech = "no_speech"
     case recordingTooShort = "recording_too_short"
+    case modelFailure = "model_failure"
 
     var analyticsEventName: String {
         switch self {
@@ -24,6 +25,8 @@ enum DictationEmptyTranscriptionReason: String {
             return "dictation_no_speech"
         case .recordingTooShort:
             return "dictation_recording_too_short"
+        case .modelFailure:
+            return "dictation_transcription_failed"
         }
     }
 
@@ -33,6 +36,8 @@ enum DictationEmptyTranscriptionReason: String {
             return "no_voice_input"
         case .recordingTooShort:
             return "dictation_recording_too_short"
+        case .modelFailure:
+            return "dictation_transcription_failed"
         }
     }
 
@@ -42,6 +47,8 @@ enum DictationEmptyTranscriptionReason: String {
             return "Dictation transcription empty"
         case .recordingTooShort:
             return "Dictation ended before enough audio was captured"
+        case .modelFailure:
+            return "Dictation transcription model failed"
         }
     }
 
@@ -55,6 +62,8 @@ enum DictationEmptyTranscriptionReason: String {
             return "no_speech"
         case .recordingTooShort:
             return "recording_too_short"
+        case .modelFailure:
+            return "model_failure"
         }
     }
 }

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -40,15 +40,20 @@ enum ParakeetStartRecordingFailurePolicy {
         isRecoveryAttempt: Bool
     ) -> ParakeetStartRecordingFailureAction {
         let shouldScheduleRetry: Bool
+        let shouldRebuildAudioEngine: Bool
         switch reason {
-        case .invalidAudioFormat, .audioRouteNotSettled, .audioEngineStartFailed, .audioEngineStartTimedOut:
+        case .invalidAudioFormat, .audioEngineStartFailed, .audioEngineStartTimedOut:
             shouldScheduleRetry = !isRecoveryAttempt
+            shouldRebuildAudioEngine = true
+        case .audioRouteNotSettled:
+            shouldScheduleRetry = true
+            shouldRebuildAudioEngine = false
         }
 
         return ParakeetStartRecordingFailureAction(
             markFormatUnready: true,
             schedulePrewarmRetry: shouldScheduleRetry,
-            rebuildAudioEngine: true
+            rebuildAudioEngine: shouldRebuildAudioEngine
         )
     }
 }
@@ -172,7 +177,7 @@ enum ParakeetAudioFormatReadinessPolicy {
         selectedInputClass: String,
         outputDeviceClass: String,
         selectionOverrodeDefault: Bool,
-        selectionReason _: DictationInputDeviceSelectionReason? = nil
+        selectionReason: DictationInputDeviceSelectionReason? = nil
     ) -> ParakeetAudioFormatReadiness {
         guard isUsableCaptureSampleRate(outputSampleRate), outputChannelCount > 0,
               isUsableCaptureSampleRate(inputSampleRate), inputChannelCount > 0 else {
@@ -182,11 +187,18 @@ enum ParakeetAudioFormatReadinessPolicy {
         let lowRateOutputBus = likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded()))
         let overriddenBluetoothOutputRoute = selectionOverrodeDefault
             && outputDeviceClass == "bluetooth"
+        let suppressedRecoveryBluetoothRoute = selectedInputClass == "bluetooth"
+            && outputDeviceClass == "bluetooth"
+            && selectionReason == .builtInFallbackSuppressedForRecoveryAttempt
 
         if selectedInputClass != "bluetooth",
            inputSampleRate >= 44_100,
            lowRateOutputBus,
            (outputDeviceClass != "bluetooth" || overriddenBluetoothOutputRoute) {
+            return .routeNotSettled
+        }
+
+        if suppressedRecoveryBluetoothRoute, lowRateOutputBus {
             return .routeNotSettled
         }
 
@@ -235,6 +247,22 @@ enum ParakeetTapSampleRatePolicy {
         hardwareSampleRate _: Double? = nil
     ) -> Double {
         ParakeetAudioFormatReadinessPolicy.captureSampleRateOrFallback(bufferSampleRate)
+    }
+}
+
+enum ParakeetSampleSignalPolicy {
+    private static let nonZeroSignalThreshold: Float = 0.000_001
+
+    static func hasNonZeroSignal(_ samples: [Float]) -> Bool {
+        samples.contains { abs($0) > nonZeroSignalThreshold }
+    }
+
+    static func shouldResetStartupAudio(
+        sampleCount: Int,
+        hasNonZeroSignal: Bool,
+        isLikelyBluetoothHandsFreeRoute: Bool
+    ) -> Bool {
+        sampleCount == 0 || (sampleCount > 0 && !hasNonZeroSignal && isLikelyBluetoothHandsFreeRoute)
     }
 }
 

--- a/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
+++ b/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
@@ -8,6 +8,9 @@ enum DictationNoSpeechPresentationPolicy {
         if reason == .recordingTooShort {
             return "Recording ended too soon. Try again and speak for at least a second."
         }
+        if reason == .modelFailure {
+            return "The local speech model failed. Try again, or switch transcription models in Settings."
+        }
 
         if trigger == "physical_key" {
             return "No speech heard. Hold the dictation key while you talk."

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1119,6 +1119,14 @@ class DictationSessionController: ObservableObject {
                 } else {
                     overlayController.showSuccessAndDismiss(title: autoSendOutcome.confirmationTitle ?? "Pasted")
                 }
+            case .copied(let message, reason: let reason) where reason.isPasteConfirmationOnly:
+                AppSoundPlayer.shared.play(.dictationDelivered)
+                if let saveFailureMessage {
+                    overlayController.showError(saveFailureMessage)
+                } else {
+                    overlayController.showSuccessAndDismiss(title: autoSendOutcome.confirmationTitle ?? "Pasted")
+                }
+                appState.logger.log("DICTATION | paste confirmation missing after Cmd+V; suppressing user warning: \(message)")
             case .copied(let message, reason: _):
                 if let saveFailureMessage {
                     overlayController.showError("\(message) \(saveFailureMessage)")
@@ -2159,6 +2167,15 @@ private extension TextPasteOutcome {
 }
 
 private extension TextPasteCopyReason {
+    var isPasteConfirmationOnly: Bool {
+        switch self {
+        case .pasteConfirmationUnavailable:
+            return true
+        case .accessibilityMissing, .pasteEventCreationFailed, .focusChanged, .pasteNotConfirmed:
+            return false
+        }
+    }
+
     var diagnosticName: String {
         switch self {
         case .accessibilityMissing:

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -2087,6 +2087,8 @@ private final class DictationReadinessRefreshRunner {
         operation = operationName
         startedAt = ProcessInfo.processInfo.systemUptime
         task = Task { @MainActor [weak self] in
+            guard !Task.isCancelled else { return }
+            guard self?.generation == taskGeneration else { return }
             await body()
             guard !Task.isCancelled else { return }
             guard self?.generation == taskGeneration else { return }

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -32,6 +32,15 @@ class FloatingOverlayController {
         case listening    // Recording dictation
         case drafting     // Processing dictation
         case success      // Finished successfully — brief confirmation before dismiss
+
+        var isActiveDictationState: Bool {
+            switch self {
+            case .starting, .loading, .listening:
+                return true
+            case .idle, .drafting, .success:
+                return false
+            }
+        }
     }
 
     /// How a drafting-state message should read: a real problem, or a calm
@@ -62,6 +71,9 @@ class FloatingOverlayController {
     var state: OverlayState = .idle {
         didSet {
             guard state != oldValue else { return }
+            if state.isActiveDictationState {
+                cancelPendingHideForActiveDictation()
+            }
             if state != .loading {
                 cancelMiniLoadingReveal()
             }
@@ -260,6 +272,8 @@ class FloatingOverlayController {
         errorDismissTask = nil
         loadingTimerTask?.cancel()
         loadingTimerTask = nil
+        successDismissTask?.cancel()
+        successDismissTask = nil
         errorMessage = ""
         messageTone = .error
         successTitle = "Pasted"
@@ -380,6 +394,8 @@ class FloatingOverlayController {
         errorDismissTask = nil
         loadingTimerTask?.cancel()
         loadingTimerTask = nil
+        successDismissTask?.cancel()
+        successDismissTask = nil
         cancelMiniLoadingReveal()
         errorMessage = ""
         messageTone = .error
@@ -391,6 +407,29 @@ class FloatingOverlayController {
         if !isVisible {
             showPanel(near: sourceApp, anchorRect: anchorRect)
         }
+    }
+
+    private func cancelPendingHideForActiveDictation() {
+        hideGeneration &+= 1
+        successDismissTask?.cancel()
+        successDismissTask = nil
+
+        guard let panel, isVisible else { return }
+        cancelPanelHideAnimations(panel)
+        panel.ignoresMouseEvents = isCursorMiniPanelMode
+        if !panel.isVisible {
+            panel.orderFrontRegardless()
+            isVisible = true
+        }
+    }
+
+    private func cancelPanelHideAnimations(_ panel: NSPanel) {
+        panel.animations = [:]
+        panel.contentView?.layer?.removeAllAnimations()
+        panel.contentView?.subviews.forEach { subview in
+            subview.layer?.removeAllAnimations()
+        }
+        panel.alphaValue = 1
     }
 
     @discardableResult

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -24,7 +24,9 @@
 // off the headset mic before the format is sampled. They are intentionally kept as
 // source-text contracts rather than a runtime seam: extracting one would restructure
 // real-time CoreAudio tap/format-read control flow, which is too risky to refactor for
-// testability. The "QA report names mocked proof boundary" suite is a docs/report
+// testability. The system default input override must also happen before format reads
+// so macOS moves AirPods off the headset microphone route before recording starts.
+// The "QA report names mocked proof boundary" suite is a docs/report
 // consistency check, not a runtime check. If you move/rename these functions or reorder
 // their statements, update both the source and these greps together.
 
@@ -361,6 +363,7 @@ func testBluetoothRouteContract() {
         guard let loadSelection = snapshotBody.range(of: "let selection = await Task.detached"),
               let detachedSelectionLookup = snapshotBody.range(of: "Self.loadDictationInputDeviceSelection"),
               let avoidDefaultRead = snapshotBody.range(of: "Avoid touching the current default input before the override is applied."),
+              let systemInputOverride = snapshotBody.range(of: "Self.applyPreferredSystemInputDevice(for: selection)"),
               let applyOverride = snapshotBody.range(of: "Self.applyPreferredDictationInputDevice(selection, to: inputNode)"),
               let outputFormatRead = snapshotBody.range(of: "inputNode.outputFormat(forBus: 0)"),
               let inputFormatRead = snapshotBody.range(of: "inputNode.inputFormat(forBus: 0)") else {
@@ -370,9 +373,66 @@ func testBluetoothRouteContract() {
 
         assertTrue(loadSelection.lowerBound < detachedSelectionLookup.lowerBound, "selection should be loaded through detached CoreAudio lookup")
         assertTrue(detachedSelectionLookup.lowerBound < avoidDefaultRead.lowerBound, "selection should be loaded before the no-default-read guard")
-        assertTrue(avoidDefaultRead.lowerBound < applyOverride.lowerBound, "override guard should be set before touching the input node")
+        assertTrue(avoidDefaultRead.lowerBound < systemInputOverride.lowerBound, "override guard should be set before changing system input")
+        assertTrue(systemInputOverride.lowerBound < applyOverride.lowerBound, "system input should move off AirPods before touching the input node")
         assertTrue(applyOverride.lowerBound < outputFormatRead.lowerBound, "forced input override should happen before output format reads")
         assertTrue(applyOverride.lowerBound < inputFormatRead.lowerBound, "forced input override should happen before hardware input format reads")
+    }
+
+    runSuite("Bluetooth route contract - system input override restores after recording") {
+        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetEngine.swift")
+        guard let snapshotStart = source.range(of: "private func audioInputSnapshot"),
+              let snapshotEnd = source.range(of: "private func installTapAndStartEngine", range: snapshotStart.upperBound..<source.endIndex),
+              let startStart = source.range(of: "func startRecording(isRecoveryAttempt: Bool = false) async -> Bool"),
+              let startEnd = source.range(of: "private func extractMonoSamples", range: startStart.upperBound..<source.endIndex),
+              let cleanupStart = source.range(of: "// MARK: - Cleanup"),
+              let cleanupEnd = source.range(of: "deinit", range: cleanupStart.upperBound..<source.endIndex),
+              let stopStart = source.range(of: "func stopRecording() async"),
+              let stopEnd = source.range(of: "// MARK: - EOU Streaming", range: stopStart.upperBound..<source.endIndex) else {
+            assertTrue(false, "test should find dictation audioInputSnapshot and stopRecording")
+            return
+        }
+        let snapshotBody = String(source[snapshotStart.lowerBound..<snapshotEnd.lowerBound])
+        let startBody = String(source[startStart.lowerBound..<startEnd.lowerBound])
+        let cleanupBody = String(source[cleanupStart.lowerBound..<cleanupEnd.lowerBound])
+        let stopBody = String(source[stopStart.lowerBound..<stopEnd.lowerBound])
+
+        assertTrue(
+            snapshotBody.contains("pendingSystemInputRestore = restoreTarget"),
+            "start_recording should remember the prior system input when it temporarily moves AirPods input to built-in"
+        )
+        assertTrue(
+            snapshotBody.contains("operation: \"\\(operation)_system_input_stale_recovery\""),
+            "superseded recovery snapshots should restore the temporary system input before throwing cancellation"
+        )
+        assertTrue(
+            startBody.contains("func failAudioStart(_ operation: String) async -> Bool"),
+            "failed starts should share one cleanup path for temporary system input restores"
+        )
+        assertTrue(
+            startBody.contains("return await failAudioStart(\"start_recording_engine_start_failed\")"),
+            "engine-start failures after the temporary system input override should restore before returning false"
+        )
+        assertTrue(
+            stopBody.contains("await restorePendingSystemInputAfterRecording(operation: \"stop_recording\")"),
+            "normal stop should restore the prior system input if Transcripted still owns the temporary input"
+        )
+        assertTrue(
+            stopBody.contains("await restorePendingSystemInputAfterRecording(operation: \"stop_recording_idle\")"),
+            "canceled or interrupted start paths should not leave the temporary system input behind"
+        )
+        assertTrue(
+            cleanupBody.contains("schedulePendingSystemInputRestore(operation: \"cancel\")"),
+            "explicit cancellation should restore the temporary system input even though cancel() is synchronous"
+        )
+        assertTrue(
+            cleanupBody.contains("schedulePendingSystemInputRestore(operation: \"cleanup\")"),
+            "quit cleanup should restore the temporary system input even though cleanup() is synchronous"
+        )
+        assertTrue(
+            cleanupBody.contains("schedulePendingSystemInputRestore(operation: \"abandon_blocked_recording_start\")"),
+            "blocked-start abandonment should restore the temporary system input"
+        )
     }
 
     runSuite("Bluetooth route contract - QA report names mocked proof boundary") {

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -125,6 +125,39 @@ func testBluetoothRouteContract() {
         assertEqual(routeShape, "bluetooth_input_to_bluetooth_output", "suppressed fallback should expose the matched Bluetooth route shape")
     }
 
+    runSuite("Bluetooth route contract - suppressed recovery route waits on Bluetooth speech output") {
+        for outputRate in [8_000.0, 16_000.0, 24_000.0] {
+            let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+                outputSampleRate: outputRate,
+                outputChannelCount: 3,
+                inputSampleRate: 48_000,
+                inputChannelCount: 1,
+                selectedInputClass: "bluetooth",
+                outputDeviceClass: "bluetooth",
+                selectionOverrodeDefault: false,
+                selectionReason: .builtInFallbackSuppressedForRecoveryAttempt
+            )
+
+            assertEqual(readiness, .routeNotSettled, "recovery should not start recording on the low-rate Bluetooth speech bus \(outputRate)")
+            assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "suppressed recovery routes should stay recoverable")
+        }
+    }
+
+    runSuite("Bluetooth route contract - settled suppressed recovery route can record") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 48_000,
+            outputChannelCount: 1,
+            inputSampleRate: 24_000,
+            inputChannelCount: 1,
+            selectedInputClass: "bluetooth",
+            outputDeviceClass: "bluetooth",
+            selectionOverrodeDefault: false,
+            selectionReason: .builtInFallbackSuppressedForRecoveryAttempt
+        )
+
+        assertEqual(readiness, .ready, "settled Bluetooth recovery capture should not be blocked")
+    }
+
     runSuite("Bluetooth route contract - native AirPods HFP capture stays allowed") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 48_000,

--- a/Tests/ParakeetShortAudioGateTests.swift
+++ b/Tests/ParakeetShortAudioGateTests.swift
@@ -96,5 +96,15 @@ func testParakeetShortAudioGate() {
             "dictation_no_speech",
             "real no-speech dictation should keep the existing analytics event"
         )
+        assertEqual(
+            DictationEmptyTranscriptionReason.modelFailure.analyticsEventName,
+            "dictation_transcription_failed",
+            "model runtime errors should not inflate no-speech analytics"
+        )
+        assertEqual(
+            DictationEmptyTranscriptionReason.modelFailure.localEventName,
+            "dictation_transcription_failed",
+            "local diagnostics should name model failures explicitly"
+        )
     }
 }

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -101,18 +101,18 @@ func testParakeetStartRecordingFailurePolicy() {
 
         assertTrue(action.markFormatUnready, "stale route formats should hold recording starts")
         assertTrue(action.schedulePrewarmRetry, "stale route formats should wait for the next prewarm")
-        assertTrue(action.rebuildAudioEngine, "stale route formats should rebuild the audio engine")
+        assertFalse(action.rebuildAudioEngine, "stale route formats should wait without rebuilding the audio engine")
     }
 
-    runSuite("ParakeetStartRecordingFailurePolicy route-not-settled during recovery does not chain retries") {
+    runSuite("ParakeetStartRecordingFailurePolicy route-not-settled during recovery keeps readiness retry") {
         let action = ParakeetStartRecordingFailurePolicy.action(
             for: .audioRouteNotSettled,
             isRecoveryAttempt: true
         )
 
         assertTrue(action.markFormatUnready, "recovery route failures should still hold recording starts")
-        assertFalse(action.schedulePrewarmRetry, "recovery route failures should not recursively schedule retries")
-        assertTrue(action.rebuildAudioEngine, "recovery route failures should rebuild the audio engine")
+        assertTrue(action.schedulePrewarmRetry, "recovery route failures should leave a bounded readiness retry path")
+        assertFalse(action.rebuildAudioEngine, "recovery route failures should not churn the audio graph")
     }
 
     runSuite("ParakeetDeviceRecoveryFailurePolicy keeps idle device settling out of Sentry") {
@@ -325,6 +325,39 @@ func testParakeetStartRecordingFailurePolicy() {
         }
     }
 
+    runSuite("ParakeetAudioFormatReadinessPolicy defers suppressed Bluetooth recovery speech bus") {
+        for outputRate in [8_000.0, 16_000.0, 24_000.0] {
+            let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+                outputSampleRate: outputRate,
+                outputChannelCount: 3,
+                inputSampleRate: 48_000,
+                inputChannelCount: 1,
+                selectedInputClass: "bluetooth",
+                outputDeviceClass: "bluetooth",
+                selectionOverrodeDefault: false,
+                selectionReason: .builtInFallbackSuppressedForRecoveryAttempt
+            )
+
+            assertEqual(readiness, .routeNotSettled, "suppressed recovery should wait instead of recording on a low-rate Bluetooth output bus \(outputRate)")
+            assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "suppressed Bluetooth recovery should remain a recoverable route-settling failure")
+        }
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy allows settled suppressed Bluetooth recovery bus") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 48_000,
+            outputChannelCount: 1,
+            inputSampleRate: 24_000,
+            inputChannelCount: 1,
+            selectedInputClass: "bluetooth",
+            outputDeviceClass: "bluetooth",
+            selectionOverrodeDefault: false,
+            selectionReason: .builtInFallbackSuppressedForRecoveryAttempt
+        )
+
+        assertEqual(readiness, .ready, "suppressed recovery should still allow a settled Bluetooth capture bus")
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy defers non-preferred override reasons on Bluetooth output") {
         let nonPreferredReasons: [DictationInputDeviceSelectionReason] = [
             .defaultIsSafe,
@@ -493,6 +526,60 @@ func testParakeetStartRecordingFailurePolicy() {
             effectiveSampleRate,
             ParakeetAudioFormatReadinessPolicy.fallbackCaptureSampleRate,
             "invalid tap rates should still use the central safe fallback"
+        )
+    }
+
+    runSuite("ParakeetSampleSignalPolicy distinguishes zero callbacks from real signal") {
+        assertFalse(
+            ParakeetSampleSignalPolicy.hasNonZeroSignal([]),
+            "empty buffers should not count as signal"
+        )
+        assertFalse(
+            ParakeetSampleSignalPolicy.hasNonZeroSignal([0, 0, 0]),
+            "all-zero buffers should not mark the microphone route healthy"
+        )
+        assertFalse(
+            ParakeetSampleSignalPolicy.hasNonZeroSignal([0, 0.000_000_1, -0.000_000_5]),
+            "sub-threshold noise should not defeat the zero-route watchdog"
+        )
+        assertTrue(
+            ParakeetSampleSignalPolicy.hasNonZeroSignal([0, 0.000_01, 0]),
+            "normal mic noise or speech should count as real sample signal"
+        )
+    }
+
+    runSuite("ParakeetSampleSignalPolicy scopes zero-signal restart to risky routes") {
+        assertTrue(
+            ParakeetSampleSignalPolicy.shouldResetStartupAudio(
+                sampleCount: 0,
+                hasNonZeroSignal: false,
+                isLikelyBluetoothHandsFreeRoute: false
+            ),
+            "no callbacks should still trigger startup recovery on any route"
+        )
+        assertFalse(
+            ParakeetSampleSignalPolicy.shouldResetStartupAudio(
+                sampleCount: 512,
+                hasNonZeroSignal: false,
+                isLikelyBluetoothHandsFreeRoute: false
+            ),
+            "normal initial silence should not look like a dead engine"
+        )
+        assertTrue(
+            ParakeetSampleSignalPolicy.shouldResetStartupAudio(
+                sampleCount: 512,
+                hasNonZeroSignal: false,
+                isLikelyBluetoothHandsFreeRoute: true
+            ),
+            "zero-only buffers on Bluetooth HFP should recover from the garbled route"
+        )
+        assertFalse(
+            ParakeetSampleSignalPolicy.shouldResetStartupAudio(
+                sampleCount: 512,
+                hasNonZeroSignal: true,
+                isLikelyBluetoothHandsFreeRoute: true
+            ),
+            "real signal on Bluetooth HFP should not be restarted"
         )
     }
 


### PR DESCRIPTION
## Summary
- defer suppressed Bluetooth recovery starts when the route is still on low-rate Bluetooth speech output
- stop rebuilding the audio engine for route-settling failures; keep a bounded readiness retry instead
- track real non-zero sample signal separately from callback flow so Bluetooth zero-buffer starts can recover without treating normal initial silence as a failure
- make forced readiness refresh/recovery respect cancellation before touching the audio graph

## Proof
- Live repro evidence captured on Justin's Mac: `/tmp/transcripted-repro-lab/dictation-live-20260705-141305`
- Synthetic audio reliability check: `/tmp/transcripted-repro-lab/audio-daily-20260705-141508/daily-audio-reliability-report.md`
- `bash run-tests.sh --filter testParakeetStartRecordingFailurePolicy` -> 143 passed
- `bash run-tests.sh --filter BluetoothRouteContractTests` -> 81 passed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` -> 12,701 passed
- `bash run-integration-smoke.sh` -> passed
- `bash build.sh --no-open` -> passed, signed, launch smoke passed, performance budget OK

## Review
- `codex review --base origin/main` found one P2 about false resets on normal initial silence.
- Addressed by scoping zero-signal restart to likely Bluetooth hands-free routes while keeping no-callback recovery route-wide.

## Manual boundary
This is code and synthetic proof. It still needs a real AirPods/Bluetooth manual pass on hardware before calling the user-flow fully proven.

lanes used: Codex=implementation, live-log review, build/test/PR; Claude=maestro review and codex review; Local=maestro log triage; Windows=skipped, local Mac audio hardware needed