### PR TITLE
ci: make repo merge-queue-ready (merge_group trigger + enablement doc)

### DIFF
--- a/.github/merge-queue-ruleset.json
+++ b/.github/merge-queue-ruleset.json
@@ -1,0 +1,37 @@
+{
+  "name": "merge-queue-main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "MERGE",
+        "max_entries_to_build": 1,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5,
+        "grouping_strategy": "ALLGREEN",
+        "check_response_timeout_minutes": 120
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "build-and-test" },
+          { "context": "repo-hygiene" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/merge-queue.md
+++ b/.github/merge-queue.md
@@ -1,0 +1,76 @@
+# Merge queue — status and enablement
+
+## Why we want it
+
+Parallel PRs go stale against a fast-moving `main`. When two branches both
+build green in isolation but touch the same ground, whichever lands second
+carries a silent conflict: PSV registry collisions, duplicate Swift
+declarations, family-name renames. These have been the #1 source of manual
+conflict-resolution work on this repo.
+
+GitHub's native **merge queue** removes the class of bug: it rebases each PR
+onto the current `main`, runs the required CI against that temporary merged
+ref, and only lands if it still passes — serially, one PR at a time. A branch
+can never land against a `main` it wasn't just tested against.
+
+## Current status: BLOCKED on repository ownership
+
+Merge queue is **not available for user-owned repositories**. GitHub offers it
+only for repositories owned by an **organization** (public org repos on any
+plan; private org repos on GitHub Enterprise Cloud). `r3dbars/transcripted` is
+owned by the user account `r3dbars`, so the `merge_queue` ruleset rule is
+rejected at the API with `422 Validation Failed — Invalid rule 'merge_queue'`.
+
+This is a platform restriction, not a permissions or plan gap on the current
+account, and there is no Settings toggle that changes it for a user-owned repo.
+The only way to unblock is to move the repo under an organization.
+
+The repo is otherwise **ready**: both required CI workflows now declare the
+`merge_group:` trigger (see `.github/workflows/swift-ci.yml` and
+`.github/workflows/repo-hygiene.yml`), so the queue's checks will fire the
+moment merge queue is turned on.
+
+## To enable (once the repo is org-owned)
+
+1. **Transfer the repo to a GitHub organization** (Settings → General →
+   Danger Zone → Transfer, or `gh api`), or create it under an org.
+
+2. **Create the merge-queue ruleset** with the exact payload below. The
+   required checks are the job names GitHub reports, `build-and-test` (from
+   Swift CI) and `repo-hygiene` (from Repo Hygiene) — not the workflow display
+   names. Config chosen for this repo: merge-commit method to match convention,
+   and batch size 1 (`max_entries_to_build: 1`) because the macOS Swift build
+   is long and batching PRs behind it wastes a rebuild on every failure.
+
+   ```bash
+   gh api -X POST /repos/<org>/transcripted/rulesets --input .github/merge-queue-ruleset.json
+   ```
+
+3. **Verify it is live:**
+
+   ```bash
+   gh api /repos/<org>/transcripted/rulesets \
+     --jq '.[] | select(.name=="merge-queue-main") | {id, enforcement}'
+   ```
+
+   Then confirm the `merge_queue` rule resolved:
+
+   ```bash
+   RID=$(gh api /repos/<org>/transcripted/rulesets --jq '.[]|select(.name=="merge-queue-main").id')
+   gh api /repos/<org>/transcripted/rulesets/$RID --jq '.rules[].type'
+   ```
+
+The ready-to-apply payload lives beside this file at
+`.github/merge-queue-ruleset.json`.
+
+## Notes on the config
+
+- **Required checks stay `strict: false`.** The queue itself guarantees each
+  PR is tested against current `main`, so the classic "require branches up to
+  date" flag is redundant and would only add friction.
+- **`hardware-smokes` is unaffected.** It is gated on
+  `github.event_name == 'workflow_dispatch'`, so it never runs for a
+  `merge_group` event and can never block the queue.
+- The existing classic branch-protection rule on `main` (required PR,
+  conversation resolution, no force-push, admins included) can remain; the
+  ruleset layers the queue on top.

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -2,6 +2,11 @@ name: Repo Hygiene
 
 on:
   pull_request:
+  # Run for GitHub merge-queue merge groups so this required gate executes
+  # against the queue's temporary merged ref before landing. Without this
+  # trigger the queue would wait forever for a "repo-hygiene" check that
+  # never starts. See .github/merge-queue.md.
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -45,6 +45,11 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Run for GitHub merge-queue merge groups so this required gate executes
+  # against the queue's temporary merged ref before landing. Without this
+  # trigger the queue would wait forever for a "build-and-test" check that
+  # never starts. See .github/merge-queue.md.
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Prepares the repo for GitHub's native **merge queue**, whose whole point here is to kill the parallel-branches-go-stale conflict cascade (PSV registry collisions, duplicate Swift declarations, family-name renames) by rebasing each PR onto current `main` and running required CI against that merged ref before landing — serially, one PR at a time.

Two changes:

1. **`on: merge_group:` added to both required workflows** — `swift-ci.yml` (`build-and-test`) and `repo-hygiene.yml` (`repo-hygiene`). GitHub Actions won't run a workflow for queued PRs without this trigger, so without it the queue stalls waiting on checks that never start. This is the one genuine in-repo change the queue needs.
2. **`.github/merge-queue.md` + `.github/merge-queue-ruleset.json`** — the enablement runbook and the ready-to-apply ruleset payload.

## Why the queue isn't enabled in this PR

Merge queue is **not available for user-owned repositories** — GitHub restricts it to org-owned repos (public org repos on any plan; private on Enterprise Cloud). `r3dbars/transcripted` is owned by the user `r3dbars`, so the `merge_queue` ruleset rule is rejected at the API:

```
422 Validation Failed — Invalid rule 'merge_queue'
```

This is a platform restriction, not a permissions/plan gap and not a missing Settings toggle — no UI click enables it for a user-owned repo. **The only unblock is transferring the repo to a GitHub organization**, after which the queue turns on by applying the committed ruleset JSON (see the doc). These workflow changes are inert until then and don't affect current `pull_request`/`push` runs.

## Config chosen (in the committed ruleset)

- **merge method:** merge commit (matches repo convention)
- **batch size 1** (`max_entries_to_build: 1`) — the macOS Swift build is long; batching PRs behind it just wastes a rebuild on every failure
- **required checks:** `build-and-test`, `repo-hygiene` (the job names GitHub reports, which is what branch protection already requires — not the workflow display names)
- **`strict: false`** — the queue guarantees up-to-dateness itself, so "require branches up to date" is redundant
- `hardware-smokes` stays `workflow_dispatch`-only, so it never runs for a merge group and can't block the queue

## Verification

- Both workflows parse and now list `merge_group` under `on:`.
- No ruleset was created (confirmed 0 rulesets on the repo); both API attempts returned the 422 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)