### PR TITLE
Add crash-free-rate release gate (Sentry Release Health)

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -184,6 +184,13 @@ rules:
       - "python3 scripts/ops/release-health-card.py --self-test"
 
   - paths:
+      - "scripts/ops/check-crash-free-rate.py"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "python3 -m py_compile scripts/ops/check-crash-free-rate.py"
+      - "python3 scripts/ops/check-crash-free-rate.py --self-test"
+
+  - paths:
       - "scripts/release/post-dmg-release-audit.py"
     checks:
       - "scripts/dev/agent-preflight.sh"

--- a/docs/release-guardrails.md
+++ b/docs/release-guardrails.md
@@ -18,6 +18,13 @@ A user-facing Transcripted release needs all of these gates:
 - **Manual QA:** human proof for install, launch, menu bar, dictation, meeting
   capture, pasteback, update prompts, and any hardware/audio route touched by
   the release. Missing manual proof is `YELLOW` or `UNKNOWN`, never green.
+- **Crash-free rate:** `scripts/ops/check-crash-free-rate.py --version <version>`
+  must return green. Crash-free-sessions below the threshold (default 99.5%) is
+  a hard `RED` block. If the check cannot verify the rate — credentials absent,
+  the Sentry API is unreachable, or the release has no/too-little session data —
+  it is `YELLOW`/`UNKNOWN`, never green, and the release is not cleared. The
+  script exits non-zero for both cases (red `1`, yellow `3`), so a wrapper can
+  gate on exit code. See "Crash-free-rate gate" below.
 - **Notarized artifact:** a final signed, notarized
   `build/Transcripted-<version>.dmg` built from the intended source revision.
 - **Packaged app smoke:** the release candidate passes packaged-app smoke with
@@ -26,12 +33,50 @@ A user-facing Transcripted release needs all of these gates:
   `/download/latest.dmg`, download page, Homebrew cask, Sentry release, and
   dSYM status are checked as separate rows.
 
+## Crash-free-rate gate
+
+`scripts/ops/check-crash-free-rate.py` is the automated go/no-go for release
+health. It queries Sentry's Release Health (Sessions) API for the crash-free
+session rate and crash-free user rate of `transcripted@<version>` and maps the
+result to a verdict:
+
+- `green` (exit `0`): crash-free-sessions >= threshold on enough session data.
+- `red` (exit `1`): crash-free-sessions below threshold. Hard block.
+- `yellow`/`unknown` (exit `3`): cannot verify — no `SENTRY_AUTH_TOKEN`, Sentry
+  unreachable, or the release has no/too-little session data. Never green.
+
+Both `red` and `yellow` exit non-zero, so a release is not cleared to ship if
+crash-free is below threshold OR unverifiable. This matches how missing manual
+proof is treated: unknown is never green.
+
+Defaults (all overridable by flag or env, see `--help`):
+
+- `--threshold 99.5` (`CRASH_FREE_SESSION_THRESHOLD`) — crash-free-sessions
+  floor. 99.5% is the common release-health ship line (Sentry's default
+  release-health target; above Google Play's ~98.9% bad-behavior floor).
+- `--user-threshold 99.0` (`CRASH_FREE_USER_THRESHOLD`) — crash-free-users
+  floor, a looser secondary gate (one crashing user with many sessions skews it).
+- `--min-sessions 25` (`CRASH_FREE_MIN_SESSIONS`) — below this the rate is not
+  trusted and the verdict is `yellow`, not a false green on thin data. For a
+  low-volume release, widen `--stats-period` (e.g. `14d`) rather than shipping
+  on a handful of sessions.
+- `--stats-period 24h` (`SENTRY_STATS_PERIOD`) — lookback window.
+
+Note: as of this writing the Transcripted Sentry project reports no session
+data, so a live run returns `yellow`/`unknown` for real releases (session
+tracking is not populating Release Health). That is the correct safe posture —
+the gate blocks rather than false-greening — and it also surfaces that Release
+Health is not yet wired up in the app's Sentry SDK. Wiring session tracking is
+what turns this gate green-capable; until then crash-free is an `UNKNOWN` row,
+handled by manual QA.
+
 ## Safe While Justin Is Away
 
 These are safe without extra approval:
 
 - docs-only release planning
 - read-only release-health checks
+- `check-crash-free-rate.py` (read-only Sentry Release Health query)
 - local packaging dry runs that do not publish or notarize for shipment
 - draft PRs
 - draft release notes clearly marked as not published

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -59,6 +59,9 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
 - `scripts/ops/release-health-card.py` — print a compact release-health card for one app version by combining local release metadata, GitHub downloads, live public release surfaces, and PostHog update/workflow counts when credentials are present; installed workflow rows are grouped by `app_version`, `build_version`, `build_channel`, and `build_revision` so local/current-main builds cannot be counted as shipped-release proof
   - Usage: `python3 scripts/ops/release-health-card.py --version 1.1.47`
+- `scripts/ops/check-crash-free-rate.py` — crash-free-rate release gate: query Sentry Release Health (Sessions) for a release's crash-free session/user rate and exit non-zero if it is below threshold (red) or unverifiable (yellow, e.g. credentials absent or no session data), so it can be a go/no-go gate; read-only, never publishes
+  - Usage: `python3 scripts/ops/check-crash-free-rate.py --version 1.1.48`
+  - Verdicts: exit 0 green (>= threshold), exit 1 red (below threshold), exit 3 yellow (cannot verify; never auto-green)
 - `scripts/ops/retention-cohort-report.py` — print a privacy-safe PostHog retention cohort report for first/second artifact, next-day and 7-day return, repeat dictation/meeting/agent/summary use, 3-days-this-week, version adoption, and first-run drop-off
   - Usage: `python3 scripts/ops/retention-cohort-report.py`
   - Health output: `python3 scripts/ops/retention-cohort-report.py --write-dir /tmp/transcripted-retention-health`

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -154,6 +154,12 @@ if [ -n "$changed_paths" ]; then
             add_command "python3 scripts/ops/release-health-card.py --self-test"
         fi
 
+        if matches_any "$path" "scripts/ops/check-crash-free-rate.py"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "python3 -m py_compile scripts/ops/check-crash-free-rate.py"
+            add_command "python3 scripts/ops/check-crash-free-rate.py --self-test"
+        fi
+
         if matches_any "$path" "scripts/ops/posthog-product-dashboard-summary.py" "Tests/Fixtures/posthog-product-dashboard-summary.json"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "python3 -m py_compile scripts/ops/posthog-product-dashboard-summary.py"

--- a/scripts/ops/check-crash-free-rate.py
+++ b/scripts/ops/check-crash-free-rate.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Crash-free-rate release gate for Transcripted.
+
+Queries Sentry's Release Health (Sessions) API for a release's crash-free
+session rate and crash-free user rate, then decides a go/no-go verdict:
+
+    green  (exit 0)  crash-free-sessions >= threshold on enough data
+    red    (exit 1)  crash-free-sessions <  threshold           -> blocks ship
+    yellow (exit 3)  cannot verify (creds absent, API error, or
+                     too little session data)                    -> never auto-green
+
+Both red and yellow exit non-zero: a release is not "cleared to ship" if the
+crash-free rate is below threshold OR unverifiable. This mirrors how
+`docs/release-guardrails.md` treats missing proof (YELLOW/UNKNOWN, never green).
+
+Auth reuses the ops-script convention: SENTRY_AUTH_TOKEN from the environment or
+one of the ops env files (see load_env). Org/project default to r3dbars /
+apple-macos and can be overridden by SENTRY_ORG / SENTRY_PROJECT. The release
+name matches scripts/release/sentry-release-metadata.py: `transcripted@<version>`.
+
+This script is read-only. It never tags, notarizes, publishes, or mutates any
+release surface. It only reports a gate verdict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+# Verdict -> process exit code. Matches scripts/ops/release-gate-report.py so a
+# wrapper sees the same red=1 / yellow=3 semantics across the ops toolkit.
+EXIT_CODES = {"green": 0, "red": 1, "yellow": 3}
+
+DEFAULT_ORG = "r3dbars"
+DEFAULT_PROJECT = "apple-macos"
+DEFAULT_RELEASE_PREFIX = "transcripted"
+SENTRY_BASE = "https://sentry.io/api/0"
+HTTP_HEADERS = {"User-Agent": "TranscriptedCrashFreeGate/1.0"}
+
+# Threshold reasoning (all overridable by flag or env):
+#
+# * 99.5% crash-free sessions is the widely used release-health ship gate:
+#   Sentry's own default release-health alert target is 99.5%, and Google Play's
+#   "bad behavior" line sits at ~1.1% crash rate (~98.9% crash-free). 99.5%
+#   gives a little headroom above that floor without demanding perfection.
+# * Crash-free USERS is gated looser (99.0%) and treated as a secondary signal:
+#   one crashing user with many sessions can drag the user rate down hard on a
+#   low-volume desktop app, so a red there alone should not block on its own.
+#   It is reported and can gate if you tighten --user-threshold.
+# * --min-sessions guards against false-green on thin data. A 100% rate from 3
+#   sessions is not proof of health. Below the floor the verdict is YELLOW
+#   (unknown), never green. 25 is a low but non-trivial default; widen the
+#   window with --stats-period for low-volume releases instead of trusting a
+#   handful of sessions.
+DEFAULT_SESSION_THRESHOLD = 99.5
+DEFAULT_USER_THRESHOLD = 99.0
+DEFAULT_MIN_SESSIONS = 25
+# 24h reflects "the release right now". Low-volume releases should widen this
+# (e.g. --stats-period 14d) rather than ship on a thin 24h sample; the
+# min-sessions guard turns a thin sample into YELLOW, not a false green.
+DEFAULT_STATS_PERIOD = "24h"
+
+
+def load_env() -> None:
+    """Populate os.environ from the ops env files, matching release-health-card.py.
+
+    Existing environment values win, so an explicit export is never clobbered.
+    """
+    for path in (
+        Path.cwd() / ".env.local",
+        Path.cwd() / ".env",
+        Path.home() / ".transcripted-ops.env",
+        Path.home() / ".hermes" / ".env",
+        Path.home() / ".hermes" / "profiles" / "ops" / ".env",
+    ):
+        if not path.is_file():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip().removeprefix("export ").strip()
+            value = value.strip().strip('"').strip("'")
+            if key and value and key not in os.environ:
+                os.environ[key] = value
+
+
+def info_plist_version(root: Path) -> str | None:
+    plist_path = root / "Info.plist"
+    if not plist_path.is_file():
+        return None
+    with plist_path.open("rb") as handle:
+        plist = plistlib.load(handle)
+    version = str(plist.get("CFBundleShortVersionString") or "").strip()
+    return version or None
+
+
+def info_plist_release_prefix(root: Path) -> str:
+    plist_path = root / "Info.plist"
+    if not plist_path.is_file():
+        return DEFAULT_RELEASE_PREFIX
+    with plist_path.open("rb") as handle:
+        plist = plistlib.load(handle)
+    prefix = str(plist.get("TranscriptedSentryReleasePrefix") or DEFAULT_RELEASE_PREFIX).strip()
+    return prefix or DEFAULT_RELEASE_PREFIX
+
+
+def resolve_release(root: Path, args: argparse.Namespace) -> str | None:
+    """Resolve the Sentry release string, e.g. transcripted@1.1.47."""
+    if args.release:
+        return args.release.strip()
+    env_release = os.environ.get("SENTRY_RELEASE")
+    if env_release:
+        return env_release.strip()
+    version = args.version or info_plist_version(root)
+    if not version:
+        return None
+    return f"{info_plist_release_prefix(root)}@{version}"
+
+
+def interval_for_period(period: str) -> str:
+    """Coarse interval so totals queries don't trip Sentry's bucket-count limit."""
+    return "1h" if period.strip().lower().endswith("h") else "1d"
+
+
+def sentry_get(url: str, token: str, timeout: int = 20) -> tuple[int, Any]:
+    """GET a Sentry API URL. Returns (status_code, parsed_json_or_None).
+
+    status_code is 0 for a transport-level failure (DNS, timeout, TLS).
+    """
+    request = urllib.request.Request(
+        url,
+        headers={**HTTP_HEADERS, "Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return response.status, json.loads(body)
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read().decode("utf-8", errors="replace"))
+        except (ValueError, OSError):
+            payload = None
+        return exc.code, payload
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return 0, None
+
+
+def project_numeric_id(org: str, project: str, token: str) -> str | None:
+    status, payload = sentry_get(f"{SENTRY_BASE}/projects/{org}/{project}/", token)
+    if status == 200 and isinstance(payload, dict) and payload.get("id"):
+        return str(payload["id"])
+    return None
+
+
+def fetch_session_totals(
+    org: str,
+    project_id: str,
+    release: str,
+    period: str,
+    token: str,
+) -> tuple[str | None, dict[str, Any]]:
+    """Fetch crash-free totals for a release. Returns (error, totals).
+
+    error is None on success; a human-readable string otherwise. On success,
+    totals holds crash_free_rate(session)/(user) and sum(session)/count_unique(user).
+    """
+    query = urllib.parse.urlencode(
+        [
+            ("field", "crash_free_rate(session)"),
+            ("field", "crash_free_rate(user)"),
+            ("field", "sum(session)"),
+            ("field", "count_unique(user)"),
+            ("query", f"release:{release}"),
+            ("statsPeriod", period),
+            ("interval", interval_for_period(period)),
+            ("project", project_id),
+        ]
+    )
+    status, payload = sentry_get(f"{SENTRY_BASE}/organizations/{org}/sessions/?{query}", token)
+    if status == 401 or status == 403:
+        return f"Sentry auth rejected (HTTP {status})", {}
+    if status == 0:
+        return "Sentry API unreachable (network error)", {}
+    if status != 200 or not isinstance(payload, dict):
+        detail = ""
+        if isinstance(payload, dict) and payload.get("detail"):
+            detail = f": {payload['detail']}"
+        return f"Sentry sessions API returned HTTP {status}{detail}", {}
+    groups = payload.get("groups") or []
+    if not groups:
+        return None, {
+            "crash_free_rate(session)": None,
+            "crash_free_rate(user)": None,
+            "sum(session)": 0,
+            "count_unique(user)": 0,
+        }
+    return None, dict(groups[0].get("totals") or {})
+
+
+def rate_to_pct(raw: Any) -> float | None:
+    """Sentry returns crash-free rate as a 0..1 fraction. Convert to percent."""
+    if raw is None:
+        return None
+    try:
+        return round(float(raw) * 100, 4)
+    except (TypeError, ValueError):
+        return None
+
+
+def classify(
+    *,
+    creds_present: bool,
+    api_error: str | None,
+    session_rate: float | None,
+    user_rate: float | None,
+    total_sessions: int,
+    session_threshold: float,
+    user_threshold: float,
+    min_sessions: int,
+) -> dict[str, Any]:
+    """Pure verdict function. No I/O, so --self-test can exercise every path.
+
+    Returns {verdict, color, exit_code, reason}. verdict in
+    {pass, fail, unknown}; color in {green, red, yellow}.
+    """
+    def unknown(reason: str) -> dict[str, Any]:
+        return {"verdict": "unknown", "color": "yellow", "exit_code": EXIT_CODES["yellow"], "reason": reason}
+
+    if not creds_present:
+        return unknown("cannot verify - credentials absent (SENTRY_AUTH_TOKEN not set)")
+    if api_error:
+        return unknown(f"cannot verify - {api_error}")
+    if session_rate is None:
+        return unknown(
+            "cannot verify - no crash-free-session data for this release "
+            "(release health / session tracking may not be reporting)"
+        )
+    if total_sessions < min_sessions:
+        return unknown(
+            f"cannot verify - only {total_sessions} sessions in window "
+            f"(< min-sessions {min_sessions}); widen --stats-period or wait for more data"
+        )
+
+    below = []
+    if session_rate < session_threshold:
+        below.append(f"crash-free-sessions {session_rate:.3f}% < {session_threshold}%")
+    if user_rate is not None and user_rate < user_threshold:
+        below.append(f"crash-free-users {user_rate:.3f}% < {user_threshold}%")
+    if below:
+        return {
+            "verdict": "fail",
+            "color": "red",
+            "exit_code": EXIT_CODES["red"],
+            "reason": "; ".join(below),
+        }
+
+    reason = f"crash-free-sessions {session_rate:.3f}% >= {session_threshold}%"
+    if user_rate is not None:
+        reason += f", crash-free-users {user_rate:.3f}% (>= {user_threshold}%)"
+    reason += f" over {total_sessions} sessions"
+    return {"verdict": "pass", "color": "green", "exit_code": EXIT_CODES["green"], "reason": reason}
+
+
+def run_self_test() -> int:
+    cases = [
+        # (kwargs, expected_verdict, expected_exit)
+        (
+            dict(creds_present=False, api_error=None, session_rate=None, user_rate=None,
+                 total_sessions=0, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "unknown", 3,
+        ),
+        (
+            dict(creds_present=True, api_error="Sentry auth rejected (HTTP 401)", session_rate=None,
+                 user_rate=None, total_sessions=0, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "unknown", 3,
+        ),
+        (
+            dict(creds_present=True, api_error=None, session_rate=None, user_rate=None,
+                 total_sessions=0, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "unknown", 3,
+        ),
+        (  # thin data: healthy-looking rate but too few sessions -> not green
+            dict(creds_present=True, api_error=None, session_rate=100.0, user_rate=100.0,
+                 total_sessions=3, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "unknown", 3,
+        ),
+        (  # clear pass
+            dict(creds_present=True, api_error=None, session_rate=99.87, user_rate=99.95,
+                 total_sessions=500, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "pass", 0,
+        ),
+        (  # exactly at threshold passes (>=)
+            dict(creds_present=True, api_error=None, session_rate=99.5, user_rate=99.0,
+                 total_sessions=500, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "pass", 0,
+        ),
+        (  # sessions below threshold -> fail
+            dict(creds_present=True, api_error=None, session_rate=98.9, user_rate=99.99,
+                 total_sessions=500, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "fail", 1,
+        ),
+        (  # users below threshold -> fail (secondary gate)
+            dict(creds_present=True, api_error=None, session_rate=99.9, user_rate=97.0,
+                 total_sessions=500, session_threshold=99.5, user_threshold=99.0, min_sessions=25),
+            "fail", 1,
+        ),
+    ]
+    failures = 0
+    for i, (kwargs, want_verdict, want_exit) in enumerate(cases):
+        got = classify(**kwargs)
+        if got["verdict"] != want_verdict or got["exit_code"] != want_exit:
+            failures += 1
+            print(
+                f"self-test case {i} FAILED: want ({want_verdict}, exit {want_exit}), "
+                f"got ({got['verdict']}, exit {got['exit_code']}) - {got['reason']}",
+                file=sys.stderr,
+            )
+    # Guard the invariant the guardrails doc depends on: unknown/fail never exit 0.
+    for verdict, color in (("unknown", "yellow"), ("fail", "red")):
+        if EXIT_CODES[color] == 0:
+            failures += 1
+            print(f"self-test FAILED: {verdict} must not map to exit 0", file=sys.stderr)
+    if failures:
+        print(f"self-test: {failures} failure(s)", file=sys.stderr)
+        return 1
+    print(f"self-test passed ({len(cases)} cases)")
+    return 0
+
+
+def emit(result: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return
+    verdict = result["verdict"].upper()
+    color = result["color"].upper()
+    print(f"[{color}] crash-free gate: {verdict}")
+    print(f"  release: {result.get('release')}")
+    if result.get("session_rate") is not None:
+        print(f"  crash-free-sessions: {result['session_rate']:.3f}% (threshold {result['session_threshold']}%)")
+    else:
+        print(f"  crash-free-sessions: n/a (threshold {result['session_threshold']}%)")
+    if result.get("user_rate") is not None:
+        print(f"  crash-free-users:    {result['user_rate']:.3f}% (threshold {result['user_threshold']}%)")
+    else:
+        print(f"  crash-free-users:    n/a (threshold {result['user_threshold']}%)")
+    print(f"  sessions in window:  {result.get('total_sessions', 0)} ({result.get('stats_period')})")
+    print(f"  {result['reason']}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--version", default=None, help="Release version, e.g. 1.1.47. Defaults to Info.plist.")
+    parser.add_argument("--release", default=None, help="Full Sentry release override, e.g. transcripted@1.1.47.")
+    parser.add_argument("--org", default=os.environ.get("SENTRY_ORG", DEFAULT_ORG))
+    parser.add_argument("--project", default=os.environ.get("SENTRY_PROJECT", DEFAULT_PROJECT))
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=float(os.environ.get("CRASH_FREE_SESSION_THRESHOLD", DEFAULT_SESSION_THRESHOLD)),
+        help=f"Crash-free-session percent floor (default {DEFAULT_SESSION_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--user-threshold",
+        type=float,
+        default=float(os.environ.get("CRASH_FREE_USER_THRESHOLD", DEFAULT_USER_THRESHOLD)),
+        help=f"Crash-free-user percent floor (default {DEFAULT_USER_THRESHOLD}).",
+    )
+    parser.add_argument(
+        "--min-sessions",
+        type=int,
+        default=int(os.environ.get("CRASH_FREE_MIN_SESSIONS", DEFAULT_MIN_SESSIONS)),
+        help=f"Minimum sessions to trust the rate; below this is YELLOW (default {DEFAULT_MIN_SESSIONS}).",
+    )
+    parser.add_argument(
+        "--stats-period",
+        default=os.environ.get("SENTRY_STATS_PERIOD", DEFAULT_STATS_PERIOD),
+        help=f"Sentry lookback window, e.g. 24h, 14d, 90d (default {DEFAULT_STATS_PERIOD}).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the verdict as JSON.")
+    parser.add_argument("--self-test", action="store_true", help="Run offline verdict checks without network access.")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    root = Path.cwd()
+    load_env()
+
+    release = resolve_release(root, args)
+    token = os.environ.get("SENTRY_AUTH_TOKEN")
+
+    result: dict[str, Any] = {
+        "release": release,
+        "org": args.org,
+        "project": args.project,
+        "stats_period": args.stats_period,
+        "session_threshold": args.threshold,
+        "user_threshold": args.user_threshold,
+        "min_sessions": args.min_sessions,
+        "session_rate": None,
+        "user_rate": None,
+        "total_sessions": 0,
+        "total_users": 0,
+    }
+
+    if not release:
+        result.update(
+            classify(
+                creds_present=bool(token), api_error="no release resolved (pass --version or --release, or run from repo root with Info.plist)",
+                session_rate=None, user_rate=None, total_sessions=0,
+                session_threshold=args.threshold, user_threshold=args.user_threshold, min_sessions=args.min_sessions,
+            )
+        )
+        emit(result, args.json)
+        return result["exit_code"]
+
+    if not token:
+        result.update(
+            classify(
+                creds_present=False, api_error=None, session_rate=None, user_rate=None, total_sessions=0,
+                session_threshold=args.threshold, user_threshold=args.user_threshold, min_sessions=args.min_sessions,
+            )
+        )
+        emit(result, args.json)
+        return result["exit_code"]
+
+    api_error: str | None = None
+    project_id = project_numeric_id(args.org, args.project, token)
+    if project_id is None:
+        api_error = f"could not resolve project id for {args.org}/{args.project} (check org/project or token scope)"
+        totals: dict[str, Any] = {}
+    else:
+        api_error, totals = fetch_session_totals(args.org, project_id, release, args.stats_period, token)
+
+    session_rate = rate_to_pct(totals.get("crash_free_rate(session)"))
+    user_rate = rate_to_pct(totals.get("crash_free_rate(user)"))
+    total_sessions = int(totals.get("sum(session)") or 0)
+    total_users = int(totals.get("count_unique(user)") or 0)
+
+    result.update(
+        {
+            "session_rate": session_rate,
+            "user_rate": user_rate,
+            "total_sessions": total_sessions,
+            "total_users": total_users,
+        }
+    )
+    result.update(
+        classify(
+            creds_present=True,
+            api_error=api_error,
+            session_rate=session_rate,
+            user_rate=user_rate,
+            total_sessions=total_sessions,
+            session_threshold=args.threshold,
+            user_threshold=args.user_threshold,
+            min_sessions=args.min_sessions,
+        )
+    )
+    emit(result, args.json)
+    return result["exit_code"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds an **automated crash-free-rate release gate** so a Transcripted version is not "cleared to ship" when its crash-free rate is below threshold **or** cannot be verified. Previously `docs/release-guardrails.md` referenced Sentry as a manual eyeball step; this makes it a first-class, exit-code-gated check.

### New script: `scripts/ops/check-crash-free-rate.py`
Queries Sentry's Release Health (Sessions) API (`GET /api/0/organizations/{org}/sessions/`, `field=crash_free_rate(session)/(user)`) for `transcripted@<version>` and maps to a verdict:

| verdict | exit | meaning |
|---|---|---|
| `green` | 0 | crash-free-sessions ≥ threshold on enough data |
| `red` | 1 | crash-free-sessions below threshold — **hard block** |
| `yellow`/`unknown` | 3 | cannot verify (creds absent, API error, no/thin session data) — **never auto-green** |

Both red and yellow exit non-zero → not cleared to ship, mirroring how guardrails treat missing manual proof. Read-only: it never tags, notarizes, or publishes anything.

- Auth reuses the ops convention (`SENTRY_AUTH_TOKEN` via env or `~/.hermes/.env` / `~/.transcripted-ops.env`), org/project default `r3dbars`/`apple-macos`.
- Release name matches `scripts/release/sentry-release-metadata.py` (`transcripted@<version>`).
- Distinguishes auth-rejected (401/403), unreachable, bad-project, empty-data, and thin-data — all degrade to YELLOW, never green.
- Pure `classify()` with `--self-test` (8 cases, incl. the invariant that unknown/fail never map to exit 0). `--json` output.

### Threshold choice + reasoning
- **`--threshold 99.5`** (crash-free-sessions) — the common release-health ship line: Sentry's default release-health target is 99.5%, comfortably above Google Play's ~98.9% bad-behavior floor.
- **`--user-threshold 99.0`** — looser secondary gate; one crashing user with many sessions skews the user rate on a low-volume desktop app.
- **`--min-sessions 25`** — below this the rate is not trusted → YELLOW, not a false green on thin data. Widen `--stats-period` for low-volume releases instead.
- **`--stats-period 24h`** — recent window. All overridable by flag or env.

### Wiring
- `docs/release-guardrails.md` — added **Crash-free rate** as a Required Release Gate row + a dedicated "Crash-free-rate gate" section; listed the read-only check under "Safe While Justin Is Away".
- `.agents/test-matrix.yml`, `scripts/dev/agent-preflight.sh`, `scripts/README.md` — registered `py_compile` + `--self-test` (matrix↔preflight contract holds).

## Verification

- `--self-test`: **passes, 8 cases.**
- **Live against real Sentry** (creds present): `transcripted@1.1.47` (24h) and `transcripted@1.1.48` (90d) both return **YELLOW/UNKNOWN, exit 3** — the Sentry project currently reports **zero session data** (Release Health is not yet populated by the app's SDK). This is the correct safe posture (blocks rather than false-greens) and surfaces that Release Health isn't wired up yet.
- Confirmed the token is valid independently (org endpoint 200, issues return data, bad token → 401), so the empty result is real "no session data", not an auth failure.
- Degradation paths individually verified: credentials-absent, bad token, bad org/project → all YELLOW/exit 3.

```
$ python3 scripts/ops/check-crash-free-rate.py --release transcripted@1.1.47
[YELLOW] crash-free gate: UNKNOWN
  release: transcripted@1.1.47
  crash-free-sessions: n/a (threshold 99.5%)
  crash-free-users:    n/a (threshold 99.0%)
  sessions in window:  0 (24h)
  cannot verify - no crash-free-session data for this release (release health / session tracking may not be reporting)
$ echo $?
3
```

Once the app's Sentry SDK reports sessions, this gate becomes green-capable; until then crash-free is an UNKNOWN row handled by manual QA.

> Note: an independent Codex review was attempted but Codex hit its account usage cap (resets Jul 9) before producing findings. Verification above is manual + the pure-function self-test.

## Scope / safety
Adds a gate only. Does **not** publish, tag, notarize, or touch any release surface — consistent with `docs/release-guardrails.md` (all publish actions require explicit human go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)