### PR TITLE
Multi-exemplar voiceprints for speaker matching

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -148,6 +148,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
         createProvenanceTablesImpl()
         createMatchOutcomeTablesImpl()
         createNegativeExemplarTablesImpl()
+        createExemplarTablesImpl()
     }
 
     /// Add columns that may be missing from older databases.
@@ -309,10 +310,23 @@ public final class SpeakerDatabase: @unchecked Sendable {
             }
             sqlite3_finalize(statement)
 
+            var updatedExemplars = existing.exemplars
             if !sqlSucceeded {
                 AppLogger.speakers.error("CRITICAL: speaker update was NOT persisted to database — returning stale profile", ["id": existingId.uuidString])
             } else {
                 recordContributionImpl(profileId: existingId, embedding: embedding, kind: SpeakerProvenanceKind.contribution)
+                // Multi-exemplar voiceprints: fold this confirmed session mean into the profile's
+                // exemplar set so distinct capture conditions (clean in-person vs compressed remote)
+                // are stored separately rather than blended into one mediocre average. Gated on
+                // alpha > 0 — the same write-back quality gate that protects the average — so an
+                // ambiguous/frozen match never seeds or drifts an exemplar either.
+                if alpha > 0 {
+                    updatedExemplars = updateExemplarsImpl(
+                        profileId: existingId,
+                        newMean: embedding,
+                        average: normalized
+                    )
+                }
             }
 
             return SpeakerProfile(
@@ -324,7 +338,8 @@ public final class SpeakerDatabase: @unchecked Sendable {
                 lastSeen: Date(),
                 callCount: existing.callCount + 1,
                 confidence: newConfidence,
-                disputeCount: existing.disputeCount
+                disputeCount: existing.disputeCount,
+                exemplars: updatedExemplars
             )
         } else {
             return insertSpeakerImpl(embedding: embedding, preferredId: existingId, now: now)
@@ -457,6 +472,17 @@ public final class SpeakerDatabase: @unchecked Sendable {
             AppLogger.speakers.error("Failed to prepare allSpeakers query", ["sqlite_error": dbErrorMessage()])
         }
         sqlite3_finalize(statement)
+
+        // Attach multi-exemplar voiceprints as a read-side cache. One batched query, so the hot
+        // pipeline snapshot stays a single pass. Legacy profiles with no exemplar rows keep [].
+        let exemplarsByProfile = exemplarsByProfileImpl()
+        if !exemplarsByProfile.isEmpty {
+            for i in speakers.indices {
+                if let exemplars = exemplarsByProfile[speakers[i].id] {
+                    speakers[i].exemplars = exemplars
+                }
+            }
+        }
         return speakers
     }
 
@@ -481,6 +507,9 @@ public final class SpeakerDatabase: @unchecked Sendable {
             AppLogger.speakers.error("Failed to prepare getSpeaker query", ["sqlite_error": dbErrorMessage(), "id": id.uuidString])
         }
         sqlite3_finalize(statement)
+        if profile != nil {
+            profile?.exemplars = exemplarEmbeddingsImpl(forProfileId: id)
+        }
         return profile
     }
 
@@ -488,6 +517,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
     public func deleteSpeaker(id: UUID) {
         queue.sync { [self] in
             guard isDatabaseOpen else { return }
+            deleteExemplarsImpl(profileId: id)
             let sql = "DELETE FROM speakers WHERE id = ?;"
             var statement: OpaquePointer?
             if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {

--- a/Sources/TranscriptedCore/Speaker/SpeakerEmbeddingMatcher.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerEmbeddingMatcher.swift
@@ -27,7 +27,10 @@ extension SpeakerDatabase {
 
         for speaker in allSpeakers {
             guard speaker.embedding.count == embedding.count else { continue }
-            let similarity = SpeakerVectorMath.cosineSimilarity(embedding, speaker.embedding)
+            // Best-fitting representative (blended average or any stored exemplar); identical to the
+            // single cosine for legacy profiles whose exemplar set is empty.
+            let similarity = SpeakerVectorMath.bestSimilarity(
+                candidate: embedding, average: speaker.embedding, exemplars: speaker.exemplars)
             // Negative-exemplar veto — see matchAgainstProfiles for the shared rationale.
             if let negatives = negativeExemplarsByProfile[speaker.id],
                SpeakerNegativeExemplarPolicy.shouldVeto(

--- a/Sources/TranscriptedCore/Speaker/SpeakerExemplarPolicy.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerExemplarPolicy.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// Multi-exemplar voiceprint maintenance (additive to the single running-average fingerprint).
+///
+/// A person's clean in-person mic and their compressed remote/Zoom mic produce systematically
+/// different embeddings. Blending both into one running average (`SpeakerProfile.embedding` via the
+/// EMA in `SpeakerDatabase.addOrUpdateSpeaker`) yields a mediocre centroid that fits neither
+/// condition well, depressing match similarity in both. Multi-exemplar voiceprints instead keep a
+/// small set of representative embeddings per person — the K most distinct-yet-confirmed session
+/// means — so a returning voice is compared against the BEST-fitting exemplar rather than a single
+/// blended vector (see `SpeakerVectorMath.bestSimilarity`).
+///
+/// This policy is pure and deterministic (no randomness, no clock) so the eval harness and unit
+/// tests can exercise it directly. The profile's blended average always participates as an implicit
+/// always-present representative at match time and is never stored here, so:
+///   - a legacy profile with an empty exemplar set matches EXACTLY as it did before (max over the
+///     single average), and
+///   - a stored exemplar only ever *adds* a candidate vector, so per-profile similarity is
+///     monotonically non-decreasing — the change cannot lower a true match's score.
+///
+/// Exemplar writes reuse the write-path quality gate: the caller only updates exemplars when the
+/// matched write-back alpha is > 0 (a confident/cautious, well-separated match), so an ambiguous or
+/// weak match that freezes the average can never seed or drift an exemplar either. Exemplars and the
+/// average share one contamination guard.
+public enum SpeakerExemplarPolicy {
+
+    /// Maximum representative exemplars stored per profile, in addition to the blended average.
+    /// Small on purpose: enough to cover the common clean-vs-compressed split (plus one) without
+    /// letting a profile balloon or a stray condition dominate. Tune on the SpeakerEvalHarness.
+    public static let maxExemplars = 3
+
+    /// At or above this cosine to an existing representative (the average or a stored exemplar), a
+    /// new confirmed session mean is treated as the SAME capture condition and folded into that
+    /// nearest exemplar (denoise) instead of being stored as a near-duplicate. Below it, the mean is
+    /// a distinct condition and earns its own exemplar slot. Mirrors
+    /// `SpeakerWritePathPolicy.confidentWriteBackSimilarity` (0.80) — the point at which a match is
+    /// "clearly the same voice, same context."
+    public static let sameConditionSimilarity: Double = 0.80
+
+    /// EMA weight for folding a same-condition mean into its exemplar. Higher than the profile
+    /// average's 0.15 because each exemplar tracks ONE condition, so it should adapt to that
+    /// condition quickly rather than lag behind it the way the all-conditions average must.
+    public static let exemplarBlendAlpha: Float = 0.30
+
+    /// One stored representative embedding plus how many session means built it.
+    public struct Exemplar: Sendable, Equatable {
+        public var embedding: [Float]
+        public var segmentCount: Int
+
+        public init(embedding: [Float], segmentCount: Int) {
+            self.embedding = embedding
+            self.segmentCount = segmentCount
+        }
+    }
+
+    /// Pure update of a profile's exemplar set given a new confirmed session mean and the profile's
+    /// (post-blend) average embedding.
+    ///
+    /// - `current`: the profile's existing exemplars (authoritative, from storage).
+    /// - `newMean`: the L2-normalized session mean that just confidently matched this profile.
+    /// - `average`: the profile's blended `embedding` — always an implicit representative, never
+    ///   stored in `current`; passing it in lets a mean already covered by the average be dropped
+    ///   rather than duplicated.
+    ///
+    /// Returns the new exemplar set (≤ `maxExemplars`). Diversity is non-decreasing: an eviction only
+    /// happens when the incoming mean is strictly more distinct than the most-redundant existing
+    /// exemplar, so the stored set never gets *less* spread.
+    public static func updated(
+        current: [Exemplar],
+        newMean: [Float],
+        average: [Float]
+    ) -> [Exemplar] {
+        guard !newMean.isEmpty, newMean.count == average.count else { return current }
+
+        // Only compare against same-dimension representatives (defensive — exemplars always share
+        // the profile dimension, but never mix 192-d and 256-d geometry).
+        let usable = current.filter { $0.embedding.count == newMean.count }
+
+        // Best representative already covering this mean: the average (index -1) or an exemplar.
+        let simToAverage = SpeakerVectorMath.cosineSimilarity(newMean, average)
+        var bestRepSim = simToAverage
+        var bestExemplarIndex: Int? = nil  // nil ⇒ the average is the best representative
+        for (i, exemplar) in usable.enumerated() {
+            let sim = SpeakerVectorMath.cosineSimilarity(newMean, exemplar.embedding)
+            if sim > bestRepSim {
+                bestRepSim = sim
+                bestExemplarIndex = i
+            }
+        }
+
+        // Same condition as an existing representative → denoise, don't duplicate.
+        if bestRepSim >= sameConditionSimilarity {
+            guard let i = bestExemplarIndex else {
+                // Already covered by the average (which is EMA-updated separately). Nothing to add.
+                return usable
+            }
+            var updated = usable
+            let blended = blend(updated[i].embedding, newMean, alpha: exemplarBlendAlpha)
+            updated[i] = Exemplar(embedding: blended, segmentCount: updated[i].segmentCount + 1)
+            return updated
+        }
+
+        // Distinct condition. Grow the set, or evict the most-redundant exemplar if it is more
+        // redundant than the incoming mean is — which keeps the retained set at least as diverse.
+        if usable.count < maxExemplars {
+            return usable + [Exemplar(embedding: newMean, segmentCount: 1)]
+        }
+
+        let (victim, victimRedundancy) = mostRedundantExemplar(usable, average: average)
+        guard let victim, victimRedundancy > bestRepSim else {
+            // Incoming mean is no more distinct than what we already hold — keep the set.
+            return usable
+        }
+        var updated = usable
+        updated[victim] = Exemplar(embedding: newMean, segmentCount: 1)
+        return updated
+    }
+
+    /// Index of the exemplar whose removal loses the least coverage (highest cosine to any other
+    /// representative — average or another exemplar), and that redundancy value. `nil` if empty.
+    private static func mostRedundantExemplar(
+        _ exemplars: [Exemplar],
+        average: [Float]
+    ) -> (index: Int?, redundancy: Double) {
+        var victim: Int? = nil
+        var maxRedundancy = -Double.infinity
+        for (i, exemplar) in exemplars.enumerated() {
+            var redundancy = SpeakerVectorMath.cosineSimilarity(exemplar.embedding, average)
+            for (j, other) in exemplars.enumerated() where j != i {
+                redundancy = max(redundancy, SpeakerVectorMath.cosineSimilarity(exemplar.embedding, other.embedding))
+            }
+            if redundancy > maxRedundancy {
+                maxRedundancy = redundancy
+                victim = i
+            }
+        }
+        return (victim, maxRedundancy)
+    }
+
+    private static func blend(_ existing: [Float], _ incoming: [Float], alpha: Float) -> [Float] {
+        let a = max(0, min(1, alpha))
+        let mixed = zip(existing, incoming).map { old, new in old * (1 - a) + new * a }
+        return SpeakerVectorMath.l2Normalize(mixed)
+    }
+}

--- a/Sources/TranscriptedCore/Speaker/SpeakerExemplarStore.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerExemplarStore.swift
@@ -1,0 +1,161 @@
+// SpeakerExemplarStore.swift
+// Persistence for multi-exemplar voiceprints (see SpeakerExemplarPolicy).
+//
+// The `speakers` table keeps ONE blended-average embedding per person. This table stores a small,
+// bounded set of additional representative embeddings ("exemplars") per person — the K most
+// distinct-yet-confirmed session means — so the matcher can score a returning voice against its
+// best-fitting capture condition (clean in-person vs compressed remote) instead of a single average
+// that fits neither.
+//
+// Additive and backward-compatible: profiles built before this shipped simply have no exemplar rows,
+// so `SpeakerProfile.exemplars` loads empty and matching falls back to the single average exactly.
+// Exemplars are a rebuildable cache of gated centroids, never the source of truth for identity, so
+// any structural edit that re-derives the average (merge / un-merge / reassign) safely clears them
+// and lets them re-accumulate.
+
+import Foundation
+import SQLite3
+
+@available(macOS 14.0, *)
+extension SpeakerDatabase {
+
+    // MARK: - Schema
+
+    /// Create the exemplar table. Idempotent; called from createTables().
+    func createExemplarTablesImpl() {
+        let sql = """
+        CREATE TABLE IF NOT EXISTS speaker_exemplars (
+            id TEXT PRIMARY KEY,
+            profile_id TEXT NOT NULL,
+            embedding BLOB NOT NULL,
+            segment_count INTEGER NOT NULL DEFAULT 1,
+            updated_at TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+        """
+        executeSQL(sql)
+        executeSQL("CREATE INDEX IF NOT EXISTS idx_exemplars_profile ON speaker_exemplars(profile_id);")
+    }
+
+    // MARK: - Reads (called on the serialized queue)
+
+    /// A single profile's exemplar embeddings, ordered oldest-first for determinism.
+    func exemplarEmbeddingsImpl(forProfileId profileId: UUID) -> [[Float]] {
+        exemplarsImpl(forProfileId: profileId).map { $0.embedding }
+    }
+
+    /// Batch-load every profile's exemplar embeddings in one query — used by `allSpeakers` so the
+    /// hot pipeline snapshot doesn't issue one query per profile.
+    func exemplarsByProfileImpl() -> [UUID: [[Float]]] {
+        guard isDatabaseOpen else { return [:] }
+        var result: [UUID: [[Float]]] = [:]
+        let sql = "SELECT profile_id, embedding FROM speaker_exemplars ORDER BY profile_id, rowid;"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let idStr = sqlite3_column_text(statement, 0).map(String.init(cString:)),
+                      let profileId = UUID(uuidString: idStr) else { continue }
+                if let vector = readEmbeddingColumn(statement, index: 1) {
+                    result[profileId, default: []].append(vector)
+                }
+            }
+        } else {
+            AppLogger.speakers.error("Failed to prepare exemplarsByProfile query", ["sqlite_error": dbErrorMessage()])
+        }
+        sqlite3_finalize(statement)
+        return result
+    }
+
+    /// Full exemplars (with segment counts) for the write-path policy. Ordered oldest-first.
+    private func exemplarsImpl(forProfileId profileId: UUID) -> [SpeakerExemplarPolicy.Exemplar] {
+        guard isDatabaseOpen else { return [] }
+        var rows: [SpeakerExemplarPolicy.Exemplar] = []
+        let sql = "SELECT embedding, segment_count FROM speaker_exemplars WHERE profile_id = ? ORDER BY rowid;"
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let vector = readEmbeddingColumn(statement, index: 0) else { continue }
+                let count = Int(sqlite3_column_int(statement, 1))
+                rows.append(SpeakerExemplarPolicy.Exemplar(embedding: vector, segmentCount: max(1, count)))
+            }
+        }
+        sqlite3_finalize(statement)
+        return rows
+    }
+
+    private func readEmbeddingColumn(_ statement: OpaquePointer?, index: Int32) -> [Float]? {
+        guard let statement, let blobPtr = sqlite3_column_blob(statement, index) else { return nil }
+        let blobSize = sqlite3_column_bytes(statement, index)
+        guard blobSize > 0 else { return nil }
+        let floatCount = Int(blobSize) / MemoryLayout<Float>.size
+        return Array(UnsafeBufferPointer(start: blobPtr.assumingMemoryBound(to: Float.self), count: floatCount))
+    }
+
+    // MARK: - Writes (called on the serialized queue)
+
+    /// Fold a new confirmed session mean into the profile's exemplar set per `SpeakerExemplarPolicy`,
+    /// persist the result, and return the resulting exemplar embeddings for the caller's in-memory
+    /// profile. Best-effort: a failure here never fails the parent speaker write. Must be called on
+    /// `queue`.
+    ///
+    /// `average` is the profile's post-blend `embedding` (an implicit always-present representative,
+    /// so a mean already covered by the average is dropped rather than duplicated). The caller gates
+    /// this on a positive write-back alpha, so ambiguous/frozen matches never touch exemplars.
+    @discardableResult
+    func updateExemplarsImpl(profileId: UUID, newMean: [Float], average: [Float]) -> [[Float]] {
+        guard isDatabaseOpen, !newMean.isEmpty else {
+            return exemplarEmbeddingsImpl(forProfileId: profileId)
+        }
+        let current = exemplarsImpl(forProfileId: profileId)
+        let updated = SpeakerExemplarPolicy.updated(current: current, newMean: newMean, average: average)
+        if updated == current { return current.map { $0.embedding } }
+
+        persistExemplarsImpl(profileId: profileId, exemplars: updated)
+        return updated.map { $0.embedding }
+    }
+
+    /// Replace all of a profile's exemplar rows with `exemplars`. Simple delete-then-insert keeps the
+    /// stored set an exact image of the policy output without diff bookkeeping.
+    private func persistExemplarsImpl(profileId: UUID, exemplars: [SpeakerExemplarPolicy.Exemplar]) {
+        deleteExemplarsImpl(profileId: profileId)
+        guard !exemplars.isEmpty else { return }
+        let now = ISO8601DateFormatter().string(from: Date())
+        let sql = """
+        INSERT INTO speaker_exemplars (id, profile_id, embedding, segment_count, updated_at)
+        VALUES (?, ?, ?, ?, ?);
+        """
+        for exemplar in exemplars {
+            var statement: OpaquePointer?
+            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+                let embeddingData = exemplar.embedding.withUnsafeBufferPointer { Data(buffer: $0) }
+                sqlite3_bind_text(statement, 1, (UUID().uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_text(statement, 2, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_blob(statement, 3, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
+                sqlite3_bind_int(statement, 4, Int32(exemplar.segmentCount))
+                sqlite3_bind_text(statement, 5, (now as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to insert exemplar", ["sqlite_error": dbErrorMessage(), "profileId": profileId.uuidString])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare exemplar insert", ["sqlite_error": dbErrorMessage()])
+            }
+            sqlite3_finalize(statement)
+        }
+    }
+
+    /// Drop all exemplar rows for a profile. Called when a profile is deleted or its average is
+    /// structurally re-derived (merge / un-merge / reassign), so exemplars never outlive the identity
+    /// they represented. Must be called on `queue`.
+    func deleteExemplarsImpl(profileId: UUID) {
+        guard isDatabaseOpen else { return }
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, "DELETE FROM speaker_exemplars WHERE profile_id = ?;", -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(statement) != SQLITE_DONE {
+                AppLogger.speakers.error("Failed to delete exemplars", ["sqlite_error": dbErrorMessage(), "profileId": profileId.uuidString])
+            }
+        }
+        sqlite3_finalize(statement)
+    }
+}

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -67,7 +67,12 @@ extension Transcription {
             // auto-match future recordings back into it until the user repairs it.
             guard profile.disputeCount == 0 else { continue }
             guard profile.embedding.count == embedding.count else { continue }
-            let similarity = cosineSimilarityStatic(embedding, profile.embedding)
+            // Score against the best-fitting representative: the blended average OR any stored
+            // multi-exemplar voiceprint (empty for legacy profiles ⇒ identical to the old single
+            // cosine). All downstream semantics — maturity bonus, separation, second-best margin —
+            // operate on this per-profile best.
+            let similarity = SpeakerVectorMath.bestSimilarity(
+                candidate: embedding, average: profile.embedding, exemplars: profile.exemplars)
             // Negative-exemplar veto: if this embedding looks at least as much like a previously
             // rejected sample for this profile as it does like the profile itself, exclude the
             // profile entirely (best AND runner-up) — the user already said "not this person".

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfile.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfile.swift
@@ -11,6 +11,13 @@ public struct SpeakerProfile: Identifiable, Sendable {
     public var displayName: String?        // "Nate", "Travis", or nil if unnamed
     public var nameSource: String?         // NameSource.userManual or nil
     public var embedding: [Float]          // 256-dim average voice vector
+    /// Additional representative voiceprints ("exemplars") for this person, beyond the blended
+    /// `embedding` average — e.g. one for clean in-person mic and one for compressed remote audio.
+    /// Empty for legacy single-average profiles, which then match exactly as before. Matching scores
+    /// a candidate against the best-fitting exemplar (see `SpeakerVectorMath.bestSimilarity`).
+    /// Populated as a read-side cache when profiles are loaded from `SpeakerDatabase`; the
+    /// authoritative rows live in the `speaker_exemplars` table.
+    public var exemplars: [[Float]]
     public var firstSeen: Date
     public var lastSeen: Date
     public var callCount: Int
@@ -26,12 +33,14 @@ public struct SpeakerProfile: Identifiable, Sendable {
         lastSeen: Date,
         callCount: Int,
         confidence: Double,
-        disputeCount: Int
+        disputeCount: Int,
+        exemplars: [[Float]] = []
     ) {
         self.id = id
         self.displayName = displayName
         self.nameSource = nameSource
         self.embedding = embedding
+        self.exemplars = exemplars
         self.firstSeen = firstSeen
         self.lastSeen = lastSeen
         self.callCount = callCount

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
@@ -225,6 +225,14 @@ extension SpeakerDatabase {
             }
             sqlite3_finalize(statement)
 
+            // Exemplars are a rebuildable cache of gated centroids tied to a specific identity/average.
+            // The merge blends a second voice into the target and deletes the source, so drop both
+            // sets: the source's would orphan, and the target's no longer match its changed average.
+            // They re-accumulate from future confident matches. Un-merge restores neither (both start
+            // empty), which degrades to single-average matching — never wrong, just less enriched.
+            deleteExemplarsImpl(profileId: sourceId)
+            deleteExemplarsImpl(profileId: targetId)
+
             // Delete source profile
             let deleteSql = "DELETE FROM speakers WHERE id = ?;"
             var deleteStmt: OpaquePointer?

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
@@ -537,6 +537,12 @@ extension SpeakerDatabase {
             }
         }
         sqlite3_finalize(statement)
+        // The average was just rebuilt from a changed contribution set (un-merge / reassign), so any
+        // cached multi-exemplar voiceprints no longer represent this identity — drop them and let
+        // them re-accumulate from future confident matches.
+        if ok {
+            deleteExemplarsImpl(profileId: profileId)
+        }
         return ok
     }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerVectorMath.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerVectorMath.swift
@@ -19,6 +19,23 @@ public enum SpeakerVectorMath {
         return Double(dotProduct / denominator)
     }
 
+    /// Best cosine of `candidate` against a profile's representative vectors: its blended `average`
+    /// (`SpeakerProfile.embedding`) plus any stored multi-exemplar voiceprints. Representatives whose
+    /// dimension differs from `candidate` are skipped.
+    ///
+    /// With an empty `exemplars` set this returns exactly `cosineSimilarity(candidate, average)`, so
+    /// legacy single-average profiles match identically. With exemplars it returns the max, so a
+    /// returning voice is scored against its best-fitting capture condition rather than a single
+    /// blended-across-conditions centroid. Because it only ever *adds* candidate vectors, the score
+    /// is monotonically non-decreasing versus the single-average path.
+    public static func bestSimilarity(candidate: [Float], average: [Float], exemplars: [[Float]]) -> Double {
+        var best = candidate.count == average.count ? cosineSimilarity(candidate, average) : -1
+        for exemplar in exemplars where exemplar.count == candidate.count {
+            best = max(best, cosineSimilarity(candidate, exemplar))
+        }
+        return best
+    }
+
     public static func l2Normalize(_ values: [Float]) -> [Float] {
         var norm: Float = 0
         vDSP_dotpr(values, 1, values, 1, &norm, vDSP_Length(values.count))

--- a/Tests/TranscriptedCoreTests/SpeakerExemplarPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerExemplarPolicyTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import Foundation
+@testable import TranscriptedCore
+
+/// Unit tests for the pure multi-exemplar maintenance policy — no database, no audio.
+@available(macOS 14.0, *)
+final class SpeakerExemplarPolicyTests: XCTestCase {
+
+    /// A 4-dim unit basis vector, optionally tilted toward another axis, L2-normalized.
+    private func vec(_ a: Float, _ b: Float, _ c: Float, _ d: Float) -> [Float] {
+        SpeakerVectorMath.l2Normalize([a, b, c, d])
+    }
+
+    // A mean already covered by the average (same direction) adds no exemplar.
+    func testSameAsAverageStoresNoExemplar() {
+        let average = vec(1, 0, 0, 0)
+        let mean = vec(0.98, 0.02, 0, 0) // cos ~0.9998 > sameConditionSimilarity
+        let result = SpeakerExemplarPolicy.updated(current: [], newMean: mean, average: average)
+        XCTAssertTrue(result.isEmpty, "A mean the average already covers should not be stored")
+    }
+
+    // A mean from a distinct condition (far from the average) earns its own exemplar.
+    func testDistinctConditionCreatesExemplar() {
+        let average = vec(1, 0, 0, 0)
+        let mean = vec(0, 1, 0, 0) // orthogonal → cos 0 < threshold
+        let result = SpeakerExemplarPolicy.updated(current: [], newMean: mean, average: average)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].segmentCount, 1)
+    }
+
+    // A second same-condition mean blends into the existing exemplar rather than duplicating it.
+    func testSameConditionBlendsIntoExemplarAndBumpsCount() {
+        let average = vec(1, 0, 0, 0)
+        let cond2 = vec(0, 1, 0, 0)
+        var exemplars = SpeakerExemplarPolicy.updated(current: [], newMean: cond2, average: average)
+        XCTAssertEqual(exemplars.count, 1)
+
+        let cond2Again = vec(0.05, 0.99, 0, 0) // very close to cond2 → same condition
+        exemplars = SpeakerExemplarPolicy.updated(current: exemplars, newMean: cond2Again, average: average)
+        XCTAssertEqual(exemplars.count, 1, "Same-condition mean should blend, not add a slot")
+        XCTAssertEqual(exemplars[0].segmentCount, 2)
+        // Stays unit-norm after the EMA blend.
+        let norm = exemplars[0].embedding.reduce(Float(0)) { $0 + $1 * $1 }.squareRoot()
+        XCTAssertEqual(norm, 1, accuracy: 1e-3)
+    }
+
+    // The set never exceeds maxExemplars; a further distinct mean evicts the most-redundant slot.
+    func testCapEnforcedAndEvictsMostRedundant() {
+        let average = vec(1, 0, 0, 0)
+        var exemplars: [SpeakerExemplarPolicy.Exemplar] = []
+        // Three distinct conditions fill the three slots.
+        for m in [vec(0, 1, 0, 0), vec(0, 0, 1, 0), vec(0, 0, 0, 1)] {
+            exemplars = SpeakerExemplarPolicy.updated(current: exemplars, newMean: m, average: average)
+        }
+        XCTAssertEqual(exemplars.count, SpeakerExemplarPolicy.maxExemplars)
+
+        // A brand-new, maximally-distinct direction. It is more distinct than the most-redundant
+        // existing exemplar, so the set stays at the cap and swaps one out.
+        let novel = vec(-1, -1, -1, -1)
+        let after = SpeakerExemplarPolicy.updated(current: exemplars, newMean: novel, average: average)
+        XCTAssertEqual(after.count, SpeakerExemplarPolicy.maxExemplars, "Never exceeds the cap")
+        XCTAssertTrue(
+            after.contains { SpeakerVectorMath.cosineSimilarity($0.embedding, novel) > 0.99 },
+            "The novel distinct condition should be retained after eviction"
+        )
+    }
+
+    // A dimension-mismatched mean is ignored (never mixes 192-d and 256-d geometry).
+    func testDimensionMismatchIgnored() {
+        let average = vec(1, 0, 0, 0)
+        let wrongDim = SpeakerVectorMath.l2Normalize([0, 1, 0]) // 3-dim
+        let result = SpeakerExemplarPolicy.updated(current: [], newMean: wrongDim, average: average)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // bestSimilarity is monotonic: adding an exemplar never lowers the score, and matching the
+    // exemplar direction beats matching the average alone.
+    func testBestSimilarityUsesBestFittingRepresentative() {
+        let average = vec(1, 0, 0, 0)
+        let exemplar = vec(0, 1, 0, 0)
+        let candidate = vec(0.1, 0.99, 0, 0) // close to the exemplar, far from the average
+
+        let averageOnly = SpeakerVectorMath.bestSimilarity(candidate: candidate, average: average, exemplars: [])
+        let withExemplar = SpeakerVectorMath.bestSimilarity(candidate: candidate, average: average, exemplars: [exemplar])
+
+        XCTAssertGreaterThan(withExemplar, averageOnly)
+        XCTAssertEqual(withExemplar, SpeakerVectorMath.cosineSimilarity(candidate, exemplar), accuracy: 1e-6)
+        // Empty exemplar set is exactly the single-average cosine (legacy behavior).
+        XCTAssertEqual(averageOnly, SpeakerVectorMath.cosineSimilarity(candidate, average), accuracy: 1e-6)
+    }
+}

--- a/Tests/TranscriptedCoreTests/SpeakerMultiExemplarMatchingTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerMultiExemplarMatchingTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+import Foundation
+@testable import TranscriptedCore
+
+/// End-to-end (DB write → read → match) coverage for multi-exemplar voiceprints, plus the
+/// backward-compatibility guarantee that a legacy single-average profile matches exactly as before.
+@available(macOS 14.0, *)
+final class SpeakerMultiExemplarMatchingTests: XCTestCase {
+
+    private func tmpDB() -> SpeakerDatabase {
+        SpeakerDatabase(path: NSTemporaryDirectory() + "spk_exemplar_\(UUID().uuidString).sqlite")
+    }
+
+    private func vec(_ a: Float, _ b: Float, _ c: Float, _ d: Float) -> [Float] {
+        SpeakerVectorMath.l2Normalize([a, b, c, d])
+    }
+
+    // MARK: - Backward compatibility (single-average / no exemplars)
+
+    func testLegacyProfileWithoutExemplarsMatchesUnchanged() {
+        let db = tmpDB()
+        let a = vec(1, 0, 0, 0)
+        let profile = db.addOrUpdateSpeaker(embedding: a, existingId: nil)
+
+        // Fresh profile has no exemplars; a near-A candidate matches on the single average exactly
+        // as it did before this feature.
+        XCTAssertTrue(db.allSpeakers().allSatisfy { $0.exemplars.isEmpty })
+        let match = db.matchSpeaker(embedding: vec(0.98, 0.02, 0, 0), threshold: 0.6)
+        XCTAssertEqual(match?.profile.id, profile.id)
+    }
+
+    func testMatchAgainstProfilesEmptyExemplarsEqualsSingleCosine() {
+        let a = vec(1, 0, 0, 0)
+        let profile = SpeakerProfile(
+            id: UUID(), displayName: "A", nameSource: nil, embedding: a,
+            firstSeen: Date(), lastSeen: Date(), callCount: 10, confidence: 0.9, disputeCount: 0)
+        // A candidate orthogonal to the only representative must not match — exemplars can't help.
+        XCTAssertNil(Transcription.matchAgainstProfiles(vec(0, 1, 0, 0), profiles: [profile], threshold: 0.6))
+        // A near-A candidate matches.
+        XCTAssertNotNil(Transcription.matchAgainstProfiles(vec(0.95, 0.05, 0, 0), profiles: [profile], threshold: 0.6))
+    }
+
+    // MARK: - Multi-exemplar benefit
+
+    // A profile that has seen two distinct capture conditions matches a candidate from the SECOND
+    // condition via its exemplar — where the single blended average alone would fall below threshold.
+    func testDistinctConditionMatchesViaExemplarNotAverage() {
+        let db = tmpDB()
+        let condition1 = vec(1, 0, 0, 0)   // e.g. clean in-person mic
+        let condition2 = vec(0, 1, 0, 0)   // e.g. compressed remote mic
+
+        let profile = db.addOrUpdateSpeaker(embedding: condition1, existingId: nil)
+        // A confident write-back of a distinct second condition into the same profile.
+        _ = db.addOrUpdateSpeaker(embedding: condition2, existingId: profile.id)
+
+        // The exemplar was persisted and reloads on read.
+        let reloaded = db.getSpeaker(id: profile.id)
+        XCTAssertEqual(reloaded?.exemplars.count, 1, "The distinct second condition should be stored as an exemplar")
+
+        // The blended average now sits mostly on condition1; a condition2-like candidate is far from it.
+        let average = reloaded!.embedding
+        let candidate = vec(0.1, 0.99, 0, 0)
+        let avgSimilarity = SpeakerVectorMath.cosineSimilarity(candidate, average)
+        XCTAssertLessThan(avgSimilarity, 0.6, "Precondition: the single average alone would miss this candidate")
+
+        // With the exemplar, the candidate matches back to the same person.
+        let match = db.matchSpeaker(embedding: candidate, threshold: 0.6)
+        XCTAssertEqual(match?.profile.id, profile.id)
+        XCTAssertGreaterThan(match?.similarity ?? 0, avgSimilarity)
+    }
+
+    // matchAgainstProfiles (the in-memory snapshot path used by the pipeline and eval harness)
+    // scores against the best-fitting exemplar while preserving the dimension guard.
+    func testSnapshotMatchUsesBestExemplar() {
+        let profile = SpeakerProfile(
+            id: UUID(), displayName: "Multi", nameSource: nil, embedding: vec(1, 0, 0, 0),
+            firstSeen: Date(), lastSeen: Date(), callCount: 10, confidence: 0.9, disputeCount: 0,
+            exemplars: [vec(0, 1, 0, 0)])
+
+        // Near the exemplar (far from the average) → matches via the exemplar.
+        let viaExemplar = Transcription.matchAgainstProfiles(vec(0.1, 0.99, 0, 0), profiles: [profile], threshold: 0.6)
+        XCTAssertEqual(viaExemplar?.profileId, profile.id)
+
+        // Near the average → still matches via the average.
+        let viaAverage = Transcription.matchAgainstProfiles(vec(0.99, 0.1, 0, 0), profiles: [profile], threshold: 0.6)
+        XCTAssertEqual(viaAverage?.profileId, profile.id)
+
+        // Orthogonal to every representative → no match.
+        XCTAssertNil(Transcription.matchAgainstProfiles(vec(0, 0, 1, 0), profiles: [profile], threshold: 0.6))
+    }
+
+    // Ambiguous / weak matches freeze the average (alpha 0); they must not seed an exemplar either.
+    func testFrozenWriteBackDoesNotCreateExemplar() {
+        let db = tmpDB()
+        let profile = db.addOrUpdateSpeaker(embedding: vec(1, 0, 0, 0), existingId: nil)
+        // alpha 0 == frozen (ambiguous match): record the appearance without touching the voiceprint.
+        _ = db.addOrUpdateSpeaker(embedding: vec(0, 1, 0, 0), existingId: profile.id, blendAlpha: 0)
+        XCTAssertEqual(db.getSpeaker(id: profile.id)?.exemplars.count, 0, "Frozen write-back must not create an exemplar")
+    }
+
+    // Deleting a profile removes its exemplar rows (no orphans).
+    func testDeleteProfileRemovesExemplars() {
+        let db = tmpDB()
+        let profile = db.addOrUpdateSpeaker(embedding: vec(1, 0, 0, 0), existingId: nil)
+        _ = db.addOrUpdateSpeaker(embedding: vec(0, 1, 0, 0), existingId: profile.id)
+        XCTAssertEqual(db.getSpeaker(id: profile.id)?.exemplars.count, 1)
+        db.deleteSpeaker(id: profile.id)
+        let fresh = db.addOrUpdateSpeaker(embedding: vec(1, 0, 0, 0), existingId: nil)
+        XCTAssertTrue(fresh.exemplars.isEmpty, "A new profile must not inherit a deleted one's exemplars")
+    }
+}


### PR DESCRIPTION
## What

Replaces the single running-average voiceprint per person with a small, bounded **set of representative exemplars**, and matches a candidate against the **best-fitting** exemplar instead of one blended-across-conditions average.

### Why
A person's clean in-person mic and their compressed remote/Zoom mic produce systematically different embeddings. EMA-blending both into one `SpeakerProfile.embedding` yields a mediocre centroid that fits neither condition well, depressing match confidence in both. Storing the K most distinct-yet-confirmed session means lets a returning voice match its actual capture condition.

## How
- **`SpeakerExemplarPolicy`** (new, pure/deterministic): maintains ≤ `maxExemplars` (3) exemplars via a centroid-distance/diversity heuristic — a same-condition mean (cosine ≥ 0.80 to a representative) EMA-blends into the nearest exemplar (denoise); a distinct condition earns its own slot; at the cap, the most-redundant exemplar is evicted only when the newcomer is strictly more distinct (diversity never decreases).
- **`SpeakerVectorMath.bestSimilarity(candidate:average:exemplars:)`**: max cosine over `{average} ∪ exemplars`, skipping dimension-mismatched vectors.
- **`speaker_exemplars` table** (`SpeakerExemplarStore`): batch-loaded into `SpeakerProfile.exemplars` on read; both matchers (`matchAgainstProfiles` snapshot path + `matchSpeakerImpl`) now use `bestSimilarity`.

## Additive & backward-compatible
- `SpeakerProfile.exemplars` defaults to `[]` → a legacy single-average profile matches **byte-identically** (max over the single average). The change only ever *adds* candidate vectors, so per-profile similarity is **monotonically non-decreasing** — it cannot lower a true match's score.
- Single-average path (EMA blend, merge, provenance re-derivation) untouched; exemplars are a rebuildable read-side cache on top.
- 192-d/256-d dimension-isolation guard preserved in both matchers.
- **Contamination guard preserved**: exemplars are written only on a confident/cautious match (write-back `alpha > 0`) — the same gate that protects the average — so an ambiguous/frozen match can never seed or drift an exemplar.
- Existing match semantics (maturity bonus, separation/ambiguity guard, second-best margin) still operate on the per-profile best similarity.
- Structural edits stay consistent: merge drops both profiles' exemplars; average re-derivation (un-merge / reassign) and profile deletion clear them; they re-accumulate from future confident matches.
- Invisible to the user per the "names just appear" design — model/pipeline layer only, no UI surface.

## Validation
- **Full Core `swift test`: 694 tests, 0 failures** (12 skipped/timing-sensitive), including:
  - `SpeakerNamingSimulationRunnerTests` — the in-package deterministic **speaker eval harness** (false-merge / confusion / identity-stability indicators): **no regression**.
  - `SpeakerDBDimensionIsolationTests`, `SpeakerMatchingServiceTests`, `SpeakerEmbeddingMatcherTests`, `SpeakerProfileMergerTests`, `SpeakerProfileProvenanceTests`: pass.
- New focused tests: `SpeakerExemplarPolicyTests` (pure policy) + `SpeakerMultiExemplarMatchingTests` (legacy single-exemplar regression **and** multi-exemplar benefit through the real DB write→read→match path).
- `bash build.sh --no-open` (app build + launch smoke) exit 0; source-list guardrail passes; `build-deps` compiles Core into both the app and SPM archives.

### Eval-corpus note
The AMI audio corpus (`data/ami/…`, gitignored, multi-GB download) is **not present locally**, so a numeric before/after DER sweep (`scripts/run_speaker_eval.sh`) was not runnable in this environment. Validation is against the runnable in-package eval (`SpeakerNamingSimulationRunner`), which exercises the real clusterer + `matchAgainstProfiles` + naming/write path and reports no regression. A full AMI sweep on a machine with the corpus is the recommended follow-up before broad rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)