### PR TITLE
fix(timeline): close capture pause and retention gaps

### DIFF
--- a/Sources/Timeline/ScreenCaptureEngine.swift
+++ b/Sources/Timeline/ScreenCaptureEngine.swift
@@ -119,6 +119,7 @@ final class ScreenCaptureEngine: @unchecked Sendable {
     private var observerTokens: [NSObjectProtocol] = []
     private var distributedObserverTokens: [NSObjectProtocol] = []
     private var captureInFlight = false
+    private var captureGeneration = 0
 
     init(
         displayTracker: ActiveDisplayTracker = ActiveDisplayTracker(),
@@ -155,6 +156,7 @@ final class ScreenCaptureEngine: @unchecked Sendable {
     func stop() {
         queue.async { [weak self] in
             guard let self else { return }
+            self.captureGeneration &+= 1
             self.stopTimerLocked()
             self.removeSystemObserversLocked()
             self.transitionLocked { $0.stop() }
@@ -183,6 +185,7 @@ final class ScreenCaptureEngine: @unchecked Sendable {
     }
 
     private func pauseLocked(_ reason: ScreenCapturePauseReason) {
+        captureGeneration &+= 1
         stopTimerLocked()
         transitionLocked { $0.pause(reason) }
     }
@@ -235,13 +238,15 @@ final class ScreenCaptureEngine: @unchecked Sendable {
         )
         let idleSnapshot = idleSnapshotProvider()
         let foregroundSnapshot = foregroundAppSampler.currentSnapshot()
+        let generation = captureGeneration
 
         Task.detached(priority: .utility) { [weak self] in
             do {
                 let record = try await self?.captureAndStore(
                     request: request,
                     idleSnapshot: idleSnapshot,
-                    foregroundSnapshot: foregroundSnapshot
+                    foregroundSnapshot: foregroundSnapshot,
+                    generation: generation
                 )
                 self?.queue.async {
                     self?.captureInFlight = false
@@ -250,6 +255,13 @@ final class ScreenCaptureEngine: @unchecked Sendable {
                     }
                 }
             } catch {
+                if let captureError = error as? TimelineCaptureError,
+                   captureError == .captureInvalidated {
+                    self?.queue.async {
+                        self?.captureInFlight = false
+                    }
+                    return
+                }
                 self?.queue.async {
                     guard let self else { return }
                     self.captureInFlight = false
@@ -267,7 +279,8 @@ final class ScreenCaptureEngine: @unchecked Sendable {
     private func captureAndStore(
         request: TimelineScreenshotCaptureRequest,
         idleSnapshot: InputIdleSnapshot,
-        foregroundSnapshot: ForegroundAppSnapshot
+        foregroundSnapshot: ForegroundAppSnapshot,
+        generation: Int
     ) async throws -> TimelineScreenshotRecord {
         let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
         guard let scDisplay = content.displays.first(where: { $0.displayID == request.display.id }) ?? content.displays.first else {
@@ -286,18 +299,44 @@ final class ScreenCaptureEngine: @unchecked Sendable {
         configuration.scalesToFit = true
 
         let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: configuration)
-        let fileURL = try screenshotStore.writeJPEG(image, capturedAt: idleSnapshot.capturedAt)
-        let fileSize = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber)?.int64Value ?? 0
-        return TimelineScreenshotRecord(
-            capturedAt: idleSnapshot.capturedAt,
-            fileURL: fileURL,
-            fileSize: fileSize,
-            idleSecondsAtCapture: idleSnapshot.idleSeconds,
-            appBundleIdentifier: foregroundSnapshot.bundleIdentifier,
-            appName: foregroundSnapshot.appName,
-            windowTitle: foregroundSnapshot.windowTitle,
-            displayID: request.display.id
+        return try storeScreenshotIfCurrent(
+            image,
+            request: request,
+            idleSnapshot: idleSnapshot,
+            foregroundSnapshot: foregroundSnapshot,
+            generation: generation
         )
+    }
+
+    /// Commit the screenshot on the engine queue so pause/stop and persistence
+    /// are ordered. A capture that finishes after invalidation is discarded
+    /// before it can touch the local screenshot store.
+    private func storeScreenshotIfCurrent(
+        _ image: CGImage,
+        request: TimelineScreenshotCaptureRequest,
+        idleSnapshot: InputIdleSnapshot,
+        foregroundSnapshot: ForegroundAppSnapshot,
+        generation: Int
+    ) throws -> TimelineScreenshotRecord {
+        try queue.sync {
+            guard stateMachine.state == .capturing,
+                  captureGeneration == generation else {
+                throw TimelineCaptureError.captureInvalidated
+            }
+
+            let fileURL = try screenshotStore.writeJPEG(image, capturedAt: idleSnapshot.capturedAt)
+            let fileSize = (try? FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? NSNumber)?.int64Value ?? 0
+            return TimelineScreenshotRecord(
+                capturedAt: idleSnapshot.capturedAt,
+                fileURL: fileURL,
+                fileSize: fileSize,
+                idleSecondsAtCapture: idleSnapshot.idleSeconds,
+                appBundleIdentifier: foregroundSnapshot.bundleIdentifier,
+                appName: foregroundSnapshot.appName,
+                windowTitle: foregroundSnapshot.windowTitle,
+                displayID: request.display.id
+            )
+        }
     }
 
     private func installSystemObserversLocked() {
@@ -396,6 +435,7 @@ enum TimelineCaptureError: Error, Equatable {
     case noDisplayAvailable
     case imageDestinationUnavailable
     case imageEncodingFailed
+    case captureInvalidated
 }
 
 final class LocalTimelineScreenshotStore {

--- a/Sources/Timeline/TimelineDatabase.swift
+++ b/Sources/Timeline/TimelineDatabase.swift
@@ -197,6 +197,24 @@ final class TimelineDatabase {
         }
     }
 
+    func deletedScreenshotCandidates() throws -> [TimelineScreenshotRow] {
+        try queue.sync {
+            let sql = """
+            SELECT s.* FROM screenshots s
+            WHERE s.is_deleted = 1
+              AND NOT EXISTS (
+                SELECT 1
+                FROM batch_screenshots bs
+                JOIN analysis_batches ab ON ab.id = bs.batch_id
+                WHERE bs.screenshot_id = s.id
+                  AND ab.status = 'processing'
+              )
+            ORDER BY s.captured_at ASC, s.id ASC;
+            """
+            return try screenshotRows(sql)
+        }
+    }
+
     func markScreenshotsDeleted(ids: [Int64]) throws {
         guard !ids.isEmpty else { return }
         try queue.sync {

--- a/Sources/Timeline/TimelineRetentionManager.swift
+++ b/Sources/Timeline/TimelineRetentionManager.swift
@@ -62,11 +62,15 @@ final class TimelineRetentionManager {
         let startingBytes = directorySize(screenshotsRoot)
         var endingBytes = startingBytes
         var deletedRows: [Int64] = []
+        var repairedDatabaseRows = 0
         var remainingFileBudget = max(0, maxFilesPerPass)
         var deletedFiles = 0
         if remainingFileBudget > 0 {
-            deletedFiles = try repairPreviouslyDeletedScreenshots(limit: remainingFileBudget)
-            remainingFileBudget -= deletedFiles
+            let repair = try repairPreviouslyDeletedScreenshots(limit: remainingFileBudget)
+            repairedDatabaseRows = repair.deletedRows
+            deletedFiles = repair.deletedFiles
+            endingBytes = max(0, endingBytes - repair.deletedBytes)
+            remainingFileBudget -= repair.deletedFiles
         }
         var deletedOrphanFiles = 0
 
@@ -108,28 +112,31 @@ final class TimelineRetentionManager {
         return TimelineRetentionSummary(
             startingBytes: startingBytes,
             endingBytes: directorySize(screenshotsRoot),
-            deletedDatabaseRows: deletedRows.count,
+            deletedDatabaseRows: repairedDatabaseRows + deletedRows.count,
             deletedFiles: deletedFiles,
             deletedOrphanFiles: deletedOrphanFiles
         )
     }
 
-    private func repairPreviouslyDeletedScreenshots(limit: Int) throws -> Int {
+    private func repairPreviouslyDeletedScreenshots(limit: Int) throws -> (deletedRows: Int, deletedFiles: Int, deletedBytes: Int64) {
         let candidates = try database.deletedScreenshotCandidates().prefix(limit)
-        guard !candidates.isEmpty else { return 0 }
+        guard !candidates.isEmpty else { return (0, 0, 0) }
 
         var deletedFiles = 0
+        var deletedBytes: Int64 = 0
         var repairedIDs: [Int64] = []
         for candidate in candidates {
             if let url = fileURL(for: candidate.filePath), fileManager.fileExists(atPath: url.path) {
+                let bytes = fileSize(url) ?? candidate.fileSize
                 try fileManager.removeItem(at: url)
                 deletedFiles += 1
+                deletedBytes += max(0, bytes)
             }
             repairedIDs.append(candidate.id)
         }
 
         try database.hardDeleteScreenshots(ids: repairedIDs)
-        return deletedFiles
+        return (repairedIDs.count, deletedFiles, deletedBytes)
     }
 
     private func fileURL(for relativePath: String) -> URL? {

--- a/Sources/Timeline/TimelineRetentionManager.swift
+++ b/Sources/Timeline/TimelineRetentionManager.swift
@@ -62,22 +62,31 @@ final class TimelineRetentionManager {
         let startingBytes = directorySize(screenshotsRoot)
         var endingBytes = startingBytes
         var deletedRows: [Int64] = []
-        var deletedFiles = 0
-        var deletedOrphanFiles = 0
         var remainingFileBudget = max(0, maxFilesPerPass)
+        var deletedFiles = 0
+        if remainingFileBudget > 0 {
+            deletedFiles = try repairPreviouslyDeletedScreenshots(limit: remainingFileBudget)
+            remainingFileBudget -= deletedFiles
+        }
+        var deletedOrphanFiles = 0
 
         if storageCapBytes >= 0, endingBytes > storageCapBytes, remainingFileBudget > 0 {
             let candidates = try database.oldestPurgeCandidates(limit: remainingFileBudget)
 
             for candidate in candidates where endingBytes > storageCapBytes && remainingFileBudget > 0 {
                 guard let url = fileURL(for: candidate.filePath) else { continue }
-                let bytes = fileSize(url) ?? candidate.fileSize
-                try database.markScreenshotsDeleted(ids: [candidate.id])
+                let fileWasPresent = fileManager.fileExists(atPath: url.path)
+                let bytes = fileWasPresent ? (fileSize(url) ?? candidate.fileSize) : 0
                 if fileManager.fileExists(atPath: url.path) {
                     try fileManager.removeItem(at: url)
                     deletedFiles += 1
                     remainingFileBudget -= 1
                 }
+                // Delete the file before marking the row. If the process dies
+                // after the unlink, the next pass can still remove the now
+                // missing row; reversing this order would strand the file
+                // behind is_deleted=1 forever.
+                try database.markScreenshotsDeleted(ids: [candidate.id])
                 endingBytes = max(0, endingBytes - max(0, bytes))
                 deletedRows.append(candidate.id)
             }
@@ -103,6 +112,24 @@ final class TimelineRetentionManager {
             deletedFiles: deletedFiles,
             deletedOrphanFiles: deletedOrphanFiles
         )
+    }
+
+    private func repairPreviouslyDeletedScreenshots(limit: Int) throws -> Int {
+        let candidates = try database.deletedScreenshotCandidates().prefix(limit)
+        guard !candidates.isEmpty else { return 0 }
+
+        var deletedFiles = 0
+        var repairedIDs: [Int64] = []
+        for candidate in candidates {
+            if let url = fileURL(for: candidate.filePath), fileManager.fileExists(atPath: url.path) {
+                try fileManager.removeItem(at: url)
+                deletedFiles += 1
+            }
+            repairedIDs.append(candidate.id)
+        }
+
+        try database.hardDeleteScreenshots(ids: repairedIDs)
+        return deletedFiles
     }
 
     private func fileURL(for relativePath: String) -> URL? {

--- a/Tests/TimelineDatabaseTests.swift
+++ b/Tests/TimelineDatabaseTests.swift
@@ -164,6 +164,35 @@ func testTimelineDatabase() {
         }
     }
 
+    runSuite("TimelineRetentionManager repairs rows stranded after a soft-delete") {
+        let fixture = TimelineDatabaseFixture()
+        defer { fixture.cleanup() }
+
+        do {
+            let db = try TimelineDatabase(databaseURL: fixture.databaseURL)
+            try fixture.writeScreenshot(relativePath: "2026-07-03/stranded.jpg", bytes: 4)
+            let id = try db.insertScreenshot(NewTimelineScreenshot(
+                capturedAt: 10,
+                filePath: "2026-07-03/stranded.jpg",
+                fileSize: 4,
+                idleSecondsAtCapture: 0
+            ))
+            try db.markScreenshotsDeleted(ids: [id])
+
+            let manager = TimelineRetentionManager(database: db, screenshotsRoot: fixture.screenshotsRoot)
+            let summary = try manager.runRetentionPass(storageCapBytes: 100)
+
+            assertEqual(summary.deletedFiles, 1, "a stranded soft-delete should remove its retained screenshot file")
+            assertFalse(
+                FileManager.default.fileExists(atPath: fixture.url("2026-07-03/stranded.jpg").path),
+                "a stranded soft-delete should not leave the screenshot on disk"
+            )
+            assertTrue(try db.screenshots(includeDeleted: true).isEmpty, "a repaired soft-delete should remove its database row")
+        } catch {
+            assertTrue(false, "soft-delete repair should not throw: \(error)")
+        }
+    }
+
     runSuite("TimelineRetentionManager does no work when maxFilesPerPass is zero") {
         let fixture = TimelineDatabaseFixture()
         defer { fixture.cleanup() }

--- a/Tests/TimelineDatabaseTests.swift
+++ b/Tests/TimelineDatabaseTests.swift
@@ -171,23 +171,39 @@ func testTimelineDatabase() {
         do {
             let db = try TimelineDatabase(databaseURL: fixture.databaseURL)
             try fixture.writeScreenshot(relativePath: "2026-07-03/stranded.jpg", bytes: 4)
+            try fixture.writeScreenshot(relativePath: "2026-07-03/live.jpg", bytes: 4)
             let id = try db.insertScreenshot(NewTimelineScreenshot(
                 capturedAt: 10,
                 filePath: "2026-07-03/stranded.jpg",
                 fileSize: 4,
                 idleSecondsAtCapture: 0
             ))
+            _ = try db.insertScreenshot(NewTimelineScreenshot(
+                capturedAt: 20,
+                filePath: "2026-07-03/live.jpg",
+                fileSize: 4,
+                idleSecondsAtCapture: 0
+            ))
             try db.markScreenshotsDeleted(ids: [id])
 
             let manager = TimelineRetentionManager(database: db, screenshotsRoot: fixture.screenshotsRoot)
-            let summary = try manager.runRetentionPass(storageCapBytes: 100)
+            let summary = try manager.runRetentionPass(storageCapBytes: 4)
 
             assertEqual(summary.deletedFiles, 1, "a stranded soft-delete should remove its retained screenshot file")
+            assertEqual(summary.deletedDatabaseRows, 1, "a repaired soft-delete should count as one deleted database row")
             assertFalse(
                 FileManager.default.fileExists(atPath: fixture.url("2026-07-03/stranded.jpg").path),
                 "a stranded soft-delete should not leave the screenshot on disk"
             )
-            assertTrue(try db.screenshots(includeDeleted: true).isEmpty, "a repaired soft-delete should remove its database row")
+            assertTrue(
+                FileManager.default.fileExists(atPath: fixture.url("2026-07-03/live.jpg").path),
+                "repairing a stranded file should update the byte budget before purging live screenshots"
+            )
+            assertEqual(
+                try db.screenshots(includeDeleted: true).map(\.filePath),
+                ["2026-07-03/live.jpg"],
+                "a repaired soft-delete should remove only its database row"
+            )
         } catch {
             assertTrue(false, "soft-delete repair should not throw: \(error)")
         }


### PR DESCRIPTION
## Summary
- Invalidate detached timeline screenshot captures when capture is paused or stopped, before they can write to the local screenshot store.
- Reconcile rows stranded as `is_deleted = 1` after a retention crash, and delete screenshot files before marking new rows deleted.
- Add deterministic coverage for stranded soft-delete recovery.

## Why
This closes a privacy race where a screenshot could be persisted after pause/stop, and a data-retention failure mode where an on-disk screenshot could remain indefinitely behind a soft-deleted database row.

## Verification
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12,758/12,758 passed
- `bash run-tests.sh --filter TimelineCapture` — 44/44 passed
- `bash run-tests.sh --filter TimelineDatabase` — 32/32 passed
- `bash run-e2e-smoke.sh` — passed
- Privacy leak sweep — PASS, 0 findings
- Nightly security check — 100/100
- Build source-list validation — passed
- TranscriptedMCP — 170/170; CaptureKit, CLI, and QA package tests completed successfully

## Boundaries
- `bash build.sh --no-open` is blocked in this isolated checkout because the prebuilt dependency bundle is absent; app-build proof requires `bash build-deps.sh --force`.
- Root `swift test` is blocked by the missing prebuilt `FluidAudio` module.
- ScreenCaptureKit/TCC, real display capture, mic/system audio, sleep/wake, and install/update proof remain UNKNOWN/YELLOW.
- No release, appcast, Homebrew, website, tag, or notarization surfaces changed.
- PR #1498 remains separate; this PR does not touch its legacy logging patch.

Independent Claude audit proof: `/Users/redbars/.codex/maestro/runs/20260710T000208Z-transcripted-security-claude-claude`. The local Codex review helper found no findings; direct `codex review` could not run because the installed CLI rejected configured model `gpt-5.6-luna`.