### PR TITLE
Restore prominent available-update callout

### DIFF
--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -425,16 +425,13 @@ final class MenuBarPanelController: NSViewController {
                 )
             }
 
-            // Available-but-not-downloaded stays in the quiet utility row;
-            // the loud callout is reserved for the one state that actually
-            // needs the user (restart to finish installing).
             return (
-                "arrow.down.circle",
+                "arrow.down.circle.fill",
                 "Update available: \(version)",
                 "A new version is ready to install",
                 "Install",
-                .standard,
-                false
+                .warning,
+                true
             )
         case .downloading(let version):
             return (


### PR DESCRIPTION
## What changed

Restore the prominent, actionable menu-bar callout for an available Sparkle update. This matches public v1.1.48 and prevents the update from disappearing into a quiet utility row.

## Evidence

- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh — 12,755 passed
- swift test --package-path Tools/TranscriptedQA --filter SparkleUpdateSmokeTests — 3 passed
- bash build.sh --no-open — passed; signed app valid; launch performance budget passed
- transcripted-qa sparkle-update-smoke — available and downloading scenarios passed
- Initial pre-fix smoke reproduced the defect: available callout was hidden/empty

## Limits

- AX UI smoke is incomplete because another Transcripted instance is already running; the runner correctly refused ambiguous duplicate menu-bar targeting.
- Real mic/system audio, Bluetooth/AirPods, meeting-app, TCC, sleep/wake, install/update, and subjective feel checks remain manual/unknown.
- Codex review helper was attempted but blocked by the installed CLI requesting unsupported model gpt-5.6-luna; no review result was available.

No release, appcast, Homebrew, website, or publish actions were performed.