### PR TITLE
Fix packaged smoke feedback title

### DIFF
--- a/scripts/ops/packaged-app-smoke.py
+++ b/scripts/ops/packaged-app-smoke.py
@@ -198,7 +198,7 @@ def validate_launch_report(report: dict[str, Any]) -> list[str]:
     }
     required_utility = {
         "connectAgent": ("Connect Agent", "transcripted.menubar.utility.connect-agent"),
-        "submitFeedback": ("Submit feedback", "transcripted.menubar.utility.submit-feedback"),
+        "submitFeedback": ("Submit Feedback", "transcripted.menubar.utility.submit-feedback"),
         "checkUpdates": ("Check for Updates", "transcripted.menubar.utility.check-updates"),
         "settings": ("Settings", "transcripted.menubar.utility.settings"),
         "quit": ("Quit", "transcripted.menubar.utility.quit"),


### PR DESCRIPTION
## Summary

- Fix the packaged app smoke expectation to match the production `Submit Feedback` menu title.
- This removes a deterministic false negative in the release-package gate.

## Root cause

`scripts/ops/packaged-app-smoke.py` expected `Submit feedback`, while the shipped menu row, build contract, and observed packaged app all use `Submit Feedback`.

## Validation

- `python3 -m py_compile scripts/ops/packaged-app-smoke.py`
- `python3 scripts/ops/packaged-app-smoke.py --self-test`
- `SKIP_NOTARIZATION=1 ... bash build-beta.sh \\\ dry-run` — package build passed\n- Packaged app smoke after fix — only expected WARN for skipped notarization; no failed checks\n- `bash scripts/ops/transcripted-qa-bench.sh --mode packaged` — package build passed; wrapper remained INCOMPLETE only for intentional no-notarization WARN\n- `bash scripts/release/verify-sparkle-release.sh 1.1.48` — passed\n- `python3 scripts/ops/nightly-security-check.py --strict --require-release-debug-files` — 100/100\n- Sentry release dry-run — READY for current 1.1.48 metadata and matching dSYM\n\nNo version, appcast, Homebrew, website, GitHub release, tag, Sentry release, or notarization surface was mutated.