### PR TITLE
Fix concurrent meeting transcript writes

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -304,28 +304,30 @@ enum LocalMeetingSummaryStore {
         for transcriptURL: URL,
         fileManager: FileManager = .default
     ) throws -> Bool {
-        var didRemove = false
-        let url = summaryURL(for: transcriptURL)
-        if fileManager.fileExists(atPath: url.path),
-           let values = try TranscriptFrontmatter.readValues(from: url),
-           values["capture_type"] == "meeting_summary",
-           values["source_transcript"] == transcriptURL.lastPathComponent {
-            try fileManager.removeItem(at: url)
-            didRemove = true
-        }
+        try MeetingTranscriptFileUpdateSerializer.sync {
+            var didRemove = false
+            let url = summaryURL(for: transcriptURL)
+            if fileManager.fileExists(atPath: url.path),
+               let values = try TranscriptFrontmatter.readValues(from: url),
+               values["capture_type"] == "meeting_summary",
+               values["source_transcript"] == transcriptURL.lastPathComponent {
+                try fileManager.removeItem(at: url)
+                didRemove = true
+            }
 
-        guard fileManager.fileExists(atPath: transcriptURL.path),
-              let values = try? TranscriptFrontmatter.readValues(from: transcriptURL),
-              values["capture_type"]?.lowercased() == "meeting" else {
-            return didRemove
-        }
+            guard fileManager.fileExists(atPath: transcriptURL.path),
+                  let values = try? TranscriptFrontmatter.readValues(from: transcriptURL),
+                  values["capture_type"]?.lowercased() == "meeting" else {
+                return didRemove
+            }
 
-        let raw = try String(contentsOf: transcriptURL, encoding: .utf8)
-        let updated = LocalMeetingSummaryMarkdownUpdater.removingGeneratedSummary(from: raw)
-        guard updated != raw else { return didRemove }
-        try updated.write(to: transcriptURL, atomically: true, encoding: .utf8)
-        fileManager.restrictFileToOwnerOnly(at: transcriptURL)
-        return true
+            let raw = try String(contentsOf: transcriptURL, encoding: .utf8)
+            let updated = LocalMeetingSummaryMarkdownUpdater.removingGeneratedSummary(from: raw)
+            guard updated != raw else { return didRemove }
+            try updated.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            fileManager.restrictFileToOwnerOnly(at: transcriptURL)
+            return true
+        }
     }
 }
 
@@ -1155,23 +1157,25 @@ struct LocalMeetingSummarizer: @unchecked Sendable {
         let normalizedBody = LocalMeetingSummaryNormalizer.normalized(summaryBody)
         let sections = LocalMeetingSummaryNormalizer.sections(in: normalizedBody)
             .withTranscriptParticipants(from: transcript)
-        let latestMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
-        let latestTranscript = LocalMeetingTranscriptExtractor.transcriptText(from: latestMarkdown)
-        guard latestTranscript == transcript else {
-            throw LocalMeetingSummaryError.transcriptChanged
-        }
-        let updatedMarkdown = LocalMeetingSummaryMarkdownUpdater.markdown(
-            byApplying: sections,
-            to: latestMarkdown,
-            metadata: .gemma(configuration: configuration),
-            generatedAt: date,
-            chunkCount: chunks.count,
-            sourceTranscriptFilename: transcriptURL.lastPathComponent
-        )
+        try MeetingTranscriptFileUpdateSerializer.sync {
+            let latestMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+            let latestTranscript = LocalMeetingTranscriptExtractor.transcriptText(from: latestMarkdown)
+            guard latestTranscript == transcript else {
+                throw LocalMeetingSummaryError.transcriptChanged
+            }
+            let updatedMarkdown = LocalMeetingSummaryMarkdownUpdater.markdown(
+                byApplying: sections,
+                to: latestMarkdown,
+                metadata: .gemma(configuration: configuration),
+                generatedAt: date,
+                chunkCount: chunks.count,
+                sourceTranscriptFilename: transcriptURL.lastPathComponent
+            )
 
-        try Task.checkCancellation()
-        try updatedMarkdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
-        fileManager.restrictFileToOwnerOnly(at: transcriptURL)
+            try Task.checkCancellation()
+            try updatedMarkdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            fileManager.restrictFileToOwnerOnly(at: transcriptURL)
+        }
 
         return LocalMeetingSummaryResult(
             transcriptURL: transcriptURL,
@@ -1295,21 +1299,23 @@ struct AppleFoundationMeetingSummarizer: @unchecked Sendable {
         let normalizedBody = LocalMeetingSummaryNormalizer.normalized(summaryBody)
         let sections = LocalMeetingSummaryNormalizer.sections(in: normalizedBody)
             .withTranscriptParticipants(from: transcript)
-        let latestMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
-        let latestTranscript = LocalMeetingTranscriptExtractor.transcriptText(from: latestMarkdown)
-        guard latestTranscript == transcript else {
-            throw LocalMeetingSummaryError.transcriptChanged
+        try MeetingTranscriptFileUpdateSerializer.sync {
+            let latestMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+            let latestTranscript = LocalMeetingTranscriptExtractor.transcriptText(from: latestMarkdown)
+            guard latestTranscript == transcript else {
+                throw LocalMeetingSummaryError.transcriptChanged
+            }
+            let updatedMarkdown = LocalMeetingSummaryMarkdownUpdater.markdown(
+                byApplying: sections,
+                to: latestMarkdown,
+                metadata: runtime.metadata,
+                generatedAt: date,
+                chunkCount: chunks.count,
+                sourceTranscriptFilename: transcriptURL.lastPathComponent
+            )
+            try updatedMarkdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            fileManager.restrictFileToOwnerOnly(at: transcriptURL)
         }
-        let updatedMarkdown = LocalMeetingSummaryMarkdownUpdater.markdown(
-            byApplying: sections,
-            to: latestMarkdown,
-            metadata: runtime.metadata,
-            generatedAt: date,
-            chunkCount: chunks.count,
-            sourceTranscriptFilename: transcriptURL.lastPathComponent
-        )
-        try updatedMarkdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
-        fileManager.restrictFileToOwnerOnly(at: transcriptURL)
 
         return LocalMeetingSummaryResult(
             transcriptURL: transcriptURL,

--- a/Sources/Meeting/MeetingQuickSummaryWriter.swift
+++ b/Sources/Meeting/MeetingQuickSummaryWriter.swift
@@ -60,18 +60,19 @@ enum MeetingQuickSummaryWriter {
         fileManager: FileManager = .default,
         generatedAt: Date = Date()
     ) -> Bool {
-        guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return false }
-        guard let updated = markdown(byApplyingQuickSummaryTo: raw, generatedAt: generatedAt) else {
-            return false
-        }
-        guard updated != raw else { return false }
-        do {
+        // This is a whole-file read/modify/write. Keep the read and write in the
+        // same critical section as transcript saves, restyles, renames, and
+        // speaker rewrites so a concurrent artifact update cannot be lost.
+        (try? MeetingTranscriptFileUpdateSerializer.sync {
+            guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return false }
+            guard let updated = markdown(byApplyingQuickSummaryTo: raw, generatedAt: generatedAt) else {
+                return false
+            }
+            guard updated != raw else { return false }
             try updated.write(to: url, atomically: true, encoding: .utf8)
             fileManager.restrictFileToOwnerOnly(at: url)
             return true
-        } catch {
-            return false
-        }
+        }) ?? false
     }
 
     /// Pure transform used by `ensureQuickSummary` and tests. Returns the rewritten

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -353,6 +353,52 @@ func testLocalMeetingSummarizer() async {
         }
     }
 
+    runSuite("LocalMeetingSummaryStore joins the shared transcript update serializer") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalMeetingSummarySerializerTests-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = root.appendingPathComponent("Call.md")
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try """
+            ---
+            capture_type: meeting
+            title: "Call"
+            ---
+
+            ## Transcript
+
+            **00:01** [Mic/You]
+            Keep the real transcript.
+            """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+            let entered = DispatchSemaphore(value: 0)
+            let release = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                MeetingTranscriptFileUpdateSerializer.sync {
+                    entered.signal()
+                    _ = release.wait(timeout: .now() + 2)
+                }
+            }
+            assertEqual(entered.wait(timeout: .now() + 2), .success, "serializer fixture should acquire the shared lock")
+
+            let cleanupFinished = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                _ = try? LocalMeetingSummaryStore.removeGeneratedSummary(for: transcriptURL)
+                cleanupFinished.signal()
+            }
+            assertEqual(
+                cleanupFinished.wait(timeout: .now() + 0.1),
+                .timedOut,
+                "summary invalidation must wait for concurrent transcript updates"
+            )
+            release.signal()
+            assertEqual(cleanupFinished.wait(timeout: .now() + 2), .success, "summary invalidation should continue after the shared lock is released")
+        } catch {
+            assertTrue(false, "serializer fixture should run: \(error)")
+        }
+        try? FileManager.default.removeItem(at: root)
+    }
+
     runSuite("LocalMeetingSummaryNormalizer restores missing sections") {
         let normalized = LocalMeetingSummaryNormalizer.normalized("# Summary\nUseful brief.")
         for heading in [

--- a/Tests/MeetingQuickSummaryExtractorTests.swift
+++ b/Tests/MeetingQuickSummaryExtractorTests.swift
@@ -178,4 +178,51 @@ func testMeetingQuickSummaryExtractor() {
             "writer should skip non-meeting captures"
         )
     }
+
+    runSuite("writer joins the shared transcript update serializer") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingQuickSummarySerializerTests-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = root.appendingPathComponent("Call.md")
+        let markdown = """
+        ---
+        capture_type: meeting
+        title: "Call"
+        ---
+
+        ## Transcript
+
+        **00:01** [Mic/Justin]
+        I will send the launch checklist before Friday.
+        """
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+            let entered = DispatchSemaphore(value: 0)
+            let release = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                MeetingTranscriptFileUpdateSerializer.sync {
+                    entered.signal()
+                    _ = release.wait(timeout: .now() + 2)
+                }
+            }
+            assertEqual(entered.wait(timeout: .now() + 2), .success, "serializer fixture should acquire the shared lock")
+
+            let writerFinished = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                _ = MeetingQuickSummaryWriter.ensureQuickSummary(at: transcriptURL)
+                writerFinished.signal()
+            }
+            assertEqual(
+                writerFinished.wait(timeout: .now() + 0.1),
+                .timedOut,
+                "whole-file quick-summary writes must wait for concurrent transcript updates"
+            )
+            release.signal()
+            assertEqual(writerFinished.wait(timeout: .now() + 2), .success, "writer should continue after the shared lock is released")
+        } catch {
+            assertTrue(false, "serializer fixture should run: \(error)")
+        }
+        try? FileManager.default.removeItem(at: root)
+    }
 }


### PR DESCRIPTION
## Summary
- Route quick-summary injection and summary invalidation through the shared transcript file serializer.
- Serialize the final Markdown read/check/write for Gemma and Apple Foundation summaries.
- Add deterministic lock-regression coverage for concurrent transcript updates.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12,761 passed
- focused summary suites — 31 + 188 passed
- `bash run-integration-smoke.sh`
- `swift test` — 719 passed, 13 skipped
- real mic/system audio, Zoom/Meet/Teams, TCC, Bluetooth, sleep/wake, and subjective UI feel remain UNKNOWN/YELLOW.

## Review
- Codex review helper was attempted twice but the installed CLI rejected its configured `gpt-5.6-luna` model as requiring a newer CLI; no review findings were produced.
- No release, appcast, Homebrew, website, or packaging publication work was performed.