### PR TITLE
fix: preserve same-text rich clipboard fallback

### DIFF
--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -443,10 +443,15 @@ final class ClipboardRestoringTextPaster {
 
         let pasteboard = pendingClipboardRestore.pasteboard
         let temporaryString = pendingClipboardRestore.temporaryString
-        let stillBorrowedClipboard = pasteboard.changeCount == pendingClipboardRestore.temporaryChangeCount
-            || pasteboard.string(forType: .string) == temporaryString
+        let temporaryChangeCount = pendingClipboardRestore.temporaryChangeCount
         clearPendingClipboardRestore(restore: false)
-        guard stillBorrowedClipboard else { return true }
+        // A user copy with the same plain text can still carry rich data. Keep it
+        // intact when the pasteboard changed after paste started. An unchanged
+        // pasteboard may still hold our lazy provider, so materialize it before
+        // returning the text for manual recovery.
+        if pasteboard.changeCount != temporaryChangeCount {
+            return true
+        }
         return copyTextToClipboard(temporaryString, to: pasteboard)
     }
 

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -174,6 +174,77 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster.paste — unconfirmed lazy clipboard stays manually pasteable") {
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedUnconfirmedLazyClipboardTest-\(UUID().uuidString)"))
+            let paster = ClipboardRestoringTextPaster()
+            let dictationText = "synthetic lazy provider dictation"
+
+            pasteboard.clearContents()
+            pasteboard.setString("synthetic original clipboard", forType: .string)
+            let outcome = paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: { true },
+                pasteConfirmationWait: 0.01
+            )
+
+            assertEqual(
+                outcome,
+                .copied(
+                    "Transcripted sent paste, but this target did not expose paste confirmation. The text stays copied.",
+                    reason: .pasteConfirmationUnavailable
+                ),
+                "unconfirmed paste should leave the dictation available for manual recovery"
+            )
+            assertEqual(
+                pasteboard.string(forType: .string),
+                dictationText,
+                "unconfirmed lazy clipboard content should be materialized before provider cleanup"
+            )
+        }
+
+        runSuite("ClipboardRestoringTextPaster.paste — same-text user rich clipboard survives unconfirmed paste") {
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedSameTextRichClipboardTest-\(UUID().uuidString)"))
+            let paster = ClipboardRestoringTextPaster()
+            let dictationText = "synthetic shared text"
+            let customType = NSPasteboard.PasteboardType("com.transcripted.same-text-rich-clipboard")
+            let customData = Data([0xca, 0xfe, 0xba, 0xbe])
+
+            pasteboard.clearContents()
+            pasteboard.setString("synthetic original clipboard", forType: .string)
+            let outcome = paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    let userItem = NSPasteboardItem()
+                    userItem.setString(dictationText, forType: .string)
+                    userItem.setData(customData, forType: customType)
+                    pasteboard.clearContents()
+                    pasteboard.writeObjects([userItem])
+                    return true
+                },
+                pasteConfirmationWait: 0.01
+            )
+
+            assertEqual(
+                outcome,
+                .copied(
+                    "Transcripted sent paste, but this target did not expose paste confirmation. The text stays copied.",
+                    reason: .pasteConfirmationUnavailable
+                ),
+                "unconfirmed paste should keep same-text user clipboard content available"
+            )
+            assertEqual(
+                pasteboard.pasteboardItems?.first?.data(forType: customType),
+                customData,
+                "same-text user rich clipboard data should not be flattened to plain text"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.paste — blocks Cmd+V when the dictation clipboard write fails") {
             let existingClipboard = "synthetic existing clipboard"
             let pasteboard = FakeClipboardPasteboard(


### PR DESCRIPTION
## Summary
- preserve user rich clipboard data when its plain text matches the dictation during unconfirmed paste fallback
- materialize unchanged lazy dictation clipboard content so manual Cmd+V recovery remains reliable
- add deterministic regression coverage for both cases

## Verification
- `python3 scripts/dev/check-build-source-lists.py`
- `bash build-deps.sh --force`
- `bash build.sh --no-open` (build/sign/launch smoke passed; launch-to-interactive 906.3ms)
- `bash run-tests.sh` (12,759 passed)
- `bash run-tests.sh --filter ClipboardRestoringTextPasterTests` (67 passed)
- `bash run-slow-pasteback-smoke.sh` (exit 0)

## Review
- Claude read-only final review: PASS, no actionable findings.
- Codex review helper was attempted twice but the installed CLI rejected configured model `gpt-5.6-luna` as requiring a newer Codex; no clean Codex verdict was claimed.
- Real app paste feel, Accessibility/TCC, hardware, AirPods/Bluetooth, sleep/wake, and other manual proof remain UNKNOWN.