### PR TITLE
fix(speaker): remove orphaned negative exemplars

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -518,6 +518,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
         queue.sync { [self] in
             guard isDatabaseOpen else { return }
             deleteExemplarsImpl(profileId: id)
+            deleteNegativeExemplarsImpl(profileId: id)
             let sql = "DELETE FROM speakers WHERE id = ?;"
             var statement: OpaquePointer?
             if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {

--- a/Sources/TranscriptedCore/Speaker/SpeakerNegativeExemplarStore.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNegativeExemplarStore.swift
@@ -164,6 +164,34 @@ extension SpeakerDatabase {
         return byProfile
     }
 
+    /// Drop all negative-exemplar rows for a profile that is being deleted or absorbed.
+    /// Must be called on `queue`.
+    func deleteNegativeExemplarsImpl(profileId: UUID) {
+        guard isDatabaseOpen else { return }
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(
+            db,
+            "DELETE FROM speaker_negative_exemplars WHERE profile_id = ?;",
+            -1,
+            &statement,
+            nil
+        ) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(statement) != SQLITE_DONE {
+                AppLogger.speakers.error("Failed to delete negative exemplars", [
+                    "sqlite_error": dbErrorMessage(),
+                    "profileId": profileId.uuidString
+                ])
+            }
+        } else {
+            AppLogger.speakers.error("Failed to prepare delete negative exemplars", [
+                "sqlite_error": dbErrorMessage(),
+                "profileId": profileId.uuidString
+            ])
+        }
+        sqlite3_finalize(statement)
+    }
+
     private static func readEmbeddingBlob(_ statement: OpaquePointer?, column: Int32) -> [Float]? {
         guard let statement, let blobPtr = sqlite3_column_blob(statement, column) else { return nil }
         let blobSize = sqlite3_column_bytes(statement, column)

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
@@ -232,6 +232,9 @@ extension SpeakerDatabase {
             // empty), which degrades to single-average matching — never wrong, just less enriched.
             deleteExemplarsImpl(profileId: sourceId)
             deleteExemplarsImpl(profileId: targetId)
+            // Negative exemplars are also identity-bound. The source profile is deleted, so its
+            // rejected samples must not remain as orphaned voice embeddings in the database.
+            deleteNegativeExemplarsImpl(profileId: sourceId)
 
             // Delete source profile
             let deleteSql = "DELETE FROM speakers WHERE id = ?;"
@@ -414,12 +417,48 @@ extension SpeakerDatabase {
         // Only prune profiles created more than 1 hour ago — don't prune profiles from
         // the current recording that are about to be named in the speaker naming flow.
         let cutoff = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
-        let protectedIds = persistedReviewClipSpeakerIds()
+        let protectedIds = persistedReviewClipSpeakerIds().sorted { $0.uuidString < $1.uuidString }
         let protectedClause: String
         if protectedIds.isEmpty {
             protectedClause = ""
         } else {
             protectedClause = "AND id NOT IN (\(Array(repeating: "?", count: protectedIds.count).joined(separator: ",")))"
+        }
+
+        // Clean both exemplar caches before deleting the matching profiles. These tables are
+        // intentionally not foreign-key cascades because older databases may predate them, so a
+        // direct bulk profile delete must remove their identity-bound embeddings explicitly.
+        for table in ["speaker_exemplars", "speaker_negative_exemplars"] {
+            let cleanupSQL = """
+            DELETE FROM \(table)
+            WHERE profile_id IN (
+                SELECT id FROM speakers
+                WHERE display_name IS NULL
+                  AND call_count <= 1
+                  AND confidence <= 0.5
+                  AND first_seen < ?
+                  \(protectedClause)
+            );
+            """
+            var cleanupStatement: OpaquePointer?
+            if sqlite3_prepare_v2(db, cleanupSQL, -1, &cleanupStatement, nil) == SQLITE_OK {
+                sqlite3_bind_text(cleanupStatement, 1, (cutoff as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                for (offset, id) in protectedIds.enumerated() {
+                    sqlite3_bind_text(cleanupStatement, Int32(offset + 2), (id.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                }
+                if sqlite3_step(cleanupStatement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to clean pruned speaker exemplars", [
+                        "sqlite_error": dbErrorMessage(),
+                        "table": table
+                    ])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare pruned speaker exemplar cleanup", [
+                    "sqlite_error": dbErrorMessage(),
+                    "table": table
+                ])
+            }
+            sqlite3_finalize(cleanupStatement)
         }
 
         let sql = """

--- a/Tests/TranscriptedCoreTests/SpeakerNegativeExemplarTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNegativeExemplarTests.swift
@@ -44,6 +44,24 @@ final class SpeakerNegativeExemplarTests: XCTestCase {
         XCTAssertEqual(db.negativeExemplars(profileId: profileId).count, cap)
     }
 
+    func testDeletingSpeakerRemovesNegativeExemplars() {
+        let (db, _) = makeDatabase()
+        let profile = db.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.25, count: 256),
+            existingId: nil
+        )
+        db.recordNegativeExemplar(profileId: profile.id, embedding: vector(degrees: 19))
+
+        db.deleteSpeaker(id: profile.id)
+
+        XCTAssertNil(db.getSpeaker(id: profile.id))
+        XCTAssertTrue(
+            db.negativeExemplars(profileId: profile.id).isEmpty,
+            "deleting a profile must delete its identity-bound negative embeddings"
+        )
+        XCTAssertNil(db.negativeExemplarsByProfile()[profile.id])
+    }
+
     // MARK: - In-memory matcher veto (matchAgainstProfiles)
 
     func testNegativeExemplarExcludesWrongProfileButKeepsCorrectMatch() {

--- a/Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift
@@ -132,10 +132,15 @@ final class SpeakerProfileMergerTests: XCTestCase {
 
         let targetBefore = try XCTUnwrap(database.getSpeaker(id: target.id))
         let sourceBefore = try XCTUnwrap(database.getSpeaker(id: source.id))
+        database.recordNegativeExemplar(profileId: source.id, embedding: [Float](repeating: 0.12, count: 256))
 
         database.mergeProfiles(sourceId: source.id, into: target.id)
 
         XCTAssertNil(database.getSpeaker(id: source.id), "source profile is deleted after merge")
+        XCTAssertTrue(
+            database.negativeExemplars(profileId: source.id).isEmpty,
+            "absorbed profile must not leave identity-bound negative embeddings behind"
+        )
 
         let merged = try XCTUnwrap(database.getSpeaker(id: target.id))
         XCTAssertEqual(merged.callCount, targetBefore.callCount + sourceBefore.callCount, "call counts sum")
@@ -168,6 +173,31 @@ final class SpeakerProfileMergerTests: XCTestCase {
 
         let survivors = [a.id, b.id].compactMap { database.getSpeaker(id: $0) }
         XCTAssertEqual(survivors.count, 1, "identical unnamed embeddings above threshold merge into one")
+    }
+
+    func testPruneWeakProfilesRemovesNegativeExemplarsWithProfile() {
+        let profileId = UUID()
+        _ = database.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.25, count: 256),
+            existingId: profileId
+        )
+        database.restoreProfile(SpeakerProfile(
+            id: profileId,
+            displayName: nil,
+            nameSource: nil,
+            embedding: [Float](repeating: 0.25, count: 256),
+            firstSeen: Date().addingTimeInterval(-7200),
+            lastSeen: Date().addingTimeInterval(-7200),
+            callCount: 1,
+            confidence: 0.5,
+            disputeCount: 0
+        ))
+        database.recordNegativeExemplar(profileId: profileId, embedding: [Float](repeating: 0.12, count: 256))
+
+        database.pruneWeakProfiles()
+
+        XCTAssertNil(database.getSpeaker(id: profileId))
+        XCTAssertTrue(database.negativeExemplars(profileId: profileId).isEmpty)
     }
 }
 


### PR DESCRIPTION
## Summary
- remove negative exemplar embeddings when a speaker profile is deleted
- clean source-profile negative exemplars during merges and bulk weak-profile pruning
- add regression coverage for deletion, merge absorption, and pruning

## Audit evidence
- Audited speaker changes since v1.1.48, including PRs #1487, #1488, #1493, #1496, #1497, rename-chain recovery, persistence, privacy, and false-auto risk.
- Checked-in qmatrix evidence: multi-exemplar AMI recall 0.549 -> 0.659, false-auto 0 -> 12 before the margin fix; after #1496 false-auto 12 -> 2 with recall retained; #1497 cross-condition AMI veto 0.350 -> 0.374 with owner collateral 2.17% -> 2.32%, VoxCeleb unchanged.
- Real AMI/VoxCeleb corpus was not present in this worktree, so the real-audio harness was not rerun; deterministic suites and checked-in metrics were used.

## Verification
- `bash build-deps.sh --force`
- `swift test` — 721 passed, 13 skipped
- `bash run-tests.sh` — 12,755 passed
- `swift build --package-path Tools/SpeakerEvalHarness`
- shell/Python speaker harness checks
- `bash build.sh --no-open`
- `bash run-integration-smoke.sh`

Manual hardware/TCC/Bluetooth/real meeting-app proof remains out of scope and unproven. The independent Codex review helper was attempted twice but the installed CLI rejected its configured reviewer model as requiring a newer Codex.