### PR TITLE
fix: wire Sentry Release Health sessions

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -19,6 +19,7 @@ final class CrashReporter {
     private init() {}
 
     private var hasStarted = false
+    private var sessionTrackingEnabled = false
 
     static func setup(dsn: String? = SentryRuntimeConfiguration.dsn()) {
         guard let dsn, !shared.hasStarted else { return }
@@ -32,6 +33,9 @@ final class CrashReporter {
         options.enableCrashHandler = true
         options.enableUncaughtNSExceptionReporting = true
         options.enableAppHangTracking = SentryRuntimeConfiguration.appHangTrackingEnabled()
+        // Session tracking is started explicitly after onboarding and when the
+        // user changes the crash-reporting preference. That keeps the first-run
+        // choice and later opt-outs aligned with Release Health envelopes.
         options.enableAutoSessionTracking = false
         options.enableNetworkBreadcrumbs = false
         options.maxBreadcrumbs = 0
@@ -49,6 +53,31 @@ final class CrashReporter {
         shared.hasStarted = true
 
         installUnrecognizedSelectorCapture()
+    }
+
+    /// Starts or ends the current Release Health session after the preference
+    /// is settled. Fresh installs stay session-free until onboarding completes.
+    static func applySessionTrackingPreference() {
+        guard shared.hasStarted else { return }
+
+        let shouldTrack = CrashReportingPreferences.isEnabled()
+        guard shouldTrack != shared.sessionTrackingEnabled else { return }
+
+        shared.sessionTrackingEnabled = shouldTrack
+        if shouldTrack {
+            SentrySDK.startSession()
+        } else {
+            SentrySDK.endSession()
+        }
+    }
+
+    /// Ends an opted-in session before normal app termination so Release
+    /// Health receives a completed session rather than only a later abnormal
+    /// session marker.
+    static func endSession() {
+        guard shared.sessionTrackingEnabled else { return }
+        shared.sessionTrackingEnabled = false
+        SentrySDK.endSession()
     }
 
     // MARK: - Unrecognized-selector enrichment

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -121,6 +121,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
         // Crash reporting
         CrashReporter.setup()
+        if PermissionsOnboardingPreferences.hasCompleted() {
+            CrashReporter.applySessionTrackingPreference()
+        }
 
         let activationController = ActivationPolicyController(
             actualPolicy: { NSApp.activationPolicy() }
@@ -525,6 +528,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             cameraActivityMonitor.stop()
         }
         appState.shutdown()
+        CrashReporter.endSession()
         singleInstanceGuard.release()
     }
 
@@ -1066,6 +1070,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
     private func finishOnboarding() {
         PermissionsOnboardingPreferences.markCompleted()
+        CrashReporter.applySessionTrackingPreference()
         // Meeting detection only works while the app runs; register the login
         // item by default now that onboarding gives the macOS notice context.
         // One-time, and an explicit Settings choice always wins.

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -3108,6 +3108,7 @@ struct TranscriptedSettingsView: View {
                             crashReportingEnabled = newValue
                             trackSettingsToggle("crash_reporting", enabled: newValue, page: .general)
                             CrashReportingPreferences.setEnabled(newValue)
+                            CrashReporter.applySessionTrackingPreference()
                             sentryTestStatus = nil
                             diagnosticsActionStatus = nil
                         }
@@ -4513,6 +4514,7 @@ struct TranscriptedSettingsView: View {
                             crashReportingEnabled = newValue
                             trackSettingsToggle("crash_reporting", enabled: newValue, page: .privacy)
                             CrashReportingPreferences.setEnabled(newValue)
+                            CrashReporter.applySessionTrackingPreference()
                             sentryTestStatus = nil
                             diagnosticsActionStatus = nil
                         }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -104,6 +104,18 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - Sentry release health follows crash reporting preference") {
+        let contents = readRepoTextFile("Sources/Observability/CrashReporter.swift")
+
+        assertTrue(
+            contents.contains("options.enableAutoSessionTracking = false")
+                && contents.contains("static func applySessionTrackingPreference()")
+                && contents.contains("SentrySDK.startSession()")
+                && contents.contains("SentrySDK.endSession()"),
+            "Sentry Release Health sessions should be explicitly gated by the user's crash-reporting preference"
+        )
+    }
+
     runSuite("Repo command contract - PostHog health probe uses the query API") {
         let contents = readRepoTextFile("scripts/ops/health-probe.sh")
 

--- a/docs/release-guardrails.md
+++ b/docs/release-guardrails.md
@@ -62,13 +62,12 @@ Defaults (all overridable by flag or env, see `--help`):
   on a handful of sessions.
 - `--stats-period 24h` (`SENTRY_STATS_PERIOD`) — lookback window.
 
-Note: as of this writing the Transcripted Sentry project reports no session
-data, so a live run returns `yellow`/`unknown` for real releases (session
-tracking is not populating Release Health). That is the correct safe posture —
-the gate blocks rather than false-greening — and it also surfaces that Release
-Health is not yet wired up in the app's Sentry SDK. Wiring session tracking is
-what turns this gate green-capable; until then crash-free is an `UNKNOWN` row,
-handled by manual QA.
+Release Health session tracking starts after onboarding when crash reporting is
+enabled, and follows later Settings changes. Existing releases may still
+report no session data if they shipped before that wiring or if users opted
+out, so a live run can remain `yellow`/`unknown` until a later release has
+enough opted-in production sessions. That is the correct safe posture: the
+gate blocks rather than false-greening.
 
 ## Safe While Justin Is Away
 


### PR DESCRIPTION
## Summary
- keep Sentry auto-session tracking off until onboarding is complete
- start/end manual Release Health sessions from the crash-reporting preference
- apply Settings changes and normal termination explicitly
- add a source contract test and update release guardrails

## Why
The live 1.1.48 crash-free gate returned YELLOW/UNKNOWN with 0 Sentry sessions because CrashReporter disabled auto-session tracking. This patch wires the gate without sending sessions before the first-run choice or after opt-out.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 12,756 passed
- `python3 scripts/ops/check-crash-free-rate.py --self-test`
- `python3 scripts/ops/privacy-leak-sweep.py --write-report /tmp/transcripted-privacy-leak-sweep-final.json` — PASS
- independent Claude review — no actionable findings

## Proof boundaries
- 1.1.48 remains YELLOW/UNKNOWN until a future opted-in release reports enough sessions
- no manual mic, system-audio, Bluetooth, TCC, sleep/wake, meeting-app, install, or subjective UI proof claimed
- no release, tag, appcast, Homebrew, website, or download surface changed