### PR TITLE
Fix Parakeet performance budget model name

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1336,7 +1336,7 @@ func testRepoCommandContract() {
     runSuite("Repo command contract - performance budget checks release bloat") {
         let contents = readRepoTextFile("scripts/ops/performance-budget.rb")
         assertTrue(
-            contents.contains("EXPECTED_PARAKEET_MODEL_DIR = \"parakeet-tdt-0.6b-v3-coreml\""),
+            contents.contains("EXPECTED_PARAKEET_MODEL_DIR = \"parakeet-tdt-0.6b-v3\""),
             "performance budget should assert the runtime Parakeet model directory"
         )
         assertTrue(

--- a/scripts/ops/performance-budget.rb
+++ b/scripts/ops/performance-budget.rb
@@ -9,7 +9,7 @@ require "pathname"
 require "time"
 
 REPO_ROOT = Pathname.new(__dir__).join("../..").expand_path
-EXPECTED_PARAKEET_MODEL_DIR = "parakeet-tdt-0.6b-v3-coreml"
+EXPECTED_PARAKEET_MODEL_DIR = "parakeet-tdt-0.6b-v3"
 EXPECTED_RESOURCE_ICONS = ["Transcripted.icns"].freeze
 MAX_APP_BYTES = 650 * 1024 * 1024
 MAX_RESOURCES_BYTES = 520 * 1024 * 1024


### PR DESCRIPTION
## What changed

Fix the Parakeet model-directory expectation in `performance-budget.rb` and its repo contract test. FluidAudio 0.15.x and `build.sh` now use `parakeet-tdt-0.6b-v3`; the budget still required the retired `-coreml` name, so valid full/offline builds failed their own post-build gate.

## Proof

- Fresh `origin/main` baseline: `776096e`.
- Home recent-captures benchmark: current main averaged 265.2 ms at 10,000 captures over 5 repeats; v1.1.48 averaged 564.6 ms over 3 repeats. Both stayed under the 750 ms budget.
- Thin signed build: launch-to-interactive 1206.9 ms; performance budget passed.
- Full bundled dictation autoeval: model init 21.879 s; synthetic stop-to-delivery 272–658 ms; transcription 0.11–0.50 s; saved artifacts were produced.
- After this fix, the full bundle budget passes with the measured 4907.1 ms launch sample when scored with the separate 6000 ms full-bundle diagnostic ceiling; the default 3000 ms launch gate still correctly flags that cold full-bundle launch.
- `bash run-tests.sh`: 12,755 passed.
- `swift test`: 719 passed, 13 skipped.
- `bash run-integration-smoke.sh`: passed.
- Quick QA bench with build skipped: deterministic E2E, slow pasteback, and local summary fixture passed; build row intentionally skipped.

## Known follow-up

The 3000 ms CI launch ceiling is intentionally a coarse catastrophic-regression guard. A Time Profiler trace showed about 827 ms process creation, ~79 ms in `applicationDidFinishLaunching()`, and ~9 ms initial frame rendering for the thin build. A full bundled model launch measured 4907.1 ms locally and remains yellow; this PR does not widen that product gate or claim hardware/manual audio proof.

Codex review helper was attempted but the local CLI is pinned to unsupported `gpt-5.6-luna` and exited before producing a review. Claude independent risk review found no other actionable regression.
