### PR TITLE
Fix local summary fixture source list

### DIFF
--- a/scripts/ops/run-local-summary-fixture.sh
+++ b/scripts/ops/run-local-summary-fixture.sh
@@ -377,6 +377,7 @@ swiftc \
   "${REPO_ROOT}/Sources/Support/LocalMeetingSummaryPreferences.swift" \
   "${REPO_ROOT}/Sources/Support/TranscriptedStoragePaths.swift" \
   "${REPO_ROOT}/Sources/Meeting/LocalMeetingSummarizer.swift" \
+  "${REPO_ROOT}/Sources/Meeting/MeetingArtifactRenamer.swift" \
   "${REPO_ROOT}/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift" \
   -framework FoundationModels \
   -parse-as-library \


### PR DESCRIPTION
## Summary

- Add `MeetingArtifactRenamer.swift` to the deterministic local-summary fixture compiler inputs.
- Fixes the exact-final-main release gate failure: `MeetingTranscriptFileUpdateSerializer` was missing from the fixture compile.

## Verification

- `bash scripts/ops/run-local-summary-fixture.sh` — PASS.
- `bash run-tests.sh` — 12,822 passed, 0 failed.
- Full deterministic bench — PASS, 18 checks with 1 non-blocking local-artifact warning: `/tmp/transcripted-qa-bench/qa-20260709-204542/qa-report.md`.
- Strict release gate — deterministic/release surfaces GREEN, overall YELLOW for missing telemetry credentials and manual/hardware proof: `/tmp/transcripted-release-gate/release-gate-20260710-015121/release-gate-report.md`.
- Independent Codex review was attempted twice but the installed CLI rejected its configured `gpt-5.6-terra` model; no review finding was produced. Diff was manually checked with `git diff --check`.

## Release boundary

This PR does not publish, tag, notarize, update appcast/Homebrew, or cut a release. Manual gaps remain for live audio/TCC, real meeting apps, Bluetooth/AirPods, sleep/wake, pasteback and speaker-review feel, existing-install update behavior, plus Sentry/PostHog credentials.