### PR TITLE
Improve dictation, Bluetooth startup, and meeting prompts

### DIFF
--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -14,6 +14,7 @@
 - `DictationAudioLevelMeter.swift` — normalizes live PCM buffers into a 0...1 level used by the dictation waveform UI
 - `DictationAudioRecovery.swift` — analyzes recorded dictation audio for usable speech signal and extracts focused, gain-normalized retry segments when an initial transcription attempt returns empty
 - `DictationInputDeviceSelectionPolicy.swift` — prefers a built-in mic over Bluetooth headset input for dictation when that avoids HFP-style playback downgrades
+- `PersistentDictationInputController.swift` — owns the explicit faster-Bluetooth-dictation preference at runtime: keeps the preferred non-Bluetooth system input selected, follows device reconnects, and restores prior input ownership across clean or unclean exits
 - `DictationReadinessWaitPolicy.swift` — tiny policy that decides whether dictation should keep waiting for recovery, refresh input readiness, or start recording immediately
 - `ParakeetModelInitDiagnostics.swift` — builds safe diagnostic context for model-initialization failures without leaking transcript or user-content data
 - `ParakeetPrewarmPolicy.swift` — central policy for deciding whether speech-engine input-readiness checks should proceed or be skipped based on microphone authorization state

--- a/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
+++ b/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
@@ -18,6 +18,38 @@ struct DictationAudioDevice: Equatable {
     let name: String
     let transport: DictationAudioTransport
     let inputChannelCount: UInt32
+    let uid: String?
+
+    init(
+        id: UInt32,
+        name: String,
+        transport: DictationAudioTransport,
+        inputChannelCount: UInt32,
+        uid: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.transport = transport
+        self.inputChannelCount = inputChannelCount
+        self.uid = uid
+    }
+}
+
+enum DictationPreferredInputPolicy {
+    static func input(
+        preferredUID: String?,
+        availableInputs: [DictationAudioDevice],
+        automaticFallback: DictationAudioDevice
+    ) -> DictationAudioDevice {
+        guard let preferredUID,
+              let preferred = availableInputs.first(where: {
+                  $0.uid == preferredUID
+                      && DictationInputDeviceSelectionPolicy.deviceClass(for: $0) != "bluetooth"
+              }) else {
+            return automaticFallback
+        }
+        return preferred
+    }
 }
 
 enum DictationInputDeviceSelectionReason: String {

--- a/Sources/Speech/ParakeetAudioDeviceLookup.swift
+++ b/Sources/Speech/ParakeetAudioDeviceLookup.swift
@@ -42,7 +42,7 @@ enum CoreAudioInputDeviceLookup {
         allowsBuiltInBluetoothFallback: Bool = true
     ) throws -> DictationInputDeviceSelection {
         let defaultInputID = try defaultInputDeviceID()
-        var availableInputs = try allInputDevices()
+        var availableInputs = try availableInputDevices()
 
         let defaultInput: DictationAudioDevice
         if let existingDefault = availableInputs.first(where: { $0.id == defaultInputID }) {
@@ -87,7 +87,7 @@ enum CoreAudioInputDeviceLookup {
         try defaultInputDeviceID()
     }
 
-    private static func allInputDevices() throws -> [DictationAudioDevice] {
+    static func availableInputDevices() throws -> [DictationAudioDevice] {
         try allDeviceIDs().compactMap { deviceID in
             let inputChannels = (try? channelCount(for: deviceID, scope: kAudioDevicePropertyScopeInput)) ?? 0
             guard inputChannels > 0 else { return nil }
@@ -152,7 +152,11 @@ enum CoreAudioInputDeviceLookup {
             id: deviceID,
             name: name.isEmpty ? "Unknown" : name,
             transport: transport,
-            inputChannelCount: inputChannelCount
+            inputChannelCount: inputChannelCount,
+            uid: try? readStringProperty(
+                selector: kAudioDevicePropertyDeviceUID,
+                objectID: AudioObjectID(deviceID)
+            )
         )
     }
 

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -768,6 +768,26 @@ class ParakeetEngine: ObservableObject {
             return
         }
 
+        let prewarmSelection = await Task.detached(priority: .utility) {
+            Self.loadDictationInputDeviceSelection()
+        }.value
+        guard canContinuePrewarm(generation: prewarmGeneration) else { return }
+        if ParakeetPrewarmPolicy.shouldDeferHardwarePrewarm(for: prewarmSelection) {
+            if let prewarmSelection {
+                updateCachedInputDeviceSelection(prewarmSelection)
+            }
+            prewarmRetryCount = 0
+            markFormatReadyAndPublish()
+            EventReporter.shared.capture(
+                level: .info,
+                engine: "parakeet",
+                event: "prewarm_deferred_for_bluetooth_fallback",
+                message: "Deferred idle microphone graph changes until dictation starts",
+                context: dictationRouteDiagnosticsContext(selection: prewarmSelection)
+            )
+            return
+        }
+
         let snapshot: ParakeetAudioInputSnapshot
         do {
             snapshot = try await audioInputSnapshot(operation: "prewarm")
@@ -971,6 +991,13 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func handleAudioConfigChange() async {
+        // Recording startup owns route selection and format validation. Letting
+        // the config-change recovery path run at the same time makes it fight
+        // the intentional Bluetooth -> built-in override and can create a
+        // restore/override loop between consecutive dictations.
+        if audioStartInProgress {
+            return
+        }
         if CFAbsoluteTimeGetCurrent() < ignoreInputSelectionConfigChangesUntil {
             return
         }
@@ -1096,6 +1123,34 @@ class ParakeetEngine: ObservableObject {
                 surface: "runtime",
                 artifactRetained: shouldRestartRecording
             )
+
+            let recoverySelection = await Task.detached(priority: .utility) {
+                Self.loadDictationInputDeviceSelection()
+            }.value
+            guard !Task.isCancelled else { return }
+            guard !self.recoveryState.isStale(generation: myGeneration) else { return }
+            if ParakeetPrewarmPolicy.shouldDeferHardwareRecovery(
+                for: recoverySelection,
+                wasRecording: shouldRestartRecording
+            ) {
+                if let recoverySelection {
+                    self.updateCachedInputDeviceSelection(recoverySelection)
+                }
+                self.prewarmRetryCount = 0
+                guard self.recoveryState.finishRecovery(success: true, generation: myGeneration) else { return }
+                self.cancelConfigRecoveryTimeout()
+                self.publishRecoveryState()
+                EventReporter.shared.capture(
+                    level: .info,
+                    engine: "parakeet",
+                    event: "prewarm_deferred_for_bluetooth_fallback",
+                    message: "Deferred idle microphone graph changes until dictation starts",
+                    context: self.dictationRouteDiagnosticsContext(selection: recoverySelection)
+                )
+                finishWorkflowRecovery(result: "success", artifactRetained: false)
+                return
+            }
+
             do {
                 var recoveryAttempt = 0
                 var readySnapshot: ParakeetAudioInputSnapshot?
@@ -2346,8 +2401,10 @@ class ParakeetEngine: ObservableObject {
         defer {
             audioStartInProgress = false
         }
-        func failAudioStart(_ operation: String) async -> Bool {
-            await restorePendingSystemInputAfterRecording(operation: operation)
+        func failAudioStart() async -> Bool {
+            // Keep the temporary built-in input selected across the controller's
+            // bounded retry loop. The final failure reset, explicit cancel,
+            // cleanup, or a successful recording stop owns restoration.
             return false
         }
 
@@ -2356,7 +2413,7 @@ class ParakeetEngine: ObservableObject {
         guard micStatus == .authorized else {
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "mic_not_authorized",
                 message: "Microphone permission status: \(micStatus.rawValue)")
-            return await failAudioStart("start_recording_mic_not_authorized")
+            return await failAudioStart()
         }
 
         installAudioObserversIfNeeded()
@@ -2375,7 +2432,7 @@ class ParakeetEngine: ObservableObject {
             if !recoveryState.isRecovering {
                 schedulePrewarmRetry()
             }
-            return await failAudioStart("start_recording_recovering")
+            return await failAudioStart()
         }
 
         recordingInterrupted = false
@@ -2403,7 +2460,7 @@ class ParakeetEngine: ObservableObject {
                     message: "Audio start aborted because the audio graph changed before startup finished",
                     context: ["audio_graph_generation": "\(audioGraphGeneration)"]
                 )
-                return await failAudioStart("start_recording_generation_changed_before_snapshot")
+                return await failAudioStart()
             }
 
             let snapshot: ParakeetAudioInputSnapshot
@@ -2434,7 +2491,7 @@ class ParakeetEngine: ObservableObject {
                 }
                 markFormatUnreadyAndPublish()
                 schedulePrewarmRetry()
-                return await failAudioStart("start_recording_format_read_failed")
+                return await failAudioStart()
             }
             guard startGeneration == audioGraphGeneration else {
                 EventReporter.shared.capture(
@@ -2444,7 +2501,7 @@ class ParakeetEngine: ObservableObject {
                     message: "Audio start aborted because the audio graph changed while reading input format",
                     context: ["audio_graph_generation": "\(audioGraphGeneration)"]
                 )
-                return await failAudioStart("start_recording_generation_changed_after_snapshot")
+                return await failAudioStart()
             }
 
             let readiness = audioFormatReadiness(
@@ -2490,7 +2547,7 @@ class ParakeetEngine: ObservableObject {
                 if startFailureAction.schedulePrewarmRetry {
                     schedulePrewarmRetry()
                 }
-                return await failAudioStart("start_recording_format_unavailable")
+                return await failAudioStart()
             }
 
             updateNativeSampleRate(snapshot.outputFormat.sampleRate)
@@ -2514,7 +2571,7 @@ class ParakeetEngine: ObservableObject {
                         message: "Audio start aborted because the audio graph changed while starting",
                         context: ["audio_graph_generation": "\(audioGraphGeneration)"]
                     )
-                    return await failAudioStart("start_recording_generation_changed_after_start")
+                    return await failAudioStart()
                 }
                 inputTapInstalled = true
                 isEnginePrewarmed = true
@@ -2611,7 +2668,7 @@ class ParakeetEngine: ObservableObject {
                     if startFailureAction.schedulePrewarmRetry {
                         schedulePrewarmRetry()
                     }
-                    return await failAudioStart("start_recording_route_not_settled")
+                    return await failAudioStart()
                 }
 
                 if operationTimedOut {
@@ -2629,7 +2686,7 @@ class ParakeetEngine: ObservableObject {
                     if startFailureAction.schedulePrewarmRetry {
                         schedulePrewarmRetry()
                     }
-                    return await failAudioStart("start_recording_engine_start_timeout")
+                    return await failAudioStart()
                 }
 
                 print("❌ PARAKEET | audio engine failed after \(attempt) attempt(s): \(error.localizedDescription)")
@@ -2640,7 +2697,7 @@ class ParakeetEngine: ObservableObject {
                 if startFailureAction.schedulePrewarmRetry {
                     schedulePrewarmRetry()
                 }
-                return await failAudioStart("start_recording_engine_start_failed")
+                return await failAudioStart()
             }
 
             if attempt > 1 {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1627,6 +1627,8 @@ class ParakeetEngine: ObservableObject {
                     "error": restoreError,
                 ]
             )
+        } else {
+            DictationPersistentInputPreferences.setTemporaryRecoveryMarker(nil)
         }
     }
 
@@ -1663,6 +1665,10 @@ class ParakeetEngine: ObservableObject {
                         ]
                     )
                 }
+            } else {
+                await MainActor.run {
+                    DictationPersistentInputPreferences.setTemporaryRecoveryMarker(nil)
+                }
             }
         }
     }
@@ -1690,6 +1696,21 @@ class ParakeetEngine: ObservableObject {
                 + TranscriptedConstants.selfInducedConfigChangeIgnoreWindow
         }
         let shouldRestoreSystemInputOnStop = operation == "start_recording"
+        let recoveryMarker = selection.flatMap { selection -> DictationPersistentInputPreferences.RecoveryMarker? in
+            guard selection.didOverrideDefault,
+                  selection.reason == .preferredBuiltInForBluetoothHeadset,
+                  let selectedUID = selection.selectedInput.uid,
+                  let previousUID = selection.defaultInput.uid else {
+                return nil
+            }
+            return DictationPersistentInputPreferences.RecoveryMarker(
+                selectedUID: selectedUID,
+                previousUID: previousUID
+            )
+        }
+        if let recoveryMarker {
+            DictationPersistentInputPreferences.setTemporaryRecoveryMarker(recoveryMarker)
+        }
         let systemInputOverrideStartedAt = CFAbsoluteTimeGetCurrent()
         let systemInputOverrideError = await Task.detached(priority: .utility) {
             Self.applyPreferredSystemInputDevice(for: selection)
@@ -1700,6 +1721,9 @@ class ParakeetEngine: ObservableObject {
             var context = inputSelectionContext(selection, operation: "\(operation)_system_input")
             if let systemInputOverrideError {
                 pendingSystemInputRestore = nil
+                if recoveryMarker != nil {
+                    DictationPersistentInputPreferences.setTemporaryRecoveryMarker(nil)
+                }
                 context["error"] = systemInputOverrideError
                 EventReporter.shared.capture(
                     level: .warning,

--- a/Sources/Speech/ParakeetPrewarmPolicy.swift
+++ b/Sources/Speech/ParakeetPrewarmPolicy.swift
@@ -12,6 +12,18 @@ enum ParakeetPrewarmDecision: Equatable {
 }
 
 enum ParakeetPrewarmPolicy {
+    static func shouldDeferHardwarePrewarm(for selection: DictationInputDeviceSelection?) -> Bool {
+        selection?.didOverrideDefault == true
+            && selection?.reason == .preferredBuiltInForBluetoothHeadset
+    }
+
+    static func shouldDeferHardwareRecovery(
+        for selection: DictationInputDeviceSelection?,
+        wasRecording: Bool
+    ) -> Bool {
+        !wasRecording && shouldDeferHardwarePrewarm(for: selection)
+    }
+
     static func decision(for microphoneStatus: AVAuthorizationStatus) -> ParakeetPrewarmDecision {
         switch microphoneStatus {
         case .authorized:

--- a/Sources/Speech/PersistentDictationInputController.swift
+++ b/Sources/Speech/PersistentDictationInputController.swift
@@ -1,0 +1,331 @@
+import CoreAudio
+import Foundation
+
+/// Applies the recommended non-Bluetooth microphone once per app lifetime when
+/// the user explicitly opts in. Keeping that device as the system default avoids
+/// paying the CoreAudio Bluetooth route-switch penalty on every dictation start.
+@MainActor
+final class PersistentDictationInputController {
+    private struct ActiveOverride {
+        let selectedInput: AudioDeviceID
+        let previousInput: AudioDeviceID
+        let marker: DictationPersistentInputPreferences.RecoveryMarker?
+    }
+
+    private var activeOverride: ActiveOverride?
+    private var preferenceObserver: NSObjectProtocol?
+    private var defaultInputListener: AudioObjectPropertyListenerBlock?
+    private var deviceListListener: AudioObjectPropertyListenerBlock?
+    private var topologyRefreshTask: Task<Void, Never>?
+
+    func start() {
+        guard preferenceObserver == nil else { return }
+        preferenceObserver = NotificationCenter.default.addObserver(
+            forName: .dictationPersistentInputPreferenceChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.applyCurrentPreference()
+            }
+        }
+        installDefaultInputListener()
+        installDeviceListListener()
+        recoverPersistedOwnership()
+        applyCurrentPreference()
+    }
+
+    func stopAndRestore() {
+        if let preferenceObserver {
+            NotificationCenter.default.removeObserver(preferenceObserver)
+            self.preferenceObserver = nil
+        }
+        removeDefaultInputListener()
+        removeDeviceListListener()
+        topologyRefreshTask?.cancel()
+        topologyRefreshTask = nil
+        restoreIfStillOwned(operation: "app_termination")
+    }
+
+    private func installDefaultInputListener() {
+        guard defaultInputListener == nil else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            Task { @MainActor in
+                self?.scheduleTopologyRefresh()
+            }
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            listener
+        )
+        if status == noErr {
+            defaultInputListener = listener
+        } else {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "dictation_persistent_input_listener_failed",
+                message: "Could not monitor system microphone changes for the faster-start preference"
+            )
+        }
+    }
+
+    private func removeDefaultInputListener() {
+        guard let defaultInputListener else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            defaultInputListener
+        )
+        self.defaultInputListener = nil
+    }
+
+    private func installDeviceListListener() {
+        guard deviceListListener == nil else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            Task { @MainActor in
+                self?.scheduleTopologyRefresh()
+            }
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            listener
+        )
+        if status == noErr {
+            deviceListListener = listener
+        } else {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "dictation_persistent_input_device_listener_failed",
+                message: "Could not monitor microphone connections for the faster-start preference"
+            )
+        }
+    }
+
+    private func removeDeviceListListener() {
+        guard let deviceListListener else { return }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            deviceListListener
+        )
+        self.deviceListListener = nil
+    }
+
+    private func scheduleTopologyRefresh() {
+        guard DictationPersistentInputPreferences.isEnabled() else { return }
+        topologyRefreshTask?.cancel()
+        topologyRefreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+            guard !Task.isCancelled else { return }
+            self?.applyCurrentPreference()
+        }
+    }
+
+    private func applyCurrentPreference() {
+        if !DictationPersistentInputPreferences.isEnabled() {
+            restoreIfStillOwned(operation: "preference_disabled")
+            return
+        }
+
+        do {
+            let selection = try CoreAudioInputDeviceLookup.preferredDictationInputSelection()
+            let availableInputs = try CoreAudioInputDeviceLookup.availableInputDevices()
+            let selectedInput = DictationPreferredInputPolicy.input(
+                preferredUID: DictationPersistentInputPreferences.preferredDeviceUID(),
+                availableInputs: availableInputs,
+                automaticFallback: selection.selectedInput
+            )
+            if selection.defaultInput.id == selectedInput.id {
+                if activeOverride?.selectedInput == selectedInput.id {
+                    return
+                }
+                activeOverride = nil
+                DictationPersistentInputPreferences.setRecoveryMarker(nil)
+            }
+            guard selectedInput.id != selection.defaultInput.id else {
+                EventReporter.shared.capture(
+                    level: .info,
+                    engine: "parakeet",
+                    event: "dictation_persistent_input_already_safe",
+                    message: "Persistent dictation microphone preference required no system input change",
+                    context: [
+                        "default_input_class": DictationInputDeviceSelectionPolicy.deviceClass(for: selection.defaultInput),
+                        "default_output_class": selection.defaultOutput.map(DictationInputDeviceSelectionPolicy.deviceClass(for:)) ?? "unknown"
+                    ]
+                )
+                return
+            }
+
+            let previousInput: AudioDeviceID
+            let previousUID: String?
+            if let activeOverride, activeOverride.selectedInput == selection.defaultInput.id {
+                previousInput = activeOverride.previousInput
+                previousUID = activeOverride.marker?.previousUID
+            } else {
+                previousInput = selection.defaultInput.id
+                previousUID = selection.defaultInput.uid
+            }
+            let recoveryMarker = selectedInput.uid.flatMap { selectedUID in
+                previousUID.map {
+                    DictationPersistentInputPreferences.RecoveryMarker(
+                        selectedUID: selectedUID,
+                        previousUID: $0
+                    )
+                }
+            }
+            DictationPersistentInputPreferences.setRecoveryMarker(recoveryMarker)
+            do {
+                try CoreAudioInputDeviceLookup.setDefaultInputDeviceID(selectedInput.id)
+            } catch {
+                DictationPersistentInputPreferences.setRecoveryMarker(nil)
+                throw error
+            }
+            activeOverride = ActiveOverride(
+                selectedInput: selectedInput.id,
+                previousInput: previousInput,
+                marker: recoveryMarker
+            )
+            EventReporter.shared.capture(
+                level: .info,
+                engine: "parakeet",
+                event: "dictation_persistent_input_selected",
+                message: "Kept the recommended microphone active for faster Bluetooth dictation starts",
+                context: [
+                    "previous_input_class": DictationInputDeviceSelectionPolicy.deviceClass(for: selection.defaultInput),
+                    "selected_input_class": DictationInputDeviceSelectionPolicy.deviceClass(for: selectedInput),
+                    "selection_mode": selectedInput.uid == DictationPersistentInputPreferences.preferredDeviceUID() ? "preferred" : "automatic",
+                    "default_output_class": selection.defaultOutput.map(DictationInputDeviceSelectionPolicy.deviceClass(for:)) ?? "unknown"
+                ]
+            )
+        } catch {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "dictation_persistent_input_failed",
+                message: "Could not keep the recommended microphone active",
+                context: ["operation": "apply"]
+            )
+        }
+    }
+
+    private func restoreIfStillOwned(operation: String) {
+        guard let activeOverride else { return }
+        self.activeOverride = nil
+        do {
+            let currentInput = try CoreAudioInputDeviceLookup.currentDefaultInputDeviceID()
+            guard currentInput == activeOverride.selectedInput else {
+                DictationPersistentInputPreferences.setRecoveryMarker(nil)
+                EventReporter.shared.capture(
+                    level: .info,
+                    engine: "parakeet",
+                    event: "dictation_persistent_input_restore_skipped",
+                    message: "Preserved a microphone selection changed outside Transcripted",
+                    context: ["operation": operation]
+                )
+                return
+            }
+            try CoreAudioInputDeviceLookup.setDefaultInputDeviceID(activeOverride.previousInput)
+            DictationPersistentInputPreferences.setRecoveryMarker(nil)
+            EventReporter.shared.capture(
+                level: .info,
+                engine: "parakeet",
+                event: "dictation_persistent_input_restored",
+                message: "Restored the microphone selected before Transcripted's faster-start preference",
+                context: ["operation": operation]
+            )
+        } catch {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "dictation_persistent_input_restore_failed",
+                message: "Could not restore the previous system microphone",
+                context: ["operation": operation]
+            )
+        }
+    }
+
+    private func recoverPersistedOwnership() {
+        guard let marker = DictationPersistentInputPreferences.recoveryMarker() else { return }
+        do {
+            let availableInputs = try CoreAudioInputDeviceLookup.availableInputDevices()
+            let currentInputID = try CoreAudioInputDeviceLookup.currentDefaultInputDeviceID()
+            let currentUID = availableInputs.first(where: { $0.id == currentInputID })?.uid
+            let availableByUID = Dictionary(
+                uniqueKeysWithValues: availableInputs.compactMap { device in
+                    device.uid.map { ($0, device) }
+                }
+            )
+            let action = DictationPersistentInputRecoveryPolicy.action(
+                preferenceEnabled: DictationPersistentInputPreferences.isEnabled(),
+                currentUID: currentUID,
+                marker: marker,
+                availableUIDs: Set(availableByUID.keys)
+            )
+            switch action {
+            case .none:
+                return
+            case .adopt:
+                guard let selected = availableByUID[marker.selectedUID],
+                      let previous = availableByUID[marker.previousUID] else {
+                    DictationPersistentInputPreferences.setRecoveryMarker(nil)
+                    return
+                }
+                activeOverride = ActiveOverride(
+                    selectedInput: selected.id,
+                    previousInput: previous.id,
+                    marker: marker
+                )
+                EventReporter.shared.capture(
+                    level: .info,
+                    engine: "parakeet",
+                    event: "dictation_persistent_input_ownership_recovered",
+                    message: "Recovered microphone restoration ownership after an unclean app exit"
+                )
+            case .restore:
+                guard let previous = availableByUID[marker.previousUID] else {
+                    DictationPersistentInputPreferences.setRecoveryMarker(nil)
+                    return
+                }
+                try CoreAudioInputDeviceLookup.setDefaultInputDeviceID(previous.id)
+                DictationPersistentInputPreferences.setRecoveryMarker(nil)
+            case .clear:
+                DictationPersistentInputPreferences.setRecoveryMarker(nil)
+            }
+        } catch {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "dictation_persistent_input_ownership_recovery_failed",
+                message: "Could not reconcile microphone ownership after an unclean app exit"
+            )
+        }
+    }
+}

--- a/Sources/Speech/PersistentDictationInputController.swift
+++ b/Sources/Speech/PersistentDictationInputController.swift
@@ -17,6 +17,7 @@ final class PersistentDictationInputController {
     private var defaultInputListener: AudioObjectPropertyListenerBlock?
     private var deviceListListener: AudioObjectPropertyListenerBlock?
     private var topologyRefreshTask: Task<Void, Never>?
+    private var shouldRecoverInheritedTemporaryOverride = false
 
     func start() {
         guard preferenceObserver == nil else { return }
@@ -26,13 +27,14 @@ final class PersistentDictationInputController {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.applyCurrentPreference()
+                self?.reconcileCurrentPreference()
             }
         }
         installDefaultInputListener()
         installDeviceListListener()
-        recoverPersistedOwnership()
-        applyCurrentPreference()
+        shouldRecoverInheritedTemporaryOverride =
+            DictationPersistentInputPreferences.temporaryRecoveryMarker() != nil
+        reconcileCurrentPreference()
     }
 
     func stopAndRestore() {
@@ -140,13 +142,23 @@ final class PersistentDictationInputController {
     }
 
     private func scheduleTopologyRefresh() {
-        guard DictationPersistentInputPreferences.isEnabled() else { return }
+        guard DictationPersistentInputPreferences.isEnabled()
+                || DictationPersistentInputPreferences.recoveryMarker() != nil
+                || shouldRecoverInheritedTemporaryOverride else { return }
         topologyRefreshTask?.cancel()
         topologyRefreshTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
             guard !Task.isCancelled else { return }
-            self?.applyCurrentPreference()
+            self?.reconcileCurrentPreference()
         }
+    }
+
+    private func reconcileCurrentPreference() {
+        if shouldRecoverInheritedTemporaryOverride {
+            recoverTemporaryOwnership()
+        }
+        recoverPersistedOwnership()
+        applyCurrentPreference()
     }
 
     private func applyCurrentPreference() {
@@ -158,6 +170,11 @@ final class PersistentDictationInputController {
         do {
             let selection = try CoreAudioInputDeviceLookup.preferredDictationInputSelection()
             let availableInputs = try CoreAudioInputDeviceLookup.availableInputDevices()
+            if activeOverride == nil,
+               let marker = DictationPersistentInputPreferences.recoveryMarker(),
+               selection.defaultInput.uid == marker.selectedUID {
+                return
+            }
             let selectedInput = DictationPreferredInputPolicy.input(
                 preferredUID: DictationPersistentInputPreferences.preferredDeviceUID(),
                 availableInputs: availableInputs,
@@ -316,6 +333,8 @@ final class PersistentDictationInputController {
                 }
                 try CoreAudioInputDeviceLookup.setDefaultInputDeviceID(previous.id)
                 DictationPersistentInputPreferences.setRecoveryMarker(nil)
+            case .preserve:
+                return
             case .clear:
                 DictationPersistentInputPreferences.setRecoveryMarker(nil)
             }
@@ -325,6 +344,48 @@ final class PersistentDictationInputController {
                 engine: "parakeet",
                 event: "dictation_persistent_input_ownership_recovery_failed",
                 message: "Could not reconcile microphone ownership after an unclean app exit"
+            )
+        }
+    }
+
+    private func recoverTemporaryOwnership() {
+        guard let marker = DictationPersistentInputPreferences.temporaryRecoveryMarker() else {
+            shouldRecoverInheritedTemporaryOverride = false
+            return
+        }
+        do {
+            let availableInputs = try CoreAudioInputDeviceLookup.availableInputDevices()
+            let currentInputID = try CoreAudioInputDeviceLookup.currentDefaultInputDeviceID()
+            let currentUID = availableInputs.first(where: { $0.id == currentInputID })?.uid
+            let availableByUID = Dictionary(
+                uniqueKeysWithValues: availableInputs.compactMap { device in
+                    device.uid.map { ($0, device) }
+                }
+            )
+            let action = DictationPersistentInputRecoveryPolicy.action(
+                preferenceEnabled: false,
+                currentUID: currentUID,
+                marker: marker,
+                availableUIDs: Set(availableByUID.keys)
+            )
+            switch action {
+            case .restore:
+                guard let previous = availableByUID[marker.previousUID] else { return }
+                try CoreAudioInputDeviceLookup.setDefaultInputDeviceID(previous.id)
+                DictationPersistentInputPreferences.setTemporaryRecoveryMarker(nil)
+                shouldRecoverInheritedTemporaryOverride = false
+            case .clear:
+                DictationPersistentInputPreferences.setTemporaryRecoveryMarker(nil)
+                shouldRecoverInheritedTemporaryOverride = false
+            case .none, .adopt, .preserve:
+                return
+            }
+        } catch {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "dictation_temporary_input_ownership_recovery_failed",
+                message: "Could not restore the microphone after an interrupted dictation"
             )
         }
     }

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -17,6 +17,7 @@
 - `CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements plus text post-processing helpers
 - `DockVisibilityPreferences.swift` — persisted General setting for whether Transcripted should stay visible in the Dock while idle
 - `DictationAutoSendPreferences.swift` — persisted auto-send rules, allowed bundle list, and keypress-sending helpers for pasted dictation
+- `DictationPersistentInputPreferences.swift` — persisted faster-Bluetooth-dictation opt-in, preferred CoreAudio device UID, and crash-recovery ownership marker
 - `DictationCleanupPreferences.swift` — persisted General toggle for filler-word cleanup after dictation
 - `DictationFillerCleanupPolicy.swift` — text cleanup policy for light dictation filler removal
 - `DictationOverlayPresentationPreferences.swift` — persisted overlay presentation mode for normal vs cursor-mini dictation UI

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -50,6 +50,11 @@ enum TextPasteOutcome: Equatable {
     }
 }
 
+struct ClipboardPasteConfirmationDiagnostic: Equatable {
+    let event: String
+    let context: [String: String]
+}
+
 @MainActor
 protocol ClipboardPasteboard: AnyObject {
     var changeCount: Int { get }
@@ -152,6 +157,23 @@ struct DictationPasteTarget: Equatable {
         )
     }
 
+    static func preferredDestination(
+        frontmostProcessIdentifier: pid_t?,
+        frontmostBundleIdentifier: String?,
+        transcriptedBundleIdentifier: String?,
+        fallback: DictationPasteTarget?
+    ) -> DictationPasteTarget? {
+        guard let frontmostProcessIdentifier,
+              let frontmostBundleIdentifier,
+              frontmostBundleIdentifier != transcriptedBundleIdentifier else {
+            return fallback
+        }
+        return DictationPasteTarget(
+            processIdentifier: frontmostProcessIdentifier,
+            bundleIdentifier: frontmostBundleIdentifier
+        )
+    }
+
     func matchesCurrentFrontmostApp() -> Bool {
         guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
             return false
@@ -173,12 +195,215 @@ struct DictationPasteTarget: Equatable {
     }
 }
 
+enum FocusedTextPasteConfirmationPolicy {
+    static let selectedAutoEnterClipboardReadWindow: CFTimeInterval = 0.2
+    struct SelectionRange: Equatable {
+        let location: Int
+        let length: Int
+    }
+
+    static func observableString(from value: Any?) -> String? {
+        if let string = value as? String {
+            return string
+        }
+        if let attributedString = value as? NSAttributedString {
+            return attributedString.string
+        }
+        return nil
+    }
+
+    static func didObservePaste(
+        initialValue: String?,
+        currentValue: String?,
+        pastedText: String,
+        replacedSelectionLength: Int = 0
+    ) -> Bool {
+        guard let initialValue,
+              let currentValue,
+              currentValue != initialValue,
+              !pastedText.isEmpty else {
+            return false
+        }
+
+        let normalizedInitial = normalizedForConfirmation(initialValue)
+        let normalizedCurrent = normalizedForConfirmation(currentValue)
+        let normalizedPaste = normalizedForConfirmation(pastedText)
+        if !normalizedPaste.isEmpty,
+           !normalizedInitial.contains(normalizedPaste),
+           normalizedCurrent.contains(normalizedPaste) {
+            return true
+        }
+
+        let expectedLengthChange = pastedText.utf16.count - max(0, replacedSelectionLength)
+        let observedLengthChange = currentValue.utf16.count - initialValue.utf16.count
+        let tolerance = max(2, pastedText.utf16.count / 20)
+        return abs(observedLengthChange - expectedLengthChange) <= tolerance
+    }
+
+    static func didObserveSelectionPaste(
+        initialRange: SelectionRange?,
+        currentRange: SelectionRange?,
+        pastedText: String,
+        clipboardWasRead: Bool
+    ) -> Bool {
+        guard clipboardWasRead,
+              let initialRange,
+              let currentRange,
+              !pastedText.isEmpty,
+              currentRange.length == 0 else {
+            return false
+        }
+
+        let expectedCursorLocation = initialRange.location + pastedText.utf16.count
+        let tolerance = max(2, pastedText.utf16.count / 20)
+        return abs(currentRange.location - expectedCursorLocation) <= tolerance
+    }
+
+    static func didObserveTargetChange(
+        pasteDispatchedAt: CFAbsoluteTime,
+        clipboardReadAt: CFAbsoluteTime?,
+        targetChangedAt: CFAbsoluteTime?
+    ) -> Bool {
+        guard let clipboardReadAt,
+              let targetChangedAt,
+              clipboardReadAt >= pasteDispatchedAt,
+              targetChangedAt >= clipboardReadAt else {
+            return false
+        }
+        return targetChangedAt - clipboardReadAt <= 1.0
+    }
+
+    static func didObserveSelectedAutoEnterTargetRead(
+        pasteDispatchedAt: CFAbsoluteTime,
+        clipboardReadAt: CFAbsoluteTime?,
+        targetStillFrontmost: Bool
+    ) -> Bool {
+        guard targetStillFrontmost,
+              let clipboardReadAt,
+              clipboardReadAt >= pasteDispatchedAt else {
+            return false
+        }
+        return clipboardReadAt - pasteDispatchedAt <= selectedAutoEnterClipboardReadWindow
+    }
+
+    private static func normalizedForConfirmation(_ text: String) -> String {
+        text.precomposedStringWithCompatibilityMapping
+            .replacingOccurrences(of: "\u{2018}", with: "'")
+            .replacingOccurrences(of: "\u{2019}", with: "'")
+            .replacingOccurrences(of: "\u{201C}", with: "\"")
+            .replacingOccurrences(of: "\u{201D}", with: "\"")
+            .replacingOccurrences(of: "\u{00A0}", with: " ")
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+
+private func focusedTextChangeObserverCallback(
+    observer: AXObserver,
+    element: AXUIElement,
+    notification: CFString,
+    refcon: UnsafeMutableRawPointer?
+) {
+    guard let refcon else { return }
+    let tracker = Unmanaged<FocusedTextChangeObserver>.fromOpaque(refcon).takeUnretainedValue()
+    tracker.recordChange()
+}
+
+private final class FocusedTextChangeObserver {
+    private let focusedElement: AXUIElement
+    private let lock = NSLock()
+    private var observer: AXObserver?
+    private var monitoredNotifications: [CFString] = []
+    private var latestChangeTimestamp: CFAbsoluteTime?
+
+    var changedAt: CFAbsoluteTime? {
+        lock.lock()
+        let value = latestChangeTimestamp
+        lock.unlock()
+        return value
+    }
+
+    private init(focusedElement: AXUIElement) {
+        self.focusedElement = focusedElement
+    }
+
+    static func start(for focusedElement: AXUIElement) -> FocusedTextChangeObserver? {
+        let tracker = FocusedTextChangeObserver(focusedElement: focusedElement)
+        return tracker.install() ? tracker : nil
+    }
+
+    fileprivate func recordChange() {
+        lock.lock()
+        latestChangeTimestamp = CFAbsoluteTimeGetCurrent()
+        lock.unlock()
+    }
+
+    private func install() -> Bool {
+        var processIdentifier: pid_t = 0
+        guard AXUIElementGetPid(focusedElement, &processIdentifier) == .success else {
+            return false
+        }
+
+        var createdObserver: AXObserver?
+        guard AXObserverCreate(
+            processIdentifier,
+            focusedTextChangeObserverCallback,
+            &createdObserver
+        ) == .success,
+              let createdObserver else {
+            return false
+        }
+
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        for notification in [kAXValueChangedNotification, kAXSelectedTextChangedNotification] {
+            if AXObserverAddNotification(
+                createdObserver,
+                focusedElement,
+                notification as CFString,
+                refcon
+            ) == .success {
+                monitoredNotifications.append(notification as CFString)
+            }
+        }
+        guard !monitoredNotifications.isEmpty else { return false }
+
+        observer = createdObserver
+        CFRunLoopAddSource(
+            CFRunLoopGetMain(),
+            AXObserverGetRunLoopSource(createdObserver),
+            .commonModes
+        )
+        return true
+    }
+
+    deinit {
+        guard let observer else { return }
+        for notification in monitoredNotifications {
+            AXObserverRemoveNotification(observer, focusedElement, notification)
+        }
+        CFRunLoopRemoveSource(
+            CFRunLoopGetMain(),
+            AXObserverGetRunLoopSource(observer),
+            .commonModes
+        )
+    }
+}
+
 private struct FocusedTextPasteConfirmation {
+    /// Accessibility clients can otherwise block for several seconds when an editor is
+    /// briefly busy applying a paste (Notes is a common example). Confirmation is a
+    /// best-effort signal and must never stall delivery or the target application.
+    private static let messagingTimeout: Float = 0.05
+
     private let focusedElement: AXUIElement
     private let initialValue: String?
+    private let replacedSelectionLength: Int
+    private let initialSelectionRange: FocusedTextPasteConfirmationPolicy.SelectionRange?
+    private let changeObserver: FocusedTextChangeObserver?
 
-    var canObserveTextValue: Bool {
-        initialValue != nil
+    var canObservePaste: Bool {
+        initialValue != nil || initialSelectionRange != nil || changeObserver != nil
     }
 
     static func capture() -> FocusedTextPasteConfirmation? {
@@ -194,19 +419,59 @@ private struct FocusedTextPasteConfirmation {
         }
 
         let element = focusedElement as! AXUIElement
+        AXUIElementSetMessagingTimeout(element, messagingTimeout)
         return FocusedTextPasteConfirmation(
             focusedElement: element,
-            initialValue: stringAttribute(kAXValueAttribute as CFString, from: element)
+            initialValue: stringAttribute(kAXValueAttribute as CFString, from: element),
+            replacedSelectionLength: stringAttribute(kAXSelectedTextAttribute as CFString, from: element)?.utf16.count ?? 0,
+            initialSelectionRange: selectionRangeAttribute(from: element),
+            changeObserver: FocusedTextChangeObserver.start(for: element)
         )
     }
 
-    func containsPastedText(_ text: String) -> Bool {
-        guard !text.isEmpty,
-              let currentValue = Self.stringAttribute(kAXValueAttribute as CFString, from: focusedElement),
-              currentValue != initialValue else {
-            return false
+    func confirmationMode(
+        _ text: String,
+        clipboardWasRead: Bool,
+        clipboardReadAt: CFAbsoluteTime?,
+        pasteDispatchedAt: CFAbsoluteTime
+    ) -> String? {
+        if FocusedTextPasteConfirmationPolicy.didObservePaste(
+            initialValue: initialValue,
+            currentValue: Self.stringAttribute(kAXValueAttribute as CFString, from: focusedElement),
+            pastedText: text,
+            replacedSelectionLength: replacedSelectionLength
+        ) {
+            return "text_value"
         }
-        return currentValue.contains(text)
+        if FocusedTextPasteConfirmationPolicy.didObserveSelectionPaste(
+            initialRange: initialSelectionRange,
+            currentRange: Self.selectionRangeAttribute(from: focusedElement),
+            pastedText: text,
+            clipboardWasRead: clipboardWasRead
+        ) {
+            return "selection_range"
+        }
+        if FocusedTextPasteConfirmationPolicy.didObserveTargetChange(
+            pasteDispatchedAt: pasteDispatchedAt,
+            clipboardReadAt: clipboardReadAt,
+            targetChangedAt: changeObserver?.changedAt
+        ) {
+            return "target_change_notification"
+        }
+        return nil
+    }
+
+    func diagnosticsContext(
+        clipboardReadAt: CFAbsoluteTime?,
+        pasteDispatchedAt: CFAbsoluteTime
+    ) -> [String: String] {
+        [
+            "clipboard_read_after_dispatch": "\((clipboardReadAt ?? 0) >= pasteDispatchedAt)",
+            "target_change_after_dispatch": "\((changeObserver?.changedAt ?? 0) >= pasteDispatchedAt)",
+            "target_change_observer_available": "\(changeObserver != nil)",
+            "target_selection_observable": "\(initialSelectionRange != nil)",
+            "target_text_observable": "\(initialValue != nil)",
+        ]
     }
 
     private static func stringAttribute(_ attribute: CFString, from element: AXUIElement) -> String? {
@@ -214,7 +479,34 @@ private struct FocusedTextPasteConfirmation {
         guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else {
             return nil
         }
-        return value as? String
+        return FocusedTextPasteConfirmationPolicy.observableString(from: value)
+    }
+
+    private static func selectionRangeAttribute(
+        from element: AXUIElement
+    ) -> FocusedTextPasteConfirmationPolicy.SelectionRange? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXSelectedTextRangeAttribute as CFString,
+            &value
+        ) == .success,
+              let value,
+              CFGetTypeID(value) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        let axValue = value as! AXValue
+        var range = CFRange()
+        guard AXValueGetValue(axValue, .cfRange, &range),
+              range.location >= 0,
+              range.length >= 0 else {
+            return nil
+        }
+        return FocusedTextPasteConfirmationPolicy.SelectionRange(
+            location: range.location,
+            length: range.length
+        )
     }
 }
 
@@ -239,6 +531,7 @@ final class ClipboardRestoringTextPaster {
     private var pendingClipboardRestore: PendingClipboardRestore?
     private var temporaryPasteboardDataProvider: TemporaryPasteboardStringProvider?
     private var pasteGeneration = 0
+    private(set) var lastConfirmationDiagnostic: ClipboardPasteConfirmationDiagnostic?
 
     deinit {
         clipboardRestoreTask?.cancel()
@@ -292,10 +585,13 @@ final class ClipboardRestoringTextPaster {
         },
         pasteDispatcher: @MainActor () -> Bool = postClipboardPasteShortcut,
         pasteConfirmed: (@MainActor () -> Bool)? = nil,
+        allowClipboardReadConfirmation: Bool = false,
+        selectedTargetStillFrontmost: (@MainActor () -> Bool)? = nil,
         restoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreDelay,
         fallbackRestoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreFallbackDelay,
         pasteConfirmationWait: TimeInterval = TranscriptedConstants.clipboardPasteConfirmationWait
     ) -> TextPasteOutcome {
+        lastConfirmationDiagnostic = nil
         restorePendingClipboardBeforeNewPaste()
 
         if let target,
@@ -336,6 +632,7 @@ final class ClipboardRestoringTextPaster {
             }
         }
         temporaryChangeCount = pasteboard.changeCount
+        let temporaryProvider = temporaryPasteboardDataProvider
 
         scheduleClipboardRestore(
             savedItems,
@@ -346,6 +643,7 @@ final class ClipboardRestoringTextPaster {
             delay: fallbackRestoreDelay
         )
 
+        let pasteDispatchedAt = CFAbsoluteTimeGetCurrent()
         guard pasteDispatcher() else {
             restorePendingClipboardNow()
             guard copyTextToClipboard(text, to: pasteboard) else {
@@ -357,22 +655,51 @@ final class ClipboardRestoringTextPaster {
             )
         }
 
-        let confirmationUnavailable = pasteConfirmed == nil && accessibilityConfirmation?.canObserveTextValue != true
+        let confirmationUnavailable = pasteConfirmed == nil && accessibilityConfirmation?.canObservePaste != true
+        let selectedTargetIsFrontmost = selectedTargetStillFrontmost ?? {
+            target?.matchesCurrentFrontmostApp() == true
+        }
         let confirmPasteReceived = pasteConfirmed ?? {
-            if accessibilityConfirmation?.containsPastedText(text) == true {
+            if allowClipboardReadConfirmation,
+               FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
+                   pasteDispatchedAt: pasteDispatchedAt,
+                   clipboardReadAt: temporaryProvider?.firstReadAt,
+                   targetStillFrontmost: selectedTargetIsFrontmost()
+               ) {
                 return true
             }
-            if accessibilityConfirmation?.canObserveTextValue == true {
-                return false
+            if accessibilityConfirmation?.confirmationMode(
+                text,
+                clipboardWasRead: temporaryProvider?.didProvideData == true,
+                clipboardReadAt: temporaryProvider?.firstReadAt,
+                pasteDispatchedAt: pasteDispatchedAt
+            ) != nil {
+                return true
             }
             return false
         }
 
-        guard waitForPasteConfirmation(
+        let pasteWasConfirmed = waitForPasteConfirmation(
             target: target,
             pasteConfirmed: confirmPasteReceived,
             timeout: pasteConfirmationWait
-        ) else {
+        )
+        guard pasteWasConfirmed else {
+            var diagnostics = accessibilityConfirmation?.diagnosticsContext(
+                clipboardReadAt: temporaryProvider?.firstReadAt,
+                pasteDispatchedAt: pasteDispatchedAt
+            ) ?? [
+                "clipboard_read_after_dispatch": "\((temporaryProvider?.firstReadAt ?? 0) >= pasteDispatchedAt)",
+                "target_change_after_dispatch": "false",
+                "target_change_observer_available": "false",
+                "target_selection_observable": "false",
+                "target_text_observable": "false",
+            ]
+            diagnostics["target_still_frontmost"] = "\(target?.matchesCurrentFrontmostApp() != false)"
+            lastConfirmationDiagnostic = ClipboardPasteConfirmationDiagnostic(
+                event: "dictation_paste_confirmation_diagnostics",
+                context: diagnostics
+            )
             guard leaveTemporaryClipboardAvailable() else {
                 return .failed("Couldn't keep the dictation copied after paste-back was unconfirmed. The dictation was saved, but paste-back did not run.")
             }
@@ -387,6 +714,29 @@ final class ClipboardRestoringTextPaster {
                 reason: .pasteNotConfirmed
             )
         }
+
+        let confirmationMode: String
+        if pasteConfirmed != nil {
+            confirmationMode = "injected_confirmation"
+        } else if allowClipboardReadConfirmation,
+                  FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
+                      pasteDispatchedAt: pasteDispatchedAt,
+                      clipboardReadAt: temporaryProvider?.firstReadAt,
+                      targetStillFrontmost: selectedTargetIsFrontmost()
+                  ) {
+            confirmationMode = "clipboard_read_selected_auto_enter_target"
+        } else {
+            confirmationMode = accessibilityConfirmation?.confirmationMode(
+                text,
+                clipboardWasRead: temporaryProvider?.didProvideData == true,
+                clipboardReadAt: temporaryProvider?.firstReadAt,
+                pasteDispatchedAt: pasteDispatchedAt
+            ) ?? "unknown"
+        }
+        lastConfirmationDiagnostic = ClipboardPasteConfirmationDiagnostic(
+            event: "dictation_paste_confirmed",
+            context: ["confirmation_mode": confirmationMode]
+        )
 
         scheduleClipboardRestore(
             savedItems,
@@ -633,10 +983,18 @@ private final class TemporaryPasteboardStringProvider: NSObject, NSPasteboardIte
     private let onTemporaryStringRead: () -> Void
     private let lock = NSLock()
     private var didNotifyRead = false
+    private var firstReadTimestamp: CFAbsoluteTime?
 
     var didProvideData: Bool {
         lock.lock()
         let value = didNotifyRead
+        lock.unlock()
+        return value
+    }
+
+    var firstReadAt: CFAbsoluteTime? {
+        lock.lock()
+        let value = firstReadTimestamp
         lock.unlock()
         return value
     }
@@ -660,6 +1018,9 @@ private final class TemporaryPasteboardStringProvider: NSObject, NSPasteboardIte
         lock.lock()
         let shouldNotify = !didNotifyRead
         didNotifyRead = true
+        if firstReadTimestamp == nil {
+            firstReadTimestamp = CFAbsoluteTimeGetCurrent()
+        }
         lock.unlock()
 
         if shouldNotify {

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -196,7 +196,6 @@ struct DictationPasteTarget: Equatable {
 }
 
 enum FocusedTextPasteConfirmationPolicy {
-    static let selectedAutoEnterClipboardReadWindow: CFTimeInterval = 0.2
     struct SelectionRange: Equatable {
         let location: Int
         let length: Int
@@ -271,19 +270,6 @@ enum FocusedTextPasteConfirmationPolicy {
             return false
         }
         return targetChangedAt - clipboardReadAt <= 1.0
-    }
-
-    static func didObserveSelectedAutoEnterTargetRead(
-        pasteDispatchedAt: CFAbsoluteTime,
-        clipboardReadAt: CFAbsoluteTime?,
-        targetStillFrontmost: Bool
-    ) -> Bool {
-        guard targetStillFrontmost,
-              let clipboardReadAt,
-              clipboardReadAt >= pasteDispatchedAt else {
-            return false
-        }
-        return clipboardReadAt - pasteDispatchedAt <= selectedAutoEnterClipboardReadWindow
     }
 
     private static func normalizedForConfirmation(_ text: String) -> String {
@@ -585,8 +571,6 @@ final class ClipboardRestoringTextPaster {
         },
         pasteDispatcher: @MainActor () -> Bool = postClipboardPasteShortcut,
         pasteConfirmed: (@MainActor () -> Bool)? = nil,
-        allowClipboardReadConfirmation: Bool = false,
-        selectedTargetStillFrontmost: (@MainActor () -> Bool)? = nil,
         restoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreDelay,
         fallbackRestoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreFallbackDelay,
         pasteConfirmationWait: TimeInterval = TranscriptedConstants.clipboardPasteConfirmationWait
@@ -656,18 +640,7 @@ final class ClipboardRestoringTextPaster {
         }
 
         let confirmationUnavailable = pasteConfirmed == nil && accessibilityConfirmation?.canObservePaste != true
-        let selectedTargetIsFrontmost = selectedTargetStillFrontmost ?? {
-            target?.matchesCurrentFrontmostApp() == true
-        }
         let confirmPasteReceived = pasteConfirmed ?? {
-            if allowClipboardReadConfirmation,
-               FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
-                   pasteDispatchedAt: pasteDispatchedAt,
-                   clipboardReadAt: temporaryProvider?.firstReadAt,
-                   targetStillFrontmost: selectedTargetIsFrontmost()
-               ) {
-                return true
-            }
             if accessibilityConfirmation?.confirmationMode(
                 text,
                 clipboardWasRead: temporaryProvider?.didProvideData == true,
@@ -718,13 +691,6 @@ final class ClipboardRestoringTextPaster {
         let confirmationMode: String
         if pasteConfirmed != nil {
             confirmationMode = "injected_confirmation"
-        } else if allowClipboardReadConfirmation,
-                  FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
-                      pasteDispatchedAt: pasteDispatchedAt,
-                      clipboardReadAt: temporaryProvider?.firstReadAt,
-                      targetStillFrontmost: selectedTargetIsFrontmost()
-                  ) {
-            confirmationMode = "clipboard_read_selected_auto_enter_target"
         } else {
             confirmationMode = accessibilityConfirmation?.confirmationMode(
                 text,

--- a/Sources/Support/DictationPersistentInputPreferences.swift
+++ b/Sources/Support/DictationPersistentInputPreferences.swift
@@ -11,6 +11,8 @@ enum DictationPersistentInputPreferences {
     private static let preferredDeviceUIDKey = "dictationPreferredInputDeviceUID"
     private static let recoverySelectedUIDKey = "dictationPersistentInputRecoverySelectedUID"
     private static let recoveryPreviousUIDKey = "dictationPersistentInputRecoveryPreviousUID"
+    private static let temporaryRecoverySelectedUIDKey = "dictationTemporaryInputRecoverySelectedUID"
+    private static let temporaryRecoveryPreviousUIDKey = "dictationTemporaryInputRecoveryPreviousUID"
 
     struct RecoveryMarker: Equatable {
         let selectedUID: String
@@ -73,12 +75,37 @@ enum DictationPersistentInputPreferences {
         }
         userDefaults.synchronize()
     }
+
+    static func temporaryRecoveryMarker(userDefaults: UserDefaults = .standard) -> RecoveryMarker? {
+        guard let selectedUID = userDefaults.string(forKey: temporaryRecoverySelectedUIDKey),
+              !selectedUID.isEmpty,
+              let previousUID = userDefaults.string(forKey: temporaryRecoveryPreviousUIDKey),
+              !previousUID.isEmpty else {
+            return nil
+        }
+        return RecoveryMarker(selectedUID: selectedUID, previousUID: previousUID)
+    }
+
+    static func setTemporaryRecoveryMarker(
+        _ marker: RecoveryMarker?,
+        userDefaults: UserDefaults = .standard
+    ) {
+        if let marker {
+            userDefaults.set(marker.selectedUID, forKey: temporaryRecoverySelectedUIDKey)
+            userDefaults.set(marker.previousUID, forKey: temporaryRecoveryPreviousUIDKey)
+        } else {
+            userDefaults.removeObject(forKey: temporaryRecoverySelectedUIDKey)
+            userDefaults.removeObject(forKey: temporaryRecoveryPreviousUIDKey)
+        }
+        userDefaults.synchronize()
+    }
 }
 
 enum DictationPersistentInputRecoveryAction: Equatable {
     case none
     case adopt
     case restore
+    case preserve
     case clear
 }
 
@@ -90,10 +117,10 @@ enum DictationPersistentInputRecoveryPolicy {
         availableUIDs: Set<String>
     ) -> DictationPersistentInputRecoveryAction {
         guard let marker else { return .none }
-        guard currentUID == marker.selectedUID,
-              availableUIDs.contains(marker.previousUID) else {
+        guard currentUID == marker.selectedUID else {
             return .clear
         }
+        guard availableUIDs.contains(marker.previousUID) else { return .preserve }
         return preferenceEnabled ? .adopt : .restore
     }
 }

--- a/Sources/Support/DictationPersistentInputPreferences.swift
+++ b/Sources/Support/DictationPersistentInputPreferences.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+extension Notification.Name {
+    static let dictationPersistentInputPreferenceChanged = Notification.Name(
+        "dictationPersistentInputPreferenceChanged"
+    )
+}
+
+enum DictationPersistentInputPreferences {
+    private static let enabledKey = "dictationKeepRecommendedMicrophoneActive"
+    private static let preferredDeviceUIDKey = "dictationPreferredInputDeviceUID"
+    private static let recoverySelectedUIDKey = "dictationPersistentInputRecoverySelectedUID"
+    private static let recoveryPreviousUIDKey = "dictationPersistentInputRecoveryPreviousUID"
+
+    struct RecoveryMarker: Equatable {
+        let selectedUID: String
+        let previousUID: String
+    }
+
+    static func isEnabled(userDefaults: UserDefaults = .standard) -> Bool {
+        userDefaults.bool(forKey: enabledKey)
+    }
+
+    static func setEnabled(_ enabled: Bool, userDefaults: UserDefaults = .standard) {
+        userDefaults.set(enabled, forKey: enabledKey)
+        NotificationCenter.default.post(
+            name: .dictationPersistentInputPreferenceChanged,
+            object: nil
+        )
+    }
+
+    static func preferredDeviceUID(userDefaults: UserDefaults = .standard) -> String? {
+        guard let value = userDefaults.string(forKey: preferredDeviceUIDKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    static func setPreferredDeviceUID(_ uid: String?, userDefaults: UserDefaults = .standard) {
+        if let uid, !uid.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            userDefaults.set(uid, forKey: preferredDeviceUIDKey)
+        } else {
+            userDefaults.removeObject(forKey: preferredDeviceUIDKey)
+        }
+        NotificationCenter.default.post(
+            name: .dictationPersistentInputPreferenceChanged,
+            object: nil
+        )
+    }
+
+    static func recoveryMarker(userDefaults: UserDefaults = .standard) -> RecoveryMarker? {
+        guard let selectedUID = userDefaults.string(forKey: recoverySelectedUIDKey),
+              !selectedUID.isEmpty,
+              let previousUID = userDefaults.string(forKey: recoveryPreviousUIDKey),
+              !previousUID.isEmpty else {
+            return nil
+        }
+        return RecoveryMarker(selectedUID: selectedUID, previousUID: previousUID)
+    }
+
+    static func setRecoveryMarker(
+        _ marker: RecoveryMarker?,
+        userDefaults: UserDefaults = .standard
+    ) {
+        if let marker {
+            userDefaults.set(marker.selectedUID, forKey: recoverySelectedUIDKey)
+            userDefaults.set(marker.previousUID, forKey: recoveryPreviousUIDKey)
+        } else {
+            userDefaults.removeObject(forKey: recoverySelectedUIDKey)
+            userDefaults.removeObject(forKey: recoveryPreviousUIDKey)
+        }
+        userDefaults.synchronize()
+    }
+}
+
+enum DictationPersistentInputRecoveryAction: Equatable {
+    case none
+    case adopt
+    case restore
+    case clear
+}
+
+enum DictationPersistentInputRecoveryPolicy {
+    static func action(
+        preferenceEnabled: Bool,
+        currentUID: String?,
+        marker: DictationPersistentInputPreferences.RecoveryMarker?,
+        availableUIDs: Set<String>
+    ) -> DictationPersistentInputRecoveryAction {
+        guard let marker else { return .none }
+        guard currentUID == marker.selectedUID,
+              availableUIDs.contains(marker.previousUID) else {
+            return .clear
+        }
+        return preferenceEnabled ? .adopt : .restore
+    }
+}

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -111,6 +111,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     /// AppKit is ready.
     private var activationPolicyController: ActivationPolicyController?
     private var activationPolicySubscriptions: Set<AnyCancellable> = []
+    private let persistentDictationInputController = PersistentDictationInputController()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         if DictationStopBenchmarkRunner.runFromEnvironmentIfRequested() {
@@ -124,6 +125,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         if PermissionsOnboardingPreferences.hasCompleted() {
             CrashReporter.applySessionTrackingPreference()
         }
+        persistentDictationInputController.start()
 
         let activationController = ActivationPolicyController(
             actualPolicy: { NSApp.activationPolicy() }
@@ -506,6 +508,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         if duplicateInstanceShouldTerminateImmediately {
             return
         }
+
+        persistentDictationInputController.stopAndRestore()
 
         if onboardingWindowController.isVisible {
             NotificationCenter.default.post(name: .transcriptedOnboardingWillTerminate, object: nil)

--- a/Sources/UI/Overlay/CapturePillController.swift
+++ b/Sources/UI/Overlay/CapturePillController.swift
@@ -7,6 +7,7 @@ final class CapturePillController {
     private var pillView: CapturePillView?
     private var representedCandidate: MeetingPromptDetector.Candidate?
     private var dismissTask: Task<Void, Never>?
+    private var countdownTask: Task<Void, Never>?
     private var eventMonitor: Any?
 
     var onRecord: ((MeetingPromptDetector.Candidate) -> Void)?
@@ -16,6 +17,7 @@ final class CapturePillController {
 
     deinit {
         dismissTask?.cancel()
+        countdownTask?.cancel()
         if let eventMonitor {
             NSEvent.removeMonitor(eventMonitor)
         }
@@ -30,7 +32,8 @@ final class CapturePillController {
         guard let panel, let pillView else { return false }
 
         representedCandidate = candidate
-        pillView.update(candidate: candidate)
+        let timeoutSeconds = max(1, Int(ceil(timeout)))
+        pillView.update(candidate: candidate, timeoutSeconds: timeoutSeconds)
         panel.onCancel = { [weak self] in self?.dismiss(notify: true) }
         panel.onDefault = { [weak self] in self?.record() }
 
@@ -39,12 +42,15 @@ final class CapturePillController {
 
         installEventMonitor()
         scheduleDismiss(timeout: timeout)
+        scheduleCountdown(seconds: timeoutSeconds)
         return true
     }
 
     func dismiss(notify: Bool) {
         dismissTask?.cancel()
         dismissTask = nil
+        countdownTask?.cancel()
+        countdownTask = nil
 
         if let eventMonitor {
             NSEvent.removeMonitor(eventMonitor)
@@ -102,6 +108,21 @@ final class CapturePillController {
             guard let self, let candidate = self.representedCandidate else { return }
             self.dismiss(notify: false)
             self.onExpired?(candidate)
+        }
+    }
+
+    private func scheduleCountdown(seconds: Int) {
+        countdownTask?.cancel()
+        countdownTask = Task { @MainActor [weak self] in
+            var secondsRemaining = max(1, seconds)
+            self?.pillView?.updateCountdown(secondsRemaining: secondsRemaining)
+
+            while secondsRemaining > 1 {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                secondsRemaining -= 1
+                self?.pillView?.updateCountdown(secondsRemaining: secondsRemaining)
+            }
         }
     }
 
@@ -193,7 +214,7 @@ final class CapturePillPanel: NSPanel {
 
 @available(macOS 14.0, *)
 private final class CapturePillView: NSView {
-    static let preferredSize = NSSize(width: 540, height: 74)
+    static let preferredSize = NSSize(width: 720, height: 90)
 
     var onRecord: (() -> Void)?
     var onDismiss: (() -> Void)?
@@ -202,6 +223,9 @@ private final class CapturePillView: NSView {
     private let iconView = NSImageView()
     private let titleLabel = NSTextField(labelWithString: "")
     private let detailLabel = NSTextField(labelWithString: "")
+    private let countdownLabel = NSTextField(labelWithString: "")
+    private var accessibilityMeetingName = "Meeting detected"
+    private var accessibilityDetail = "Record this meeting?"
     private let dismissButton = NSButton(title: "Not now", target: nil, action: nil)
     private let remindButton = NSButton(title: "Remind me soon", target: nil, action: nil)
     private let recordButton = NSButton(title: "Record", target: nil, action: nil)
@@ -229,6 +253,11 @@ private final class CapturePillView: NSView {
         detailLabel.lineBreakMode = .byTruncatingTail
         addSubview(detailLabel)
 
+        countdownLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .medium)
+        countdownLabel.textColor = .secondaryLabelColor
+        countdownLabel.lineBreakMode = .byTruncatingTail
+        addSubview(countdownLabel)
+
         configureButton(dismissButton, title: "Not now", isPrimary: false, action: #selector(dismissTapped))
         configureButton(remindButton, title: "Remind me soon", isPrimary: false, action: #selector(remindTapped))
         configureButton(recordButton, title: "Record", isPrimary: true, action: #selector(recordTapped))
@@ -241,6 +270,11 @@ private final class CapturePillView: NSView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+    }
 
     override func layout() {
         super.layout()
@@ -273,16 +307,27 @@ private final class CapturePillView: NSView {
 
         let textX = iconView.frame.maxX + 12
         let textWidth = dismissButton.frame.minX - 12 - textX
-        titleLabel.frame = NSRect(x: textX, y: 38, width: max(40, textWidth), height: 18)
-        detailLabel.frame = NSRect(x: textX, y: 18, width: max(40, textWidth), height: 16)
+        titleLabel.frame = NSRect(x: textX, y: 53, width: max(40, textWidth), height: 18)
+        detailLabel.frame = NSRect(x: textX, y: 33, width: max(40, textWidth), height: 16)
+        countdownLabel.frame = NSRect(x: textX, y: 15, width: max(40, textWidth), height: 14)
     }
 
-    func update(candidate: MeetingPromptDetector.Candidate) {
+    func update(candidate: MeetingPromptDetector.Candidate, timeoutSeconds: Int) {
         let meetingName = candidate.suggestedTranscriptTitle ?? candidate.title
+        accessibilityMeetingName = meetingName
+        accessibilityDetail = candidate.detail
         titleLabel.stringValue = meetingName
         detailLabel.stringValue = candidate.detail
-        setAccessibilityValue("\(meetingName). \(candidate.detail)")
+        updateCountdown(secondsRemaining: timeoutSeconds)
         needsLayout = true
+    }
+
+    func updateCountdown(secondsRemaining: Int) {
+        let clampedSeconds = max(1, secondsRemaining)
+        countdownLabel.stringValue = "Closes in \(clampedSeconds)s"
+        setAccessibilityValue(
+            "\(accessibilityMeetingName). \(accessibilityDetail). Closes in \(clampedSeconds) seconds."
+        )
     }
 
     private func configureButton(
@@ -291,17 +336,14 @@ private final class CapturePillView: NSView {
         isPrimary: Bool,
         action: Selector
     ) {
-        button.title = title
         button.target = self
         button.action = action
         button.isBordered = false
         button.font = .systemFont(ofSize: 12, weight: .semibold)
         button.wantsLayer = true
         button.layer?.cornerRadius = 8
-        button.layer?.backgroundColor = isPrimary
-            ? NSColor.controlAccentColor.cgColor
-            : NSColor.controlColor.withAlphaComponent(0.85).cgColor
-        button.contentTintColor = isPrimary ? .white : .labelColor
+        button.layer?.borderWidth = isPrimary ? 0 : 1
+        button.identifier = NSUserInterfaceItemIdentifier(isPrimary ? "primary" : "secondary")
         button.setAccessibilityLabel(title)
         let help: String
         switch title {
@@ -313,7 +355,38 @@ private final class CapturePillView: NSView {
             help = "Dismiss this meeting prompt."
         }
         button.setAccessibilityHelp(help)
+        button.attributedTitle = buttonTitle(title, isPrimary: isPrimary)
         addSubview(button)
+        applyColors(to: button, isPrimary: isPrimary)
+    }
+
+    private func applyColors() {
+        layer?.backgroundColor = NSColor.windowBackgroundColor.withAlphaComponent(0.98).cgColor
+        layer?.borderColor = NSColor.separatorColor.withAlphaComponent(0.55).cgColor
+        for button in [dismissButton, remindButton, recordButton] {
+            let isPrimary = button.identifier?.rawValue == "primary"
+            applyColors(to: button, isPrimary: isPrimary)
+            button.attributedTitle = buttonTitle(button.title, isPrimary: isPrimary)
+        }
+    }
+
+    private func applyColors(to button: NSButton, isPrimary: Bool) {
+        button.layer?.backgroundColor = isPrimary
+            ? NSColor.controlAccentColor.cgColor
+            : NSColor.labelColor.withAlphaComponent(0.12).cgColor
+        button.layer?.borderColor = isPrimary
+            ? NSColor.clear.cgColor
+            : NSColor.labelColor.withAlphaComponent(0.28).cgColor
+    }
+
+    private func buttonTitle(_ title: String, isPrimary: Bool) -> NSAttributedString {
+        NSAttributedString(
+            string: title,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 12, weight: .semibold),
+                .foregroundColor: isPrimary ? NSColor.white : NSColor.labelColor,
+            ]
+        )
     }
 
     @objc private func recordTapped() {

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1709,7 +1709,27 @@ class DictationSessionController: ObservableObject {
     }
 
     private func pasteWithClipboardRestore(_ text: String) -> DictationPasteOutcome {
-        let outcome = textPaster.paste(text, target: sessionPasteTarget)
+        retargetPasteToCurrentFocus()
+        let selectedAutoEnterTarget = DictationAutoSendPreferences.isEnabled()
+            && sessionSourceApp?.bundleIdentifier.map {
+                DictationAutoSendPreferences.allowedBundleIDs().contains($0)
+            } == true
+        let outcome = textPaster.paste(
+            text,
+            target: sessionPasteTarget,
+            allowClipboardReadConfirmation: selectedAutoEnterTarget
+        )
+        if let diagnostic = textPaster.lastConfirmationDiagnostic {
+            EventReporter.shared.capture(
+                level: diagnostic.event == "dictation_paste_confirmed" ? .info : .warning,
+                engine: "overlay",
+                event: diagnostic.event,
+                message: diagnostic.event == "dictation_paste_confirmed"
+                    ? "Paste delivery confirmed from privacy-safe target signals"
+                    : "Paste delivery could not be confirmed from privacy-safe target signals",
+                context: diagnostic.context
+            )
+        }
 
         switch outcome.copyReason {
         case .accessibilityMissing:
@@ -1735,6 +1755,35 @@ class DictationSessionController: ObservableObject {
         }
 
         return outcome
+    }
+
+    private func retargetPasteToCurrentFocus() {
+        let previousTarget = sessionPasteTarget
+        let frontmostApp = NSWorkspace.shared.frontmostApplication
+        let frontmostTarget = DictationPasteTarget.capture(sourceApp: frontmostApp)
+        let resolvedTarget = DictationPasteTarget.preferredDestination(
+            frontmostProcessIdentifier: frontmostApp?.processIdentifier,
+            frontmostBundleIdentifier: frontmostApp?.bundleIdentifier,
+            transcriptedBundleIdentifier: Bundle.main.bundleIdentifier,
+            fallback: previousTarget
+        )
+
+        sessionPasteTarget = resolvedTarget
+        if resolvedTarget == frontmostTarget,
+           frontmostApp?.bundleIdentifier != Bundle.main.bundleIdentifier {
+            sessionSourceApp = frontmostApp
+        }
+
+        if resolvedTarget != previousTarget {
+            appState?.logger.log("DICTATION | paste target updated to current focus")
+            EventReporter.shared.capture(
+                level: .info,
+                engine: "overlay",
+                event: "dictation_paste_target_updated",
+                message: "Paste target followed current focus",
+                context: ["target_changed": "true"]
+            )
+        }
     }
 
     private func performAutoEnterIfNeeded(

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1710,14 +1710,9 @@ class DictationSessionController: ObservableObject {
 
     private func pasteWithClipboardRestore(_ text: String) -> DictationPasteOutcome {
         retargetPasteToCurrentFocus()
-        let selectedAutoEnterTarget = DictationAutoSendPreferences.isEnabled()
-            && sessionSourceApp?.bundleIdentifier.map {
-                DictationAutoSendPreferences.allowedBundleIDs().contains($0)
-            } == true
         let outcome = textPaster.paste(
             text,
-            target: sessionPasteTarget,
-            allowClipboardReadConfirmation: selectedAutoEnterTarget
+            target: sessionPasteTarget
         )
         if let diagnostic = textPaster.lastConfirmationDiagnostic {
             EventReporter.shared.capture(

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -40,6 +40,9 @@ struct TranscriptedSettingsView: View {
     @State private var showSpeakerEmbedderSwitchConfirm = false
     @State private var uiSoundsEnabled = UISoundPreferences.isEnabled()
     @State private var autoEnterEnabled = DictationAutoSendPreferences.isEnabled()
+    @State private var keepRecommendedMicrophoneActive = DictationPersistentInputPreferences.isEnabled()
+    @State private var preferredDictationInputUID = DictationPersistentInputPreferences.preferredDeviceUID()
+    @State private var availableDictationInputs = (try? CoreAudioInputDeviceLookup.availableInputDevices()) ?? []
     @State private var autoEnterKey = DictationAutoSendPreferences.sendKey()
     @State private var autoEnterAllowedBundleIDs = DictationAutoSendPreferences.allowedBundleIDs()
     @State private var autoEnterAppCandidates: [AutoEnterAppCandidate] = []
@@ -2526,6 +2529,51 @@ struct TranscriptedSettingsView: View {
                     .disabled(!autoEnterEnabled)
                 }
             }
+
+            SettingsSection(
+                title: "Bluetooth Start Speed",
+                detail: "Avoid switching microphone routes every time dictation starts."
+            ) {
+                SettingsToggleRow(
+                    title: "Faster Bluetooth dictation",
+                    detail: keepRecommendedMicrophoneActive
+                        ? "Keeps your preferred non-Bluetooth microphone selected while Transcripted is open. This changes the microphone used by other apps, but does not record while idle."
+                        : "Off. Bluetooth dictation may take longer while macOS switches microphone routes.",
+                    isOn: Binding(
+                        get: { keepRecommendedMicrophoneActive },
+                        set: { newValue in
+                            keepRecommendedMicrophoneActive = newValue
+                            trackSettingsToggle("keep_recommended_microphone_active", enabled: newValue, page: .shortcuts)
+                            DictationPersistentInputPreferences.setEnabled(newValue)
+                        }
+                    )
+                )
+
+                Picker("Preferred microphone", selection: Binding(
+                    get: { preferredDictationInputUID },
+                    set: { newValue in
+                        preferredDictationInputUID = newValue
+                        trackSettingsAction("change_preferred_dictation_microphone", page: .shortcuts)
+                        DictationPersistentInputPreferences.setPreferredDeviceUID(newValue)
+                    }
+                )) {
+                    Text("Automatic (recommended)").tag(String?.none)
+                    ForEach(preferredDictationInputCandidates, id: \.id) { device in
+                        Text(device.name).tag(device.uid)
+                    }
+                }
+                .disabled(!keepRecommendedMicrophoneActive)
+
+                SettingsInlineActionButton(title: "Refresh microphones", symbolName: "arrow.clockwise") {
+                    trackSettingsAction("refresh_dictation_microphones", page: .shortcuts)
+                    refreshDictationInputCandidates()
+                }
+
+                Text("Fallback order: preferred microphone, then the recommended Mac or display microphone, then the current system input.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
@@ -2935,6 +2983,43 @@ struct TranscriptedSettingsView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .font(.caption)
+            }
+
+            Divider()
+
+            SettingsToggleRow(
+                title: "Faster Bluetooth dictation",
+                detail: keepRecommendedMicrophoneActive
+                    ? "Keeps the preferred microphone selected Mac-wide while Transcripted is open; it does not record while idle."
+                    : "Allow macOS to switch microphone routes for each dictation.",
+                isOn: Binding(
+                    get: { keepRecommendedMicrophoneActive },
+                    set: { newValue in
+                        keepRecommendedMicrophoneActive = newValue
+                        trackSettingsToggle("keep_recommended_microphone_active", enabled: newValue, page: .general)
+                        DictationPersistentInputPreferences.setEnabled(newValue)
+                    }
+                )
+            )
+
+            Picker("Preferred microphone", selection: Binding(
+                get: { preferredDictationInputUID },
+                set: { newValue in
+                    preferredDictationInputUID = newValue
+                    trackSettingsAction("change_preferred_dictation_microphone", page: .general)
+                    DictationPersistentInputPreferences.setPreferredDeviceUID(newValue)
+                }
+            )) {
+                Text("Automatic (recommended)").tag(String?.none)
+                ForEach(preferredDictationInputCandidates, id: \.id) { device in
+                    Text(device.name).tag(device.uid)
+                }
+            }
+            .disabled(!keepRecommendedMicrophoneActive)
+
+            SettingsInlineActionButton(title: "Refresh microphones", symbolName: "arrow.clockwise") {
+                trackSettingsAction("refresh_dictation_microphones", page: .general)
+                refreshDictationInputCandidates()
             }
 
             Divider()
@@ -5500,6 +5585,17 @@ struct TranscriptedSettingsView: View {
         autoEnterAllowedBundleIDs.sorted { lhs, rhs in
             autoEnterDisplayName(for: lhs).localizedCaseInsensitiveCompare(autoEnterDisplayName(for: rhs)) == .orderedAscending
         }
+    }
+
+    private var preferredDictationInputCandidates: [DictationAudioDevice] {
+        availableDictationInputs
+            .filter { $0.uid != nil }
+            .filter { DictationInputDeviceSelectionPolicy.deviceClass(for: $0) != "bluetooth" }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    private func refreshDictationInputCandidates() {
+        availableDictationInputs = (try? CoreAudioInputDeviceLookup.availableInputDevices()) ?? []
     }
 
     private func setAutoEnterApp(

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -406,12 +406,12 @@ func testBluetoothRouteContract() {
             "superseded recovery snapshots should restore the temporary system input before throwing cancellation"
         )
         assertTrue(
-            startBody.contains("func failAudioStart(_ operation: String) async -> Bool"),
-            "failed starts should share one cleanup path for temporary system input restores"
+            startBody.contains("func failAudioStart() async -> Bool"),
+            "failed starts should share one bounded-retry path"
         )
-        assertTrue(
-            startBody.contains("return await failAudioStart(\"start_recording_engine_start_failed\")"),
-            "engine-start failures after the temporary system input override should restore before returning false"
+        assertFalse(
+            startBody.contains("restorePendingSystemInputAfterRecording"),
+            "retryable start failures should keep the temporary built-in input stable instead of restoring and reapplying it"
         )
         assertTrue(
             stopBody.contains("await restorePendingSystemInputAfterRecording(operation: \"stop_recording\")"),
@@ -432,6 +432,60 @@ func testBluetoothRouteContract() {
         assertTrue(
             cleanupBody.contains("schedulePendingSystemInputRestore(operation: \"abandon_blocked_recording_start\")"),
             "blocked-start abandonment should restore the temporary system input"
+        )
+        assertTrue(
+            cleanupBody.contains("await restorePendingSystemInputAfterRecording(operation: \"reset_after_failed_recording_start\")"),
+            "final failed-start cleanup should restore the temporary system input after retries are exhausted"
+        )
+    }
+
+    runSuite("Bluetooth route contract - active startup owns its config changes") {
+        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetEngine.swift")
+        guard let handlerStart = source.range(of: "private func handleAudioConfigChange() async"),
+              let handlerEnd = source.range(of: "private func recordRouteChangeAnalytics", range: handlerStart.upperBound..<source.endIndex) else {
+            assertTrue(false, "test should find the audio config-change handler")
+            return
+        }
+        let handlerBody = String(source[handlerStart.lowerBound..<handlerEnd.lowerBound])
+        guard let startupGuard = handlerBody.range(of: "if audioStartInProgress"),
+              let generationBump = handlerBody.range(of: "audioGraphGeneration += 1") else {
+            assertTrue(false, "startup config changes should be ignored before recovery mutates the graph")
+            return
+        }
+        assertTrue(
+            startupGuard.lowerBound < generationBump.lowerBound,
+            "recording startup should own route validation before config recovery can rebuild the graph"
+        )
+    }
+
+    runSuite("Bluetooth route contract - persistent input follows reconnects and restores on shutdown") {
+        let source = readBluetoothRouteContractFile("Sources/Speech/PersistentDictationInputController.swift")
+        guard let start = source.range(of: "func start()"),
+              let stop = source.range(of: "func stopAndRestore()"),
+              let install = source.range(of: "private func installDefaultInputListener()"),
+              let installDeviceList = source.range(of: "private func installDeviceListListener()"),
+              let remove = source.range(of: "private func removeDefaultInputListener()"),
+              let removeDeviceList = source.range(of: "private func removeDeviceListListener()"),
+              let restore = source.range(of: "private func restoreIfStillOwned") else {
+            assertTrue(false, "persistent input controller should expose bounded lifecycle seams")
+            return
+        }
+
+        assertTrue(start.lowerBound < install.lowerBound, "controller startup should install its reconnect listener")
+        assertTrue(install.lowerBound < remove.lowerBound, "listener teardown should remain paired with installation")
+        assertTrue(installDeviceList.lowerBound < removeDeviceList.lowerBound, "USB device-list monitoring should have paired teardown")
+        assertTrue(stop.lowerBound < restore.lowerBound, "shutdown should route through ownership-safe restoration")
+        assertTrue(
+            source.contains("guard DictationPersistentInputPreferences.isEnabled() else { return }"),
+            "device-change reapplication must stay gated by explicit user opt-in"
+        )
+        assertTrue(
+            source.contains("guard currentInput == activeOverride.selectedInput else"),
+            "restoration must not overwrite a microphone the user changed outside Transcripted"
+        )
+        assertTrue(
+            source.contains("mSelector: kAudioHardwarePropertyDevices"),
+            "the saved preferred microphone should be reconsidered when USB devices reconnect"
         )
     }
 

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -437,6 +437,14 @@ func testBluetoothRouteContract() {
             cleanupBody.contains("await restorePendingSystemInputAfterRecording(operation: \"reset_after_failed_recording_start\")"),
             "final failed-start cleanup should restore the temporary system input after retries are exhausted"
         )
+        assertTrue(
+            source.contains("DictationPersistentInputPreferences.setTemporaryRecoveryMarker(recoveryMarker)"),
+            "temporary system-input ownership must survive a crash during dictation"
+        )
+        assertTrue(
+            source.contains("DictationPersistentInputPreferences.setTemporaryRecoveryMarker(nil)"),
+            "successful restoration must clear the temporary crash marker"
+        )
     }
 
     runSuite("Bluetooth route contract - active startup owns its config changes") {
@@ -476,8 +484,10 @@ func testBluetoothRouteContract() {
         assertTrue(installDeviceList.lowerBound < removeDeviceList.lowerBound, "USB device-list monitoring should have paired teardown")
         assertTrue(stop.lowerBound < restore.lowerBound, "shutdown should route through ownership-safe restoration")
         assertTrue(
-            source.contains("guard DictationPersistentInputPreferences.isEnabled() else { return }"),
-            "device-change reapplication must stay gated by explicit user opt-in"
+            source.contains("guard DictationPersistentInputPreferences.isEnabled()")
+                && source.contains("|| DictationPersistentInputPreferences.recoveryMarker() != nil")
+                && source.contains("|| shouldRecoverInheritedTemporaryOverride"),
+            "device changes must retry inherited crash restoration without treating current-session overrides as inherited"
         )
         assertTrue(
             source.contains("guard currentInput == activeOverride.selectedInput else"),

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -6,6 +6,21 @@ import Foundation
 
 func testClipboardRestoringTextPaster() async {
     await MainActor.run {
+        runSuite("ClipboardRestoringTextPaster confirmation bounds synchronous AX reads") {
+            let source = try! String(
+                contentsOfFile: "Sources/Support/ClipboardRestoringTextPaster.swift",
+                encoding: .utf8
+            )
+            assertTrue(
+                source.contains("AXUIElementSetMessagingTimeout(element, messagingTimeout)"),
+                "paste confirmation must bound synchronous AX reads so busy editors cannot stall delivery"
+            )
+            assertTrue(
+                source.contains("private static let messagingTimeout: Float = 0.05"),
+                "paste confirmation should fail fast when a target editor is temporarily unresponsive"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.restorePasteboardItems — preserves user clipboard changes") {
             let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedClipboardTest-\(UUID().uuidString)"))
             let paster = ClipboardRestoringTextPaster()
@@ -340,6 +355,178 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("DictationPasteTarget — follows the app focused at paste time") {
+            let originalTarget = DictationPasteTarget(
+                processIdentifier: 42,
+                bundleIdentifier: "com.example.Original"
+            )
+
+            assertEqual(
+                DictationPasteTarget.preferredDestination(
+                    frontmostProcessIdentifier: 84,
+                    frontmostBundleIdentifier: "com.example.Current",
+                    transcriptedBundleIdentifier: "com.justinbetker.draft",
+                    fallback: originalTarget
+                ),
+                DictationPasteTarget(
+                    processIdentifier: 84,
+                    bundleIdentifier: "com.example.Current"
+                ),
+                "manual dictation should paste into the app focused when pasteback runs"
+            )
+            assertEqual(
+                DictationPasteTarget.preferredDestination(
+                    frontmostProcessIdentifier: 7,
+                    frontmostBundleIdentifier: "com.justinbetker.draft",
+                    transcriptedBundleIdentifier: "com.justinbetker.draft",
+                    fallback: originalTarget
+                ),
+                originalTarget,
+                "Transcripted's own overlay should not replace the user's last external target"
+            )
+            assertEqual(
+                DictationPasteTarget.preferredDestination(
+                    frontmostProcessIdentifier: nil,
+                    frontmostBundleIdentifier: nil,
+                    transcriptedBundleIdentifier: "com.justinbetker.draft",
+                    fallback: originalTarget
+                ),
+                originalTarget,
+                "missing frontmost-app metadata should preserve the safe fallback target"
+            )
+        }
+
+        runSuite("FocusedTextPasteConfirmationPolicy — accepts editor-normalized paste changes") {
+            assertEqual(
+                FocusedTextPasteConfirmationPolicy.observableString(
+                    from: NSAttributedString(string: "Notes editor value")
+                ),
+                "Notes editor value",
+                "rich editors should expose attributed AX values as confirmable text"
+            )
+            assertTrue(
+                FocusedTextPasteConfirmationPolicy.didObservePaste(
+                    initialValue: "Before ",
+                    currentValue: "Before Transcripted changed \u{201C}straight quotes\u{201D} to smart quotes",
+                    pastedText: "Transcripted changed \"straight quotes\" to smart quotes"
+                ),
+                "a changed focused-editor value should confirm paste even when the target normalizes text"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObservePaste(
+                    initialValue: "Unchanged",
+                    currentValue: "Unchanged",
+                    pastedText: "Expected paste"
+                ),
+                "an unchanged editor value should not confirm paste"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObservePaste(
+                    initialValue: nil,
+                    currentValue: "Changed",
+                    pastedText: "Changed"
+                ),
+                "confirmation remains unavailable when the initial editor value cannot be observed"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObservePaste(
+                    initialValue: "Before",
+                    currentValue: "Before unrelated edit",
+                    pastedText: "A much longer expected dictation that was not inserted"
+                ),
+                "an unrelated editor change should not confirm the requested paste"
+            )
+            assertTrue(
+                FocusedTextPasteConfirmationPolicy.didObservePaste(
+                    initialValue: "Replace this",
+                    currentValue: "Replacement",
+                    pastedText: "Replacement",
+                    replacedSelectionLength: "Replace this".utf16.count
+                ),
+                "replacement pastes should confirm from the observed length change"
+            )
+            assertTrue(
+                FocusedTextPasteConfirmationPolicy.didObserveSelectionPaste(
+                    initialRange: .init(location: 7, length: 0),
+                    currentRange: .init(location: 7 + "Inserted text".utf16.count, length: 0),
+                    pastedText: "Inserted text",
+                    clipboardWasRead: true
+                ),
+                "rich editors should confirm a clipboard read plus the expected cursor movement"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObserveSelectionPaste(
+                    initialRange: .init(location: 7, length: 0),
+                    currentRange: .init(location: 7 + "Inserted text".utf16.count, length: 0),
+                    pastedText: "Inserted text",
+                    clipboardWasRead: false
+                ),
+                "cursor movement alone should not treat an unrelated edit as paste proof"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObserveSelectionPaste(
+                    initialRange: .init(location: 7, length: 0),
+                    currentRange: .init(location: 8, length: 0),
+                    pastedText: "Inserted text",
+                    clipboardWasRead: true
+                ),
+                "an observer read plus unrelated cursor movement should not confirm paste"
+            )
+            let dispatchTime: CFAbsoluteTime = 100
+            assertTrue(
+                FocusedTextPasteConfirmationPolicy.didObserveTargetChange(
+                    pasteDispatchedAt: dispatchTime,
+                    clipboardReadAt: dispatchTime + 0.02,
+                    targetChangedAt: dispatchTime + 0.04
+                ),
+                "the exact target changing immediately after its post-dispatch clipboard read should confirm paste"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObserveTargetChange(
+                    pasteDispatchedAt: dispatchTime,
+                    clipboardReadAt: dispatchTime - 0.01,
+                    targetChangedAt: dispatchTime + 0.04
+                ),
+                "a clipboard observer read before Cmd+V should not confirm a later target edit"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObserveTargetChange(
+                    pasteDispatchedAt: dispatchTime,
+                    clipboardReadAt: dispatchTime + 0.02,
+                    targetChangedAt: dispatchTime + 1.5
+                ),
+                "an unrelated delayed target edit should not confirm paste"
+            )
+        }
+
+        runSuite("FocusedTextPasteConfirmationPolicy — selected Auto Enter reads stay immediate and frontmost") {
+            let dispatchedAt: CFAbsoluteTime = 100
+            assertTrue(
+                FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
+                    pasteDispatchedAt: dispatchedAt,
+                    clipboardReadAt: dispatchedAt + 0.05,
+                    targetStillFrontmost: true
+                ),
+                "an immediate selected-target clipboard read should confirm the opted-in Auto Enter path"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
+                    pasteDispatchedAt: dispatchedAt,
+                    clipboardReadAt: dispatchedAt + 0.25,
+                    targetStillFrontmost: true
+                ),
+                "a delayed clipboard observer read must not confirm Auto Enter"
+            )
+            assertFalse(
+                FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
+                    pasteDispatchedAt: dispatchedAt,
+                    clipboardReadAt: dispatchedAt + 0.05,
+                    targetStillFrontmost: false
+                ),
+                "a clipboard read after focus changes must not confirm Auto Enter"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster — waits briefly for menu-triggered target activation") {
             assertTrue(
                 TranscriptedConstants.clipboardTargetActivationWait > 0
@@ -434,6 +621,56 @@ func testClipboardRestoringTextPaster() async {
             restoredClipboard,
             existingClipboard,
             "waiting for pending restore should include the fallback restore before auto-enter"
+        )
+    }
+
+    await runSuite("ClipboardRestoringTextPaster.paste — selected Auto Enter target may confirm its post-dispatch clipboard read") {
+        let existingClipboard = "selected app original clipboard"
+        let dictationText = "selected app dictation"
+        let pasteboardName = NSPasteboard.Name("TranscriptedSelectedAutoEnterPasteTest-\(UUID().uuidString)")
+        let paster = await MainActor.run { ClipboardRestoringTextPaster() }
+
+        let outcome = await MainActor.run {
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            pasteboard.clearContents()
+            pasteboard.setString(existingClipboard, forType: .string)
+            return paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    _ = pasteboard.string(forType: .string)
+                    return true
+                },
+                allowClipboardReadConfirmation: true,
+                selectedTargetStillFrontmost: { true },
+                restoreDelay: 5_000_000,
+                fallbackRestoreDelay: 120_000_000,
+                pasteConfirmationWait: 0.2
+            )
+        }
+
+        assertEqual(outcome, .pasted, "an explicitly selected Auto Enter app may confirm its own post-dispatch clipboard read")
+        await paster.waitForPendingClipboardRestore()
+        let restoredClipboard = await MainActor.run {
+            NSPasteboard(name: pasteboardName).string(forType: .string)
+        }
+        assertEqual(restoredClipboard, existingClipboard, "selected-app confirmation should restore the original clipboard")
+    }
+
+    runSuite("ClipboardRestoringTextPaster.paste — selected Auto Enter clipboard read fails closed without a target") {
+        let source = try! String(
+            contentsOfFile: "Sources/Support/ClipboardRestoringTextPaster.swift",
+            encoding: .utf8
+        )
+        assertTrue(
+            source.contains("let selectedTargetIsFrontmost = selectedTargetStillFrontmost ?? {\n            target?.matchesCurrentFrontmostApp() == true"),
+            "a missing target must not be treated as frontmost for Auto Enter confirmation"
+        )
+        assertFalse(
+            source.contains("let selectedTargetIsFrontmost = selectedTargetStillFrontmost ?? {\n            target?.matchesCurrentFrontmostApp() != false"),
+            "the nil-target permissive check must not return"
         )
     }
 

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -499,34 +499,6 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
-        runSuite("FocusedTextPasteConfirmationPolicy — selected Auto Enter reads stay immediate and frontmost") {
-            let dispatchedAt: CFAbsoluteTime = 100
-            assertTrue(
-                FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
-                    pasteDispatchedAt: dispatchedAt,
-                    clipboardReadAt: dispatchedAt + 0.05,
-                    targetStillFrontmost: true
-                ),
-                "an immediate selected-target clipboard read should confirm the opted-in Auto Enter path"
-            )
-            assertFalse(
-                FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
-                    pasteDispatchedAt: dispatchedAt,
-                    clipboardReadAt: dispatchedAt + 0.25,
-                    targetStillFrontmost: true
-                ),
-                "a delayed clipboard observer read must not confirm Auto Enter"
-            )
-            assertFalse(
-                FocusedTextPasteConfirmationPolicy.didObserveSelectedAutoEnterTargetRead(
-                    pasteDispatchedAt: dispatchedAt,
-                    clipboardReadAt: dispatchedAt + 0.05,
-                    targetStillFrontmost: false
-                ),
-                "a clipboard read after focus changes must not confirm Auto Enter"
-            )
-        }
-
         runSuite("ClipboardRestoringTextPaster — waits briefly for menu-triggered target activation") {
             assertTrue(
                 TranscriptedConstants.clipboardTargetActivationWait > 0
@@ -624,7 +596,7 @@ func testClipboardRestoringTextPaster() async {
         )
     }
 
-    await runSuite("ClipboardRestoringTextPaster.paste — selected Auto Enter target may confirm its post-dispatch clipboard read") {
+    await runSuite("ClipboardRestoringTextPaster.paste — unattributed clipboard reads never confirm paste") {
         let existingClipboard = "selected app original clipboard"
         let dictationText = "selected app dictation"
         let pasteboardName = NSPasteboard.Name("TranscriptedSelectedAutoEnterPasteTest-\(UUID().uuidString)")
@@ -643,34 +615,36 @@ func testClipboardRestoringTextPaster() async {
                     _ = pasteboard.string(forType: .string)
                     return true
                 },
-                allowClipboardReadConfirmation: true,
-                selectedTargetStillFrontmost: { true },
                 restoreDelay: 5_000_000,
                 fallbackRestoreDelay: 120_000_000,
                 pasteConfirmationWait: 0.2
             )
         }
 
-        assertEqual(outcome, .pasted, "an explicitly selected Auto Enter app may confirm its own post-dispatch clipboard read")
+        assertEqual(
+            outcome,
+            .copied(
+                "Transcripted sent paste, but this target did not expose paste confirmation. The text stays copied.",
+                reason: .pasteConfirmationUnavailable
+            ),
+            "a clipboard manager read must not masquerade as target-specific paste confirmation"
+        )
         await paster.waitForPendingClipboardRestore()
-        let restoredClipboard = await MainActor.run {
+        let retainedClipboard = await MainActor.run {
             NSPasteboard(name: pasteboardName).string(forType: .string)
         }
-        assertEqual(restoredClipboard, existingClipboard, "selected-app confirmation should restore the original clipboard")
+        assertEqual(retainedClipboard, dictationText, "unconfirmed paste must keep recovery text available")
     }
 
-    runSuite("ClipboardRestoringTextPaster.paste — selected Auto Enter clipboard read fails closed without a target") {
+    runSuite("ClipboardRestoringTextPaster.paste — provider reads are not an Auto Enter confirmation API") {
         let source = try! String(
             contentsOfFile: "Sources/Support/ClipboardRestoringTextPaster.swift",
             encoding: .utf8
         )
-        assertTrue(
-            source.contains("let selectedTargetIsFrontmost = selectedTargetStillFrontmost ?? {\n            target?.matchesCurrentFrontmostApp() == true"),
-            "a missing target must not be treated as frontmost for Auto Enter confirmation"
-        )
         assertFalse(
-            source.contains("let selectedTargetIsFrontmost = selectedTargetStillFrontmost ?? {\n            target?.matchesCurrentFrontmostApp() != false"),
-            "the nil-target permissive check must not return"
+            source.contains("allowClipboardReadConfirmation")
+                || source.contains("selectedTargetStillFrontmost"),
+            "an unattributed pasteboard provider read must never restore the clipboard or enable Auto Enter"
         )
     }
 

--- a/Tests/DictationInputDeviceSelectionPolicyTests.swift
+++ b/Tests/DictationInputDeviceSelectionPolicyTests.swift
@@ -1,6 +1,98 @@
 import Foundation
 
 func testDictationInputDeviceSelectionPolicy() {
+    runSuite("DictationPersistentInputPreferences defaults off and persists explicit opt-in") {
+        let suiteName = "DictationPersistentInputPreferencesTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        assertFalse(
+            DictationPersistentInputPreferences.isEnabled(userDefaults: defaults),
+            "keeping a Mac-wide microphone active must remain explicit opt-in"
+        )
+        DictationPersistentInputPreferences.setEnabled(true, userDefaults: defaults)
+        assertTrue(
+            DictationPersistentInputPreferences.isEnabled(userDefaults: defaults),
+            "the faster Bluetooth start preference should persist"
+        )
+        DictationPersistentInputPreferences.setPreferredDeviceUID("usb-mic-uid", userDefaults: defaults)
+        assertEqual(
+            DictationPersistentInputPreferences.preferredDeviceUID(userDefaults: defaults),
+            "usb-mic-uid",
+            "the preferred microphone should persist by stable CoreAudio UID"
+        )
+        let marker = DictationPersistentInputPreferences.RecoveryMarker(
+            selectedUID: "usb-mic-uid",
+            previousUID: "system-mic-uid"
+        )
+        DictationPersistentInputPreferences.setRecoveryMarker(marker, userDefaults: defaults)
+        assertEqual(
+            DictationPersistentInputPreferences.recoveryMarker(userDefaults: defaults),
+            marker,
+            "unclean exits should leave a durable restoration obligation"
+        )
+    }
+
+    runSuite("DictationPersistentInputRecoveryPolicy adopts, restores, or clears crash markers") {
+        let marker = DictationPersistentInputPreferences.RecoveryMarker(
+            selectedUID: "selected",
+            previousUID: "previous"
+        )
+        assertEqual(
+            DictationPersistentInputRecoveryPolicy.action(
+                preferenceEnabled: true,
+                currentUID: "selected",
+                marker: marker,
+                availableUIDs: ["selected", "previous"]
+            ),
+            .adopt,
+            "a relaunched opted-in app should reclaim the restoration obligation"
+        )
+        assertEqual(
+            DictationPersistentInputRecoveryPolicy.action(
+                preferenceEnabled: false,
+                currentUID: "selected",
+                marker: marker,
+                availableUIDs: ["selected", "previous"]
+            ),
+            .restore,
+            "a disabled preference should restore the prior microphone on relaunch"
+        )
+        assertEqual(
+            DictationPersistentInputRecoveryPolicy.action(
+                preferenceEnabled: true,
+                currentUID: "user-changed",
+                marker: marker,
+                availableUIDs: ["selected", "previous", "user-changed"]
+            ),
+            .clear,
+            "an external microphone change should cancel stale restoration ownership"
+        )
+    }
+
+    runSuite("DictationPreferredInputPolicy uses preferred USB then automatic fallback") {
+        let bluetooth = DictationAudioDevice(id: 1, name: "AirPods", transport: .bluetooth, inputChannelCount: 1, uid: "airpods")
+        let macMic = DictationAudioDevice(id: 2, name: "MacBook Pro Microphone", transport: .builtIn, inputChannelCount: 1, uid: "mac")
+        let usbMic = DictationAudioDevice(id: 3, name: "Studio USB Mic", transport: .usb, inputChannelCount: 1, uid: "usb")
+
+        assertEqual(
+            DictationPreferredInputPolicy.input(preferredUID: "usb", availableInputs: [bluetooth, macMic, usbMic], automaticFallback: macMic),
+            usbMic,
+            "an available preferred USB microphone should win"
+        )
+        assertEqual(
+            DictationPreferredInputPolicy.input(preferredUID: "missing", availableInputs: [bluetooth, macMic], automaticFallback: macMic),
+            macMic,
+            "an unavailable preferred microphone should fall back automatically"
+        )
+        assertEqual(
+            DictationPreferredInputPolicy.input(preferredUID: "airpods", availableInputs: [bluetooth, macMic], automaticFallback: macMic),
+            macMic,
+            "the faster-start preference should not silently choose a Bluetooth headset microphone"
+        )
+    }
+
     runSuite("DictationInputDeviceSelectionPolicy chooses MacBook mic for AirPods input/output") {
         let airPodsInput = device(1, "Justin's AirPods Pro", .bluetooth)
         let airPodsOutput = device(2, "Justin's AirPods Pro", .bluetooth, inputChannels: 0)

--- a/Tests/DictationInputDeviceSelectionPolicyTests.swift
+++ b/Tests/DictationInputDeviceSelectionPolicyTests.swift
@@ -32,6 +32,12 @@ func testDictationInputDeviceSelectionPolicy() {
             marker,
             "unclean exits should leave a durable restoration obligation"
         )
+        DictationPersistentInputPreferences.setTemporaryRecoveryMarker(marker, userDefaults: defaults)
+        assertEqual(
+            DictationPersistentInputPreferences.temporaryRecoveryMarker(userDefaults: defaults),
+            marker,
+            "temporary per-dictation overrides should have an independent crash marker"
+        )
     }
 
     runSuite("DictationPersistentInputRecoveryPolicy adopts, restores, or clears crash markers") {
@@ -68,6 +74,16 @@ func testDictationInputDeviceSelectionPolicy() {
             ),
             .clear,
             "an external microphone change should cancel stale restoration ownership"
+        )
+        assertEqual(
+            DictationPersistentInputRecoveryPolicy.action(
+                preferenceEnabled: false,
+                currentUID: "selected",
+                marker: marker,
+                availableUIDs: ["selected"]
+            ),
+            .preserve,
+            "a disconnected previous microphone must keep its restoration obligation"
         )
     }
 

--- a/Tests/E2E/SlowPastebackSmoke.swift
+++ b/Tests/E2E/SlowPastebackSmoke.swift
@@ -69,6 +69,7 @@ struct SlowPastebackSmoke {
         for scenario in scenarios {
             results.append(await runScenario(scenario))
         }
+        results.append(await runTargetChangeConfirmationScenario())
         results.append(await runRetryWhileRestorePendingScenario())
         results.append(await runCancelPendingRestoreScenario())
 
@@ -180,6 +181,74 @@ struct SlowPastebackSmoke {
             freshDictation: freshDictation,
             userCopy: userCopy,
             autoEnterReadyAt: autoEnterReadyAt
+        )
+    }
+
+    @MainActor
+    private static func runTargetChangeConfirmationScenario() async -> SmokeResult {
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("TranscriptedSlowPasteback-target-change-\(UUID().uuidString)")
+        )
+        let paster = ClipboardRestoringTextPaster()
+        let originalClipboard = "synthetic original clipboard \(UUID().uuidString)"
+        let freshDictation = "synthetic target-change dictation \(UUID().uuidString)"
+        pasteboard.clearContents()
+        pasteboard.setString(originalClipboard, forType: .string)
+
+        var pasteDispatchedAt: CFAbsoluteTime = 0
+        var clipboardReadAt: CFAbsoluteTime?
+        var targetChangedAt: CFAbsoluteTime?
+        let outcome = paster.paste(
+            freshDictation,
+            pasteboard: pasteboard,
+            accessibilityTrusted: { true },
+            requestAccessibilityTrust: {},
+            pasteDispatcher: {
+                pasteDispatchedAt = CFAbsoluteTimeGetCurrent()
+                _ = pasteboard.string(forType: .string)
+                clipboardReadAt = CFAbsoluteTimeGetCurrent()
+                targetChangedAt = clipboardReadAt.map { $0 + 0.02 }
+                return true
+            },
+            pasteConfirmed: {
+                FocusedTextPasteConfirmationPolicy.didObserveTargetChange(
+                    pasteDispatchedAt: pasteDispatchedAt,
+                    clipboardReadAt: clipboardReadAt,
+                    targetChangedAt: targetChangedAt
+                )
+            },
+            restoreDelay: SmokeDelay.milliseconds(20).nanoseconds,
+            fallbackRestoreDelay: SmokeDelay.milliseconds(500).nanoseconds,
+            pasteConfirmationWait: 0.2
+        )
+
+        await paster.waitForPendingClipboardRestore()
+        let finalClipboard = pasteboard.string(forType: .string)
+        var failures: [String] = []
+        if outcome != .pasted {
+            failures.append("paste outcome was \(outcome.diagnosticName)")
+        }
+        if finalClipboard != originalClipboard {
+            failures.append("final clipboard was \(category(for: finalClipboard, original: originalClipboard, fresh: freshDictation, userCopy: nil))")
+        }
+
+        let status: SmokeStatus = failures.isEmpty ? .pass : .fail
+        return SmokeResult(
+            scenarioID: "target-change-confirmation-restores-original",
+            status: status,
+            readDelayMS: 0,
+            fallbackDelayMS: 500,
+            insertedCategory: "fresh_dictation",
+            finalClipboardCategory: category(
+                for: finalClipboard,
+                original: originalClipboard,
+                fresh: freshDictation,
+                userCopy: nil
+            ),
+            autoEnterReadyMS: nil,
+            detail: failures.isEmpty
+                ? "A post-dispatch clipboard read plus target change confirms delivery and restores the original clipboard"
+                : failures.joined(separator: "; ")
         )
     }
 

--- a/Tests/ParakeetPrewarmPolicyTests.swift
+++ b/Tests/ParakeetPrewarmPolicyTests.swift
@@ -2,6 +2,67 @@ import AVFoundation
 import Foundation
 
 func testParakeetPrewarmPolicy() {
+    runSuite("ParakeetPrewarmPolicy — defers invasive Bluetooth fallback prewarm") {
+        let bluetoothInput = DictationAudioDevice(
+            id: 10,
+            name: "Bluetooth Headset",
+            transport: .bluetooth,
+            inputChannelCount: 1
+        )
+        let builtInInput = DictationAudioDevice(
+            id: 20,
+            name: "MacBook Pro Microphone",
+            transport: .builtIn,
+            inputChannelCount: 1
+        )
+        let bluetoothOutput = DictationAudioDevice(
+            id: 30,
+            name: "Bluetooth Headset",
+            transport: .bluetooth,
+            inputChannelCount: 0
+        )
+        let fallbackSelection = DictationInputDeviceSelection(
+            defaultInput: bluetoothInput,
+            selectedInput: builtInInput,
+            defaultOutput: bluetoothOutput,
+            reason: .preferredBuiltInForBluetoothHeadset
+        )
+
+        assertTrue(
+            ParakeetPrewarmPolicy.shouldDeferHardwarePrewarm(for: fallbackSelection),
+            "idle prewarm should not repeatedly change the Mac-wide input for Bluetooth fallback"
+        )
+        assertTrue(
+            ParakeetPrewarmPolicy.shouldDeferHardwareRecovery(
+                for: fallbackSelection,
+                wasRecording: false
+            ),
+            "idle route recovery after stop should not reapply the Bluetooth fallback override"
+        )
+        assertFalse(
+            ParakeetPrewarmPolicy.shouldDeferHardwareRecovery(
+                for: fallbackSelection,
+                wasRecording: true
+            ),
+            "an interrupted recording should still recover its real microphone graph"
+        )
+        assertFalse(
+            ParakeetPrewarmPolicy.shouldDeferHardwarePrewarm(
+                for: DictationInputDeviceSelection(
+                    defaultInput: builtInInput,
+                    selectedInput: builtInInput,
+                    defaultOutput: bluetoothOutput,
+                    reason: .defaultIsSafe
+                )
+            ),
+            "safe native routes should keep normal hardware prewarm"
+        )
+        assertFalse(
+            ParakeetPrewarmPolicy.shouldDeferHardwarePrewarm(for: nil),
+            "missing route metadata should keep normal prewarm behavior"
+        )
+    }
+
     runSuite("ParakeetPrewarmPolicy.decision — authorized microphone can prewarm") {
         let decision = ParakeetPrewarmPolicy.decision(for: .authorized)
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3678,6 +3678,18 @@ func testRepoCommandContract() {
             "capture pill prompts should use heuristic timeouts and route remind/expiry distinctly"
         )
         assertTrue(
+            pillContents.contains("static let preferredSize = NSSize(width: 720, height: 90)")
+                && pillContents.contains("Closes in ")
+                && pillContents.contains("scheduleCountdown(seconds: timeoutSeconds)")
+                && pillContents.contains("setAccessibilityValue("),
+            "detected-call prompts should reserve room for full copy and show their expiry countdown"
+        )
+        assertTrue(
+            pillContents.contains("button.attributedTitle = buttonTitle(title, isPrimary: isPrimary)")
+                && pillContents.contains("NSColor.labelColor.withAlphaComponent(0.12)"),
+            "secondary prompt actions should use explicit high-contrast text and surfaces"
+        )
+        assertTrue(
             pillContents.contains("event.window === panel || panel.isKeyWindow")
                 && !pillContents.contains("panel.makeKey()")
                 && pillContents.contains("CapturePillPlacementPolicy.selectedScreenFrame(")

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -295,6 +295,7 @@ APP_SOURCES=(
     "Sources/Support/ModelCacheInventory.swift"
     "Sources/Support/SingleInstanceGuard.swift"
     "Sources/Support/DictationAutoSendPreferences.swift"
+    "Sources/Support/DictationPersistentInputPreferences.swift"
     "Sources/Support/DictationCleanupPreferences.swift"
     "Sources/Support/DictationOverlayPresentationPreferences.swift"
     "Sources/Support/DictationFillerCleanupPolicy.swift"


### PR DESCRIPTION
## Summary

- paste manual dictation into the editor focused when dictation stops
- confirm Notes-style normalized/replacement pastes without blocking Accessibility reads
- restore the original clipboard after confirmed paste and keep recovery text copied when confirmation genuinely fails
- make selected-app Auto Enter work for AX-inaccessible editors with bounded, frontmost clipboard-read confirmation
- prevent Bluetooth idle prewarm/start recovery from repeatedly flipping the system input
- add explicit Faster Bluetooth Dictation preference with preferred USB/Mac microphone selection, reconnect fallback, and crash-safe restoration ownership

## Manual hardware proof

- AirPods output + MacBook mic: repeated starts reached first audio around 0.19-0.24s
- AirPods output + BEACN Mic: repeated starts reached first audio around 0.21-0.25s after the one-time device transition
- BEACN disconnect fell back to MacBook mic; reconnect returned to BEACN; no repeated route loop
- preference and preferred microphone survived relaunch
- Codex -> Notes passed three consecutive times; Notes confirmed the paste and the original clipboard was restored
- same-app Codex paste and Auto Enter submitted successfully
- newest-build session audit: seven dictations, average first audio 240ms, seven successful pastes, zero warnings/errors

## Automated proof

- `bash build.sh --no-open` — signed build and launch smoke passed, 1073ms
- `bash run-tests.sh` — 12,871/12,871 passed
- `bash run-slow-pasteback-smoke.sh` — 9/9 passed
- `bash scripts/ops/transcripted-qa-bench.sh --mode full` — PASS, 18 checks with one warnings-only local-artifact validator note
- QA report: `/tmp/transcripted-qa-bench/qa-20260710-141304/qa-report.md`

## Review

- Claude risky review found crash-restoration and Auto Enter confirmation gaps; both were fixed and the final follow-up was GREEN
- Claude proof: `/Users/redbars/.codex/maestro/runs/20260710T190557Z-transcripted-dictation-rc-final-risk-review-claude`
- `codex-review --uncommitted` was attempted three times, but local Codex CLI v0.136.0 cannot run its configured `gpt-5.6-terra` model; manual Codex file-by-file review found no actionable findings

## Proof boundary

- Real Bluetooth/USB hardware proof above was run locally on this Mac.
- Meetings remain a separate release hold and will be tested after this PR; this PR does not claim meeting release readiness.
- No release, tag, notarization, appcast, Homebrew, website, or merge action is included.

## Maestro lanes

- Codex: implementation, manual hardware/log verification, build/tests, final manual diff review
- Claude: independent risky diff review and follow-up
- Local: skipped; privacy-safe log triage was performed directly by Codex
- Windows: skipped; hardware proof required this Mac

## Meeting prompt follow-up

- widened the detected-call prompt so the full instruction is readable
- added a visible 60-second live-call countdown and synchronized VoiceOver accessibility text
- improved secondary button contrast and appearance refresh behavior
- added source-contract regression guards for prompt sizing, countdown, accessibility, and contrast
- manual check: rebuilt app relaunched and prompt readability/controls looked correct
- `bash build.sh --no-open` — signed build and launch smoke passed
- `bash run-tests.sh` — 12,873/12,873 passed
- `bash run-tests.sh --filter RepoCommandContractTests` — 673/673 passed
- Codex review: clean; Claude review: no actionable findings

Meeting release readiness remains a separate manual hold; no merge or release is included.