### PR TITLE
fix: crash-proof transcript parsing and remove force-unwraps/casts

### DIFF
--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -404,6 +404,19 @@ private struct FocusedTextPasteConfirmation {
             return nil
         }
 
+        // AXUIElement is a toll-free-bridged CF opaque type: Swift can't runtime-check
+        // `as?`/`as!` against it (the compiler treats the downcast as unconditionally
+        // successful), so CFGetTypeID is the actual safety net before we hand this
+        // value to AX APIs that assume it really is an AXUIElement. This file is
+        // compiled directly into the fast-test binary without the TranscriptedCore
+        // module's search path (see APP_SOURCES in run-tests.sh), so importing that
+        // module here isn't an option — this follows the same fputs(..., stderr)
+        // idiom Sources/Observability/AppLogger.swift itself falls back to for
+        // internal diagnostics.
+        guard CFGetTypeID(focusedElement) == AXUIElementGetTypeID() else {
+            fputs("⚠️ ClipboardRestoringTextPaster | focused UI element attribute returned an unexpected CF type (expected AXUIElement)\n", stderr)
+            return nil
+        }
         let element = focusedElement as! AXUIElement
         AXUIElementSetMessagingTimeout(element, messagingTimeout)
         return FocusedTextPasteConfirmation(

--- a/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
+++ b/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
@@ -114,11 +114,13 @@ public enum EmbeddingClusterer {
 
         func find(_ x: Int) -> Int {
             var root = x
-            while parent[root] != root { root = parent[root]! }
+            // A missing key can only mean `root` was never inserted (e.g. an id
+            // outside `speakerIds`); treat it as its own root rather than trapping.
+            while let next = parent[root], next != root { root = next }
             // Path compression
             var node = x
             while node != root {
-                let next = parent[node]!
+                guard let next = parent[node] else { break }
                 parent[node] = root
                 node = next
             }

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -214,9 +214,15 @@ extension Transcription {
             var parent = Dictionary(uniqueKeysWithValues: clusters.map { ($0, $0) })
             func find(_ x: Int) -> Int {
                 var r = x
-                while parent[r]! != r { r = parent[r]! }
+                // A missing key can only mean `r` was never inserted (e.g. an id
+                // outside `clusters`); treat it as its own root rather than trapping.
+                while let next = parent[r], next != r { r = next }
                 var n = x
-                while n != r { let nx = parent[n]!; parent[n] = r; n = nx }
+                while n != r {
+                    guard let nx = parent[n] else { break }
+                    parent[n] = r
+                    n = nx
+                }
                 return r
             }
             func union(_ a: Int, _ b: Int) {
@@ -225,7 +231,8 @@ extension Transcription {
             }
             for i in 0..<clusters.count {
                 for j in (i + 1)..<clusters.count {
-                    let s = cosineSimilarityStatic(meanBySpeaker[clusters[i]]!, meanBySpeaker[clusters[j]]!)
+                    guard let embA = meanBySpeaker[clusters[i]], let embB = meanBySpeaker[clusters[j]] else { continue }
+                    let s = cosineSimilarityStatic(embA, embB)
                     if SpeakerWritePathPolicy.shouldFuseMatchedClusters(crossClusterSimilarity: s) {
                         union(clusters[i], clusters[j])
                     }
@@ -243,7 +250,10 @@ extension Transcription {
             var components: [Int: [Int]] = [:]
             for c in clusters { components[find(c), default: []].append(c) }
             for (root, members) in components {
-                let rep = members.max(by: { rank($0) < rank($1) })!
+                // `members` is always non-empty (seeded from `clusters`), but guard
+                // rather than force-unwrap so an empty component fails closed instead
+                // of trapping.
+                guard let rep = members.max(by: { rank($0) < rank($1) }) else { continue }
                 for other in members where other != rep { plan.remaps[other] = rep }
                 if root != keeperRoot { plan.spinOffs.append(rep) }
             }

--- a/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
+++ b/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
@@ -96,7 +96,12 @@ struct HomeMeetingPreviewContent {
     }
 
     private static func parseBracketTimestampMarker(_ line: String) -> TranscriptMarker? {
-        guard let timeEnd = line.firstIndex(of: "]") else { return nil }
+        // Defensive parity with RecentCaptureScanners' sibling parser: this function
+        // assumes a leading "[". Without the hasPrefix guard, firstIndex(of: "]")
+        // landing at startIndex (a line that never had a leading "[") would make
+        // line.index(after: line.startIndex) step past it, producing an inverted
+        // range and trapping.
+        guard line.hasPrefix("["), let timeEnd = line.firstIndex(of: "]") else { return nil }
         let time = String(line[line.index(after: line.startIndex)..<timeEnd])
         guard looksLikeTimestamp(time) else { return nil }
         let remainder = line[line.index(after: timeEnd)...].trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -144,7 +144,13 @@ enum RecentMeetingSpeakerStatus: Equatable, Sendable {
     }
 
     private static func speakerLabel(fromBracketTimestampLine line: String) -> String? {
-        guard let timeEnd = line.firstIndex(of: "]") else { return nil }
+        // Callers besides the direct "[" dispatch (e.g. the bold-prefix fallback in
+        // speakerLabel(fromTranscriptLine:)) can hand this a string that never had a
+        // leading "[". Without this guard, a line whose first character is "]" (e.g. the
+        // malformed "**]" transcript line, which unbolds to "]") makes firstIndex(of: "]")
+        // land at startIndex while line.index(after: line.startIndex) steps one past it,
+        // producing an inverted range and trapping.
+        guard line.hasPrefix("["), let timeEnd = line.firstIndex(of: "]") else { return nil }
         let time = String(line[line.index(after: line.startIndex)..<timeEnd])
         guard looksLikeTimestamp(time) else { return nil }
         let remainder = String(line[line.index(after: timeEnd)...])

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -21,6 +21,33 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster.capture — focused element cast is crash-proof") {
+            // Regression: kAXFocusedUIElementAttribute's CFTypeRef was force-cast
+            // straight to AXUIElement with no type check. AXUIElement is a toll-free
+            // CF opaque type, so Swift can't verify `as?`/`as!` against it at runtime
+            // (the compiler treats the downcast as unconditionally successful) — the
+            // real guard has to be an explicit CFGetTypeID comparison before the cast,
+            // matching the existing AXValue-cast pattern in this file. A live
+            // AXUIElement isn't constructible in a unit test, so this asserts on
+            // source shape like the sibling test above.
+            let source = try! String(
+                contentsOfFile: "Sources/Support/ClipboardRestoringTextPaster.swift",
+                encoding: .utf8
+            )
+            assertTrue(
+                source.contains("CFGetTypeID(focusedElement) == AXUIElementGetTypeID()"),
+                "the focused UI element must be type-checked before use, since AXUIElement casts can't fail at runtime on their own"
+            )
+            assertTrue(
+                source.contains("focused UI element attribute returned an unexpected CF type"),
+                "a mismatched CF type should log and degrade to no confirmation instead of misusing the wrong object with AX APIs"
+            )
+            assertFalse(
+                source.contains("import TranscriptedCore"),
+                "this file is compiled directly into the fast-test binary without the TranscriptedCore module search path"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.restorePasteboardItems — preserves user clipboard changes") {
             let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedClipboardTest-\(UUID().uuidString)"))
             let paster = ClipboardRestoringTextPaster()

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -79,6 +79,34 @@ func testRecentCaptureScanners() async {
         )
     }
 
+    runSuite("RecentMeetingSpeakerStatus.detect tolerates a malformed bold-prefixed line without crashing") {
+        // Regression for a real crash: "**]" is a line that hasPrefix("**") (safe to
+        // offset into), but after speakerLabel(fromTranscriptLine:) strips the "**"
+        // and trims stray asterisks/whitespace, the remainder "]" is handed to
+        // speakerLabel(fromBracketTimestampLine:) without ever having a leading "[".
+        // firstIndex(of: "]") then lands at startIndex while
+        // line.index(after: line.startIndex) steps one past it, building an inverted
+        // range (`1..<0`) that trapped with "Range requires lowerBound <= upperBound"
+        // before the hasPrefix("[") guard was added.
+        let markdown = """
+        # Malformed transcript
+
+        ## Transcript
+
+        **]
+        A stray closing bracket right after the bold marker used to crash the scanner.
+
+        **00:01**  [System/Maya]
+        A valid speaker label on the next line should still be recognized.
+        """
+
+        assertEqual(
+            RecentMeetingSpeakerStatus.detect(in: markdown),
+            .ready,
+            "A malformed '**]' line must not crash the scanner and must not itself be treated as a speaker label"
+        )
+    }
+
     runSuite("RecentMeetingSpeakerStatus.detect deduplicates repeated generic labels") {
         let markdown = """
         # Repeated generic labels

--- a/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
+++ b/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
@@ -4,6 +4,26 @@ import XCTest
 @available(macOS 14.0, *)
 final class EmbeddingClustererTests: XCTestCase {
 
+    // MARK: - Empty-input edge cases (crash-proofing regression, codebase audit 2026-07-08)
+
+    func testPairwiseMergeWithNoSegmentsReturnsEmpty() {
+        // The union-find helpers inside pairwiseMerge must never run for empty input;
+        // this guards the early-return path (speakerIds.count >= 2) that keeps the
+        // dictionary-backed find()/union() helpers from ever touching a missing key.
+        let merged = EmbeddingClusterer.pairwiseMerge(segments: [], threshold: 0.85)
+        XCTAssertTrue(merged.isEmpty)
+    }
+
+    func testPairwiseMergeWithSingleSpeakerSkipsUnionFind() {
+        // A single speaker never reaches the union-find loop (speakerIds.count >= 2
+        // guard) and must be returned unchanged.
+        let segments = [
+            segment(speakerId: 1, startTime: 0, endTime: 3, embedding: [1.0, 0.0]),
+        ]
+        let merged = EmbeddingClusterer.pairwiseMerge(segments: segments, threshold: 0.85)
+        XCTAssertEqual(merged.map(\.speakerId), [1])
+    }
+
     func testPairwiseMergeHandlesTransitiveSpeakerMatches() {
         let merged = EmbeddingClusterer.pairwiseMerge(
             segments: [

--- a/Tests/TranscriptedCoreTests/SpeakerWritePathPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerWritePathPolicyTests.swift
@@ -149,6 +149,36 @@ final class SpeakerWritePathPolicyTests: XCTestCase {
         XCTAssertEqual(plan.remaps, [z: y], "its second fragment fuses into it, not a third profile")
     }
 
+    // MARK: - Empty-input edge cases (crash-proofing regression, codebase audit 2026-07-08)
+
+    func testPlanCrossClusterLinksWithNoSpeakersReturnsEmptyPlan() {
+        // The union-find setup inside planCrossClusterLinks must never run for an
+        // empty input; this guards the early-return path that keeps the
+        // dictionary-backed find()/union() helpers from ever touching a missing key.
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [:],
+            matchSimilarityBySpeaker: [:],
+            meanBySpeaker: [:],
+            segmentCountBySpeaker: [:]
+        )
+        XCTAssertTrue(plan.remaps.isEmpty)
+        XCTAssertTrue(plan.spinOffs.isEmpty)
+    }
+
+    func testPlanCrossClusterLinksWithSingleSpeakerSkipsUnionFind() {
+        // A single cluster on a profile never reaches the union-find loop
+        // (ids.count >= 2 guard) and must not fuse or spin off anything.
+        let p = UUID()
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [1: p],
+            matchSimilarityBySpeaker: [1: 0.95],
+            meanBySpeaker: [1: unit(cos: 1.0)],
+            segmentCountBySpeaker: [1: 5]
+        )
+        XCTAssertTrue(plan.remaps.isEmpty)
+        XCTAssertTrue(plan.spinOffs.isEmpty)
+    }
+
     // MARK: - Helpers
 
     /// 2-D unit vector with a given cosine to the x-axis reference [1, 0].


### PR DESCRIPTION
## What / why

Spec W1-A3 from **codebase audit 2026-07-08**. The audit's naive claim ("`**` input crashes the transcript parser") was wrong — `hasPrefix("**")` guarantees `offsetBy: 2` is safe. I re-derived the actual crash inputs by reading each parser and, where reachable, confirmed them with a standalone Swift script before fixing.

### 1. `Sources/UI/Shared/RecentCaptureScanners.swift` — real crash, fixed + regression test
`speakerLabel(fromTranscriptLine:)` strips a `**` prefix and falls back to `speakerLabel(fromBracketTimestampLine:)` on the *unbolded remainder*, which is not guaranteed to start with `"["`. A transcript line `"**]"` unbolds to `"]"`. `firstIndex(of: "]")` then lands at `startIndex`, but `line.index(after: line.startIndex)` steps one past it — building the inverted range `1..<0`, which traps with `"Range requires lowerBound <= upperBound"`. Confirmed the trap in isolation before fixing. Added a `hasPrefix("[")` guard and a regression test (`RecentMeetingSpeakerStatus.detect tolerates a malformed bold-prefixed line without crashing`) in `Tests/RecentCaptureScannersTests.swift`.

### 2. `Sources/UI/Settings/HomeMeetingPreviewFormatter.swift` — defensive parity, not independently reachable
Added the identical `hasPrefix("[")` guard to `parseBracketTimestampMarker` for parity with the sibling parser above. **Deviation from spec**: I could not derive an actual crash here — unlike `RecentCaptureScanners`, this file's `parseTranscriptMarker` only ever calls `parseBracketTimestampMarker` on lines already confirmed via `line.hasPrefix("[")` (no bold-prefix fallback exists in this file), so the unguarded code was already safe on the current call graph. No crash-reproducing test was added for this file since there's no crash to reproduce; the existing 2 tests in `Tests/HomeMeetingPreviewFormatterTests.swift` still pass unchanged.

### 3. `Sources/Support/ClipboardRestoringTextPaster.swift` — force cast on an AX return
`kAXFocusedUIElementAttribute`'s `CFTypeRef` was force-cast straight to `AXUIElement` with no type check. Interesting finding: `AXUIElement` is a toll-free-bridged CF opaque type, so Swift can't runtime-check `as?`/`as!` against it at all — the compiler rejected my first attempt at `as?` with *"conditional downcast to CoreFoundation type 'AXUIElement' will always succeed."* The real guard is an explicit `CFGetTypeID(focusedElement) == AXUIElementGetTypeID()` check, mirroring the `AXValue` cast pattern already present lower in this same file. On mismatch it now logs and returns `nil` (degrading to "no paste confirmation available") instead of handing a wrongly-typed CF object to later `AXUIElementSetMessagingTimeout`/`AXUIElementCopyAttributeValue` calls. **Deviation from spec**: couldn't `import TranscriptedCore` for `AppLogger` — this file is compiled directly into the fast-test binary (`run-tests.sh`'s `APP_SOURCES`) without that module's search path, confirmed by a real "no such module" build failure. Used the `fputs(..., stderr)` idiom `Sources/Observability/AppLogger.swift` itself falls back to internally. Added a source-shape regression test matching this file's existing testing style for AX-heavy code that can't construct a live `AXUIElement` in-process.

### 4. `Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift` + `SpeakerMatchingService.swift` — union-find force-unwraps + `max()!`
Both files' union-find `find()` helpers force-unwrapped dictionary lookups (`parent[x]!`), and `SpeakerMatchingService.swift`'s cross-cluster pairwise-similarity loop and `members.max(by:)!` did the same. All are currently unreachable with a missing key given the call sites' invariants, but replaced with guard-let/if-let that fail closed (treat a missing key as its own root; `continue` past a missing mean-embedding pair; `continue` past an impossible empty component) rather than trapping, matching the guarded style already used elsewhere in these files. Added empty-input and single-element regression tests in `Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift` and `Tests/TranscriptedCoreTests/SpeakerWritePathPolicyTests.swift`.

## Test plan
- [x] `bash build-deps.sh --force` (Core touched)
- [x] `bash build.sh --no-open` — builds clean
- [x] `bash run-tests.sh --filter RecentCaptureScannersTests` — 187/187 passed
- [x] `bash run-tests.sh --filter HomeMeetingPreviewFormatterTests` — 8/8 passed
- [x] `bash run-tests.sh --filter ClipboardRestoringTextPasterTests` — 90/90 passed
- [x] `bash run-tests.sh` (full fast suite) — 12877/12877 passed
- [x] `swift test --filter EmbeddingClustererTests` — 16/16 passed
- [x] `swift test --filter SpeakerMatchingServiceTests --filter SpeakerWritePathPolicyTests` — 20/20 passed
- [x] `swift test` (full Core suite) — 726 executed, 13 skipped, 0 failures
- [x] `bash run-integration-smoke.sh` — passed
- [x] Duplicate-declaration sweep on every touched file — no unexpected hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>