### PR TITLE
refactor: consolidate scattered DateFormatters into DateFormattingHelper

### DIFF
--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -3,6 +3,9 @@
 
 import AppKit
 import Foundation
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 struct SavedDictationTranscript: Sendable {
     let url: URL
@@ -38,13 +41,6 @@ enum DictationTranscriptMutationLock {
 }
 
 enum DictationTranscriptWriter {
-    private static let dayFilenameFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }()
-
     private static let entryIdFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -71,12 +67,6 @@ enum DictationTranscriptWriter {
         let formatter = DateFormatter()
         formatter.locale = Locale.current
         formatter.dateFormat = "MMM d 'at' h:mm a"
-        return formatter
-    }()
-
-    private static let isoFormatter: ISO8601DateFormatter = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return formatter
     }()
 
@@ -165,7 +155,7 @@ enum DictationTranscriptWriter {
     }
 
     static func dailyFileURL(for date: Date, in directory: URL) -> URL {
-        let slug = dayFilenameFormatter.string(from: date)
+        let slug = DateFormattingHelper.formatDayStamp(date)
         return directory.appendingPathComponent("Dictations_\(slug).md", isDirectory: false)
     }
 
@@ -179,7 +169,7 @@ enum DictationTranscriptWriter {
         return """
         ---
         title: "\(escapedTitle)"
-        date: \(dayFilenameFormatter.string(from: date))
+        date: \(DateFormattingHelper.formatDayStamp(date))
         capture_type: dictation_day
         format_version: 1
         ---
@@ -206,7 +196,7 @@ enum DictationTranscriptWriter {
         ## \(sectionTimeFormatter.string(from: createdAt)) - \(headingTitle)
 
         Entry ID: `\(entryID)`
-        Captured: \(isoFormatter.string(from: createdAt))
+        Captured: \(DateFormattingHelper.formatISO8601WithFractionalSeconds(createdAt))
         Source app: \(sourceAppName)\(bundleLine)
         Delivery: \(delivery.rawValue)
         Words: \(wordCount)

--- a/Sources/Meeting/MeetingArtifactRenamer.swift
+++ b/Sources/Meeting/MeetingArtifactRenamer.swift
@@ -35,22 +35,13 @@ enum MeetingTranscriptFileUpdateSerializer {
 /// The date comes from the meeting's recorded date; `<name>` is the sanitized title
 /// with no date of its own (the date lives in the filename and in frontmatter).
 enum MeetingArtifactRenamer {
-    private static let datePrefixFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.timeZone = .current
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }()
-
     private static let formatterQueue = DispatchQueue(label: "Transcripted.MeetingArtifactRenamer.formatter")
 
     // MARK: - Stem building
 
     /// `YYYY-MM-dd` prefix for the given recording date.
     static func datePrefix(for date: Date) -> String {
-        formatterQueue.sync { datePrefixFormatter.string(from: date) }
+        formatterQueue.sync { DateFormattingHelper.formatDayStamp(date) }
     }
 
     /// Canonical file stem: `YYYY-MM-dd <sanitized title>`.

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -19,13 +19,6 @@ enum MeetingTranscriptStyler {
         return formatter
     }()
 
-    private static let detailFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale.current
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        return formatter
-    }()
     private static let formatterQueue = DispatchQueue(label: "Transcripted.MeetingTranscriptStyler.formatters")
 
     static func restyleTranscript(at url: URL) -> StyledMeetingTranscript {
@@ -373,7 +366,7 @@ enum MeetingTranscriptStyler {
 
     private static func detailString(from date: Date) -> String {
         formatterQueue.sync {
-            detailFormatter.string(from: date)
+            DateFormattingHelper.formatDisplay(date)
         }
     }
 

--- a/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
@@ -28,13 +28,6 @@ public enum TranscriptFrontmatter {
         return formatter
     }()
 
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }()
-
     private static let formatterQueue = DispatchQueue(label: "TranscriptedCore.TranscriptFrontmatter.formatters")
 
     public static func document(in raw: String) -> TranscriptFrontmatterDocument? {
@@ -164,7 +157,7 @@ public enum TranscriptFrontmatter {
         guard let date = values["date"] else { return nil }
 
         return formatterQueue.sync {
-            dateFormatter.date(from: date)
+            DateFormattingHelper.parseDayStamp(date)
         }
     }
 

--- a/Sources/TranscriptedCore/Utilities/DateFormattingHelper.swift
+++ b/Sources/TranscriptedCore/Utilities/DateFormattingHelper.swift
@@ -30,6 +30,30 @@ public enum DateFormattingHelper {
         return formatter
     }()
 
+    /// Day stamp format: "2024-01-15"
+    private static let dayStampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    /// ISO8601 without fractional seconds: "2024-01-15T14:30:45Z"
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    /// ISO8601 with fractional seconds: "2024-01-15T14:30:45.123Z"
+    private static let iso8601FractionalFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
     // MARK: - Public API
 
     /// Format for audio filenames with millisecond precision
@@ -56,5 +80,29 @@ public enum DateFormattingHelper {
         let minutes = Int(interval) / 60
         let seconds = Int(interval) % 60
         return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    /// Format a day stamp for filenames and frontmatter dates.
+    /// Example: "2024-01-15"
+    public static func formatDayStamp(_ date: Date) -> String {
+        dayStampFormatter.string(from: date)
+    }
+
+    /// Parse a day stamp produced by `formatDayStamp`.
+    /// Example: "2024-01-15" -> Date
+    public static func parseDayStamp(_ string: String) -> Date? {
+        dayStampFormatter.date(from: string)
+    }
+
+    /// Format an ISO8601 timestamp without fractional seconds.
+    /// Example: "2024-01-15T14:30:45Z"
+    public static func formatISO8601(_ date: Date) -> String {
+        iso8601Formatter.string(from: date)
+    }
+
+    /// Format an ISO8601 timestamp with millisecond fractional seconds.
+    /// Example: "2024-01-15T14:30:45.123Z"
+    public static func formatISO8601WithFractionalSeconds(_ date: Date) -> String {
+        iso8601FractionalFormatter.string(from: date)
     }
 }

--- a/Tests/DictationTranscriptWriterTests.swift
+++ b/Tests/DictationTranscriptWriterTests.swift
@@ -46,6 +46,14 @@ func testDictationTranscriptWriter() {
         assertTrue(contents.contains("## 4:45 PM -"), "second dictation section should include time heading")
         assertTrue(contents.contains("first note from the morning"), "first dictation text should be present")
         assertTrue(contents.contains("second note from the afternoon"), "second dictation text should be present")
+
+        // Regression guard for the DateFormattingHelper.formatDayStamp /
+        // formatISO8601WithFractionalSeconds consolidation (audit 2026-07-08, W1-A5).
+        assertTrue(contents.contains("date: 2026-04-07"), "day header date field should keep the yyyy-MM-dd shape")
+        assertTrue(
+            contents.contains(DateFormattingHelper.formatISO8601WithFractionalSeconds(firstDate)),
+            "Captured: line should use the shared ISO8601-with-fractional-seconds formatter"
+        )
     }
 
     runSuite("DictationTranscriptWriter.save — keeps daily markdown owner-only") {

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -5,6 +5,7 @@ func testMeetingAudioArchiveResolver() {
         testResolverUsesCanonicalMeetingArtifactAudioDirectory()
         testMeetingArtifactRenamerStripsLeadingDots()
         testMeetingArtifactRenamerFallsBackForAllDots()
+        testMeetingArtifactRenamerDatePrefixFormat()
         testResolverKeepsLiveMeetingAudioPairButUsesSinglePlaybackSource()
         testResolverFallsBackToMicrophonePlayback()
         testAttachmentPlaybackPrefersSystemForFailedMeetingAudio()
@@ -34,6 +35,22 @@ private func testMeetingArtifactRenamerFallsBackForAllDots() {
         MeetingArtifactRenamer.sanitizedTitleStem(for: "...", fallback: "Untitled Meeting"),
         "Untitled Meeting",
         "All-dot meeting titles should fall back to a visible artifact name"
+    )
+}
+
+// Regression guard for the DateFormattingHelper.formatDayStamp consolidation
+// (audit 2026-07-08, W1-A5): datePrefix(for:) must keep producing `yyyy-MM-dd`
+// in the local timezone identically to the old bespoke DateFormatter.
+private func testMeetingArtifactRenamerDatePrefixFormat() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = .current
+    let components = DateComponents(calendar: calendar, year: 2026, month: 4, day: 7, hour: 9, minute: 15)
+    let date = components.date ?? Date(timeIntervalSince1970: 0)
+
+    assertEqual(
+        MeetingArtifactRenamer.datePrefix(for: date),
+        "2026-04-07",
+        "datePrefix should keep the yyyy-MM-dd shape after the DateFormattingHelper migration"
     )
 }
 

--- a/Tests/TranscriptedCoreTests/DateFormattingHelperTests.swift
+++ b/Tests/TranscriptedCoreTests/DateFormattingHelperTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Byte-identical formatting coverage for `DateFormattingHelper`'s consolidated
+/// formatters (audit 2026-07-08, W1-A5). Pins TimeZone/Locale so these assertions
+/// are deterministic regardless of the machine running them.
+@available(macOS 14.0, *)
+final class DateFormattingHelperTests: XCTestCase {
+
+    /// 2024-01-15 14:30:45.123 UTC
+    private let fixedDate = Date(timeIntervalSince1970: 1_705_329_045.123)
+
+    private var originalTimeZone: TimeZone!
+
+    override func setUp() {
+        super.setUp()
+        originalTimeZone = NSTimeZone.default
+        NSTimeZone.default = TimeZone(identifier: "UTC")!
+    }
+
+    override func tearDown() {
+        NSTimeZone.default = originalTimeZone
+        super.tearDown()
+    }
+
+    func testFormatDayStampProducesYYYYMMDD() {
+        XCTAssertEqual(DateFormattingHelper.formatDayStamp(fixedDate), "2024-01-15")
+    }
+
+    func testParseDayStampRoundTripsWithFormat() {
+        let parsed = DateFormattingHelper.parseDayStamp("2024-01-15")
+        XCTAssertEqual(parsed.map(DateFormattingHelper.formatDayStamp), "2024-01-15")
+    }
+
+    func testParseDayStampRejectsMalformedInput() {
+        XCTAssertNil(DateFormattingHelper.parseDayStamp("not-a-date"))
+    }
+
+    func testFormatISO8601WithoutFractionalSeconds() {
+        XCTAssertEqual(DateFormattingHelper.formatISO8601(fixedDate), "2024-01-15T14:30:45Z")
+    }
+
+    func testFormatISO8601WithFractionalSeconds() {
+        XCTAssertEqual(
+            DateFormattingHelper.formatISO8601WithFractionalSeconds(fixedDate),
+            "2024-01-15T14:30:45.123Z"
+        )
+    }
+
+    func testFormatDisplayUsesMediumDateShortTime() {
+        // en_US_POSIX doesn't localize dateStyle/timeStyle the way a real locale
+        // does, so this asserts against the system's current locale/timezone
+        // formatting a fixed reference date, matching how the shared helper is
+        // actually consumed by call sites (no explicit locale override).
+        let expected: String = {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            return formatter.string(from: fixedDate)
+        }()
+        XCTAssertEqual(DateFormattingHelper.formatDisplay(fixedDate), expected)
+    }
+}

--- a/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
@@ -61,6 +61,23 @@ final class TranscriptFrontmatterTests: XCTestCase {
         XCTAssertEqual(components.second, 15)
     }
 
+    /// Regression guard for the DateFormattingHelper.parseDayStamp consolidation
+    /// (audit 2026-07-08, W1-A5): `date(values:)` must keep parsing the bare
+    /// `yyyy-MM-dd` frontmatter `date` field identically to before.
+    func testParsesDateOnly() throws {
+        let date = try XCTUnwrap(TranscriptFrontmatter.date(values: ["date": "2026-04-22"]))
+
+        let components = Calendar(identifier: .gregorian)
+            .dateComponents(in: TimeZone.current, from: date)
+        XCTAssertEqual(components.year, 2026)
+        XCTAssertEqual(components.month, 4)
+        XCTAssertEqual(components.day, 22)
+    }
+
+    func testDateOnlyRejectsMissingField() {
+        XCTAssertNil(TranscriptFrontmatter.date(values: [:]))
+    }
+
     func testReadValuesUsesBoundedPrefix() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptFrontmatterTests-\(UUID().uuidString)", isDirectory: true)

--- a/scripts/dev/benchmark-home-recent-captures.sh
+++ b/scripts/dev/benchmark-home-recent-captures.sh
@@ -12,6 +12,7 @@ swiftc \
   "$ROOT_DIR/Sources/Support/TranscriptedStoragePaths.swift" \
   "$ROOT_DIR/Sources/Dictation/DictationStoragePaths.swift" \
   "$ROOT_DIR/Sources/Dictation/DictationTranscriptWriter.swift" \
+  "$ROOT_DIR/Sources/TranscriptedCore/Utilities/DateFormattingHelper.swift" \
   "$ROOT_DIR/Sources/Dictation/DictationTranscriptStore.swift" \
   "$ROOT_DIR/Sources/Meeting/MeetingArtifactRenamer.swift" \
   "$ROOT_DIR/Sources/Meeting/MeetingStoragePaths.swift" \

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -36,6 +36,7 @@ SWIFT_SOURCES=(
     "Sources/Support/LocalMeetingSummaryPreferences.swift"
     "Sources/Dictation/DictationStoragePaths.swift"
     "Sources/Dictation/DictationTranscriptWriter.swift"
+    "Sources/TranscriptedCore/Utilities/DateFormattingHelper.swift"
     "Sources/Dictation/DictationTranscriptStore.swift"
     "Sources/Meeting/MeetingStoragePaths.swift"
     "Sources/Meeting/LocalMeetingSummarizer.swift"

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -388,6 +388,7 @@ APP_SOURCES=(
     "Sources/TranscriptedCore/Speaker/SpeakerPeopleReviewPolicy.swift"
     "Sources/TranscriptedCore/Storage/TranscriptFormatOptions.swift"
     "Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift"
+    "Sources/TranscriptedCore/Utilities/DateFormattingHelper.swift"
     "Sources/Support/SpeakerNameSelectionPolicy.swift"
     "Sources/UI/Shared/AgentConnectionGuide.swift"
     "Sources/UI/Shared/FeedbackIssueBuilder.swift"


### PR DESCRIPTION
## What

Migrates `DictationTranscriptWriter`, `MeetingArtifactRenamer`, `MeetingTranscriptStyler`, and `TranscriptFrontmatter` off their own ad-hoc `DateFormatter`/`ISO8601DateFormatter` instances and onto shared cached formatters on `DateFormattingHelper`:

- `formatDayStamp` / `parseDayStamp` — `yyyy-MM-dd`, `en_US_POSIX` locale, `.gregorian` calendar, `.current` timeZone (matches the removed `dayFilenameFormatter` / `datePrefixFormatter` / `dateFormatter` exactly).
- `formatISO8601` / `formatISO8601WithFractionalSeconds` — replaces the removed `isoFormatter`.
- `MeetingTranscriptStyler`'s `detailFormatter` (medium date + short time, default locale) is dropped in favor of the pre-existing `DateFormattingHelper.formatDisplay`, which already had the identical configuration.

Pure code motion — no behavior change, no public API changes beyond the new `DateFormattingHelper` methods.

## Why

Completes wave-1 spec **W1-A5** (DateFormatter consolidation) from the codebase audit (2026-07-08). The original executor's edits landed correctly but the PR never got opened — it timed out queueing behind 4 concurrent builds in wave 1. This PR (W2-G) picks up the already-implemented, already-uncommitted diff from that worktree, rebases it onto current `main` (8 commits ahead, including `audit/drift-guard-tests` which added `MeetingArtifactRenamer` parity tests — rebase was conflict-free), and takes it through build + test + PR.

## Verification

- Byte-identical output is pinned by regression tests with fixed TimeZone/locale:
  - New `Tests/TranscriptedCoreTests/DateFormattingHelperTests.swift` (6 tests) — locks `formatDayStamp`, `parseDayStamp`, `formatISO8601`, `formatISO8601WithFractionalSeconds`, `formatDisplay` output.
  - Regression guards added to `DictationTranscriptWriterTests`, `MeetingAudioArchiveResolverTests` (includes `testMeetingArtifactRenamerDatePrefixFormat`, verified against the `audit/drift-guard-tests` parity suite post-rebase), and `TranscriptFrontmatterTests`.
- `bash build-deps.sh --force` — succeeded (Core touched).
- `bash build.sh` — `Build complete!`
- `swift test --filter "DateFormattingHelperTests|TranscriptFrontmatterTests"` — 14/14 passed.
- Full fast suite (`bash scripts/entrypoints/run-tests.sh`) — 12,867/12,867 passed.
- Verified `HomeView`/`TranscriptedSettingsView` untouched (owned by other executors).

## Deviations

None from the W2-G spec. `scripts/entrypoints/run-tests.sh` gained one append-only `APP_SOURCES` line for `DateFormattingHelper.swift`, consistent with the shared-hotspot guidance.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>