### PR TITLE
refactor(ui): split TranscriptedSettingsView into per-page view files

### DIFF
--- a/Sources/UI/Settings/Pages/AboutSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/AboutSettingsPage.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+
+/// The Settings > About page. Extracted from `TranscriptedSettingsView`
+/// (codebase audit 2026-07-08 wave 2, spec W2-A). `updateActionEnabled`
+/// bundles the update-safety policy (capture-in-progress guard) that the
+/// parent's sidebar footer also consumes, so it stays owned by the parent
+/// and is passed in as a closure.
+struct AboutSettingsPage: View {
+    @ObservedObject var sparkleUpdater: SparkleUpdaterController
+    let onTrackSettingsToggle: (String, Bool, TranscriptedSettingsPage?) -> Void
+    let updateActionEnabled: (SparkleUpdaterController.UpdateStatus) -> Bool
+    let onPerformUpdateAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsPageIntro(
+                title: "About",
+                summary: "Version and updates."
+            )
+
+            SettingsSection(
+                title: "Version",
+                detail: "Build info and update controls."
+            ) {
+                SettingsStatusCard(
+                    title: "Transcripted",
+                    status: TranscriptedSupportActions.appVersionDescription,
+                    detail: "Local-first dictation and meeting notes.",
+                    tone: .ready
+                )
+
+                SettingsStatusCard(
+                    title: "Updates",
+                    status: aboutUpdateStatusTitle,
+                    detail: aboutUpdateStatusDetail,
+                    tone: aboutUpdateStatusTone
+                )
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SettingsToggleRow(
+                        title: "Check automatically",
+                        detail: sparkleUpdater.automaticUpdateSettings.automaticChecksEnabled
+                            ? "Transcripted checks for updates in the background."
+                            : "Transcripted only checks when you ask.",
+                        isOn: Binding(
+                            get: { sparkleUpdater.automaticUpdateSettings.automaticChecksEnabled },
+                            set: { newValue in
+                                onTrackSettingsToggle("automatic_update_checks", newValue, .about)
+                                sparkleUpdater.setAutomaticallyChecksForUpdates(newValue)
+                            }
+                        )
+                    )
+
+                    SettingsToggleRow(
+                        title: "Download automatically",
+                        detail: sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled
+                            ? "Transcripted downloads available updates in the background."
+                            : "Transcripted waits before downloading updates.",
+                        isOn: Binding(
+                            get: { sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled },
+                            set: { newValue in
+                                onTrackSettingsToggle("automatic_update_downloads", newValue, .about)
+                                sparkleUpdater.setAutomaticallyDownloadsUpdates(newValue)
+                            }
+                        )
+                    )
+                        .disabled(!sparkleUpdater.automaticUpdateSettings.automaticDownloadsAllowed)
+
+                    Text(automaticUpdatesDetail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                HStack {
+                    SettingsInlineActionButton(
+                        title: aboutUpdateButtonTitle,
+                        tone: .accent
+                    ) {
+                        guard aboutUpdateButtonEnabled else { return }
+                        onPerformUpdateAction()
+                    }
+                    .disabled(!aboutUpdateButtonEnabled)
+                }
+            }
+        }
+        .accessibilityIdentifier("transcripted.settings.page.about")
+    }
+
+    private var aboutUpdateStatusTitle: String {
+        switch sparkleUpdater.updateStatus.state {
+        case .unknown, .readyToCheck:
+            return "Ready to check"
+        case .checking:
+            return "Checking for updates"
+        case .noUpdateAvailable:
+            return "Up to date"
+        case .updateAvailable(let version):
+            if sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled {
+                return "Preparing update (\(version))"
+            }
+            return "Update available (\(version))"
+        case .downloading(let version):
+            return "Downloading update (\(version))"
+        case .readyToInstall(let version):
+            return "Ready to restart (\(version))"
+        }
+    }
+
+    private var aboutUpdateStatusDetail: String {
+        switch sparkleUpdater.updateStatus.state {
+        case .unknown, .readyToCheck:
+            return "Check for a newer release."
+        case .checking:
+            return "Looking for updates now."
+        case .noUpdateAvailable:
+            return "This Mac is on the newest visible version."
+        case .updateAvailable(let version):
+            if sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled {
+                return "Transcripted is preparing version \(version). You only need to restart when it is ready."
+            }
+            return "Version \(version) is ready to install."
+        case .downloading(let version):
+            return "Version \(version) is downloading."
+        case .readyToInstall(let version):
+            return "Version \(version) is downloaded."
+        }
+    }
+
+    private var aboutUpdateStatusTone: SettingsStatusCard.Tone {
+        switch sparkleUpdater.updateStatus.state {
+        case .unknown, .readyToCheck:
+            return .working
+        case .checking:
+            return .working
+        case .noUpdateAvailable:
+            return .ready
+        case .updateAvailable where sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled:
+            return .working
+        case .downloading:
+            return .working
+        case .updateAvailable, .readyToInstall:
+            return .caution
+        }
+    }
+
+    private var aboutUpdateButtonTitle: String {
+        switch sparkleUpdater.updateStatus.state {
+        case .updateAvailable(let version):
+            if sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled {
+                return "Preparing Update…"
+            }
+            return "Install \(version)"
+        case .downloading:
+            return "Downloading…"
+        case .readyToInstall:
+            return "Restart to Update"
+        case .checking:
+            return "Checking for Updates…"
+        case .unknown, .readyToCheck, .noUpdateAvailable:
+            return "Check for Updates"
+        }
+    }
+
+    private var aboutUpdateButtonEnabled: Bool {
+        updateActionEnabled(sparkleUpdater.updateStatus)
+    }
+
+    private var automaticUpdatesDetail: String {
+        let settings = sparkleUpdater.automaticUpdateSettings
+        if settings.automaticDownloadsEnabled {
+            return "Transcripted will download updates in the background. When one is ready, you only need to restart."
+        }
+        if settings.automaticChecksEnabled {
+            return "Transcripted will check in the background and show an update badge when one is ready."
+        }
+        return "Turn on automatic checks to see updates sooner."
+    }
+}

--- a/Sources/UI/Settings/Pages/DictationsSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/DictationsSettingsPage.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+/// The Settings > Dictations page. Extracted from `TranscriptedSettingsView`
+/// (see `docs/` audit 2026-07-08 wave 2, spec W2-A). All the actual
+/// open/copy/flag/delete/track logic stays owned by the parent — this struct
+/// is a pure presentation wrapper that receives pre-built closures so
+/// behavior is unchanged.
+struct DictationsSettingsPage: View {
+    @ObservedObject var homeViewModel: HomeViewModel
+    let actions: TranscriptedSettingsActions
+    let homeCopiedRowID: String?
+    let onStartDictation: () -> Void
+    let onLoadMoreDictations: () -> Void
+    let onOpenDictation: (SavedDictationEntry) -> Void
+    let onCopyDictation: (SavedDictationEntry) -> Void
+    let onFlagDictation: (SavedDictationEntry) -> Void
+    let dictationRowMenuItems: (SavedDictationEntry) -> [HomeRowMenuItem]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsPageIntro(
+                title: "Dictations",
+                summary: "Recent dictations saved to daily Markdown files."
+            )
+
+            homeDictationsListSection
+        }
+        .accessibilityIdentifier("transcripted.settings.page.dictations")
+    }
+
+    private var homeDictationsListSection: some View {
+        HomeCaptureListSection(
+            sections: homeViewModel.dictationDaySections,
+            emptyMessage: HomeCaptureListCopy.emptyDictations,
+            emptyState: HomeListEmptyState(
+                symbolName: "mic",
+                title: "No dictations yet",
+                message: "Hold your dictation shortcut and speak in any app — Transcripted types it out for you and keeps a copy here.",
+                actionTitle: "Start a dictation",
+                automationIdentifier: "transcripted.home.dictations.empty.start",
+                action: onStartDictation
+            ),
+            isLoading: homeViewModel.isLoading,
+            isLoadingMore: homeViewModel.isLoadingMore,
+            canLoadMore: homeViewModel.canLoadMoreDictations,
+            getID: { AnyHashable($0.id) },
+            onLoadMore: onLoadMoreDictations
+        ) { entry in
+            HomeDictationRow(
+                entry: entry,
+                isCopied: homeCopiedRowID == entry.id,
+                onOpen: { onOpenDictation(entry) },
+                onCopy: { onCopyDictation(entry) },
+                onFlag: { onFlagDictation(entry) },
+                menuItems: dictationRowMenuItems(entry)
+            )
+        }
+    }
+}

--- a/Sources/UI/Settings/Pages/PeopleSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/PeopleSettingsPage.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// The Settings > Speakers ("People") page. Extracted from
+/// `TranscriptedSettingsView` (codebase audit 2026-07-08 wave 2, spec W2-A).
+struct PeopleSettingsPage: View {
+    @ObservedObject var speakerPeopleModel: SpeakerPeopleSettingsViewModel
+    let onStartMeeting: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsPageIntro(
+                title: "Speakers",
+                summary: "Name new voices and manage the people in your meetings."
+            )
+
+            SpeakerPeopleSettingsSection(
+                model: speakerPeopleModel,
+                onStartMeeting: onStartMeeting
+            )
+        }
+        .accessibilityIdentifier("transcripted.settings.page.people")
+    }
+}

--- a/Sources/UI/Settings/Pages/PrivacySettingsPage.swift
+++ b/Sources/UI/Settings/Pages/PrivacySettingsPage.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+/// The Settings > Privacy page. Extracted from `TranscriptedSettingsView`
+/// (codebase audit 2026-07-08 wave 2, spec W2-A).
+///
+/// `meetingMicProcessingMode`, `splitLocalSpeakersEnabled`,
+/// `crashReportingEnabled`, `anonymousAnalyticsEnabled`, `sentryTestStatus`,
+/// `diagnosticsActionStatus`, and `permissionStates` are also read by the
+/// parent's embedded General > Privacy disclosure editor and by
+/// notification-driven refresh handlers, so they stay `@State` on the parent
+/// and are threaded through here as bindings/values per the split's rule 2.
+struct PrivacySettingsPage: View {
+    @Binding var meetingMicProcessingMode: MicrophoneProcessingMode
+    @Binding var splitLocalSpeakersEnabled: Bool
+    @Binding var crashReportingEnabled: Bool
+    @Binding var anonymousAnalyticsEnabled: Bool
+    @Binding var sentryTestStatus: String?
+    let permissionStates: PermissionSnapshot
+    let onDiagnosticsStatusesCleared: () -> Void
+    let onTrackPermissionCTA: (TranscriptedPermissionKind) -> Void
+    let onRefreshPermissions: () -> Void
+    let onTrackSettingsToggle: (String, Bool, TranscriptedSettingsPage?) -> Void
+    let onTrackSettingsAction: (String, TranscriptedSettingsPage?) -> Void
+    let onSendTestSentryEvent: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsPageIntro(
+                title: "Privacy",
+                summary: "Permissions and optional reporting."
+            )
+
+            SettingsSection(
+                title: "Permissions",
+                detail: "Needed for capture, paste-back, and meeting prompts."
+            ) {
+                ForEach(TranscriptedPermissionKind.allCases) { kind in
+                    PermissionStatusRow(kind: kind, granted: permissionStates[kind] ?? false) {
+                        onTrackPermissionCTA(kind)
+                        Task { @MainActor in
+                            await TranscriptedPermissionAccess.requestAccessOrOpenSettings(for: kind)
+                            onRefreshPermissions()
+                        }
+                    }
+                }
+            }
+
+            SettingsSection(
+                title: "Meeting Audio",
+                detail: "How Transcripted handles your microphone during meetings."
+            ) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Picker("Meeting mic processing", selection: Binding(
+                        get: { meetingMicProcessingMode },
+                        set: { newValue in
+                            meetingMicProcessingMode = newValue
+                            onTrackSettingsToggle("meeting_mic_processing_\(newValue.rawValue)", true, .privacy)
+                            MicrophoneProcessingPreferences.setMode(newValue)
+                        }
+                    )) {
+                        ForEach(MicrophoneProcessingMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .accessibilityIdentifier("transcripted.settings.privacy.meeting-mic-processing")
+
+                    Text(meetingMicProcessingMode.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                SettingsToggleRow(
+                    title: "Identify multiple people on this Mac",
+                    detail: splitLocalSpeakersEnabled
+                        ? "On. After shared-room meetings, Transcripted asks you to name the people captured by your mic."
+                        : "Off. The local mic stays as You, which is simpler when you are the only person near this Mac.",
+                    isOn: Binding(
+                        get: { splitLocalSpeakersEnabled },
+                        set: { newValue in
+                            splitLocalSpeakersEnabled = newValue
+                            onTrackSettingsToggle("local_speaker_split", newValue, .privacy)
+                            LocalSpeakerPreferences.setEnabled(newValue)
+                        }
+                    )
+                )
+
+                Text("Changes here apply from the next recording.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            SettingsSection(
+                title: "Reporting",
+                detail: "Optional. Scrubbed before anything leaves this Mac."
+            ) {
+                SettingsToggleRow(
+                    title: "Send crash and error reports",
+                    detail: crashReportingFootnote,
+                    isOn: Binding(
+                        get: { crashReportingEnabled },
+                        set: { newValue in
+                            crashReportingEnabled = newValue
+                            onTrackSettingsToggle("crash_reporting", newValue, .privacy)
+                            CrashReportingPreferences.setEnabled(newValue)
+                            CrashReporter.applySessionTrackingPreference()
+                            sentryTestStatus = nil
+                            onDiagnosticsStatusesCleared()
+                        }
+                    )
+                )
+                    .disabled(!CrashReporter.isAvailable)
+
+                SettingsToggleRow(
+                    title: "Send anonymous usage stats",
+                    detail: analyticsFootnote,
+                    isOn: Binding(
+                        get: { anonymousAnalyticsEnabled },
+                        set: { newValue in
+                            anonymousAnalyticsEnabled = newValue
+                            if newValue {
+                                AnalyticsPreferences.setEnabled(true)
+                                onTrackSettingsToggle("anonymous_analytics", true, .privacy)
+                            } else {
+                                onTrackSettingsToggle("anonymous_analytics", false, .privacy)
+                                AnalyticsPreferences.setEnabled(false)
+                            }
+                            onDiagnosticsStatusesCleared()
+                        }
+                    )
+                )
+                    .disabled(!AnalyticsReporter.isAvailable)
+
+                HStack {
+                    SettingsInlineActionButton(title: "Send Test Sentry Event", tone: .warning) {
+                        onTrackSettingsAction("send_test_sentry_event", .privacy)
+                        onSendTestSentryEvent()
+                    }
+                    .disabled(!CrashReporter.isAvailable || !crashReportingEnabled)
+
+                    if let sentryTestStatus {
+                        Text(sentryTestStatus)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Text("Never sent: transcript text, audio, names, emails, file paths, raw URLs, or meeting titles.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var crashReportingFootnote: String {
+        if CrashReporter.isAvailable {
+            return crashReportingEnabled
+                ? "On. Sends scrubbed crash and error data to Sentry."
+                : "Off. Crash and error details stay on this Mac."
+        }
+        return "Sentry is not configured in this build. Reports stay local."
+    }
+
+    private var analyticsFootnote: String {
+        if AnalyticsReporter.isAvailable {
+            return anonymousAnalyticsEnabled
+                ? "On. Sends only allowlisted anonymous product events."
+                : "Off. No anonymous usage stats leave this Mac."
+        }
+        return "PostHog is not configured in this build. Usage stats stay off."
+    }
+}

--- a/Sources/UI/Settings/Pages/SupportSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/SupportSettingsPage.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// The Settings > Support page. Extracted from `TranscriptedSettingsView`
+/// (codebase audit 2026-07-08 wave 2, spec W2-A). Tracking and diagnostic
+/// dispatch stay owned by the parent and are passed in as closures.
+struct SupportSettingsPage: View {
+    let actions: TranscriptedSettingsActions
+    let diagnosticsActionStatus: String?
+    let crashReportingEnabled: Bool
+    let onSubmitFeedback: () -> Void
+    let onSendDiagnosticEvent: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            SettingsPageIntro(
+                title: "Support",
+                summary: "Need help, found a bug, or want to send feedback? Email is the best way to reach the team building Transcripted."
+            )
+
+            SupportActionCard(
+                symbolName: "envelope.fill",
+                title: "Email support",
+                detail: "Send feedback, ask for help, or tell us what felt broken. This opens a prefilled email to help@transcripted.app.",
+                buttonTitle: "Email support",
+                buttonSymbolName: "paperplane.fill",
+                tone: .primary,
+                status: nil,
+                isEnabled: true,
+                action: onSubmitFeedback
+            )
+
+            SupportActionCard(
+                symbolName: "waveform.path.ecg",
+                title: "Send diagnostics",
+                detail: "Had an error or something felt broken? Send a privacy-safe diagnostic event so we can investigate and try to fix it.",
+                buttonTitle: "One-click send diagnostics",
+                buttonSymbolName: "bolt.fill",
+                tone: .secondary,
+                status: diagnosticsActionStatus,
+                isEnabled: CrashReporter.isAvailable && crashReportingEnabled,
+                action: onSendDiagnosticEvent
+            )
+
+            SupportPrivacyNote()
+        }
+        .accessibilityIdentifier("transcripted.settings.page.support")
+    }
+}

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -691,15 +691,47 @@ struct TranscriptedSettingsView: View {
     }
 
     private var dictationsPage: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "Dictations",
-                summary: "Recent dictations saved to daily Markdown files."
-            )
-
-            homeDictationsListSection
-        }
-        .accessibilityIdentifier("transcripted.settings.page.dictations")
+        DictationsSettingsPage(
+            homeViewModel: homeViewModel,
+            actions: actions,
+            homeCopiedRowID: homeCopiedRowID,
+            onStartDictation: {
+                trackSettingsAction("empty_start_dictation", page: .dictations)
+                actions.startDictation()
+            },
+            onLoadMoreDictations: {
+                trackSettingsAction("load_more_dictations", page: navigation.selectedPage)
+                homeViewModel.loadMoreDictations()
+            },
+            onOpenDictation: { entry in
+                trackSettingsAction("open_recent_dictation", page: navigation.selectedPage)
+                let didOpen = openOwnFile(
+                    candidateURLs: [entry.url],
+                    failureTitle: "Could not open dictation",
+                    failureMessage: SettingsArtifactMessage.dictationFileNotFound
+                )
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .dictation,
+                    actionKind: .openMarkdown,
+                    surface: .homeRow,
+                    artifactDate: entry.createdAt,
+                    result: didOpen ? .success : .failed
+                )
+                ActivationTelemetry.trackHabitLoopAction(
+                    actionKind: .reviewYesterday,
+                    surface: .homeRow,
+                    artifactKind: .dictation,
+                    artifactDate: entry.createdAt,
+                    result: didOpen ? .success : .failed
+                )
+            },
+            onCopyDictation: { entry in handleCopyDictation(entry) },
+            onFlagDictation: { entry in
+                trackSettingsAction("flag_dictation", page: navigation.selectedPage)
+                homeFeedbackTarget = HomeFeedbackTarget.dictation(entry)
+            },
+            dictationRowMenuItems: { entry in dictationRowMenuItems(for: entry) }
+        )
     }
 
     private var homeMeetingsListSection: some View {
@@ -776,64 +808,6 @@ struct TranscriptedSettingsView: View {
         }
     }
 
-    private var homeDictationsListSection: some View {
-        HomeCaptureListSection(
-            sections: homeViewModel.dictationDaySections,
-            emptyMessage: HomeCaptureListCopy.emptyDictations,
-            emptyState: HomeListEmptyState(
-                symbolName: "mic",
-                title: "No dictations yet",
-                message: "Hold your dictation shortcut and speak in any app — Transcripted types it out for you and keeps a copy here.",
-                actionTitle: "Start a dictation",
-                automationIdentifier: "transcripted.home.dictations.empty.start",
-                action: {
-                    trackSettingsAction("empty_start_dictation", page: .dictations)
-                    actions.startDictation()
-                }
-            ),
-            isLoading: homeViewModel.isLoading,
-            isLoadingMore: homeViewModel.isLoadingMore,
-            canLoadMore: homeViewModel.canLoadMoreDictations,
-            getID: { AnyHashable($0.id) },
-            onLoadMore: {
-                trackSettingsAction("load_more_dictations", page: navigation.selectedPage)
-                homeViewModel.loadMoreDictations()
-            }
-        ) { entry in
-            HomeDictationRow(
-                entry: entry,
-                isCopied: homeCopiedRowID == entry.id,
-                onOpen: {
-                    trackSettingsAction("open_recent_dictation", page: navigation.selectedPage)
-                    let didOpen = openOwnFile(
-                        candidateURLs: [entry.url],
-                        failureTitle: "Could not open dictation",
-                        failureMessage: SettingsArtifactMessage.dictationFileNotFound
-                    )
-                    ActivationTelemetry.trackArtifactAction(
-                        artifactKind: .dictation,
-                        actionKind: .openMarkdown,
-                        surface: .homeRow,
-                        artifactDate: entry.createdAt,
-                        result: didOpen ? .success : .failed
-                    )
-                    ActivationTelemetry.trackHabitLoopAction(
-                        actionKind: .reviewYesterday,
-                        surface: .homeRow,
-                        artifactKind: .dictation,
-                        artifactDate: entry.createdAt,
-                        result: didOpen ? .success : .failed
-                    )
-                },
-                onCopy: { handleCopyDictation(entry) },
-                onFlag: {
-                    trackSettingsAction("flag_dictation", page: navigation.selectedPage)
-                    homeFeedbackTarget = HomeFeedbackTarget.dictation(entry)
-                },
-                menuItems: dictationRowMenuItems(for: entry)
-            )
-        }
-    }
 
     private var homeGreeting: String {
         HomeCanvasGreeting.text(
@@ -3453,18 +3427,10 @@ struct TranscriptedSettingsView: View {
     }
 
     private var peoplePage: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "Speakers",
-                summary: "Name new voices and manage the people in your meetings."
-            )
-
-            SpeakerPeopleSettingsSection(
-                model: speakerPeopleModel,
-                onStartMeeting: { actions.startMeeting() }
-            )
-        }
-        .accessibilityIdentifier("transcripted.settings.page.people")
+        PeopleSettingsPage(
+            speakerPeopleModel: speakerPeopleModel,
+            onStartMeeting: { actions.startMeeting() }
+        )
     }
 
     private var storagePage: some View {
@@ -4519,250 +4485,54 @@ struct TranscriptedSettingsView: View {
     }
 
     private var privacyPage: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "Privacy",
-                summary: "Permissions and optional reporting."
-            )
-
-            SettingsSection(
-                title: "Permissions",
-                detail: "Needed for capture, paste-back, and meeting prompts."
-            ) {
-                ForEach(TranscriptedPermissionKind.allCases) { kind in
-                    PermissionStatusRow(kind: kind, granted: permissionStates[kind] ?? false) {
-                        trackPermissionCTA(kind)
-                        Task { @MainActor in
-                            await TranscriptedPermissionAccess.requestAccessOrOpenSettings(for: kind)
-                            refreshPermissions()
-                        }
-                    }
-                }
-            }
-
-            SettingsSection(
-                title: "Meeting Audio",
-                detail: "How Transcripted handles your microphone during meetings."
-            ) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Picker("Meeting mic processing", selection: Binding(
-                        get: { meetingMicProcessingMode },
-                        set: { newValue in
-                            meetingMicProcessingMode = newValue
-                            trackSettingsToggle("meeting_mic_processing_\(newValue.rawValue)", enabled: true, page: .privacy)
-                            MicrophoneProcessingPreferences.setMode(newValue)
-                        }
-                    )) {
-                        ForEach(MicrophoneProcessingMode.allCases) { mode in
-                            Text(mode.title).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    .accessibilityIdentifier("transcripted.settings.privacy.meeting-mic-processing")
-
-                    Text(meetingMicProcessingMode.detail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                SettingsToggleRow(
-                    title: "Identify multiple people on this Mac",
-                    detail: splitLocalSpeakersEnabled
-                        ? "On. After shared-room meetings, Transcripted asks you to name the people captured by your mic."
-                        : "Off. The local mic stays as You, which is simpler when you are the only person near this Mac.",
-                    isOn: Binding(
-                        get: { splitLocalSpeakersEnabled },
-                        set: { newValue in
-                            splitLocalSpeakersEnabled = newValue
-                            trackSettingsToggle("local_speaker_split", enabled: newValue, page: .privacy)
-                            LocalSpeakerPreferences.setEnabled(newValue)
-                        }
-                    )
-                )
-
-                Text("Changes here apply from the next recording.")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-            }
-
-            SettingsSection(
-                title: "Reporting",
-                detail: "Optional. Scrubbed before anything leaves this Mac."
-            ) {
-                SettingsToggleRow(
-                    title: "Send crash and error reports",
-                    detail: crashReportingFootnote,
-                    isOn: Binding(
-                        get: { crashReportingEnabled },
-                        set: { newValue in
-                            crashReportingEnabled = newValue
-                            trackSettingsToggle("crash_reporting", enabled: newValue, page: .privacy)
-                            CrashReportingPreferences.setEnabled(newValue)
-                            CrashReporter.applySessionTrackingPreference()
-                            sentryTestStatus = nil
-                            diagnosticsActionStatus = nil
-                        }
-                    )
-                )
-                    .disabled(!CrashReporter.isAvailable)
-
-                SettingsToggleRow(
-                    title: "Send anonymous usage stats",
-                    detail: analyticsFootnote,
-                    isOn: Binding(
-                        get: { anonymousAnalyticsEnabled },
-                        set: { newValue in
-                            anonymousAnalyticsEnabled = newValue
-                            if newValue {
-                                AnalyticsPreferences.setEnabled(true)
-                                trackSettingsToggle("anonymous_analytics", enabled: true, page: .privacy)
-                            } else {
-                                trackSettingsToggle("anonymous_analytics", enabled: false, page: .privacy)
-                                AnalyticsPreferences.setEnabled(false)
-                            }
-                            diagnosticsActionStatus = nil
-                        }
-                    )
-                )
-                    .disabled(!AnalyticsReporter.isAvailable)
-
-                HStack {
-                    SettingsInlineActionButton(title: "Send Test Sentry Event", tone: .warning) {
-                        trackSettingsAction("send_test_sentry_event", page: .privacy)
-                        sendTestSentryEvent()
-                    }
-                    .disabled(!CrashReporter.isAvailable || !crashReportingEnabled)
-
-                    if let sentryTestStatus {
-                        Text(sentryTestStatus)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                Text("Never sent: transcript text, audio, names, emails, file paths, raw URLs, or meeting titles.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
+        PrivacySettingsPage(
+            meetingMicProcessingMode: $meetingMicProcessingMode,
+            splitLocalSpeakersEnabled: $splitLocalSpeakersEnabled,
+            crashReportingEnabled: $crashReportingEnabled,
+            anonymousAnalyticsEnabled: $anonymousAnalyticsEnabled,
+            sentryTestStatus: $sentryTestStatus,
+            permissionStates: permissionStates,
+            onDiagnosticsStatusesCleared: { diagnosticsActionStatus = nil },
+            onTrackPermissionCTA: { kind in trackPermissionCTA(kind) },
+            onRefreshPermissions: { refreshPermissions() },
+            onTrackSettingsToggle: { settingID, enabled, page in
+                trackSettingsToggle(settingID, enabled: enabled, page: page)
+            },
+            onTrackSettingsAction: { actionID, page in
+                trackSettingsAction(actionID, page: page)
+            },
+            onSendTestSentryEvent: { sendTestSentryEvent() }
+        )
     }
 
     private var aboutPage: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "About",
-                summary: "Version and updates."
-            )
-
-            SettingsSection(
-                title: "Version",
-                detail: "Build info and update controls."
-            ) {
-                SettingsStatusCard(
-                    title: "Transcripted",
-                    status: TranscriptedSupportActions.appVersionDescription,
-                    detail: "Local-first dictation and meeting notes.",
-                    tone: .ready
-                )
-
-                SettingsStatusCard(
-                    title: "Updates",
-                    status: aboutUpdateStatusTitle,
-                    detail: aboutUpdateStatusDetail,
-                    tone: aboutUpdateStatusTone
-                )
-
-                VStack(alignment: .leading, spacing: 8) {
-                    SettingsToggleRow(
-                        title: "Check automatically",
-                        detail: sparkleUpdater.automaticUpdateSettings.automaticChecksEnabled
-                            ? "Transcripted checks for updates in the background."
-                            : "Transcripted only checks when you ask.",
-                        isOn: Binding(
-                            get: { sparkleUpdater.automaticUpdateSettings.automaticChecksEnabled },
-                            set: { newValue in
-                                trackSettingsToggle("automatic_update_checks", enabled: newValue, page: .about)
-                                sparkleUpdater.setAutomaticallyChecksForUpdates(newValue)
-                            }
-                        )
-                    )
-
-                    SettingsToggleRow(
-                        title: "Download automatically",
-                        detail: sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled
-                            ? "Transcripted downloads available updates in the background."
-                            : "Transcripted waits before downloading updates.",
-                        isOn: Binding(
-                            get: { sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled },
-                            set: { newValue in
-                                trackSettingsToggle("automatic_update_downloads", enabled: newValue, page: .about)
-                                sparkleUpdater.setAutomaticallyDownloadsUpdates(newValue)
-                            }
-                        )
-                    )
-                        .disabled(!sparkleUpdater.automaticUpdateSettings.automaticDownloadsAllowed)
-
-                    Text(automaticUpdatesDetail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                HStack {
-                    SettingsInlineActionButton(
-                        title: aboutUpdateButtonTitle,
-                        tone: .accent
-                    ) {
-                        guard aboutUpdateButtonEnabled else { return }
-                        trackSettingsAction(settingsUpdateActionID, page: .about)
-                        sparkleUpdater.performUserUpdateAction(surface: "settings_about")
-                    }
-                    .disabled(!aboutUpdateButtonEnabled)
-                }
+        AboutSettingsPage(
+            sparkleUpdater: sparkleUpdater,
+            onTrackSettingsToggle: { settingID, enabled, page in
+                trackSettingsToggle(settingID, enabled: enabled, page: page)
+            },
+            updateActionEnabled: { status in updateActionEnabled(for: status) },
+            onPerformUpdateAction: {
+                trackSettingsAction(settingsUpdateActionID, page: .about)
+                sparkleUpdater.performUserUpdateAction(surface: "settings_about")
             }
-        }
-        .accessibilityIdentifier("transcripted.settings.page.about")
+        )
     }
 
     private var supportPage: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            SettingsPageIntro(
-                title: "Support",
-                summary: "Need help, found a bug, or want to send feedback? Email is the best way to reach the team building Transcripted."
-            )
-
-            SupportActionCard(
-                symbolName: "envelope.fill",
-                title: "Email support",
-                detail: "Send feedback, ask for help, or tell us what felt broken. This opens a prefilled email to help@transcripted.app.",
-                buttonTitle: "Email support",
-                buttonSymbolName: "paperplane.fill",
-                tone: .primary,
-                status: nil,
-                isEnabled: true
-            ) {
+        SupportSettingsPage(
+            actions: actions,
+            diagnosticsActionStatus: diagnosticsActionStatus,
+            crashReportingEnabled: crashReportingEnabled,
+            onSubmitFeedback: {
                 trackSettingsAction("submit_feedback", page: .support)
                 actions.sendFeedback()
-            }
-
-            SupportActionCard(
-                symbolName: "waveform.path.ecg",
-                title: "Send diagnostics",
-                detail: "Had an error or something felt broken? Send a privacy-safe diagnostic event so we can investigate and try to fix it.",
-                buttonTitle: "One-click send diagnostics",
-                buttonSymbolName: "bolt.fill",
-                tone: .secondary,
-                status: diagnosticsActionStatus,
-                isEnabled: CrashReporter.isAvailable && crashReportingEnabled
-            ) {
+            },
+            onSendDiagnosticEvent: {
                 trackSettingsAction("send_diagnostic_event", page: .support)
                 sendDiagnosticEvent()
             }
-
-            SupportPrivacyNote()
-        }
-        .accessibilityIdentifier("transcripted.settings.page.support")
+        )
     }
 
     private var settingsFooterShowsUpdateBadge: Bool {
@@ -5661,96 +5431,6 @@ struct TranscriptedSettingsView: View {
                 return url.deletingPathExtension().lastPathComponent
             }
         )
-    }
-
-    private var aboutUpdateStatusTitle: String {
-        switch sparkleUpdater.updateStatus.state {
-        case .unknown, .readyToCheck:
-            return "Ready to check"
-        case .checking:
-            return "Checking for updates"
-        case .noUpdateAvailable:
-            return "Up to date"
-        case .updateAvailable(let version):
-            if sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled {
-                return "Preparing update (\(version))"
-            }
-            return "Update available (\(version))"
-        case .downloading(let version):
-            return "Downloading update (\(version))"
-        case .readyToInstall(let version):
-            return "Ready to restart (\(version))"
-        }
-    }
-
-    private var aboutUpdateStatusDetail: String {
-        switch sparkleUpdater.updateStatus.state {
-        case .unknown, .readyToCheck:
-            return "Check for a newer release."
-        case .checking:
-            return "Looking for updates now."
-        case .noUpdateAvailable:
-            return "This Mac is on the newest visible version."
-        case .updateAvailable(let version):
-            if sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled {
-                return "Transcripted is preparing version \(version). You only need to restart when it is ready."
-            }
-            return "Version \(version) is ready to install."
-        case .downloading(let version):
-            return "Version \(version) is downloading."
-        case .readyToInstall(let version):
-            return "Version \(version) is downloaded."
-        }
-    }
-
-    private var aboutUpdateStatusTone: SettingsStatusCard.Tone {
-        switch sparkleUpdater.updateStatus.state {
-        case .unknown, .readyToCheck:
-            return .working
-        case .checking:
-            return .working
-        case .noUpdateAvailable:
-            return .ready
-        case .updateAvailable where sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled:
-            return .working
-        case .downloading:
-            return .working
-        case .updateAvailable, .readyToInstall:
-            return .caution
-        }
-    }
-
-    private var aboutUpdateButtonTitle: String {
-        switch sparkleUpdater.updateStatus.state {
-        case .updateAvailable(let version):
-            if sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled {
-                return "Preparing Update…"
-            }
-            return "Install \(version)"
-        case .downloading:
-            return "Downloading…"
-        case .readyToInstall:
-            return "Restart to Update"
-        case .checking:
-            return "Checking for Updates…"
-        case .unknown, .readyToCheck, .noUpdateAvailable:
-            return "Check for Updates"
-        }
-    }
-
-    private var aboutUpdateButtonEnabled: Bool {
-        updateActionEnabled(for: sparkleUpdater.updateStatus)
-    }
-
-    private var automaticUpdatesDetail: String {
-        let settings = sparkleUpdater.automaticUpdateSettings
-        if settings.automaticDownloadsEnabled {
-            return "Transcripted will download updates in the background. When one is ready, you only need to restart."
-        }
-        if settings.automaticChecksEnabled {
-            return "Transcripted will check in the background and show an update badge when one is ready."
-        }
-        return "Turn on automatic checks to see updates sooner."
     }
 
     private var settingsUpdateActionID: String {


### PR DESCRIPTION
## What

Splits `Sources/UI/Settings/TranscriptedSettingsView.swift` (5855 lines) per **codebase audit 2026-07-08 wave 2, spec W2-A**: extracts the Dictations, Speakers ("People"), Privacy, About, and Support pages into their own `View` structs under `Sources/UI/Settings/Pages/`.

- `Sources/UI/Settings/Pages/DictationsSettingsPage.swift`
- `Sources/UI/Settings/Pages/PeopleSettingsPage.swift`
- `Sources/UI/Settings/Pages/PrivacySettingsPage.swift`
- `Sources/UI/Settings/Pages/AboutSettingsPage.swift`
- `Sources/UI/Settings/Pages/SupportSettingsPage.swift`

Pure code motion — no behavior or public API changes. Each new page is a presentation-only `View` struct; shared state and logic (analytics tracking, permission refresh, update-safety policy, `sendTestSentryEvent`/`sendDiagnosticEvent`, etc.) stay owned by `TranscriptedSettingsView` and are threaded down as bindings/closures, per the split's rule that state/helpers read by more than one page or by the parent's `onReceive`/`onChange` handlers stay in the parent.

`TranscriptedSettingsView.swift`: 5855 → 5535 lines.

## Why fewer than the "top 6" / short of the <1200 target

The spec's line numbers had drifted (5855 lines at HEAD vs. its 5757), so pages were located by grepping their `private var`/`func` names rather than by line number — noted per the executor instructions.

More importantly, investigation showed the spec's per-page line estimates didn't match reality:

- `dictationsPage` itself is only ~11 lines wrapping a ~57-line `homeDictationsListSection` helper — not the ~1706 lines estimated. That estimate conflated it with the much larger `homePage` + Home-helpers cluster that sits directly above it in source order (all the delete/copy/retry/local-summary logic for meeting *and* dictation rows lives in one shared ~1800-line block).
- `homePage`, `shortcutsPage`, `generalPage`, `modelsPage`, `storagePage`, and `betaPage` all share large helper/state clusters **across multiple page surfaces**: e.g. `generalPrivacySettingsEditor` and `generalModelSettingsEditor` (embedded disclosure groups inside General) duplicate `privacyPage`'s and `modelsPage`'s state and read/write the same `@State`; the beta local-summary helpers are also driven by Home's per-meeting summary generation.

Untangling those within this PR risked subtle behavior regressions and would have required rewriting large parts of `Tests/UIAutomationSurfaceContractTests.swift`, which asserts via raw-source `String.contains` against `TranscriptedSettingsView.swift` for `beta.*`/`general.*` automation identifiers, custom-dictionary hooks, and the Home action-menu/alert wiring.

Per the spec's own fallback ("a complete extraction of the top 6 with the rest left inline is an acceptable PR — say exactly what remains"), this PR ships a **complete, verified** extraction of the 5 pages above (chosen for being safely separable — dictations, then the smallest/most self-contained: privacy, about, support, people) and leaves `homePage`, `shortcutsPage`, `generalPage`, `modelsPage`, `storagePage`, `betaPage`, and `connectAgentPage` (already a 1-line wrapper around `AgentConnectionSettingsPage`) inline in the parent.

`crashReportingFootnote`/`analyticsFootnote` are tiny pure computations shared between the new `PrivacySettingsPage` and the parent's still-inline `generalPrivacySettingsEditor`; duplicated (8 lines total) rather than introducing a new shared file, to keep the diff minimal.

## Test/contract-file changes

None needed:
- `Tests/UIAutomationSurfaceContractTests.swift` — none of the moved page content is asserted by raw-source string match against `TranscriptedSettingsView.swift`; verified by grep before and after.
- `scripts/entrypoints/run-tests.sh` (`APP_SOURCES`) / `Tests/FastTests.manifest` — the fast-test allowlist already excludes all the View-heavy Settings files (`TranscriptedSettingsView.swift`, `HomeView.swift`, `AgentConnectionSettingsPage.swift`, `SpeakerPeopleSettingsSection.swift`, etc.); the new `Pages/*.swift` files fall into that same already-excluded bucket. `build.sh`'s source list is a `find Sources -name '*.swift'` glob, so the new files are picked up automatically for the real app build.

## Test plan

- [x] Duplicate-declaration sweep on every touched/new file — clean (pre-existing overloads/local `let`s only).
- [x] Full `swiftc -O -whole-module-optimization` app compile + link succeeded, producing a runnable `Transcripted-bin`.
- [x] Fast suite: **12863/12863 passed**, including every `UIAutomationSurfaceContractTests` suite.
- [ ] `deps-libs` on this machine was stale relative to `origin/main` (predates several merged `Sources/TranscriptedCore` PRs from 2026-07-08 → 2026-07-12 unrelated to this change), which trips `build.sh`'s own mtime/digest staleness gate. Since `Sources/TranscriptedCore` is excluded from the app's own compile and links via the prebuilt `deps-libs`/`deps-modules` archive regardless (confirmed in `scripts/entrypoints/lib/swiftc-app-args.sh`), this doesn't affect correctness here — the app build and fast-suite run above were done with the exact same `swiftc` invocation `build.sh` uses, just invoked directly rather than through the staleness gate. Rebuilding the shared `deps-libs` archive was out of scope for a UI-only change and would mutate a resource shared across worktrees. CI's from-scratch build is the authoritative gate for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)