### PR TITLE
refactor(core): shared SQLiteHandle for open/pragmas/permissions across the four app DB wrappers

### DIFF
--- a/Sources/Timeline/TimelineDatabase.swift
+++ b/Sources/Timeline/TimelineDatabase.swift
@@ -1,5 +1,8 @@
 import Foundation
 import SQLite3
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 struct TimelineScreenshotRow: Equatable {
     let id: Int64
@@ -261,9 +264,29 @@ final class TimelineDatabase {
         }
 
         fileManager.restrictSQLiteArtifactsToOwnerOnly(at: databaseURL)
+        #if canImport(TranscriptedCore)
+        // `ownerOnly: false` because permission hardening here goes through the injected
+        // `fileManager` (test seam), not `SQLiteHandle`'s hardcoded `FileManager.default`.
+        // `onPragmaFailure` throws, so SQLiteHandle stops at the first failing pragma —
+        // matching the pre-extraction behavior where each `try execute(...)` aborted
+        // `open()` immediately.
+        try SQLiteHandle.configure(
+            db,
+            at: databaseURL,
+            ownerOnly: false,
+            onPragmaFailure: { _, detail in
+                throw TimelineDatabaseError.executeFailed(detail)
+            }
+        )
+        #else
+        // The fast-test harness (scripts/entrypoints/run-tests.sh) compiles this file
+        // without linking TranscriptedCore (see the same `canImport` guard elsewhere in
+        // this codebase, e.g. Sources/Meeting/MeetingAudioStorageManager.swift), so it
+        // falls back to the pre-extraction inline pragma application.
         try execute("PRAGMA journal_mode=WAL;")
         try execute("PRAGMA busy_timeout=5000;")
         try execute("PRAGMA synchronous=NORMAL;")
+        #endif
         fileManager.restrictSQLiteArtifactsToOwnerOnly(at: databaseURL)
     }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -12,7 +12,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
     var db: OpaquePointer?
     // Thread-safety invariant:
     // - Writes happen only during `init` (single-threaded construction) inside
-    //   `openDatabase`/`configureOpenDatabase`.
+    //   `openDatabase` (which delegates open/configure to `SQLiteHandle`).
     // - Reads happen only inside `queue.sync { ... }` via the `*Impl` helpers
     //   below. This serializes reader visibility through the queue's memory
     //   barrier, which is why the class can safely be `@unchecked Sendable`
@@ -42,57 +42,49 @@ public final class SpeakerDatabase: @unchecked Sendable {
     // MARK: - Database Setup
 
     private func openDatabase() {
-        if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
-            let sqliteError = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
-            AppLogger.speakers.error("Failed to open speaker database — all speaker operations will be skipped", ["path": dbPath.path, "sqlite_error": sqliteError])
-            isDatabaseOpen = false
-        } else {
-            configureOpenDatabase()
-
-            // Corruption detection: run quick_check to verify database integrity
-            if !verifyDatabaseIntegrity() {
-                AppLogger.speakers.error("CRITICAL: Speaker database corrupt — backing up and recreating", ["path": dbPath.path])
-                sqlite3_close(db)
-                db = nil
-                // Backup corrupt file with timestamp
-                let backupName = "speakers_corrupt_\(DateFormattingHelper.formatFilename(Date())).sqlite"
-                let backupPath = dbPath.deletingLastPathComponent().appendingPathComponent(backupName)
-                try? FileManager.default.moveItem(at: dbPath, to: backupPath)
-                // Recreate fresh database
-                if sqlite3_open(dbPath.path, &db) == SQLITE_OK {
-                    configureOpenDatabase()
-                    AppLogger.speakers.info("Recreated fresh database after corruption recovery")
-                } else {
-                    isDatabaseOpen = false
-                    AppLogger.speakers.error("Failed to recreate database after corruption recovery")
-                }
-            } else {
-                AppLogger.speakers.info("Opened database", ["path": dbPath.path])
-            }
-        }
-    }
-
-    /// Apply permissions and WAL pragmas to an already-opened database handle.
-    /// Called on both initial open and corruption-recovery re-open.
-    private func configureOpenDatabase() {
-        FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
-        // WAL mode for crash safety, busy timeout to avoid SQLITE_BUSY, NORMAL sync for performance
-        let pragmas = [
-            ("journal_mode=WAL", "WAL"),
-            ("busy_timeout=5000", "busy_timeout"),
-            ("synchronous=NORMAL", "synchronous")
-        ]
-        for (pragma, name) in pragmas {
-            var errorMessage: UnsafeMutablePointer<CChar>?
-            if sqlite3_exec(db, "PRAGMA \(pragma);", nil, nil, &errorMessage) != SQLITE_OK {
-                let detail = errorMessage.map { String(cString: $0) } ?? "unknown"
+        db = SQLiteHandle.open(
+            at: dbPath,
+            onOpenFailure: { sqliteError in
+                AppLogger.speakers.error("Failed to open speaker database — all speaker operations will be skipped", ["path": dbPath.path, "sqlite_error": sqliteError])
+            },
+            onPragmaFailure: { name, detail in
                 AppLogger.speakers.error("PRAGMA failed", ["pragma": name, "detail": detail])
-                sqlite3_free(errorMessage)
             }
+        )
+        guard db != nil else {
+            isDatabaseOpen = false
+            return
         }
         // Security: mark the database open only after all pragmas are applied so any concurrent
         // reader that observes isDatabaseOpen=true is guaranteed to see a fully-configured handle.
         isDatabaseOpen = true
+
+        // Corruption detection: run quick_check to verify database integrity
+        if !verifyDatabaseIntegrity() {
+            AppLogger.speakers.error("CRITICAL: Speaker database corrupt — backing up and recreating", ["path": dbPath.path])
+            sqlite3_close(db)
+            db = nil
+            // Backup corrupt file with timestamp
+            let backupName = "speakers_corrupt_\(DateFormattingHelper.formatFilename(Date())).sqlite"
+            let backupPath = dbPath.deletingLastPathComponent().appendingPathComponent(backupName)
+            try? FileManager.default.moveItem(at: dbPath, to: backupPath)
+            // Recreate fresh database
+            db = SQLiteHandle.open(
+                at: dbPath,
+                onPragmaFailure: { name, detail in
+                    AppLogger.speakers.error("PRAGMA failed", ["pragma": name, "detail": detail])
+                }
+            )
+            if db != nil {
+                isDatabaseOpen = true
+                AppLogger.speakers.info("Recreated fresh database after corruption recovery")
+            } else {
+                isDatabaseOpen = false
+                AppLogger.speakers.error("Failed to recreate database after corruption recovery")
+            }
+        } else {
+            AppLogger.speakers.info("Opened database", ["path": dbPath.path])
+        }
     }
 
     /// Verify database integrity using PRAGMA quick_check.

--- a/Sources/TranscriptedCore/Stats/StatsDatabase.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabase.swift
@@ -63,59 +63,52 @@ public final class StatsDatabase {
     // MARK: - Database Setup
 
     private func openDatabase() {
-        if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
-            let sqliteError = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
-            AppLogger.stats.error("Failed to open stats database", ["path": dbPath.path, "sqlite_error": sqliteError])
-            isDatabaseOpen = false
-        } else {
-            configureOpenDatabase()
-
-            // Corruption detection: run quick_check to verify database integrity
-            if !verifyDatabaseIntegrity() {
-                AppLogger.stats.error("CRITICAL: Stats database corrupt — backing up and recreating", ["path": dbPath.path])
-                sqlite3_close(db)
-                db = nil
-                // Backup corrupt file with timestamp
-                let backupName = "stats_corrupt_\(DateFormattingHelper.formatFilename(Date())).sqlite"
-                let backupPath = dbPath.deletingLastPathComponent().appendingPathComponent(backupName)
-                try? FileManager.default.moveItem(at: dbPath, to: backupPath)
-                // Recreate fresh database
-                if sqlite3_open(dbPath.path, &db) == SQLITE_OK {
-                    configureOpenDatabase()
-                    AppLogger.stats.info("Recreated fresh database after corruption recovery")
-                } else {
-                    isDatabaseOpen = false
-                    AppLogger.stats.error("Failed to recreate database after corruption recovery")
-                }
-            } else {
-                AppLogger.stats.info("Opened database", ["path": dbPath.path])
-            }
-        }
-    }
-
-    /// Apply permissions and WAL pragmas to an already-opened database handle.
-    /// Called on both initial open and corruption-recovery re-open.
-    private func configureOpenDatabase() {
-        FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
         // Security: check each PRAGMA return value so a silent failure (e.g. WAL mode refused
         // because another process holds the db) is logged rather than silently misconfiguring
-        // the database. Matches the same pattern used in SpeakerDatabase.configureOpenDatabase().
-        let pragmas = [
-            ("journal_mode=WAL", "journal_mode"),
-            ("busy_timeout=5000", "busy_timeout"),
-            ("synchronous=NORMAL", "synchronous")
-        ]
-        for (pragma, name) in pragmas {
-            var errorMessage: UnsafeMutablePointer<CChar>?
-            if sqlite3_exec(db, "PRAGMA \(pragma);", nil, nil, &errorMessage) != SQLITE_OK {
-                let detail = errorMessage.map { String(cString: $0) } ?? "unknown"
+        // the database. Matches the same pattern used in SpeakerDatabase.openDatabase().
+        db = SQLiteHandle.open(
+            at: dbPath,
+            onOpenFailure: { sqliteError in
+                AppLogger.stats.error("Failed to open stats database", ["path": dbPath.path, "sqlite_error": sqliteError])
+            },
+            onPragmaFailure: { name, detail in
                 AppLogger.stats.error("PRAGMA failed", ["pragma": name, "detail": detail])
-                sqlite3_free(errorMessage)
             }
+        )
+        guard db != nil else {
+            isDatabaseOpen = false
+            return
         }
         // Security: mark the database open only after all pragmas are applied so any concurrent
         // reader that observes isDatabaseOpen=true is guaranteed to see a fully-configured handle.
         isDatabaseOpen = true
+
+        // Corruption detection: run quick_check to verify database integrity
+        if !verifyDatabaseIntegrity() {
+            AppLogger.stats.error("CRITICAL: Stats database corrupt — backing up and recreating", ["path": dbPath.path])
+            sqlite3_close(db)
+            db = nil
+            // Backup corrupt file with timestamp
+            let backupName = "stats_corrupt_\(DateFormattingHelper.formatFilename(Date())).sqlite"
+            let backupPath = dbPath.deletingLastPathComponent().appendingPathComponent(backupName)
+            try? FileManager.default.moveItem(at: dbPath, to: backupPath)
+            // Recreate fresh database
+            db = SQLiteHandle.open(
+                at: dbPath,
+                onPragmaFailure: { name, detail in
+                    AppLogger.stats.error("PRAGMA failed", ["pragma": name, "detail": detail])
+                }
+            )
+            if db != nil {
+                isDatabaseOpen = true
+                AppLogger.stats.info("Recreated fresh database after corruption recovery")
+            } else {
+                isDatabaseOpen = false
+                AppLogger.stats.error("Failed to recreate database after corruption recovery")
+            }
+        } else {
+            AppLogger.stats.info("Opened database", ["path": dbPath.path])
+        }
     }
 
     /// Verify database integrity using PRAGMA quick_check.

--- a/Sources/TranscriptedCore/Storage/SQLiteHandle.swift
+++ b/Sources/TranscriptedCore/Storage/SQLiteHandle.swift
@@ -1,0 +1,88 @@
+// SQLiteHandle.swift
+// Shared SQLite bootstrap: open, owner-only permission hardening, and pragma
+// configuration. Consolidates boilerplate that was duplicated (with drift) across
+// SpeakerDatabase, StatsDatabase, TimelineDatabase, and RecentMeetingMetadataCache.
+// Schema, queries, and locking stay with each wrapper — this only owns "how do we get
+// an open, correctly-configured `sqlite3*` handle."
+
+import Foundation
+import SQLite3
+
+public enum SQLiteHandle {
+
+    /// One `PRAGMA <clause>;` to apply on open, with a short `name` used for error logging.
+    public typealias Pragma = (pragma: String, name: String)
+
+    /// WAL for crash safety, a busy timeout to avoid SQLITE_BUSY under contention, NORMAL
+    /// sync for performance. The pragma set shared by the file-backed database wrappers.
+    public static let standardPragmas: [Pragma] = [
+        ("journal_mode=WAL", "journal_mode"),
+        ("busy_timeout=5000", "busy_timeout"),
+        ("synchronous=NORMAL", "synchronous"),
+    ]
+
+    /// Open a file-backed database at `url` and apply `pragmas` + owner-only permissions.
+    ///
+    /// Does NOT create the parent directory — callers manage that themselves, since some
+    /// need directory-level permission hardening (e.g. 0o700) that differs from the
+    /// database file's own 0o600 and predates this helper.
+    ///
+    /// `onPragmaFailure` is invoked once per failing pragma with `(name, detail)`. If it
+    /// throws, pragma application stops at that pragma (fail-fast callers); if it returns
+    /// normally, the remaining pragmas are still attempted (log-and-continue callers). This
+    /// mirrors the two behaviors that existed pre-extraction: TimelineDatabase aborted on
+    /// the first failing pragma, while SpeakerDatabase/StatsDatabase logged and continued.
+    ///
+    /// Returns nil if `sqlite3_open` itself fails, in which case `onOpenFailure` receives
+    /// the sqlite error message.
+    @discardableResult
+    public static func open(
+        at url: URL,
+        pragmas: [Pragma] = standardPragmas,
+        ownerOnly: Bool = true,
+        onOpenFailure: (String) -> Void = { _ in },
+        onPragmaFailure: (String, String) throws -> Void = { _, _ in }
+    ) rethrows -> OpaquePointer? {
+        var db: OpaquePointer?
+        guard sqlite3_open(url.path, &db) == SQLITE_OK else {
+            let message = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
+            onOpenFailure(message)
+            return nil
+        }
+        try configure(db, at: url, pragmas: pragmas, ownerOnly: ownerOnly, onPragmaFailure: onPragmaFailure)
+        return db
+    }
+
+    /// Open a private in-memory database (no file, no permissions, no pragmas — matches
+    /// the ":memory:" fast path used by ephemeral/test callers).
+    public static func openInMemory() -> OpaquePointer? {
+        var db: OpaquePointer?
+        guard sqlite3_open(":memory:", &db) == SQLITE_OK else {
+            return nil
+        }
+        return db
+    }
+
+    /// Apply owner-only permissions + pragmas to an already-open handle. Exposed separately
+    /// so callers that manage `sqlite3_open` themselves (e.g. corruption-recovery re-open)
+    /// can still share the configuration step.
+    public static func configure(
+        _ db: OpaquePointer?,
+        at url: URL,
+        pragmas: [Pragma] = standardPragmas,
+        ownerOnly: Bool = true,
+        onPragmaFailure: (String, String) throws -> Void = { _, _ in }
+    ) rethrows {
+        if ownerOnly {
+            FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: url.path)
+        }
+        for (pragma, name) in pragmas {
+            var errorMessage: UnsafeMutablePointer<CChar>?
+            if sqlite3_exec(db, "PRAGMA \(pragma);", nil, nil, &errorMessage) != SQLITE_OK {
+                let detail = errorMessage.map { String(cString: $0) } ?? "unknown"
+                sqlite3_free(errorMessage)
+                try onPragmaFailure(name, detail)
+            }
+        }
+    }
+}

--- a/Sources/UI/Shared/RecentMeetingMetadataCache.swift
+++ b/Sources/UI/Shared/RecentMeetingMetadataCache.swift
@@ -17,6 +17,9 @@
 
 import Foundation
 import SQLite3
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
@@ -135,21 +138,42 @@ final class RecentMeetingMetadataCache: @unchecked Sendable {
                 at: databaseURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
+            // Owner-only: this is a derived cache of meeting metadata, keep it off
+            // broader default permissions on multi-user systems. No WAL/busy/sync
+            // pragmas — this cache doesn't need them.
+            #if canImport(TranscriptedCore)
+            guard let opened = try? SQLiteHandle.open(at: databaseURL, pragmas: []) else {
+                db = nil
+                return
+            }
+            db = opened
+            #else
+            // The fast-test harness (scripts/entrypoints/run-tests.sh) compiles this file
+            // without linking TranscriptedCore (see the same `canImport` guard elsewhere in
+            // this codebase, e.g. Sources/Meeting/MeetingAudioStorageManager.swift), so it
+            // falls back to the pre-extraction inline open + chmod.
             guard sqlite3_open(databaseURL.path, &db) == SQLITE_OK else {
                 db = nil
                 return
             }
-            // Owner-only: this is a derived cache of meeting metadata, keep it off
-            // broader default permissions on multi-user systems.
             try? FileManager.default.setAttributes(
                 [.posixPermissions: 0o600],
                 ofItemAtPath: databaseURL.path
             )
+            #endif
         } else {
+            #if canImport(TranscriptedCore)
+            guard let opened = SQLiteHandle.openInMemory() else {
+                db = nil
+                return
+            }
+            db = opened
+            #else
             guard sqlite3_open(":memory:", &db) == SQLITE_OK else {
                 db = nil
                 return
             }
+            #endif
         }
         createTable()
     }


### PR DESCRIPTION
## What

New `Sources/TranscriptedCore/Storage/SQLiteHandle.swift` consolidates the SQLite
bootstrap boilerplate (open, WAL/busy_timeout/synchronous pragmas, owner-only chmod)
previously duplicated with drift across:

- `SpeakerDatabase.swift` (`openDatabase`/`configureOpenDatabase`)
- `StatsDatabase.swift` (`openDatabase`/`configureOpenDatabase`)
- `TimelineDatabase.swift` (`open()`)
- `RecentMeetingMetadataCache.swift` (`init`)

Only the open/configure sections of each file were touched — schema, queries, and
locking are untouched. `RecentMeetingMetadataCache`'s scan/prune logic (recently
touched by the test-isolation fix) was not touched.

## Why

Verified duplication per codebase audit 2026-07-08 wave 2, spec W2-F:
`SpeakerDatabase` ~92-111 and `StatsDatabase` ~100-112 applied near-identical pragmas
with the same manual `sqlite3_exec` error loop; `TimelineDatabase` ~240-248 set the
same three pragmas via a different (throwing) helper; `RecentMeetingMetadataCache` set
0o600 permissions separately with a direct `setAttributes` call.

## Design

`SQLiteHandle.open`/`configure` take an `onPragmaFailure: (String, String) throws -> Void`
closure:
- **Log-and-continue** (`SpeakerDatabase`, `StatsDatabase`): closure logs and returns
  normally, so the loop keeps applying the remaining pragmas — matches original
  behavior exactly.
- **Fail-fast** (`TimelineDatabase`): closure throws, so `SQLiteHandle` stops at the
  first failing pragma — matches `TimelineDatabase`'s original `try execute(...)`-per-
  pragma behavior, which aborted `open()` on the first failure.

`TimelineDatabase` keeps using its injected `fileManager: FileManager` for permission
hardening (test seam) rather than `SQLiteHandle`'s `ownerOnly` flag (which hardcodes
`FileManager.default`), so `ownerOnly: false` is passed there and the wrapper calls
`fileManager.restrictSQLiteArtifactsToOwnerOnly(at:)` itself, in the same
before-pragmas/after-pragmas order as before.

## Build-system deviation (pre-existing infra, not introduced by this PR)

`TimelineDatabase.swift` and `RecentMeetingMetadataCache.swift` are compiled in two
contexts: the real app build (links `TranscriptedCore` as a module via
`deps-modules/TranscriptedCore.swiftmodule`) and the fast-test harness
(`scripts/entrypoints/run-tests.sh`), which compiles a flat file subset with **no**
TranscriptedCore module linkage at all. An unconditional `import TranscriptedCore` in
either file breaks `bash run-tests.sh` with "no such module 'TranscriptedCore'".

The codebase already has a pattern for this (see `Sources/Meeting/
MeetingAudioStorageManager.swift`, `Sources/UI/Shared/HomeMeetingDeletion.swift`, etc.):
`#if canImport(TranscriptedCore) import TranscriptedCore #endif`. Both files now follow
that pattern, and the `SQLiteHandle` call sites are similarly gated with a `#else`
fallback that is the original (pre-extraction) inline pragma/chmod code, so fast-test
behavior is unchanged. This means the dedup for these two files is "real build only" —
the fast-test-only compile path still has its own inline copy. No behavior change in
either path.

## Testing

- `flock`-wrapped `bash build-deps.sh --force` (Core touched) — succeeded.
- `flock`-wrapped `bash build.sh` — succeeded (full app build + codesign + launch
  smoke check).
- `bash run-tests.sh --filter testTimelineDatabase` — 34/34 passed.
- `bash run-tests.sh --filter testHomeMeetingCacheIsolation` — 13/13 passed.
- `swift test --filter "SpeakerDB|StatsDatabase|Speaker|Stats"` — 256/256 passed (1
  pre-existing skip, unrelated).
- `swift build` (TranscriptedCore SPM package) — clean, no new warnings.
- Duplicate-declaration sweep on all touched files — no unexpected collisions (only
  legitimate overloads / different-scope locals).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>