### PR TITLE
refactor(meeting): extract FailedMeetingStore + TranscriptionQueueCoordinator from MeetingSessionController

### DIFF
--- a/Sources/Meeting/FailedMeetingStore.swift
+++ b/Sources/Meeting/FailedMeetingStore.swift
@@ -1,0 +1,255 @@
+// FailedMeetingStore.swift
+// Failed-meeting queue/persistence/retry bookkeeping extracted from
+// MeetingSessionController (audit 2026-07-08 wave 2, W2-B). Pure code motion —
+// no behavior change. This is a plain owned object (not an ObservableObject);
+// MeetingSessionController still owns the `@Published var failedMeetings`
+// surface and calls back into the controller for state it doesn't itself own
+// (`taskManager`, `failedManager`, diagnostics helpers) via `controller`.
+//
+// MeetingSessionController.FailedMeetingItem stays resolvable via a typealias
+// on the controller so every existing call site (Settings/Home UI,
+// FailedMeetingPresentation) keeps compiling unchanged.
+
+import Foundation
+import TranscriptedCore
+
+@available(macOS 14.0, *)
+@MainActor
+final class FailedMeetingStore {
+    struct FailedMeetingItem: Identifiable, Equatable {
+        let id: UUID
+        let timestamp: Date
+        let title: String
+        let detail: String
+        let meta: String
+        let failureKind: MeetingFailureKind
+        let isRetryable: Bool
+        let isRetrying: Bool
+        let hasAudioFiles: Bool
+        let audioURLs: [URL]
+    }
+
+    unowned let controller: MeetingSessionController
+
+    private var retryingFailedMeetingIDs: Set<UUID> = []
+    private var failedAudioCompressionTask: Task<Void, Never>?
+    private var failedAudioCompressionNeedsReschedule = false
+
+    init(controller: MeetingSessionController) {
+        self.controller = controller
+    }
+
+    @discardableResult
+    func retryFailedMeeting(id: UUID) -> Bool {
+        guard !controller.isRecording, !controller.hasBackgroundTranscriptionWork, !controller.isSpeakerReviewPending else { return false }
+        guard !retryingFailedMeetingIDs.contains(id) else { return false }
+        guard controller.failedManager.failedTranscriptions.contains(where: { $0.id == id }) else {
+            controller.refreshFailedMeetings()
+            return false
+        }
+
+        failedAudioCompressionTask?.cancel()
+        retryingFailedMeetingIDs.insert(id)
+        controller.activeTranscriptionTrigger = .unknown
+        controller.refreshFailedMeetings()
+        let retryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "meeting_transcription",
+            failureKind: "failed_meeting",
+            retrySource: "failed_meeting_retry",
+            surface: "home",
+            artifactRetained: true
+        )
+
+        Task { [weak self] in
+            guard let self else { return }
+            await self.controller.prepareModels()
+            guard case .ready = self.controller.state else {
+                DiagnosticsTrail.record(
+                    level: .warning,
+                    engine: "meeting",
+                    event: "meeting_failed_retry_blocked_models",
+                    message: "Failed meeting retry blocked because models were not ready",
+                    context: self.controller.baseDiagnosticsContext(extra: ["failed_id": id.uuidString])
+                )
+                self.retryingFailedMeetingIDs.remove(id)
+                self.controller.refreshFailedMeetings()
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "meeting_transcription",
+                    failureKind: "failed_meeting",
+                    retrySource: "failed_meeting_retry",
+                    result: "failed",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
+                    surface: "home",
+                    artifactRetained: true
+                )
+                return
+            }
+
+            let retryPublished = await self.controller.taskManager.retryFailedTranscription(
+                failedId: id,
+                outputFolder: MeetingStoragePaths.transcriptsFolder
+            )
+            self.retryingFailedMeetingIDs.remove(id)
+            self.controller.refreshFailedMeetings()
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "meeting_transcription",
+                failureKind: "failed_meeting",
+                retrySource: "failed_meeting_retry",
+                result: retryPublished ? "success" : "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
+                surface: "home",
+                artifactRetained: true
+            )
+        }
+        return true
+    }
+
+    @discardableResult
+    func dismissFailedMeeting(id: UUID) -> Bool {
+        retryingFailedMeetingIDs.remove(id)
+        let didDismiss = controller.failedManager.removeFailedTranscription(id: id)
+        controller.refreshFailedMeetings()
+        return didDismiss || !controller.failedManager.failedTranscriptions.contains(where: { $0.id == id })
+    }
+
+    @discardableResult
+    func deleteFailedMeeting(id: UUID) -> Bool {
+        retryingFailedMeetingIDs.remove(id)
+        let didDelete = controller.failedManager.deleteFailedTranscription(id: id)
+        controller.refreshFailedMeetings()
+        return didDelete || !controller.failedManager.failedTranscriptions.contains(where: { $0.id == id })
+    }
+
+    @discardableResult
+    func preserveFailedMeetingForRetry(
+        taskId: UUID = UUID(),
+        micAudioURL: URL?,
+        systemAudioURL: URL?,
+        errorMessage: String,
+        meetingTitle: String?,
+        recordingDate: Date? = nil,
+        archiveAudio: Bool = true
+    ) -> Bool {
+        let preserved = controller.taskManager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micAudioURL,
+            systemAudioURL: systemAudioURL,
+            errorMessage: errorMessage,
+            taskId: taskId,
+            meetingTitle: meetingTitle,
+            recordingDate: recordingDate,
+            archiveAudio: archiveAudio
+        )
+        if preserved {
+            controller.refreshFailedMeetings()
+        }
+        return preserved
+    }
+
+    func refreshTimedOutFailedMeetingAudio(id: UUID, result: CaptureStopResult) {
+        let existingFailure = controller.failedManager.failedTranscriptions
+            .first(where: { $0.id == id })
+        let existingMicURL = existingFailure?.micAudioURL
+        let existingSystemURL = existingFailure?.systemAudioURL
+        guard let micURL = result.micURL ?? existingMicURL else { return }
+        let systemURL = result.systemURL ?? existingSystemURL
+
+        let updated = controller.taskManager.promoteFinalizedFailedTranscriptionAudio(
+            id: id,
+            micAudioURL: micURL,
+            systemAudioURL: systemURL
+        )
+        DiagnosticsTrail.record(
+            level: updated ? .info : .warning,
+            engine: "meeting",
+            event: "meeting_recording_stop_timeout_audio_finalized",
+            message: updated
+                ? "Timed-out meeting audio finalized and failed queue was refreshed"
+                : "Timed-out meeting audio finalized but failed queue entry was not found",
+            context: controller.baseDiagnosticsContext(
+                extra: [
+                    "failed_id": id.uuidString,
+                    "mic_file_present": controller.boolString(FileManager.default.fileExists(atPath: micURL.path)),
+                    "system_file_present": controller.boolString(systemURL.map { FileManager.default.fileExists(atPath: $0.path) } ?? false)
+                ]
+            )
+        )
+        if updated {
+            controller.refreshFailedMeetings()
+        }
+    }
+
+    /// Recomputes the presented failed-meeting list. Called from the
+    /// controller's `refreshFailedMeetings(_:)`, which assigns the result to
+    /// its own `@Published var failedMeetings` (kept on the controller —
+    /// this store never touches the published surface directly).
+    func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) -> [FailedMeetingItem] {
+        let failedTranscriptions = updatedFailedTranscriptions ?? controller.failedManager.failedTranscriptions
+        retryingFailedMeetingIDs.formIntersection(Set(failedTranscriptions.map(\.id)))
+
+        let items = failedTranscriptions
+            .sorted(by: { $0.timestamp > $1.timestamp })
+            .map { failed in
+                FailedMeetingPresentation.item(
+                    from: failed,
+                    isRetrying: retryingFailedMeetingIDs.contains(failed.id)
+                )
+            }
+        scheduleFailedAudioCompression(for: failedTranscriptions)
+        return items
+    }
+
+    private func scheduleFailedAudioCompression(for failedTranscriptions: [FailedTranscription]) {
+        guard failedAudioCompressionTask == nil else {
+            failedAudioCompressionNeedsReschedule = true
+            return
+        }
+
+        let candidates = failedTranscriptions.compactMap { failed -> FailedMeetingAudioCompressionCandidate? in
+            guard !retryingFailedMeetingIDs.contains(failed.id) else { return nil }
+            var urls = [failed.micAudioURL]
+            if let systemAudioURL = failed.systemAudioURL {
+                urls.append(systemAudioURL)
+            }
+            guard urls.contains(where: { $0.pathExtension.localizedCaseInsensitiveCompare("wav") == .orderedSame }) else {
+                return nil
+            }
+            return FailedMeetingAudioCompressionCandidate(
+                id: failed.id,
+                micAudioURL: failed.micAudioURL,
+                systemAudioURL: failed.systemAudioURL
+            )
+        }
+        guard !candidates.isEmpty else { return }
+
+        failedAudioCompressionNeedsReschedule = false
+        let audioArchiveRoot = MeetingStoragePaths.audioArchiveFolder
+        failedAudioCompressionTask = Task { [weak self] in
+            _ = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
+                candidates: candidates,
+                audioArchiveRoot: audioArchiveRoot,
+                persistUpdate: { [weak self] update in
+                    await MainActor.run {
+                        guard let self,
+                              !self.retryingFailedMeetingIDs.contains(update.id) else {
+                            return false
+                        }
+                        return self.controller.failedManager.updateFailedTranscriptionAudio(
+                            id: update.id,
+                            micAudioURL: update.micAudioURL,
+                            systemAudioURL: update.systemAudioURL
+                        )
+                    }
+                }
+            )
+            await MainActor.run { [weak self] in
+                let shouldReschedule = self?.failedAudioCompressionNeedsReschedule == true
+                self?.failedAudioCompressionTask = nil
+                self?.failedAudioCompressionNeedsReschedule = false
+                if shouldReschedule, let self {
+                    self.scheduleFailedAudioCompression(for: self.controller.failedManager.failedTranscriptions)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -62,63 +62,15 @@ final class MeetingSessionController: ObservableObject {
 
     typealias ModelWarmupStatus = MeetingWarmupStatus
 
-    struct FailedMeetingItem: Identifiable, Equatable {
-        let id: UUID
-        let timestamp: Date
-        let title: String
-        let detail: String
-        let meta: String
-        let failureKind: MeetingFailureKind
-        let isRetryable: Bool
-        let isRetrying: Bool
-        let hasAudioFiles: Bool
-        let audioURLs: [URL]
-    }
+    // Moved to FailedMeetingStore.swift / TranscriptionQueueCoordinator.swift
+    // (audit 2026-07-08 wave 2, W2-B). Typealiases keep every existing
+    // reference — including `MeetingSessionController.FailedMeetingItem` in
+    // UI files — resolving unchanged.
+    typealias FailedMeetingItem = FailedMeetingStore.FailedMeetingItem
+    typealias QueuedTranscriptionJob = TranscriptionQueueCoordinator.QueuedTranscriptionJob
+    typealias BackgroundTranscriptionWorkSnapshot = TranscriptionQueueCoordinator.BackgroundTranscriptionWorkSnapshot
 
-    private struct QueuedTranscriptionJob {
-        enum Kind {
-            case recorded(
-                micURL: URL,
-                systemURL: URL?,
-                healthInfo: RecordingHealthInfo,
-                captureDiagnostics: [String: String],
-                meetingTitle: String?,
-                recordingDate: Date
-            )
-            case imported(
-                audioURL: URL,
-                suggestedTitle: String,
-                recordingDate: Date
-            )
-        }
-
-        let id = UUID()
-        let kind: Kind
-        let startTrigger: StartTrigger
-        let sttModel: TranscriptionModelChoice
-        let promptTelemetryProperties: [String: String]?
-        let promptRecordingStartedAt: Date?
-
-        var captureDiagnostics: [String: String]? {
-            switch kind {
-            case .recorded(_, _, _, let captureDiagnostics, _, _):
-                return captureDiagnostics
-            case .imported:
-                return nil
-            }
-        }
-
-        var artifactRetained: Bool {
-            switch kind {
-            case .recorded:
-                return true
-            case .imported:
-                return true
-            }
-        }
-    }
-
-    private enum TerminalTranscriptionOutcome: Equatable {
+    enum TerminalTranscriptionOutcome: Equatable {
         case transcriptSaved
         case failed(String)
     }
@@ -132,11 +84,6 @@ final class MeetingSessionController: ObservableObject {
         let pipelineSnapshot: AudioPipelineDiagnosticsSnapshot
         let suggestedTitle: String?
         let recordingStartedAt: Date?
-    }
-
-    private struct BackgroundTranscriptionWorkSnapshot {
-        let activeCount: Int
-        let speakerNamingRequest: SpeakerNamingRequest?
     }
 
     // MARK: - Published state (for meeting UI bindings)
@@ -191,7 +138,9 @@ final class MeetingSessionController: ObservableObject {
     // MARK: - Core services (owned)
 
     private let storagePaths: CoreStoragePaths
-    private let sttRouter: STTRouter
+    // Was `private`; FailedMeetingStore / TranscriptionQueueCoordinator live in
+    // sibling files and need module-internal access (audit 2026-07-08 W2-B).
+    let sttRouter: STTRouter
     let capture: MeetingCaptureBridge
     private let liveCodexSession = LiveMeetingCodexSession()
     private let liveMeetingTranscriber = LiveMeetingTranscriber()
@@ -200,52 +149,59 @@ final class MeetingSessionController: ObservableObject {
     let liveTranscriptFeed = LiveMeetingTranscriptFeed()
     let services: AppServices
     let taskManager: TranscriptionTaskManager
-    private let failedManager: FailedTranscriptionManager
-    private let diarization: DiarizationService
-    private let sttAdapter: MeetingSTTAdapter
+    let failedManager: FailedTranscriptionManager
+    let diarization: DiarizationService
+    let sttAdapter: MeetingSTTAdapter
     private let speakerDatabase: SpeakerDatabase
     private let statsDatabase: StatsDatabase
-    private let downloader: MeetingModelDownloader
+    let downloader: MeetingModelDownloader
     var calendarSuggestedTitleProvider: (() -> String?)?
+
+    /// Failed-meeting queue/persistence/retry bookkeeping (audit 2026-07-08
+    /// wave 2, W2-B). Plain owned object — this controller stays the single
+    /// ObservableObject; `failedMeetings` below is still published here.
+    /// Implicitly-unwrapped: `FailedMeetingStore` holds an `unowned` back
+    /// reference to this controller, so it can only be constructed with
+    /// `self` — which Swift only allows once every OTHER stored property is
+    /// set. A plain `let` here would make `self` unusable for its own
+    /// assignment; this is constructed once, immediately, in `init` and
+    /// never nil afterward.
+    private(set) var failedMeetingStore: FailedMeetingStore!
+    /// Background-transcription queue/dispatch bookkeeping (audit 2026-07-08
+    /// wave 2, W2-B). Plain owned object, same rationale as above.
+    private(set) var transcriptionQueue: TranscriptionQueueCoordinator!
 
     private var cancellables: Set<AnyCancellable> = []
     private var modelPreparationTask: Task<Result<Void, Error>, Never>?
     private var savedTranscriptRestyleTask: Task<StyledMeetingTranscript, Never>?
-    private var retryingFailedMeetingIDs: Set<UUID> = []
-    private var queuedTranscriptionJobs: [QueuedTranscriptionJob] = []
-    private var preparingQueuedTranscriptionJob: QueuedTranscriptionJob?
-    private var queuedTranscriptionStartTask: Task<Void, Never>?
     private var importPreparationTask: Task<PreparedImportedMeetingAudio, Error>?
     private var importPreparationToken: UUID?
-    private var queuedRuntimeDiagnosticsJobIDs: Set<UUID> = []
-    private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
-    private var activeTranscriptionCaptureDiagnostics: [String: String]?
+    var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
+    var activeTranscriptionCaptureDiagnostics: [String: String]?
     private var activeDetectedPromptRecordingTelemetryProperties: [String: String]?
     private var activeDetectedPromptRecordingStartedAt: Date?
-    private var activeDetectedPromptTranscriptionTelemetryProperties: [String: String]?
-    private var activeDetectedPromptTranscriptionRecordingStartedAt: Date?
+    var activeDetectedPromptTranscriptionTelemetryProperties: [String: String]?
+    var activeDetectedPromptTranscriptionRecordingStartedAt: Date?
     private var activeRecordingTrigger: StartTrigger = .unknown
     private var activeRecordingIdentity: UUID?
     private var micBoostPromptRecordingIdentity: UUID?
     private var micBoostPromptOutcome: MeetingMicBoostPromptOutcome = .notShown
     private var activeRecordingSuggestedTitle: String?
     private var activeRecordingStartedAt: Date?
-    private var activeTranscriptionTrigger: StartTrigger = .unknown
+    var activeTranscriptionTrigger: StartTrigger = .unknown
     private var isFinishingRecording = false
     private var shouldSurfaceMeetingWarmupFailure = false
     private var audioInactivityDetector = MeetingAudioInactivityDetector()
     private var latestMicLevel: Float = 0
     private var latestSystemLevel: Float = 0
     private var liveCodexSessionIsActive = false
-    private var liveCodexSessionAwaitingFinalTranscript = false
+    var liveCodexSessionAwaitingFinalTranscript = false
     private var liveCodexSessionCanAttachFinalTranscript = false
     private var liveCodexSessionOwnedByActiveRecording = false
     private var liveCodexPreviewHandlersNeedClearingAfterActiveRecording = false
-    private var liveCodexFinalTranscriptNeedsQueuedJobID = false
-    private var liveCodexAwaitedTranscriptionJobID: UUID?
-    private var activeQueuedTranscriptionJobID: UUID?
-    private var failedAudioCompressionTask: Task<Void, Never>?
-    private var failedAudioCompressionNeedsReschedule = false
+    var liveCodexFinalTranscriptNeedsQueuedJobID = false
+    var liveCodexAwaitedTranscriptionJobID: UUID?
+    var activeQueuedTranscriptionJobID: UUID?
 
     var shouldConfirmQuitForActiveCapture: Bool {
         isCaptureSessionActive || isFinishingRecording
@@ -257,6 +213,23 @@ final class MeetingSessionController: ObservableObject {
 
     var shouldBlockDictationForActiveMeetingCapture: Bool {
         isCaptureSessionActive || isFinishingRecording
+    }
+
+    // MARK: - State-transition callbacks (for owned subsystems)
+
+    /// FailedMeetingStore / TranscriptionQueueCoordinator drive some of the
+    /// controller's `@Published` state as part of their own dispatch logic
+    /// (audit 2026-07-08 wave 2, W2-B design: "callbacks/async funcs back
+    /// into the controller for state transitions"). These two setters are
+    /// that seam — `state`/`displayStatus` themselves stay `private(set)`
+    /// so every other transition still goes through the controller's own
+    /// code in this file.
+    func setState(_ newState: State) {
+        state = newState
+    }
+
+    func setDisplayStatus(_ newStatus: DisplayStatus) {
+        displayStatus = newStatus
     }
 
     // MARK: - Init
@@ -352,6 +325,14 @@ final class MeetingSessionController: ObservableObject {
 
         // Model downloader — coordinates selected STT + PyAnnote readiness.
         self.downloader = MeetingModelDownloader(stt: sttAdapter, diarization: diarization)
+
+        // Failed-meeting and transcription-queue bookkeeping (audit
+        // 2026-07-08 wave 2, W2-B). Constructed last, after every other
+        // stored property, since each holds an `unowned` back-reference to
+        // this controller. `wireSubscriptions()` below calls into
+        // `failedMeetingStore` synchronously, so both must exist first.
+        self.failedMeetingStore = FailedMeetingStore(controller: self)
+        self.transcriptionQueue = TranscriptionQueueCoordinator(controller: self)
 
         capture.onUnexpectedRecordingComplete = { [weak self] result in
             self?.handleUnexpectedCaptureStop(result)
@@ -745,7 +726,7 @@ final class MeetingSessionController: ObservableObject {
 
         let stopTimeoutFailedTaskId = UUID()
         let stopResult = await capture.stopAndAwaitFiles { [weak self] lateResult in
-            self?.refreshTimedOutFailedMeetingAudio(
+            self?.failedMeetingStore.refreshTimedOutFailedMeetingAudio(
                 id: stopTimeoutFailedTaskId,
                 result: lateResult
             )
@@ -834,7 +815,7 @@ final class MeetingSessionController: ObservableObject {
         )
 
         guard let micURL = files.micURL else {
-            let preserved = preserveFailedMeetingForRetry(
+            let preserved = failedMeetingStore.preserveFailedMeetingForRetry(
                 micAudioURL: nil,
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stopped without microphone audio.",
@@ -879,7 +860,7 @@ final class MeetingSessionController: ObservableObject {
                     "reason": reason.rawValue
                 ]
             )
-            let preserved = preserveFailedMeetingForRetry(
+            let preserved = failedMeetingStore.preserveFailedMeetingForRetry(
                 taskId: stopTimeoutFailedTaskId,
                 micAudioURL: micURL,
                 systemAudioURL: files.systemURL,
@@ -929,7 +910,7 @@ final class MeetingSessionController: ObservableObject {
             healthInfoForSave = recordingSnapshot.healthInfo
         }
 
-        let outcome = enqueueTranscriptionJob(
+        let outcome = transcriptionQueue.enqueueTranscriptionJob(
             micURL: micURL,
             systemURL: files.systemURL,
             healthInfo: healthInfoForSave,
@@ -946,7 +927,7 @@ final class MeetingSessionController: ObservableObject {
         )
         clearDetectedPromptRecordingTelemetry()
 
-        let queueDepth = queuedTranscriptionJobs.count
+        let queueDepth = transcriptionQueue.queuedTranscriptionJobs.count
         DiagnosticsTrail.record(
             engine: "meeting",
             event: outcome == .startedImmediately ? "meeting_transcription_started" : "meeting_transcription_queued",
@@ -1355,7 +1336,7 @@ final class MeetingSessionController: ObservableObject {
             return false
         }
 
-        let outcome = enqueueImportedAudioJob(
+        let outcome = transcriptionQueue.enqueueImportedAudioJob(
             audioURL: preparedAudio.copiedAudioURL,
             suggestedTitle: preparedAudio.suggestedTitle,
             recordingDate: preparedAudio.recordingDate,
@@ -1372,7 +1353,7 @@ final class MeetingSessionController: ObservableObject {
                 : "Imported meeting transcription queued",
             context: baseDiagnosticsContext(
                 extra: [
-                    "queue_depth": "\(queuedTranscriptionJobs.count)",
+                    "queue_depth": "\(transcriptionQueue.queuedTranscriptionJobs.count)",
                     "trigger": StartTrigger.fileImport.rawValue
                 ]
             )
@@ -1380,7 +1361,7 @@ final class MeetingSessionController: ObservableObject {
         AnalyticsReporter.track(
             "meeting_file_imported",
             properties: [
-                "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(transcriptionQueue.queuedTranscriptionJobs.count),
             ]
         )
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
@@ -1405,12 +1386,12 @@ final class MeetingSessionController: ObservableObject {
         importPreparationTask = nil
         importPreparationToken = nil
 
-        let queuedJobs = queuedTranscriptionJobs
-        queuedTranscriptionJobs.removeAll()
-        let preparingJob = preparingQueuedTranscriptionJob
-        queuedTranscriptionStartTask?.cancel()
-        queuedTranscriptionStartTask = nil
-        preparingQueuedTranscriptionJob = nil
+        let queuedJobs = transcriptionQueue.queuedTranscriptionJobs
+        transcriptionQueue.queuedTranscriptionJobs.removeAll()
+        let preparingJob = transcriptionQueue.preparingQueuedTranscriptionJob
+        transcriptionQueue.queuedTranscriptionStartTask?.cancel()
+        transcriptionQueue.queuedTranscriptionStartTask = nil
+        transcriptionQueue.preparingQueuedTranscriptionJob = nil
         lastTerminalTranscriptionOutcome = nil
         activeTranscriptionTrigger = .unknown
         activeTranscriptionCaptureDiagnostics = nil
@@ -1418,7 +1399,7 @@ final class MeetingSessionController: ObservableObject {
         for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
             case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
-                preserveFailedMeetingForRetry(
+                failedMeetingStore.preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: "Transcription cancelled",
@@ -1429,7 +1410,7 @@ final class MeetingSessionController: ObservableObject {
                 if reason == .userRequested {
                     try? FileManager.default.removeItem(at: audioURL)
                 } else {
-                    preserveFailedMeetingForRetry(
+                    failedMeetingStore.preserveFailedMeetingForRetry(
                         micAudioURL: nil,
                         systemAudioURL: audioURL,
                         errorMessage: "Imported audio saved before cancellation. Audio is safe; finish the transcript from Home.",
@@ -1477,7 +1458,7 @@ final class MeetingSessionController: ObservableObject {
 
             let shutdownFailedTaskId = UUID()
             let files = await capture.stopAndAwaitFiles { [weak self] lateResult in
-                self?.refreshTimedOutFailedMeetingAudio(
+                self?.failedMeetingStore.refreshTimedOutFailedMeetingAudio(
                     id: shutdownFailedTaskId,
                     result: lateResult
                 )
@@ -1492,7 +1473,7 @@ final class MeetingSessionController: ObservableObject {
             activeRecordingStartedAt = nil
 
             if files.micURL != nil || files.systemURL != nil {
-                didPreserveRecording = preserveFailedMeetingForRetry(
+                didPreserveRecording = failedMeetingStore.preserveFailedMeetingForRetry(
                     taskId: shutdownFailedTaskId,
                     micAudioURL: files.micURL,
                     systemAudioURL: files.systemURL,
@@ -1506,7 +1487,7 @@ final class MeetingSessionController: ObservableObject {
             recordingTrigger = .unknown
         }
 
-        let queuedPreserved = preserveQueuedTranscriptionJobsForShutdown(
+        let queuedPreserved = transcriptionQueue.preserveQueuedTranscriptionJobsForShutdown(
             errorMessage: "Meeting saved before quit. Audio is safe; finish the queued transcript from Home after reopening."
         )
         let activePreserved = taskManager.preserveActiveTranscriptionsForShutdown(
@@ -1567,7 +1548,7 @@ final class MeetingSessionController: ObservableObject {
         activeRecordingSuggestedTitle = nil
         activeRecordingStartedAt = nil
 
-        let preserved = preserveFailedMeetingForRetry(
+        let preserved = failedMeetingStore.preserveFailedMeetingForRetry(
             micAudioURL: files.micURL,
             systemAudioURL: files.systemURL,
             errorMessage: failureMessage,
@@ -1616,108 +1597,15 @@ final class MeetingSessionController: ObservableObject {
         )
     }
 
-    private func preserveQueuedTranscriptionJobsForShutdown(errorMessage: String) -> Int {
-        let preparingJob = preparingQueuedTranscriptionJob
-        let jobs = queuedTranscriptionJobs + [preparingJob].compactMap { $0 }
-        guard !jobs.isEmpty else { return 0 }
+    // preserveQueuedTranscriptionJobsForShutdown moved to
+    // TranscriptionQueueCoordinator.swift (audit 2026-07-08 wave 2, W2-B).
 
-        queuedTranscriptionStartTask?.cancel()
-        queuedTranscriptionStartTask = nil
-        preparingQueuedTranscriptionJob = nil
-        queuedTranscriptionJobs.removeAll()
-
-        var preservedCount = 0
-        for job in jobs {
-            switch job.kind {
-            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
-                if preserveFailedMeetingForRetry(
-                    micAudioURL: micURL,
-                    systemAudioURL: systemURL,
-                    errorMessage: errorMessage,
-                    meetingTitle: meetingTitle,
-                    recordingDate: recordingDate
-                ) {
-                    preservedCount += 1
-                }
-            case .imported(let audioURL, let suggestedTitle, let recordingDate):
-                if preserveFailedMeetingForRetry(
-                    micAudioURL: audioURL,
-                    systemAudioURL: nil,
-                    errorMessage: errorMessage,
-                    meetingTitle: suggestedTitle,
-                    recordingDate: recordingDate
-                ) {
-                    preservedCount += 1
-                }
-            }
-        }
-        return preservedCount
-    }
-
+    // Full implementation moved to FailedMeetingStore.swift (audit
+    // 2026-07-08 wave 2, W2-B). This forwarder keeps the public signature
+    // controller callers (Settings/Home UI) already depend on.
     @discardableResult
     func retryFailedMeeting(id: UUID) -> Bool {
-        guard !isRecording, !hasBackgroundTranscriptionWork, !isSpeakerReviewPending else { return false }
-        guard !retryingFailedMeetingIDs.contains(id) else { return false }
-        guard failedManager.failedTranscriptions.contains(where: { $0.id == id }) else {
-            refreshFailedMeetings()
-            return false
-        }
-
-        failedAudioCompressionTask?.cancel()
-        retryingFailedMeetingIDs.insert(id)
-        activeTranscriptionTrigger = .unknown
-        refreshFailedMeetings()
-        let retryStartedAt = CFAbsoluteTimeGetCurrent()
-        WorkflowRecoveryTelemetry.attempted(
-            workflowKind: "meeting_transcription",
-            failureKind: "failed_meeting",
-            retrySource: "failed_meeting_retry",
-            surface: "home",
-            artifactRetained: true
-        )
-
-        Task { [weak self] in
-            guard let self else { return }
-            await self.prepareModels()
-            guard case .ready = self.state else {
-                DiagnosticsTrail.record(
-                    level: .warning,
-                    engine: "meeting",
-                    event: "meeting_failed_retry_blocked_models",
-                    message: "Failed meeting retry blocked because models were not ready",
-                    context: self.baseDiagnosticsContext(extra: ["failed_id": id.uuidString])
-                )
-                self.retryingFailedMeetingIDs.remove(id)
-                self.refreshFailedMeetings()
-                WorkflowRecoveryTelemetry.finished(
-                    workflowKind: "meeting_transcription",
-                    failureKind: "failed_meeting",
-                    retrySource: "failed_meeting_retry",
-                    result: "failed",
-                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
-                    surface: "home",
-                    artifactRetained: true
-                )
-                return
-            }
-
-            let retryPublished = await self.taskManager.retryFailedTranscription(
-                failedId: id,
-                outputFolder: MeetingStoragePaths.transcriptsFolder
-            )
-            self.retryingFailedMeetingIDs.remove(id)
-            self.refreshFailedMeetings()
-            WorkflowRecoveryTelemetry.finished(
-                workflowKind: "meeting_transcription",
-                failureKind: "failed_meeting",
-                retrySource: "failed_meeting_retry",
-                result: retryPublished ? "success" : "failed",
-                elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
-                surface: "home",
-                artifactRetained: true
-            )
-        }
-        return true
+        failedMeetingStore.retryFailedMeeting(id: id)
     }
 
     @discardableResult
@@ -1832,20 +1720,17 @@ final class MeetingSessionController: ObservableObject {
         }
     }
 
+    // Full implementations moved to FailedMeetingStore.swift (audit
+    // 2026-07-08 wave 2, W2-B). These forwarders keep the public signatures
+    // controller callers (Settings/Home UI) already depend on.
     @discardableResult
     func dismissFailedMeeting(id: UUID) -> Bool {
-        retryingFailedMeetingIDs.remove(id)
-        let didDismiss = failedManager.removeFailedTranscription(id: id)
-        refreshFailedMeetings()
-        return didDismiss || !failedManager.failedTranscriptions.contains(where: { $0.id == id })
+        failedMeetingStore.dismissFailedMeeting(id: id)
     }
 
     @discardableResult
     func deleteFailedMeeting(id: UUID) -> Bool {
-        retryingFailedMeetingIDs.remove(id)
-        let didDelete = failedManager.deleteFailedTranscription(id: id)
-        refreshFailedMeetings()
-        return didDelete || !failedManager.failedTranscriptions.contains(where: { $0.id == id })
+        failedMeetingStore.deleteFailedMeeting(id: id)
     }
 
     // MARK: - Subscriptions
@@ -1941,7 +1826,7 @@ final class MeetingSessionController: ObservableObject {
             .combineLatest(taskManager.$speakerNamingRequest)
             .sink { [weak self] activeCount, speakerNamingRequest in
                 guard let self else { return }
-                self.handleBackgroundTranscriptionWorkChanged(
+                self.transcriptionQueue.handleBackgroundTranscriptionWorkChanged(
                     snapshot: BackgroundTranscriptionWorkSnapshot(
                         activeCount: activeCount,
                         speakerNamingRequest: speakerNamingRequest
@@ -2309,7 +2194,9 @@ final class MeetingSessionController: ObservableObject {
         liveCodexPreviewHandlersNeedClearingAfterActiveRecording = false
     }
 
-    private func finishLiveCodexSession(
+    // Was `private`; TranscriptionQueueCoordinator lives in a sibling file
+    // and needs module-internal access (audit 2026-07-08 wave 2, W2-B).
+    func finishLiveCodexSession(
         status: LiveMeetingCodexSessionStatus,
         shouldAwaitFinalTranscript: Bool,
         clearPreviewHandlers: Bool = true
@@ -2486,15 +2373,12 @@ final class MeetingSessionController: ObservableObject {
         refreshWarmupStatus()
     }
 
-    private enum QueueInsertionOutcome: Equatable {
-        case startedImmediately
-        case queued(position: Int)
-    }
-
-    private var hasBackgroundTranscriptionWork: Bool {
+    // Was `private`; FailedMeetingStore lives in a sibling file and needs
+    // module-internal access (audit 2026-07-08 wave 2, W2-B).
+    var hasBackgroundTranscriptionWork: Bool {
         taskManager.activeCount > 0
-            || isPreparingQueuedTranscriptionStart
-            || !queuedTranscriptionJobs.isEmpty
+            || transcriptionQueue.isPreparingQueuedTranscriptionStart
+            || !transcriptionQueue.queuedTranscriptionJobs.isEmpty
     }
 
     var hasRuntimeDiagnosticsWork: Bool {
@@ -2502,7 +2386,7 @@ final class MeetingSessionController: ObservableObject {
     }
 
     var queuedTranscriptionCount: Int {
-        queuedTranscriptionJobs.count
+        transcriptionQueue.queuedTranscriptionJobs.count
     }
 
     var isSpeakerReviewPending: Bool {
@@ -2510,7 +2394,7 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private var hasVisibleBackgroundTranscriptionWork: Bool {
-        hasVisibleBackgroundTranscriptionWork(snapshot: currentBackgroundTranscriptionWorkSnapshot)
+        transcriptionQueue.hasVisibleBackgroundTranscriptionWork(snapshot: transcriptionQueue.currentBackgroundTranscriptionWorkSnapshot)
     }
 
     private var isSpeechModelPreparedForSelection: Bool {
@@ -2518,283 +2402,21 @@ final class MeetingSessionController: ObservableObject {
             && sttAdapter.isReady
     }
 
-    private var canStartQueuedTranscriptionImmediately: Bool {
-        canStartQueuedTranscriptionImmediately(snapshot: currentBackgroundTranscriptionWorkSnapshot)
-    }
-
-    private var isPreparingQueuedTranscriptionStart: Bool {
-        preparingQueuedTranscriptionJob != nil || queuedTranscriptionStartTask != nil
-    }
-
-    private var currentBackgroundTranscriptionWorkSnapshot: BackgroundTranscriptionWorkSnapshot {
-        BackgroundTranscriptionWorkSnapshot(
-            activeCount: taskManager.activeCount,
-            speakerNamingRequest: taskManager.speakerNamingRequest
-        )
-    }
-
-    private var isCaptureSessionActive: Bool {
+    // Was `private`; TranscriptionQueueCoordinator lives in a sibling file
+    // and needs module-internal access (audit 2026-07-08 wave 2, W2-B).
+    var isCaptureSessionActive: Bool {
         if case .recording = state {
             return true
         }
         return isRecording
     }
 
-    private func enqueueTranscriptionJob(
-        micURL: URL,
-        systemURL: URL?,
-        healthInfo: RecordingHealthInfo,
-        captureDiagnostics: [String: String],
-        meetingTitle: String?,
-        recordingDate: Date,
-        startTrigger: StartTrigger,
-        promptTelemetryProperties: [String: String]? = nil,
-        promptRecordingStartedAt: Date? = nil
-    ) -> QueueInsertionOutcome {
-        let job = QueuedTranscriptionJob(
-            kind: .recorded(
-                micURL: micURL,
-                systemURL: systemURL,
-                healthInfo: healthInfo,
-                captureDiagnostics: captureDiagnostics,
-                meetingTitle: meetingTitle,
-                recordingDate: recordingDate
-            ),
-            startTrigger: startTrigger,
-            sttModel: sttRouter.selectedModel,
-            promptTelemetryProperties: promptTelemetryProperties,
-            promptRecordingStartedAt: promptRecordingStartedAt
-        )
-
-        if liveCodexFinalTranscriptNeedsQueuedJobID && liveCodexSessionAwaitingFinalTranscript {
-            liveCodexAwaitedTranscriptionJobID = job.id
-            liveCodexFinalTranscriptNeedsQueuedJobID = false
-        }
-        return enqueue(job)
-    }
-
-    private func enqueueImportedAudioJob(
-        audioURL: URL,
-        suggestedTitle: String,
-        recordingDate: Date,
-        startTrigger: StartTrigger
-    ) -> QueueInsertionOutcome {
-        let job = QueuedTranscriptionJob(
-            kind: .imported(
-                audioURL: audioURL,
-                suggestedTitle: suggestedTitle,
-                recordingDate: recordingDate
-            ),
-            startTrigger: startTrigger,
-            sttModel: sttRouter.selectedModel,
-            promptTelemetryProperties: nil,
-            promptRecordingStartedAt: nil
-        )
-
-        return enqueue(job)
-    }
-
-    private func enqueue(_ job: QueuedTranscriptionJob) -> QueueInsertionOutcome {
-        if canStartQueuedTranscriptionImmediately {
-            startQueuedTranscription(job)
-            return .startedImmediately
-        }
-
-        queuedTranscriptionJobs.append(job)
-        return .queued(position: queuedTranscriptionJobs.count)
-    }
-
-    private func startQueuedTranscription(_ job: QueuedTranscriptionJob) {
-        lastTerminalTranscriptionOutcome = nil
-        activeTranscriptionTrigger = job.startTrigger
-        activeTranscriptionCaptureDiagnostics = job.captureDiagnostics
-        activeDetectedPromptTranscriptionTelemetryProperties = job.promptTelemetryProperties
-        activeDetectedPromptTranscriptionRecordingStartedAt = job.promptRecordingStartedAt
-        sttAdapter.selectPreparedModel(job.sttModel)
-        preparingQueuedTranscriptionJob = job
-
-        if !isCaptureSessionActive {
-            state = .transcribing
-        }
-        recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)
-
-        displayStatus = .gettingReady
-        queuedTranscriptionStartTask?.cancel()
-        queuedTranscriptionStartTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            await self.prepareAndStartQueuedTranscription(job)
-        }
-    }
-
-    private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {
-        let modelsReady = await ensureModelsReadyForQueuedTranscription(job)
-
-        // A cancelled task must not touch shared state: a newer
-        // startQueuedTranscription has already taken ownership of
-        // queuedTranscriptionStartTask / preparingQueuedTranscriptionJob.
-        guard !Task.isCancelled else { return }
-        guard preparingQueuedTranscriptionJob?.id == job.id else { return }
-
-        queuedTranscriptionStartTask = nil
-        preparingQueuedTranscriptionJob = nil
-
-        guard modelsReady else {
-            failQueuedTranscriptionJobAfterModelRecovery(job)
-            handleBackgroundTranscriptionWorkChanged()
-            return
-        }
-
-        runPreparedQueuedTranscription(job)
-    }
-
-    private func ensureModelsReadyForQueuedTranscription(_ job: QueuedTranscriptionJob) async -> Bool {
-        sttAdapter.selectPreparedModel(job.sttModel)
-
-        if sttAdapter.isReady && diarization.isReady {
-            return true
-        }
-
-        DiagnosticsTrail.record(
-            engine: "meeting",
-            event: "meeting_transcription_model_recovery_started",
-            message: "Meeting transcription is loading models before starting queued audio",
-            context: baseDiagnosticsContext(
-                extra: [
-                    "trigger": job.startTrigger.rawValue,
-                    "queued_stt_model": job.sttModel.rawValue
-                ]
-            )
-        )
-        let modelRecoveryStartedAt = CFAbsoluteTimeGetCurrent()
-        WorkflowRecoveryTelemetry.attempted(
-            workflowKind: "model_preparation",
-            failureKind: "models_not_ready",
-            retrySource: "queued_transcription",
-            surface: "meeting",
-            artifactRetained: job.artifactRetained
-        )
-
-        do {
-            try await TranscriptedConstants.withDetachedTimeout(
-                seconds: TranscriptedConstants.modelLoadWaitBudget
-            ) {
-                try await self.downloader.ensureModelsReady(sttModel: job.sttModel)
-            }
-            sttAdapter.selectPreparedModel(job.sttModel)
-        } catch {
-            DiagnosticsTrail.record(
-                level: .error,
-                engine: "meeting",
-                event: "meeting_transcription_model_recovery_failed",
-                message: "Meeting transcription models could not be loaded before queued audio started",
-                context: baseDiagnosticsContext(
-                    extra: [
-                        "error": error.localizedDescription,
-                        "trigger": job.startTrigger.rawValue,
-                        "queued_stt_model": job.sttModel.rawValue
-                    ]
-                )
-            )
-            WorkflowRecoveryTelemetry.finished(
-                workflowKind: "model_preparation",
-                failureKind: "models_not_ready",
-                retrySource: "queued_transcription",
-                result: "failed",
-                elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
-                surface: "meeting",
-                artifactRetained: job.artifactRetained
-            )
-            return false
-        }
-
-        let ready = sttAdapter.isReady && diarization.isReady
-        if !ready {
-            DiagnosticsTrail.record(
-                level: .error,
-                engine: "meeting",
-                event: "meeting_transcription_model_recovery_failed",
-                message: "Meeting transcription models were still unavailable after reload",
-                context: baseDiagnosticsContext(
-                    extra: [
-                        "trigger": job.startTrigger.rawValue,
-                        "queued_stt_model": job.sttModel.rawValue
-                    ]
-                )
-            )
-        }
-
-        WorkflowRecoveryTelemetry.finished(
-            workflowKind: "model_preparation",
-            failureKind: "models_not_ready",
-            retrySource: "queued_transcription",
-            result: ready ? "success" : "failed",
-            elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
-            surface: "meeting",
-            artifactRetained: job.artifactRetained
-        )
-
-        return ready
-    }
-
-    private func runPreparedQueuedTranscription(_ job: QueuedTranscriptionJob) {
-        sttAdapter.selectPreparedModel(job.sttModel)
-        queuedRuntimeDiagnosticsJobIDs.remove(job.id)
-        activeQueuedTranscriptionJobID = job.id
-
-        switch job.kind {
-        case .recorded(let micURL, let systemURL, let healthInfo, _, let meetingTitle, let recordingDate):
-            taskManager.startTranscription(
-                taskId: job.id,
-                micURL: micURL,
-                systemURL: systemURL,
-                outputFolder: MeetingStoragePaths.transcriptsFolder,
-                healthInfo: healthInfo,
-                meetingTitle: meetingTitle,
-                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled(),
-                recordingDate: recordingDate
-            )
-        case .imported(let audioURL, let suggestedTitle, let recordingDate):
-            taskManager.startImportedTranscription(
-                audioURL: audioURL,
-                outputFolder: MeetingStoragePaths.transcriptsFolder,
-                meetingTitle: suggestedTitle,
-                recordingDate: recordingDate
-            )
-        }
-    }
-
-    private func failQueuedTranscriptionJobAfterModelRecovery(_ job: QueuedTranscriptionJob) {
-        let message = "Meeting transcription models were not ready. Try again after models finish loading."
-        lastTerminalTranscriptionOutcome = .failed(message)
-        state = .error(message)
-        displayStatus = .failed(message: message)
-        if liveCodexAwaitedTranscriptionJobID == job.id {
-            finishLiveCodexSession(status: .failed, shouldAwaitFinalTranscript: false)
-        }
-        if activeQueuedTranscriptionJobID == job.id {
-            activeQueuedTranscriptionJobID = nil
-        }
-
-        switch job.kind {
-        case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
-            preserveFailedMeetingForRetry(
-                micAudioURL: micURL,
-                systemAudioURL: systemURL,
-                errorMessage: message,
-                meetingTitle: meetingTitle,
-                recordingDate: recordingDate
-            )
-        case .imported(let audioURL, let suggestedTitle, let recordingDate):
-            preserveFailedMeetingForRetry(
-                micAudioURL: nil,
-                systemAudioURL: audioURL,
-                errorMessage: message,
-                meetingTitle: suggestedTitle,
-                recordingDate: recordingDate
-            )
-        }
-        clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(for: job, outcome: "model_recovery_failed")
-    }
+    // enqueueTranscriptionJob, enqueueImportedAudioJob, enqueue,
+    // startQueuedTranscription, prepareAndStartQueuedTranscription,
+    // ensureModelsReadyForQueuedTranscription, runPreparedQueuedTranscription,
+    // and failQueuedTranscriptionJobAfterModelRecovery moved to
+    // TranscriptionQueueCoordinator.swift (audit 2026-07-08 wave 2, W2-B).
+    // Call sites below now go through `transcriptionQueue.`.
 
     private func finishLiveCodexSessionForCurrentTranscriptionFailureIfNeeded(
         failedJobID: UUID? = nil,
@@ -2810,100 +2432,13 @@ final class MeetingSessionController: ObservableObject {
         finishLiveCodexSession(status: .failed, shouldAwaitFinalTranscript: false)
     }
 
-    private func recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for job: QueuedTranscriptionJob) {
-        guard !isCaptureSessionActive else { return }
-        guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }
-        queuedRuntimeDiagnosticsJobIDs.insert(job.id)
-        Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
-    }
-
-    private func clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(
-        for job: QueuedTranscriptionJob,
-        outcome: String
-    ) {
-        guard queuedRuntimeDiagnosticsJobIDs.remove(job.id) != nil else { return }
-        guard !isCaptureSessionActive else { return }
-        guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }
-        Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: outcome)
-    }
-
-    private func canStartQueuedTranscriptionImmediately(
-        snapshot: BackgroundTranscriptionWorkSnapshot
-    ) -> Bool {
-        MeetingSessionUIPolicy.canStartQueuedTranscription(
-            activeTranscriptions: snapshot.activeCount,
-            isPreparingQueuedTranscriptionStart: isPreparingQueuedTranscriptionStart
-        )
-    }
-
-    private func hasVisibleBackgroundTranscriptionWork(
-        snapshot: BackgroundTranscriptionWorkSnapshot
-    ) -> Bool {
-        MeetingSessionUIPolicy.shouldShowTranscribing(
-            activeTranscriptions: snapshot.activeCount + (isPreparingQueuedTranscriptionStart ? 1 : 0),
-            queuedTranscriptions: queuedTranscriptionJobs.count
-        )
-    }
-
-    private func handleBackgroundTranscriptionWorkChanged() {
-        handleBackgroundTranscriptionWorkChanged(snapshot: currentBackgroundTranscriptionWorkSnapshot)
-    }
-
-    private func handleBackgroundTranscriptionWorkChanged(
-        snapshot: BackgroundTranscriptionWorkSnapshot
-    ) {
-        if canStartQueuedTranscriptionImmediately(snapshot: snapshot) {
-            if let nextJob = popNextQueuedTranscriptionJob() {
-                startQueuedTranscription(nextJob)
-                return
-            }
-
-            finalizeBackgroundTranscriptionStateIfNeeded(snapshot: snapshot)
-            return
-        }
-
-        if !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) {
-            finalizeBackgroundTranscriptionStateIfNeeded(snapshot: snapshot)
-            return
-        }
-
-        if !isCaptureSessionActive {
-            state = .transcribing
-        }
-    }
-
-    private func popNextQueuedTranscriptionJob() -> QueuedTranscriptionJob? {
-        guard !queuedTranscriptionJobs.isEmpty else { return nil }
-        return queuedTranscriptionJobs.removeFirst()
-    }
-
-    private func finalizeBackgroundTranscriptionStateIfNeeded() {
-        finalizeBackgroundTranscriptionStateIfNeeded(snapshot: currentBackgroundTranscriptionWorkSnapshot)
-    }
-
-    private func finalizeBackgroundTranscriptionStateIfNeeded(
-        snapshot: BackgroundTranscriptionWorkSnapshot
-    ) {
-        guard !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) else { return }
-        guard !isCaptureSessionActive else { return }
-        if MeetingSessionUIPolicy.shouldClearTranscriptionTriggerAfterBackgroundWork(
-            hasTerminalOutcome: lastTerminalTranscriptionOutcome != nil,
-            hasSpeakerReviewWork: snapshot.speakerNamingRequest != nil
-        ) {
-            activeTranscriptionTrigger = .unknown
-        }
-
-        switch lastTerminalTranscriptionOutcome {
-        case .failed(let message):
-            state = .error(message)
-        case .transcriptSaved:
-            state = .ready
-        case .none:
-            if case .transcribing = state {
-                state = .ready
-            }
-        }
-    }
+    // recordQueuedTranscriptionRuntimeDiagnosticsIfSafe,
+    // clearQueuedTranscriptionRuntimeDiagnosticsIfOwned,
+    // canStartQueuedTranscriptionImmediately(snapshot:),
+    // hasVisibleBackgroundTranscriptionWork(snapshot:),
+    // handleBackgroundTranscriptionWorkChanged, popNextQueuedTranscriptionJob,
+    // and finalizeBackgroundTranscriptionStateIfNeeded moved to
+    // TranscriptionQueueCoordinator.swift (audit 2026-07-08 wave 2, W2-B).
 
     private func restoreStateAfterRecordingEndedWithoutNewWork() {
         guard !hasVisibleBackgroundTranscriptionWork else {
@@ -2932,14 +2467,14 @@ final class MeetingSessionController: ObservableObject {
                 message: "Meeting transcript saved",
                 context: baseDiagnosticsContext(
                     extra: [
-                        "queue_depth": "\(queuedTranscriptionJobs.count)",
+                        "queue_depth": "\(transcriptionQueue.queuedTranscriptionJobs.count)",
                         "trigger": transcriptionTrigger.rawValue
                     ]
                 )
             )
             trackSavedTranscriptAnalyticsInBackground(
                 baseProperties: [
-                    "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                    "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(transcriptionQueue.queuedTranscriptionJobs.count),
                     "trigger": transcriptionTrigger.rawValue,
                 ],
                 promptTelemetryProperties: promptTelemetryProperties,
@@ -2971,7 +2506,7 @@ final class MeetingSessionController: ObservableObject {
                     context: baseDiagnosticsContext(
                         extra: [
                             "failure_kind": failureKind.rawValue,
-                            "queue_depth": "\(queuedTranscriptionJobs.count)",
+                            "queue_depth": "\(transcriptionQueue.queuedTranscriptionJobs.count)",
                             "trigger": transcriptionTrigger.rawValue
                         ]
                     )
@@ -2997,7 +2532,7 @@ final class MeetingSessionController: ObservableObject {
                 state = .error(diagnosticMessage)
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: failureKind.rawValue)
-                handleBackgroundTranscriptionWorkChanged()
+                transcriptionQueue.handleBackgroundTranscriptionWorkChanged()
                 return
             }
 
@@ -3007,7 +2542,7 @@ final class MeetingSessionController: ObservableObject {
                     allowLastSavedTranscriptOwner: true
                 )
                 activeQueuedTranscriptionJobID = nil
-                let queueDepthBucket = AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count)
+                let queueDepthBucket = AnalyticsReporter.queueDepthBucket(transcriptionQueue.queuedTranscriptionJobs.count)
                 DiagnosticsTrail.record(
                     level: .error,
                     engine: "meeting",
@@ -3017,7 +2552,7 @@ final class MeetingSessionController: ObservableObject {
                         extra: [
                             "failure_kind": failureKind.rawValue,
                             "session_stage": CaptureFailureStage.save.rawValue,
-                            "queue_depth": "\(queuedTranscriptionJobs.count)",
+                            "queue_depth": "\(transcriptionQueue.queuedTranscriptionJobs.count)",
                             "queue_depth_bucket": queueDepthBucket,
                             "trigger": transcriptionTrigger.rawValue
                         ]
@@ -3047,7 +2582,7 @@ final class MeetingSessionController: ObservableObject {
                 )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "speaker_finalization_failed")
-                handleBackgroundTranscriptionWorkChanged()
+                transcriptionQueue.handleBackgroundTranscriptionWorkChanged()
                 return
             }
 
@@ -3063,7 +2598,7 @@ final class MeetingSessionController: ObservableObject {
                 [
                     "error": message,
                     "diagnostic_error": diagnosticMessage,
-                    "queue_depth": "\(queuedTranscriptionJobs.count)",
+                    "queue_depth": "\(transcriptionQueue.queuedTranscriptionJobs.count)",
                 ],
                 uniquingKeysWith: { _, new in new }
             )
@@ -3093,7 +2628,7 @@ final class MeetingSessionController: ObservableObject {
             )
             activeTranscriptionCaptureDiagnostics = nil
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_failed")
-            handleBackgroundTranscriptionWorkChanged()
+            transcriptionQueue.handleBackgroundTranscriptionWorkChanged()
         case .gettingReady:
             if previousStatus.diagnosticName != status.diagnosticName {
                 DiagnosticsTrail.record(
@@ -3180,7 +2715,7 @@ final class MeetingSessionController: ObservableObject {
         (activeTranscriptionCaptureDiagnostics ?? [:]).merging(
             [
                 "failure_kind": failureKind.rawValue,
-                "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(transcriptionQueue.queuedTranscriptionJobs.count),
                 "trigger": transcriptionTrigger.rawValue,
             ],
             uniquingKeysWith: { _, new in new }
@@ -3426,7 +2961,10 @@ final class MeetingSessionController: ObservableObject {
         )
     }
 
-    private func baseDiagnosticsContext(extra: [String: String] = [:]) -> [String: String] {
+    // Was `private`; FailedMeetingStore / TranscriptionQueueCoordinator live
+    // in sibling files and need module-internal access (audit 2026-07-08
+    // wave 2, W2-B).
+    func baseDiagnosticsContext(extra: [String: String] = [:]) -> [String: String] {
         var context: [String: String] = [
             "session_state": state.diagnosticName,
             "display_status": displayStatus.diagnosticName,
@@ -3434,7 +2972,7 @@ final class MeetingSessionController: ObservableObject {
             "dictation_model_state": sttRouter.modelDownloadState.diagnosticName,
             "meeting_model_state": diarization.modelState.diagnosticName,
             "system_audio_status": capture.systemAudioStatus.diagnosticName,
-            "queue_depth": "\(queuedTranscriptionJobs.count)"
+            "queue_depth": "\(transcriptionQueue.queuedTranscriptionJobs.count)"
         ]
 
         for (key, value) in extra {
@@ -3448,135 +2986,26 @@ final class MeetingSessionController: ObservableObject {
         MeetingSystemAudioStatusCopy.message(for: status)
     }
 
-    private func boolString(_ value: Bool) -> String {
+    // Was `private`; FailedMeetingStore lives in a sibling file and needs
+    // module-internal access (audit 2026-07-08 wave 2, W2-B).
+    func boolString(_ value: Bool) -> String {
         value ? "true" : "false"
     }
 
-    @discardableResult
-    private func preserveFailedMeetingForRetry(
-        taskId: UUID = UUID(),
-        micAudioURL: URL?,
-        systemAudioURL: URL?,
-        errorMessage: String,
-        meetingTitle: String?,
-        recordingDate: Date? = nil,
-        archiveAudio: Bool = true
-    ) -> Bool {
-        let preserved = taskManager.addFailedTranscriptionRetainingAvailableAudio(
-            micAudioURL: micAudioURL,
-            systemAudioURL: systemAudioURL,
-            errorMessage: errorMessage,
-            taskId: taskId,
-            meetingTitle: meetingTitle,
-            recordingDate: recordingDate,
-            archiveAudio: archiveAudio
-        )
-        if preserved {
-            refreshFailedMeetings()
-        }
-        return preserved
-    }
+    // preserveFailedMeetingForRetry, refreshTimedOutFailedMeetingAudio, and
+    // scheduleFailedAudioCompression moved to FailedMeetingStore.swift
+    // (audit 2026-07-08 wave 2, W2-B). Call sites now go through
+    // `failedMeetingStore.`.
 
-    private func refreshTimedOutFailedMeetingAudio(id: UUID, result: CaptureStopResult) {
-        let existingFailure = failedManager.failedTranscriptions
-            .first(where: { $0.id == id })
-        let existingMicURL = existingFailure?.micAudioURL
-        let existingSystemURL = existingFailure?.systemAudioURL
-        guard let micURL = result.micURL ?? existingMicURL else { return }
-        let systemURL = result.systemURL ?? existingSystemURL
-
-        let updated = taskManager.promoteFinalizedFailedTranscriptionAudio(
-            id: id,
-            micAudioURL: micURL,
-            systemAudioURL: systemURL
-        )
-        DiagnosticsTrail.record(
-            level: updated ? .info : .warning,
-            engine: "meeting",
-            event: "meeting_recording_stop_timeout_audio_finalized",
-            message: updated
-                ? "Timed-out meeting audio finalized and failed queue was refreshed"
-                : "Timed-out meeting audio finalized but failed queue entry was not found",
-            context: baseDiagnosticsContext(
-                extra: [
-                    "failed_id": id.uuidString,
-                    "mic_file_present": boolString(FileManager.default.fileExists(atPath: micURL.path)),
-                    "system_file_present": boolString(systemURL.map { FileManager.default.fileExists(atPath: $0.path) } ?? false)
-                ]
-            )
-        )
-        if updated {
-            refreshFailedMeetings()
-        }
-    }
-
-    private func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) {
-        let failedTranscriptions = updatedFailedTranscriptions ?? failedManager.failedTranscriptions
-        retryingFailedMeetingIDs.formIntersection(Set(failedTranscriptions.map(\.id)))
-
-        failedMeetings = failedTranscriptions
-            .sorted(by: { $0.timestamp > $1.timestamp })
-            .map { failed in
-                FailedMeetingPresentation.item(
-                    from: failed,
-                    isRetrying: retryingFailedMeetingIDs.contains(failed.id)
-                )
-            }
-        scheduleFailedAudioCompression(for: failedTranscriptions)
-    }
-
-    private func scheduleFailedAudioCompression(for failedTranscriptions: [FailedTranscription]) {
-        guard failedAudioCompressionTask == nil else {
-            failedAudioCompressionNeedsReschedule = true
-            return
-        }
-
-        let candidates = failedTranscriptions.compactMap { failed -> FailedMeetingAudioCompressionCandidate? in
-            guard !retryingFailedMeetingIDs.contains(failed.id) else { return nil }
-            var urls = [failed.micAudioURL]
-            if let systemAudioURL = failed.systemAudioURL {
-                urls.append(systemAudioURL)
-            }
-            guard urls.contains(where: { $0.pathExtension.localizedCaseInsensitiveCompare("wav") == .orderedSame }) else {
-                return nil
-            }
-            return FailedMeetingAudioCompressionCandidate(
-                id: failed.id,
-                micAudioURL: failed.micAudioURL,
-                systemAudioURL: failed.systemAudioURL
-            )
-        }
-        guard !candidates.isEmpty else { return }
-
-        failedAudioCompressionNeedsReschedule = false
-        let audioArchiveRoot = MeetingStoragePaths.audioArchiveFolder
-        failedAudioCompressionTask = Task { [weak self] in
-            _ = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
-                candidates: candidates,
-                audioArchiveRoot: audioArchiveRoot,
-                persistUpdate: { [weak self] update in
-                    await MainActor.run {
-                        guard let self,
-                              !self.retryingFailedMeetingIDs.contains(update.id) else {
-                            return false
-                        }
-                        return self.failedManager.updateFailedTranscriptionAudio(
-                            id: update.id,
-                            micAudioURL: update.micAudioURL,
-                            systemAudioURL: update.systemAudioURL
-                        )
-                    }
-                }
-            )
-            await MainActor.run { [weak self] in
-                let shouldReschedule = self?.failedAudioCompressionNeedsReschedule == true
-                self?.failedAudioCompressionTask = nil
-                self?.failedAudioCompressionNeedsReschedule = false
-                if shouldReschedule, let self {
-                    self.scheduleFailedAudioCompression(for: self.failedManager.failedTranscriptions)
-                }
-            }
-        }
+    /// Recomputes and assigns the published failed-meeting list. Kept on the
+    /// controller (rather than moved wholesale) because `failedMeetings` is
+    /// `@Published` here — the store computes the list, the controller owns
+    /// the publish.
+    // Was `private`; FailedMeetingStore lives in a sibling file and calls
+    // back into this method after every mutation (audit 2026-07-08 wave 2,
+    // W2-B).
+    func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) {
+        failedMeetings = failedMeetingStore.refreshFailedMeetings(updatedFailedTranscriptions)
     }
 }
 

--- a/Sources/Meeting/TranscriptionQueueCoordinator.swift
+++ b/Sources/Meeting/TranscriptionQueueCoordinator.swift
@@ -1,0 +1,492 @@
+// TranscriptionQueueCoordinator.swift
+// Background-transcription queue/dispatch bookkeeping extracted from
+// MeetingSessionController (audit 2026-07-08 wave 2, W2-B). Pure code motion —
+// no behavior change. This is a plain owned object (not an ObservableObject);
+// MeetingSessionController still owns the state machine and @Published
+// surface. Job dispatch reaches back into the controller (`state`,
+// `displayStatus`, `taskManager`, live-sidecar bookkeeping, etc.) via
+// `controller`, using the `setState`/`setDisplayStatus` callbacks for the
+// two @Published transitions this subsystem drives.
+//
+// MeetingSessionController.QueuedTranscriptionJob and
+// MeetingSessionController.BackgroundTranscriptionWorkSnapshot stay
+// resolvable via typealiases on the controller so every existing reference
+// keeps compiling unchanged.
+
+import Foundation
+import TranscriptedCore
+
+@available(macOS 14.0, *)
+@MainActor
+final class TranscriptionQueueCoordinator {
+    struct QueuedTranscriptionJob {
+        enum Kind {
+            case recorded(
+                micURL: URL,
+                systemURL: URL?,
+                healthInfo: RecordingHealthInfo,
+                captureDiagnostics: [String: String],
+                meetingTitle: String?,
+                recordingDate: Date
+            )
+            case imported(
+                audioURL: URL,
+                suggestedTitle: String,
+                recordingDate: Date
+            )
+        }
+
+        let id = UUID()
+        let kind: Kind
+        let startTrigger: MeetingSessionController.StartTrigger
+        let sttModel: TranscriptionModelChoice
+        let promptTelemetryProperties: [String: String]?
+        let promptRecordingStartedAt: Date?
+
+        var captureDiagnostics: [String: String]? {
+            switch kind {
+            case .recorded(_, _, _, let captureDiagnostics, _, _):
+                return captureDiagnostics
+            case .imported:
+                return nil
+            }
+        }
+
+        var artifactRetained: Bool {
+            switch kind {
+            case .recorded:
+                return true
+            case .imported:
+                return true
+            }
+        }
+    }
+
+    struct BackgroundTranscriptionWorkSnapshot {
+        let activeCount: Int
+        let speakerNamingRequest: SpeakerNamingRequest?
+    }
+
+    enum QueueInsertionOutcome: Equatable {
+        case startedImmediately
+        case queued(position: Int)
+    }
+
+    unowned let controller: MeetingSessionController
+
+    var queuedTranscriptionJobs: [QueuedTranscriptionJob] = []
+    var preparingQueuedTranscriptionJob: QueuedTranscriptionJob?
+    var queuedTranscriptionStartTask: Task<Void, Never>?
+    private var queuedRuntimeDiagnosticsJobIDs: Set<UUID> = []
+
+    var isPreparingQueuedTranscriptionStart: Bool {
+        preparingQueuedTranscriptionJob != nil || queuedTranscriptionStartTask != nil
+    }
+
+    var currentBackgroundTranscriptionWorkSnapshot: BackgroundTranscriptionWorkSnapshot {
+        BackgroundTranscriptionWorkSnapshot(
+            activeCount: controller.taskManager.activeCount,
+            speakerNamingRequest: controller.taskManager.speakerNamingRequest
+        )
+    }
+
+    private var canStartQueuedTranscriptionImmediately: Bool {
+        canStartQueuedTranscriptionImmediately(snapshot: currentBackgroundTranscriptionWorkSnapshot)
+    }
+
+    init(controller: MeetingSessionController) {
+        self.controller = controller
+    }
+
+    func enqueueTranscriptionJob(
+        micURL: URL,
+        systemURL: URL?,
+        healthInfo: RecordingHealthInfo,
+        captureDiagnostics: [String: String],
+        meetingTitle: String?,
+        recordingDate: Date,
+        startTrigger: MeetingSessionController.StartTrigger,
+        promptTelemetryProperties: [String: String]? = nil,
+        promptRecordingStartedAt: Date? = nil
+    ) -> QueueInsertionOutcome {
+        let job = QueuedTranscriptionJob(
+            kind: .recorded(
+                micURL: micURL,
+                systemURL: systemURL,
+                healthInfo: healthInfo,
+                captureDiagnostics: captureDiagnostics,
+                meetingTitle: meetingTitle,
+                recordingDate: recordingDate
+            ),
+            startTrigger: startTrigger,
+            sttModel: controller.sttRouter.selectedModel,
+            promptTelemetryProperties: promptTelemetryProperties,
+            promptRecordingStartedAt: promptRecordingStartedAt
+        )
+
+        if controller.liveCodexFinalTranscriptNeedsQueuedJobID && controller.liveCodexSessionAwaitingFinalTranscript {
+            controller.liveCodexAwaitedTranscriptionJobID = job.id
+            controller.liveCodexFinalTranscriptNeedsQueuedJobID = false
+        }
+        return enqueue(job)
+    }
+
+    func enqueueImportedAudioJob(
+        audioURL: URL,
+        suggestedTitle: String,
+        recordingDate: Date,
+        startTrigger: MeetingSessionController.StartTrigger
+    ) -> QueueInsertionOutcome {
+        let job = QueuedTranscriptionJob(
+            kind: .imported(
+                audioURL: audioURL,
+                suggestedTitle: suggestedTitle,
+                recordingDate: recordingDate
+            ),
+            startTrigger: startTrigger,
+            sttModel: controller.sttRouter.selectedModel,
+            promptTelemetryProperties: nil,
+            promptRecordingStartedAt: nil
+        )
+
+        return enqueue(job)
+    }
+
+    private func enqueue(_ job: QueuedTranscriptionJob) -> QueueInsertionOutcome {
+        if canStartQueuedTranscriptionImmediately {
+            startQueuedTranscription(job)
+            return .startedImmediately
+        }
+
+        queuedTranscriptionJobs.append(job)
+        return .queued(position: queuedTranscriptionJobs.count)
+    }
+
+    private func startQueuedTranscription(_ job: QueuedTranscriptionJob) {
+        controller.lastTerminalTranscriptionOutcome = nil
+        controller.activeTranscriptionTrigger = job.startTrigger
+        controller.activeTranscriptionCaptureDiagnostics = job.captureDiagnostics
+        controller.activeDetectedPromptTranscriptionTelemetryProperties = job.promptTelemetryProperties
+        controller.activeDetectedPromptTranscriptionRecordingStartedAt = job.promptRecordingStartedAt
+        controller.sttAdapter.selectPreparedModel(job.sttModel)
+        preparingQueuedTranscriptionJob = job
+
+        if !controller.isCaptureSessionActive {
+            controller.setState(.transcribing)
+        }
+        recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)
+
+        controller.setDisplayStatus(.gettingReady)
+        queuedTranscriptionStartTask?.cancel()
+        queuedTranscriptionStartTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.prepareAndStartQueuedTranscription(job)
+        }
+    }
+
+    private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {
+        let modelsReady = await ensureModelsReadyForQueuedTranscription(job)
+
+        // A cancelled task must not touch shared state: a newer
+        // startQueuedTranscription has already taken ownership of
+        // queuedTranscriptionStartTask / preparingQueuedTranscriptionJob.
+        guard !Task.isCancelled else { return }
+        guard preparingQueuedTranscriptionJob?.id == job.id else { return }
+
+        queuedTranscriptionStartTask = nil
+        preparingQueuedTranscriptionJob = nil
+
+        guard modelsReady else {
+            failQueuedTranscriptionJobAfterModelRecovery(job)
+            handleBackgroundTranscriptionWorkChanged()
+            return
+        }
+
+        runPreparedQueuedTranscription(job)
+    }
+
+    private func ensureModelsReadyForQueuedTranscription(_ job: QueuedTranscriptionJob) async -> Bool {
+        controller.sttAdapter.selectPreparedModel(job.sttModel)
+
+        if controller.sttAdapter.isReady && controller.diarization.isReady {
+            return true
+        }
+
+        DiagnosticsTrail.record(
+            engine: "meeting",
+            event: "meeting_transcription_model_recovery_started",
+            message: "Meeting transcription is loading models before starting queued audio",
+            context: controller.baseDiagnosticsContext(
+                extra: [
+                    "trigger": job.startTrigger.rawValue,
+                    "queued_stt_model": job.sttModel.rawValue
+                ]
+            )
+        )
+        let modelRecoveryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: "queued_transcription",
+            surface: "meeting",
+            artifactRetained: job.artifactRetained
+        )
+
+        do {
+            try await TranscriptedConstants.withDetachedTimeout(
+                seconds: TranscriptedConstants.modelLoadWaitBudget
+            ) {
+                try await self.controller.downloader.ensureModelsReady(sttModel: job.sttModel)
+            }
+            controller.sttAdapter.selectPreparedModel(job.sttModel)
+        } catch {
+            DiagnosticsTrail.record(
+                level: .error,
+                engine: "meeting",
+                event: "meeting_transcription_model_recovery_failed",
+                message: "Meeting transcription models could not be loaded before queued audio started",
+                context: controller.baseDiagnosticsContext(
+                    extra: [
+                        "error": error.localizedDescription,
+                        "trigger": job.startTrigger.rawValue,
+                        "queued_stt_model": job.sttModel.rawValue
+                    ]
+                )
+            )
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "model_preparation",
+                failureKind: "models_not_ready",
+                retrySource: "queued_transcription",
+                result: "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
+                surface: "meeting",
+                artifactRetained: job.artifactRetained
+            )
+            return false
+        }
+
+        let ready = controller.sttAdapter.isReady && controller.diarization.isReady
+        if !ready {
+            DiagnosticsTrail.record(
+                level: .error,
+                engine: "meeting",
+                event: "meeting_transcription_model_recovery_failed",
+                message: "Meeting transcription models were still unavailable after reload",
+                context: controller.baseDiagnosticsContext(
+                    extra: [
+                        "trigger": job.startTrigger.rawValue,
+                        "queued_stt_model": job.sttModel.rawValue
+                    ]
+                )
+            )
+        }
+
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: "queued_transcription",
+            result: ready ? "success" : "failed",
+            elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
+            surface: "meeting",
+            artifactRetained: job.artifactRetained
+        )
+
+        return ready
+    }
+
+    private func runPreparedQueuedTranscription(_ job: QueuedTranscriptionJob) {
+        controller.sttAdapter.selectPreparedModel(job.sttModel)
+        queuedRuntimeDiagnosticsJobIDs.remove(job.id)
+        controller.activeQueuedTranscriptionJobID = job.id
+
+        switch job.kind {
+        case .recorded(let micURL, let systemURL, let healthInfo, _, let meetingTitle, let recordingDate):
+            controller.taskManager.startTranscription(
+                taskId: job.id,
+                micURL: micURL,
+                systemURL: systemURL,
+                outputFolder: MeetingStoragePaths.transcriptsFolder,
+                healthInfo: healthInfo,
+                meetingTitle: meetingTitle,
+                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled(),
+                recordingDate: recordingDate
+            )
+        case .imported(let audioURL, let suggestedTitle, let recordingDate):
+            controller.taskManager.startImportedTranscription(
+                audioURL: audioURL,
+                outputFolder: MeetingStoragePaths.transcriptsFolder,
+                meetingTitle: suggestedTitle,
+                recordingDate: recordingDate
+            )
+        }
+    }
+
+    private func failQueuedTranscriptionJobAfterModelRecovery(_ job: QueuedTranscriptionJob) {
+        let message = "Meeting transcription models were not ready. Try again after models finish loading."
+        controller.lastTerminalTranscriptionOutcome = .failed(message)
+        controller.setState(.error(message))
+        controller.setDisplayStatus(.failed(message: message))
+        if controller.liveCodexAwaitedTranscriptionJobID == job.id {
+            controller.finishLiveCodexSession(status: .failed, shouldAwaitFinalTranscript: false)
+        }
+        if controller.activeQueuedTranscriptionJobID == job.id {
+            controller.activeQueuedTranscriptionJobID = nil
+        }
+
+        switch job.kind {
+        case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
+            controller.failedMeetingStore.preserveFailedMeetingForRetry(
+                micAudioURL: micURL,
+                systemAudioURL: systemURL,
+                errorMessage: message,
+                meetingTitle: meetingTitle,
+                recordingDate: recordingDate
+            )
+        case .imported(let audioURL, let suggestedTitle, let recordingDate):
+            controller.failedMeetingStore.preserveFailedMeetingForRetry(
+                micAudioURL: nil,
+                systemAudioURL: audioURL,
+                errorMessage: message,
+                meetingTitle: suggestedTitle,
+                recordingDate: recordingDate
+            )
+        }
+        clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(for: job, outcome: "model_recovery_failed")
+    }
+
+    private func recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for job: QueuedTranscriptionJob) {
+        guard !controller.isCaptureSessionActive else { return }
+        guard !(controller.sttRouter.isRecording || controller.sttRouter.isTranscribing) else { return }
+        queuedRuntimeDiagnosticsJobIDs.insert(job.id)
+        MeetingSessionController.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
+    }
+
+    private func clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(
+        for job: QueuedTranscriptionJob,
+        outcome: String
+    ) {
+        guard queuedRuntimeDiagnosticsJobIDs.remove(job.id) != nil else { return }
+        guard !controller.isCaptureSessionActive else { return }
+        guard !(controller.sttRouter.isRecording || controller.sttRouter.isTranscribing) else { return }
+        MeetingSessionController.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: outcome)
+    }
+
+    private func canStartQueuedTranscriptionImmediately(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) -> Bool {
+        MeetingSessionUIPolicy.canStartQueuedTranscription(
+            activeTranscriptions: snapshot.activeCount,
+            isPreparingQueuedTranscriptionStart: isPreparingQueuedTranscriptionStart
+        )
+    }
+
+    func hasVisibleBackgroundTranscriptionWork(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) -> Bool {
+        MeetingSessionUIPolicy.shouldShowTranscribing(
+            activeTranscriptions: snapshot.activeCount + (isPreparingQueuedTranscriptionStart ? 1 : 0),
+            queuedTranscriptions: queuedTranscriptionJobs.count
+        )
+    }
+
+    func handleBackgroundTranscriptionWorkChanged() {
+        handleBackgroundTranscriptionWorkChanged(snapshot: currentBackgroundTranscriptionWorkSnapshot)
+    }
+
+    func handleBackgroundTranscriptionWorkChanged(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) {
+        if canStartQueuedTranscriptionImmediately(snapshot: snapshot) {
+            if let nextJob = popNextQueuedTranscriptionJob() {
+                startQueuedTranscription(nextJob)
+                return
+            }
+
+            finalizeBackgroundTranscriptionStateIfNeeded(snapshot: snapshot)
+            return
+        }
+
+        if !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) {
+            finalizeBackgroundTranscriptionStateIfNeeded(snapshot: snapshot)
+            return
+        }
+
+        if !controller.isCaptureSessionActive {
+            controller.setState(.transcribing)
+        }
+    }
+
+    private func popNextQueuedTranscriptionJob() -> QueuedTranscriptionJob? {
+        guard !queuedTranscriptionJobs.isEmpty else { return nil }
+        return queuedTranscriptionJobs.removeFirst()
+    }
+
+    private func finalizeBackgroundTranscriptionStateIfNeeded() {
+        finalizeBackgroundTranscriptionStateIfNeeded(snapshot: currentBackgroundTranscriptionWorkSnapshot)
+    }
+
+    private func finalizeBackgroundTranscriptionStateIfNeeded(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) {
+        guard !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) else { return }
+        guard !controller.isCaptureSessionActive else { return }
+        if MeetingSessionUIPolicy.shouldClearTranscriptionTriggerAfterBackgroundWork(
+            hasTerminalOutcome: controller.lastTerminalTranscriptionOutcome != nil,
+            hasSpeakerReviewWork: snapshot.speakerNamingRequest != nil
+        ) {
+            controller.activeTranscriptionTrigger = .unknown
+        }
+
+        switch controller.lastTerminalTranscriptionOutcome {
+        case .failed(let message):
+            controller.setState(.error(message))
+        case .transcriptSaved:
+            controller.setState(.ready)
+        case .none:
+            if case .transcribing = controller.state {
+                controller.setState(.ready)
+            }
+        }
+    }
+
+    /// Drains the queue (including any job mid-model-recovery) during app
+    /// shutdown, preserving each job's audio as a retryable failed meeting.
+    @discardableResult
+    func preserveQueuedTranscriptionJobsForShutdown(errorMessage: String) -> Int {
+        let preparingJob = preparingQueuedTranscriptionJob
+        let jobs = queuedTranscriptionJobs + [preparingJob].compactMap { $0 }
+        guard !jobs.isEmpty else { return 0 }
+
+        queuedTranscriptionStartTask?.cancel()
+        queuedTranscriptionStartTask = nil
+        preparingQueuedTranscriptionJob = nil
+        queuedTranscriptionJobs.removeAll()
+
+        var preservedCount = 0
+        for job in jobs {
+            switch job.kind {
+            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
+                if controller.failedMeetingStore.preserveFailedMeetingForRetry(
+                    micAudioURL: micURL,
+                    systemAudioURL: systemURL,
+                    errorMessage: errorMessage,
+                    meetingTitle: meetingTitle,
+                    recordingDate: recordingDate
+                ) {
+                    preservedCount += 1
+                }
+            case .imported(let audioURL, let suggestedTitle, let recordingDate):
+                if controller.failedMeetingStore.preserveFailedMeetingForRetry(
+                    micAudioURL: audioURL,
+                    systemAudioURL: nil,
+                    errorMessage: errorMessage,
+                    meetingTitle: suggestedTitle,
+                    recordingDate: recordingDate
+                ) {
+                    preservedCount += 1
+                }
+            }
+        }
+        return preservedCount
+    }
+}

--- a/Tests/AuditRegressionCoverageContractTests.swift
+++ b/Tests/AuditRegressionCoverageContractTests.swift
@@ -42,7 +42,9 @@ func testAuditRegressionCoverageContract() {
     }
 
     runSuite("AuditRegressionCoverageContract — failed meeting queue survives synchronous terminal failures") {
-        let source = readAuditContractSource("Sources/Meeting/MeetingSessionController.swift")
+        // Queue-dispatch logic moved to TranscriptionQueueCoordinator.swift
+        // (audit 2026-07-08 wave 2, W2-B).
+        let source = readAuditContractSource("Sources/Meeting/TranscriptionQueueCoordinator.swift")
         assertTrue(
             source.contains("finalizeBackgroundTranscriptionStateIfNeeded()"),
             "terminal display-status handlers should revisit background queue state"

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2197,16 +2197,21 @@ func testRepoCommandContract() {
     }
 
     runSuite("Repo command contract - queued meetings recover unloaded models before transcription") {
+        // Queue-dispatch logic moved to TranscriptionQueueCoordinator.swift
+        // (audit 2026-07-08 wave 2, W2-B) — this suite now reads that file
+        // for anything that moved, and the controller only for what stayed
+        // (visible first-run model warmup).
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let coordinatorContents = readRepoTextFile("Sources/Meeting/TranscriptionQueueCoordinator.swift")
         let downloaderContents = readRepoTextFile("Sources/Meeting/MeetingModelDownloader.swift")
 
         assertTrue(
-            controllerContents.contains("await ensureModelsReadyForQueuedTranscription(job)")
-                && controllerContents.contains("runPreparedQueuedTranscription(job)"),
+            coordinatorContents.contains("await ensureModelsReadyForQueuedTranscription(job)")
+                && coordinatorContents.contains("runPreparedQueuedTranscription(job)"),
             "queued meeting jobs should load models before entering TranscriptionTaskManager"
         )
         assertTrue(
-            controllerContents.contains("downloader.ensureModelsReady(sttModel: job.sttModel)"),
+            coordinatorContents.contains("downloader.ensureModelsReady(sttModel: job.sttModel)"),
             "queued meeting jobs should reload the STT model selected when the audio was queued"
         )
         let visibleWarmupBlock = sourceSlice(
@@ -2221,9 +2226,9 @@ func testRepoCommandContract() {
             "visible meeting model warmup should fail through the existing model-load budget instead of staying stuck in loadingModels"
         )
         let queuedRecoveryBlock = sourceSlice(
-            controllerContents,
+            coordinatorContents,
             from: "private func ensureModelsReadyForQueuedTranscription(_ job: QueuedTranscriptionJob) async -> Bool {",
-            to: "let ready = sttAdapter.isReady && diarization.isReady"
+            to: "let ready = controller.sttAdapter.isReady && controller.diarization.isReady"
         )
         assertTrue(
             queuedRecoveryBlock.contains("TranscriptedConstants.withDetachedTimeout")
@@ -2232,41 +2237,41 @@ func testRepoCommandContract() {
             "queued meeting model recovery should use the same bounded readiness wait as visible first-run warmup"
         )
         assertTrue(
-            controllerContents.contains("preparingQueuedTranscriptionJob")
-                && controllerContents.contains("isPreparingQueuedTranscriptionStart")
-                && controllerContents.contains("preparingQueuedTranscriptionJob?.id == job.id"),
+            coordinatorContents.contains("preparingQueuedTranscriptionJob")
+                && coordinatorContents.contains("isPreparingQueuedTranscriptionStart")
+                && coordinatorContents.contains("preparingQueuedTranscriptionJob?.id == job.id"),
             "model recovery should count as active background work and stale prep tasks must not clear newer queued work"
         )
         let startQueuedBlock = sourceSlice(
-            controllerContents,
+            coordinatorContents,
             from: "private func startQueuedTranscription(_ job: QueuedTranscriptionJob) {",
             to: "private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {"
         )
         assertTrue(
             startQueuedBlock.contains("recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)")
-                && controllerContents.contains("recordSession(kind: \"meeting\", stage: \"transcribing\")"),
+                && coordinatorContents.contains("recordSession(kind: \"meeting\", stage: \"transcribing\")"),
             "each queued meeting start should refresh runtime diagnostics away from the previous terminal outcome"
         )
         assertTrue(
-            controllerContents.contains("queuedRuntimeDiagnosticsJobIDs")
-                && controllerContents.contains("recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)")
-                && controllerContents.contains("guard !isCaptureSessionActive else { return }"),
+            coordinatorContents.contains("queuedRuntimeDiagnosticsJobIDs")
+                && coordinatorContents.contains("recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)")
+                && coordinatorContents.contains("guard !controller.isCaptureSessionActive else { return }"),
             "queued meeting diagnostics should not clobber foreground recording diagnostics"
         )
         assertTrue(
-            controllerContents.contains("guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }"),
+            coordinatorContents.contains("guard !(controller.sttRouter.isRecording || controller.sttRouter.isTranscribing) else { return }"),
             "queued meeting diagnostics should not clobber foreground dictation diagnostics"
         )
         let queuedRecoveryFailureBlock = sourceSlice(
-            controllerContents,
+            coordinatorContents,
             from: "private func failQueuedTranscriptionJobAfterModelRecovery(_ job: QueuedTranscriptionJob) {",
             to: "private func canStartQueuedTranscriptionImmediately("
         )
         assertTrue(
             queuedRecoveryFailureBlock.contains("clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(for: job, outcome: \"model_recovery_failed\")")
-                && controllerContents.contains("queuedRuntimeDiagnosticsJobIDs.remove(job.id)")
-                && queuedRecoveryFailureBlock.contains("guard !isCaptureSessionActive else { return }")
-                && queuedRecoveryFailureBlock.contains("guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }"),
+                && coordinatorContents.contains("queuedRuntimeDiagnosticsJobIDs.remove(job.id)")
+                && queuedRecoveryFailureBlock.contains("guard !controller.isCaptureSessionActive else { return }")
+                && queuedRecoveryFailureBlock.contains("guard !(controller.sttRouter.isRecording || controller.sttRouter.isTranscribing) else { return }"),
             "queued model recovery failures should clear only the runtime diagnostics session started before recovery"
         )
         assertTrue(
@@ -2340,28 +2345,25 @@ func testRepoCommandContract() {
     }
 
     runSuite("Repo command contract - failed audio compression reschedules queue changes") {
-        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
-        let schedulerBlock = sourceSlice(
-            controllerContents,
-            from: "private func scheduleFailedAudioCompression(",
-            to: "private extension MeetingSessionController.State"
-        )
+        // Failed-meeting bookkeeping moved to FailedMeetingStore.swift
+        // (audit 2026-07-08 wave 2, W2-B).
+        let storeContents = readRepoTextFile("Sources/Meeting/FailedMeetingStore.swift")
         let retryBlock = sourceSlice(
-            controllerContents,
+            storeContents,
             from: "func retryFailedMeeting(id: UUID) -> Bool",
             to: "Task { [weak self] in"
         )
 
         assertTrue(
-            controllerContents.contains("failedAudioCompressionNeedsReschedule"),
+            storeContents.contains("failedAudioCompressionNeedsReschedule"),
             "failed audio compression should track queue changes that arrive during an active pass"
         )
         assertTrue(
-            schedulerBlock.contains("failedAudioCompressionNeedsReschedule = true"),
+            storeContents.contains("failedAudioCompressionNeedsReschedule = true"),
             "an active compression pass should mark that the failed queue needs another scan"
         )
         assertTrue(
-            schedulerBlock.contains("self.scheduleFailedAudioCompression(for: self.failedManager.failedTranscriptions)"),
+            storeContents.contains("self.scheduleFailedAudioCompression(for: self.controller.failedManager.failedTranscriptions)"),
             "compression completion should re-check the latest failed queue before going idle"
         )
         assertTrue(
@@ -2372,20 +2374,23 @@ func testRepoCommandContract() {
     }
 
     runSuite("Repo command contract - stop-timeout failed meetings refresh Home immediately") {
+        // preserveFailedMeetingForRetry / refreshTimedOutFailedMeetingAudio
+        // moved to FailedMeetingStore.swift (audit 2026-07-08 wave 2, W2-B).
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let storeContents = readRepoTextFile("Sources/Meeting/FailedMeetingStore.swift")
         let timeoutBlock = sourceSlice(
             controllerContents,
             from: "if stopResult.didTimeOut {",
-            to: "let outcome = enqueueTranscriptionJob("
+            to: "let outcome = transcriptionQueue.enqueueTranscriptionJob("
         )
         let helperBlock = sourceSlice(
-            controllerContents,
-            from: "private func preserveFailedMeetingForRetry(",
-            to: "private func refreshFailedMeetings("
+            storeContents,
+            from: "func preserveFailedMeetingForRetry(",
+            to: "func refreshTimedOutFailedMeetingAudio("
         )
 
         assertTrue(
-            timeoutBlock.contains("let preserved = preserveFailedMeetingForRetry("),
+            timeoutBlock.contains("let preserved = failedMeetingStore.preserveFailedMeetingForRetry("),
             "stop timeouts should route retained audio through the refresh helper before returning"
         )
         assertTrue(
@@ -2394,16 +2399,16 @@ func testRepoCommandContract() {
         )
         assertTrue(
             controllerContents.contains("refreshTimedOutFailedMeetingAudio(")
-                && controllerContents.contains("promoteFinalizedFailedTranscriptionAudio("),
+                && storeContents.contains("promoteFinalizedFailedTranscriptionAudio("),
             "late WAV finalization should promote finalized failed audio before refreshing the failed queue"
         )
         let refreshTimedOutAudioBlock = sourceSlice(
-            controllerContents,
-            from: "private func refreshTimedOutFailedMeetingAudio(",
-            to: "private func refreshFailedMeetings("
+            storeContents,
+            from: "func refreshTimedOutFailedMeetingAudio(",
+            to: "func refreshFailedMeetings("
         )
         assertTrue(
-            refreshTimedOutAudioBlock.contains("let existingFailure = failedManager.failedTranscriptions")
+            refreshTimedOutAudioBlock.contains("let existingFailure = controller.failedManager.failedTranscriptions")
                 && refreshTimedOutAudioBlock.contains("let existingMicURL = existingFailure?.micAudioURL")
                 && refreshTimedOutAudioBlock.contains("guard let micURL = result.micURL ?? existingMicURL"),
             "late finalization should still promote system-only failed audio by reusing the failed queue mic placeholder"
@@ -2414,7 +2419,7 @@ func testRepoCommandContract() {
         )
         assertTrue(
             helperBlock.contains("taskManager.addFailedTranscriptionRetainingAvailableAudio(")
-                && helperBlock.contains("if preserved {\n            refreshFailedMeetings()"),
+                && helperBlock.contains("if preserved {\n            controller.refreshFailedMeetings()"),
             "retained failed-meeting audio should refresh MeetingSessionController.failedMeetings immediately"
         )
         assertTrue(
@@ -2422,16 +2427,17 @@ func testRepoCommandContract() {
             "the failed-manager subscription should render the emitted queue instead of re-reading stale @Published state"
         )
         assertFalse(
-            controllerContents.contains("taskManager.addFailedTranscriptionRetainingAudio("),
+            controllerContents.contains("taskManager.addFailedTranscriptionRetainingAudio(")
+                || storeContents.contains("taskManager.addFailedTranscriptionRetainingAudio("),
             "MeetingSessionController should not bypass the failed-meeting refresh helper"
         )
         assertEqual(
             countOccurrences(
                 of: "taskManager.addFailedTranscriptionRetainingAvailableAudio(",
-                in: controllerContents
+                in: storeContents
             ),
             1,
-            "direct failed-queue writes in MeetingSessionController should stay centralized in the refresh helper"
+            "direct failed-queue writes should stay centralized in FailedMeetingStore's refresh helper"
         )
     }
 
@@ -2471,7 +2477,11 @@ func testRepoCommandContract() {
         let helperBlock = sourceSlice(
             controllerContents,
             from: "private func finishLiveCodexSessionForCurrentTranscriptionFailureIfNeeded",
-            to: "private func canStartQueuedTranscriptionImmediately("
+            // canStartQueuedTranscriptionImmediately moved to
+            // TranscriptionQueueCoordinator.swift (audit 2026-07-08 wave 2,
+            // W2-B); the next controller function after this one is now
+            // restoreStateAfterRecordingEndedWithoutNewWork.
+            to: "private func restoreStateAfterRecordingEndedWithoutNewWork()"
         )
 
         assertTrue(
@@ -2494,6 +2504,10 @@ func testRepoCommandContract() {
 
     runSuite("Repo command contract - failed meeting transcripts carry capture diagnostics") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        // startQueuedTranscription moved to TranscriptionQueueCoordinator.swift
+        // (audit 2026-07-08 wave 2, W2-B) — it sets
+        // activeTranscriptionCaptureDiagnostics on the controller it holds.
+        let coordinatorContents = readRepoTextFile("Sources/Meeting/TranscriptionQueueCoordinator.swift")
         let failureBlock = sourceSlice(
             controllerContents,
             from: "case .failed(let message):",
@@ -2501,7 +2515,7 @@ func testRepoCommandContract() {
         )
 
         assertTrue(
-            controllerContents.contains("activeTranscriptionCaptureDiagnostics = job.captureDiagnostics"),
+            coordinatorContents.contains("controller.activeTranscriptionCaptureDiagnostics = job.captureDiagnostics"),
             "failed meeting transcript diagnostics should use the capture health context stored with the active queued job"
         )
         assertTrue(
@@ -2513,7 +2527,7 @@ func testRepoCommandContract() {
             "failed meeting transcript diagnostics should not sample the live capture singleton after transcription fails"
         )
         assertTrue(
-            failureBlock.contains("\"queue_depth_bucket\": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count)"),
+            failureBlock.contains("\"queue_depth_bucket\": AnalyticsReporter.queueDepthBucket(transcriptionQueue.queuedTranscriptionJobs.count)"),
             "failed meeting transcript diagnostics should include bucketed queue depth"
         )
         assertTrue(
@@ -2696,6 +2710,10 @@ func testRepoCommandContract() {
 
     runSuite("Repo command contract - live sidecar attaches only its queued meeting") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        // enqueueTranscriptionJob / enqueueImportedAudioJob / startTranscription
+        // call site moved to TranscriptionQueueCoordinator.swift (audit
+        // 2026-07-08 wave 2, W2-B).
+        let coordinatorContents = readRepoTextFile("Sources/Meeting/TranscriptionQueueCoordinator.swift")
         let taskManagerContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift")
         let startBlock = sourceSlice(
             controllerContents,
@@ -2703,9 +2721,9 @@ func testRepoCommandContract() {
             to: "private func finishLiveCodexSession"
         )
         let recordedEnqueueBlock = sourceSlice(
-            controllerContents,
-            from: "private func enqueueTranscriptionJob(",
-            to: "private func enqueueImportedAudioJob("
+            coordinatorContents,
+            from: "func enqueueTranscriptionJob(",
+            to: "func enqueueImportedAudioJob("
         )
         let attachBlock = sourceSlice(
             controllerContents,
@@ -2731,7 +2749,7 @@ func testRepoCommandContract() {
             "starting another meeting should not overwrite a sidecar that is still waiting for its final transcript handoff"
         )
         assertTrue(
-            recordedEnqueueBlock.contains("liveCodexFinalTranscriptNeedsQueuedJobID && liveCodexSessionAwaitingFinalTranscript"),
+            recordedEnqueueBlock.contains("controller.liveCodexFinalTranscriptNeedsQueuedJobID && controller.liveCodexSessionAwaitingFinalTranscript"),
             "only the recording that stopped an owned sidecar should assign the next queued transcript job as its final handoff owner"
         )
         assertTrue(
@@ -2755,7 +2773,7 @@ func testRepoCommandContract() {
             "TranscriptedCore should preserve the saved-transcript owner across speaker-review rewrites, even after another transcript saves"
         )
         assertTrue(
-            controllerContents.contains("taskManager.startTranscription(\n                taskId: job.id,"),
+            coordinatorContents.contains("taskManager.startTranscription(\n                taskId: job.id,"),
             "the app queue id should be passed into TranscriptedCore so the saved-transcript owner matches the awaited live handoff job"
         )
     }


### PR DESCRIPTION
## What

Pure code motion, no behavior change (codebase audit 2026-07-08 wave 2, spec W2-B). `Sources/Meeting/MeetingSessionController.swift` (3684 lines) inlined two coherent subsystems that are now split out:

- **`Sources/Meeting/FailedMeetingStore.swift`** — `FailedMeetingItem` + all failed-meeting queue/persistence/retry bookkeeping (`retryFailedMeeting`, `dismissFailedMeeting`, `deleteFailedMeeting`, `preserveFailedMeetingForRetry`, `refreshTimedOutFailedMeetingAudio`, the `refreshFailedMeetings` computation, `scheduleFailedAudioCompression`).
- **`Sources/Meeting/TranscriptionQueueCoordinator.swift`** — `QueuedTranscriptionJob` (+ `Kind`), `BackgroundTranscriptionWorkSnapshot`, and the queue enqueue/dispatch/recovery logic around `taskManager` (`enqueueTranscriptionJob`, `startQueuedTranscription`, `ensureModelsReadyForQueuedTranscription`, `runPreparedQueuedTranscription`, `failQueuedTranscriptionJobAfterModelRecovery`, `handleBackgroundTranscriptionWorkChanged`, etc.).

Both are plain owned objects (`let failedMeetingStore`, `let transcriptionQueue` on the controller — see "Deviations" for why they end up IUO), holding an `unowned` back-reference to the controller and reaching into it for shared state (`taskManager`, `sttAdapter`, `diarization`, `downloader`, `sttRouter`, live-sidecar bookkeeping) instead of duplicating it. The controller keeps the 6-state state machine and the full `@Published` surface — `setState`/`setDisplayStatus` are the two narrow callbacks the owned objects use to drive `state`/`displayStatus` transitions, per the "callbacks back into the controller" design in the spec.

`FailedMeetingItem`, `QueuedTranscriptionJob`, and `BackgroundTranscriptionWorkSnapshot` stay resolvable as `MeetingSessionController.X` via typealiases, so no UI or Core call site changes. `retryFailedMeeting`/`dismissFailedMeeting`/`deleteFailedMeeting` keep their exact public signatures as thin forwarders.

Several `private` members (`sttRouter`, `sttAdapter`, `diarization`, `downloader`, `failedManager`, `hasBackgroundTranscriptionWork`, `isCaptureSessionActive`, `baseDiagnosticsContext`, `boolString`, `finishLiveCodexSession`, `refreshFailedMeetings`, and a handful of controller-owned `var` fields) widen to internal so the two new same-module files can reach them — no public API changes outside the Meeting subsystem.

## Deviations from spec

- **Controller lands at 3113 lines, not <2200.** The two subsystems as scoped by the spec total ~570 lines of real motion; hitting <2200 would require pulling in code (state machine, live-sidecar handoff, telemetry) the spec explicitly said to leave in the controller this wave, given how deeply it all shares `@Published` state and diagnostics helpers. Flagging for the merge coordinator rather than expanding scope.
- `StartTrigger`/`StopReason`/`RecordingCancelReason`/`TranscriptionCancelReason` stayed nested in the controller (no `MeetingSessionTypes.swift`) per the spec's "if referenced outside" condition — grep found no call sites outside `MeetingSessionController.swift` for any of the four.
- `failedMeetingStore`/`transcriptionQueue` are implicitly-unwrapped optionals (`FailedMeetingStore!`), not plain `let`: Swift's definite-initialization checker rejects passing `self` into either type's `init` (both hold `unowned let controller`) before the property being assigned is itself set — even for the last two properties in the initializer. They're constructed unconditionally, immediately, in `init`, before any other code runs, and are `private(set)` so nothing outside `init` ever reassigns them.
- `Tests/RepoCommandContractTests.swift` and `Tests/AuditRegressionCoverageContractTests.swift` are golden-master-style contracts that assert exact source text/order inside `MeetingSessionController.swift`; ~10 suites read code that intentionally moved this wave. Retargeted `readRepoTextFile` calls and `sourceSlice` markers to the new files where the underlying invariant moved with the code; left assertions untouched wherever plain substring matching still held after the `controller.`/`transcriptionQueue.`/`failedMeetingStore.` prefixes were added. No behavioral test files needed changes.
- `run-tests.sh`'s `APP_SOURCES` and `Tests/FastTests.manifest` were not touched: `MeetingSessionController.swift` itself was never listed in either (it's Core-wiring code outside the fast-test compilation closure), so the two new files split out of it don't need tracking there either.

## Test plan

- [x] `bash build.sh` (App target, full signed build) — succeeds
- [x] `bash scripts/entrypoints/run-tests.sh` — 12863 tests, 12863 passed, 0 failed, including the full `RepoCommandContractTests`, `AuditRegressionCoverageContractTests`, `FailedMeetingPresentationTests`, and `AnalyticsEventPolicyTests` suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)