### PR TITLE
perf: async Copy Meeting transcript read; make MeetingPromptDetector event-driven

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -111,7 +111,18 @@ final class MeetingPromptDetector {
     private let defaultSnoozeInterval: TimeInterval = 30 * 60
     private let pendingCooldown: TimeInterval = 90
     private let suppressionTelemetryCooldown: TimeInterval = 90
-    private let pollIntervalNanoseconds: UInt64 = 20_000_000_000
+    // Every state change that can *newly* justify a prompt already re-evaluates
+    // immediately via an observer: workspace app activate/launch, EKEventStoreChanged,
+    // and the mic/camera/audio-output push methods below. What none of those can
+    // catch is a pure wall-clock threshold crossing — the calendar lead-time window
+    // opening (`calendarReminderLeadTime`), a snooze/pending cooldown expiring, or a
+    // runtime-dismiss resume date arriving — because nothing "happens" at that
+    // instant except time passing. The poll exists solely to catch those, so it's
+    // demoted to a slow safety net rather than removed: the widest of those windows
+    // (calendarReminderPostStartGrace, 5 min) comfortably absorbs a 120s cadence
+    // without missing a prompt window, at the cost of the poll-caught transitions
+    // landing up to ~100s later than the old 20s cadence.
+    private let pollIntervalNanoseconds: UInt64 = 120_000_000_000
     // Single fetch window covering both the near-term prompt window and the
     // farthest lookahead used for runtime-dismiss resume dates.
     private let calendarLookaheadInterval: TimeInterval = 12 * 60 * 60

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -880,87 +880,83 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeeting(_ item: RecentMeetingItem) {
         trackSettingsAction("copy_meeting", page: .home)
-        // Resolve the transcript first so a row whose path drifted (restyle/
-        // rename after scanning) still copies, and a genuinely missing file
-        // surfaces an error instead of silently no-op'ing on the empty clipboard.
-        guard let transcriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [item.transcriptURL]) else {
-            ActivationTelemetry.trackHabitLoopAction(
-                actionKind: .whatDidIPromise,
-                surface: .homeRow,
-                artifactKind: .meeting,
-                artifactDate: item.date,
-                result: .failed
-            )
-            ActivationTelemetry.trackAgentPromptAction(
-                promptKind: .meetingBundle,
-                actionKind: .copied,
-                agentTarget: .localAgent,
-                surface: .homeRow,
-                result: .failed,
-                artifactKind: .meeting
-            )
-            presentHomeActionFailure(
-                title: "Could not copy meeting",
-                message: SettingsArtifactMessage.meetingTranscriptNotFound,
-                retry: {
-                    handleCopyMeeting(item)
-                }
-            )
-            return
+        // Resolution + the transcript read (and bundle assembly) touch disk and
+        // can be sizeable for long meetings, so do them off the main thread and
+        // hop back only to write the clipboard / update UI state.
+        Task { @MainActor in
+            let result = await Self.loadCopyMeetingText(for: item)
+            switch result {
+            case .missingFile:
+                // Resolution failed so a row whose path drifted (restyle/rename
+                // after scanning) still copies, and a genuinely missing file
+                // surfaces an error instead of silently no-op'ing on the empty
+                // clipboard.
+                ActivationTelemetry.trackHabitLoopAction(
+                    actionKind: .whatDidIPromise,
+                    surface: .homeRow,
+                    artifactKind: .meeting,
+                    artifactDate: item.date,
+                    result: .failed
+                )
+                ActivationTelemetry.trackAgentPromptAction(
+                    promptKind: .meetingBundle,
+                    actionKind: .copied,
+                    agentTarget: .localAgent,
+                    surface: .homeRow,
+                    result: .failed,
+                    artifactKind: .meeting
+                )
+                presentHomeActionFailure(
+                    title: "Could not copy meeting",
+                    message: SettingsArtifactMessage.meetingTranscriptNotFound,
+                    retry: {
+                        handleCopyMeeting(item)
+                    }
+                )
+            case .readFailure:
+                ActivationTelemetry.trackHabitLoopAction(
+                    actionKind: .whatDidIPromise,
+                    surface: .homeRow,
+                    artifactKind: .meeting,
+                    artifactDate: item.date,
+                    result: .failed
+                )
+                ActivationTelemetry.trackAgentPromptAction(
+                    promptKind: .meetingBundle,
+                    actionKind: .copied,
+                    agentTarget: .localAgent,
+                    surface: .homeRow,
+                    result: .failed,
+                    artifactKind: .meeting
+                )
+                presentHomeActionFailure(
+                    title: "Could not copy meeting",
+                    message: "Transcripted found this meeting's transcript but couldn't read it. The file may be open exclusively elsewhere or corrupted.",
+                    retry: {
+                        handleCopyMeeting(item)
+                    }
+                )
+            case .success(let text, let usedBundle):
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(text, forType: .string)
+                ActivationTelemetry.trackHabitLoopAction(
+                    actionKind: .whatDidIPromise,
+                    surface: .homeRow,
+                    artifactKind: .meeting,
+                    artifactDate: item.date
+                )
+                ActivationTelemetry.trackAgentPromptAction(
+                    promptKind: usedBundle ? .meetingBundle : .meetingMarkdown,
+                    actionKind: .copied,
+                    agentTarget: .localAgent,
+                    surface: .homeRow,
+                    result: usedBundle ? .success : .fallbackCopied,
+                    artifactKind: .meeting
+                )
+                flashCopied(rowID: item.id)
+            }
         }
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        let usedBundle: Bool
-        if let bundle = AgentConnectionGuide.portableMeetingBundle(
-            title: item.title,
-            date: item.date,
-            transcriptURL: transcriptURL
-        ) {
-            pasteboard.setString(bundle, forType: .string)
-            usedBundle = true
-        } else if let raw = try? String(contentsOf: transcriptURL, encoding: .utf8) {
-            pasteboard.setString(raw, forType: .string)
-            usedBundle = false
-        } else {
-            ActivationTelemetry.trackHabitLoopAction(
-                actionKind: .whatDidIPromise,
-                surface: .homeRow,
-                artifactKind: .meeting,
-                artifactDate: item.date,
-                result: .failed
-            )
-            ActivationTelemetry.trackAgentPromptAction(
-                promptKind: .meetingBundle,
-                actionKind: .copied,
-                agentTarget: .localAgent,
-                surface: .homeRow,
-                result: .failed,
-                artifactKind: .meeting
-            )
-            presentHomeActionFailure(
-                title: "Could not copy meeting",
-                message: "Transcripted found this meeting's transcript but couldn't read it. The file may be open exclusively elsewhere or corrupted.",
-                retry: {
-                    handleCopyMeeting(item)
-                }
-            )
-            return
-        }
-        ActivationTelemetry.trackHabitLoopAction(
-            actionKind: .whatDidIPromise,
-            surface: .homeRow,
-            artifactKind: .meeting,
-            artifactDate: item.date
-        )
-        ActivationTelemetry.trackAgentPromptAction(
-            promptKind: usedBundle ? .meetingBundle : .meetingMarkdown,
-            actionKind: .copied,
-            agentTarget: .localAgent,
-            surface: .homeRow,
-            result: usedBundle ? .success : .fallbackCopied,
-            artifactKind: .meeting
-        )
-        flashCopied(rowID: item.id)
     }
 
     private func handleCopyMeetingPreview(_ preview: HomeMeetingPreview) {
@@ -1491,6 +1487,31 @@ struct TranscriptedSettingsView: View {
                 return .success(try String(contentsOf: resolved, encoding: .utf8))
             } catch {
                 return .failure(error.localizedDescription)
+            }
+        }.value
+    }
+
+    private enum HomeCopyMeetingReadResult {
+        case missingFile
+        case readFailure
+        case success(text: String, usedBundle: Bool)
+    }
+
+    private static func loadCopyMeetingText(for item: RecentMeetingItem) async -> HomeCopyMeetingReadResult {
+        await Task.detached(priority: .userInitiated) {
+            guard let transcriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [item.transcriptURL]) else {
+                return .missingFile
+            }
+            if let bundle = AgentConnectionGuide.portableMeetingBundle(
+                title: item.title,
+                date: item.date,
+                transcriptURL: transcriptURL
+            ) {
+                return .success(text: bundle, usedBundle: true)
+            } else if let raw = try? String(contentsOf: transcriptURL, encoding: .utf8) {
+                return .success(text: raw, usedBundle: false)
+            } else {
+                return .readFailure
             }
         }.value
     }


### PR DESCRIPTION
## What / why

Two verified small perf fixes from codebase audit 2026-07-08 wave 3.

**1. Copy Meeting (Home row) — async transcript read**

`handleCopyMeeting` in `TranscriptedSettingsView.swift` resolved the transcript
file, built the portable agent bundle (`AgentConnectionGuide.portableMeetingBundle`,
which itself styles/reads the transcript), and as a fallback read the raw
transcript via `String(contentsOf:)` — all synchronously inside the button's
action closure, so all on the main thread. Long meetings could visibly hitch
the UI on click.

Fix: added a `Self.loadCopyMeetingText(for:)` static helper that runs the
resolution + bundle build + raw read inside `Task.detached(priority: .userInitiated)`
(mirroring the existing `readMeetingMarkdown` pattern in the same file), and
`handleCopyMeeting` now awaits it inside `Task { @MainActor in ... }`, hopping
back to MainActor only for the pasteboard write, telemetry, and
`presentHomeActionFailure`/`flashCopied` UI calls. Clipboard content/format and
the existing missing-file / unreadable-file error idiom (title, message,
retry-by-recursing) are unchanged byte-for-byte from before.

No dedicated unit test existed for this method (only source-contract checks in
`UIAutomationSurfaceContractTests.swift` asserting the telemetry-call shape).
Verified those checks still hold against the restructured source (exactly 3
`ActivationTelemetry.trackHabitLoopAction(` calls in the function body, and
`trackSettingsAction` is not immediately followed by a habit-loop success
call) and ran the full suite.

**2. MeetingPromptDetector — event-driven, timer demoted to safety net**

`evaluate()` polled every 20s despite already having event-driven re-evaluation
wired: `NSWorkspace` app-activate/launch notifications, `.EKEventStoreChanged`,
and the `updateMicInputUsers`/`updateCameraInUse`/`updateAudioOutputUsers` push
methods all call `evaluate()` immediately on the actual state change.

Read through what the poll catches that those observers miss before touching
anything, per the task instructions — it's not legacy. The gap is real: none
of the observers fire on a pure wall-clock threshold crossing, because nothing
"happens" at that instant except time passing:
- the calendar lead-time window opening (`calendarReminderLeadTime` = 60s
  before a meeting starts, `MeetingPromptWindowPolicy.shouldOfferCalendarPrompt`)
- a `snoozedUntil`/`pendingUntil` cooldown expiring
- a runtime-dismiss resume date (`nextRuntimePromptResumeDate`) arriving

These transitions have no discrete event to observe — only re-running
`evaluate()` on a clock notices them. So I could not prove every transition is
observer-covered (the opposite: I can show at least three that provably
aren't), and removing the timer entirely would be unsafe.

Design: kept observers as the primary path (unchanged) and demoted the poll
from 20s to 120s as a slow safety net. The narrowest relevant window,
`calendarReminderPostStartGrace` (5 minutes post-start), comfortably absorbs a
120s cadence without missing a prompt opportunity — worst case the poll-only
transitions (lead-time window opening, cooldown expiry, resume date) land up
to ~100s later than before, well inside that window. Public behavior — which
notifications fire and under what conditions — is unchanged; only the poll's
cadence changed. No test asserted the exact `pollIntervalNanoseconds` value.

## Deviations

- Neither fix required touching a testable seam beyond what's covered by
  `UIAutomationSurfaceContractTests.swift`'s source-contract checks and
  `MeetingPromptDetectorTests.swift`; no new dedicated test was added since the
  restructuring changes control flow (sync → async) but not observable inputs/
  outputs, and the existing coverage already exercises both.

## Test plan

- [x] `bash scripts/entrypoints/run-tests.sh --filter testMeetingPromptDetector` — 85/85 passed
- [x] `bash scripts/entrypoints/run-tests.sh --filter testUIAutomationSurfaceContract` — 287/287 passed
- [x] `bash scripts/entrypoints/run-tests.sh` (full fast suite) — 12883/12883 passed
- [x] `bash build.sh` — signed build succeeds, launch smoke check + performance budget OK