### PR TITLE
refactor(observability): resolve AppLogger name collision, share rotation, document sink map

### DIFF
--- a/Sources/Meeting/MeetingModelDownloader.swift
+++ b/Sources/Meeting/MeetingModelDownloader.swift
@@ -61,11 +61,11 @@ final class MeetingModelDownloader {
                 ])
             }
 
-            TranscriptedCore.AppLogger.pipeline.info("Meeting model warmup complete", [
+            AppLogger.pipeline.info("Meeting model warmup complete", [
                 "elapsed_ms": "\(Int(Date().timeIntervalSince(startedAt) * 1000))"
             ])
         } catch {
-            TranscriptedCore.AppLogger.pipeline.error("Meeting model warmup failed", [
+            AppLogger.pipeline.error("Meeting model warmup failed", [
                 "elapsed_ms": "\(Int(Date().timeIntervalSince(startedAt) * 1000))",
                 "error": error.localizedDescription
             ])

--- a/Sources/Observability/AppLogSink.swift
+++ b/Sources/Observability/AppLogSink.swift
@@ -1,11 +1,15 @@
-// AppLogger.swift
+// AppLogSink.swift
 // Shared logging service — tracks every user action with timestamps.
 // Writes to both the in-app debug panel and the app-owned logs folder.
+//
+// See docs/observability.md for how this fits alongside TranscriptedCore's
+// AppLogger, FileLogger, EventReporter, and ReliabilityPacketRecorder.
 
 import Foundation
 import SwiftUI
+import TranscriptedCore
 
-private actor AppLogFileWriter {
+private actor AppLogSinkFileWriter {
     private var logPath: String?
     private var handle: FileHandle?
 
@@ -19,16 +23,16 @@ private actor AppLogFileWriter {
             do {
                 let attrs = try fm.attributesOfItem(atPath: path)
                 if let size = attrs[.size] as? UInt64, size > TranscriptedConstants.logRotationThreshold {
-                    if let data = fm.contents(atPath: path),
-                       let content = String(data: data, encoding: .utf8) {
-                        let lines = content.components(separatedBy: "\n")
-                        let kept = lines.suffix(TranscriptedConstants.logRotationKeepLines).joined(separator: "\n")
-                        do {
-                            try kept.write(toFile: path, atomically: true, encoding: .utf8)
-                        } catch {
-                            fputs("⚠️ LOGGER | log rotation write failed: \(error.localizedDescription)\n", stderr)
-                        }
-                    }
+                    // Trigger (byte size, checked once here at session start) stays
+                    // local; the actual read/trim/rewrite mechanics are shared with
+                    // TranscriptedCore's FileLogger via LogTailTrimmer.
+                    LogTailTrimmer.trimIfNeeded(
+                        at: path,
+                        maxLines: nil,
+                        keepLines: TranscriptedConstants.logRotationKeepLines,
+                        filterEmptyLines: false,
+                        appendsTrailingNewline: false
+                    )
                 }
             } catch {
                 fputs("⚠️ LOGGER | failed to read log file attributes: \(error.localizedDescription)\n", stderr)
@@ -73,13 +77,13 @@ private actor AppLogFileWriter {
 }
 
 @MainActor
-class AppLogger: ObservableObject {
+class AppLogSink: ObservableObject {
     @Published var entries: [String] = []
 
     private let logFilePath = FileManager.default.transcriptedLogsDirURL
         .appendingPathComponent("debug.log", isDirectory: false)
         .path
-    private let fileWriter = AppLogFileWriter()
+    private let fileWriter = AppLogSinkFileWriter()
     private var lastLogByKey: [String: CFAbsoluteTime] = [:]
 
     private let dateFormatter: DateFormatter = {

--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -7,7 +7,7 @@ anonymous analytics, and Sparkle update plumbing.
 
 ## Key Files
 
-- `AppLogger.swift` — developer-facing debug log writer
+- `AppLogSink.swift` — developer-facing debug log writer (in-app debug panel + `debug.log`); see `docs/observability.md` for how this relates to `TranscriptedCore`'s `AppLogger`
 - `EventReporter.swift` — structured event capture
 - `ObservabilityEvent.swift` — shared structured event payload used by local event logging and derived reliability packets
 - `LocalObservabilityPayloadSanitizer.swift` — redacts local event messages and context before disk writes
@@ -52,7 +52,7 @@ anonymous analytics, and Sparkle update plumbing.
 - Timeline analytics should route through `TimelineAnalyticsTelemetry` so future Dayflow events keep screen-derived data local and only send coarse enum/bucket payloads.
 - Non-fatal error forwarding to Sentry is allowlisted. New `.error` events should not automatically assume they are safe to send off-device.
 - `RuntimeDiagnostics` writes only coarse runtime state under app-owned state. Keep it free of transcript text, raw audio, file paths, device names, meeting titles, and speaker names.
-- `ReliabilityPacketRecorder` derives packets from already-reviewed observability events. Keep its context allowlist coarse and bucketed; do not add raw error text, transcript text, raw audio, file paths, device names, meeting titles, speaker names, emails, tokens, or source app names.
+- `ReliabilityPacketRecorder` derives packets from already-reviewed observability events (`EventReporter.capture` calls `ReliabilityPacketRecorder.record` directly — see the sink map in `docs/observability.md`). Keep its context allowlist coarse and bucketed; do not add raw error text, transcript text, raw audio, file paths, device names, meeting titles, speaker names, emails, tokens, or source app names.
 - Update telemetry should keep using `UpdateFailureKind` instead of ad hoc string parsing so dashboards stay stable across Sparkle error wording changes.
 
 ## Verification

--- a/Sources/Observability/DiagnosticsTrail.swift
+++ b/Sources/Observability/DiagnosticsTrail.swift
@@ -3,7 +3,7 @@ import Foundation
 @MainActor
 enum DiagnosticsTrail {
     static func record(
-        logger: AppLogger? = nil,
+        logger: AppLogSink? = nil,
         level: EventLevel = .info,
         engine: String,
         event: String,

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -1,7 +1,7 @@
 // EventReporter.swift
 // Centralized event tracking — structured JSONL for local diagnostics + optional Sentry forwarding.
 //
-// Design: @MainActor singleton + actor-based file writer (same pattern as AppLogger).
+// Design: @MainActor singleton + actor-based file writer (same pattern as AppLogSink).
 // Fire-and-forget via Task.detached — capture() never blocks the caller.
 
 import Foundation

--- a/Sources/Speech/NemotronEngine.swift
+++ b/Sources/Speech/NemotronEngine.swift
@@ -144,7 +144,7 @@ final class NemotronEngine: ObservableObject {
             let audioDuration = Double(samples.count) / TranscriptedConstants.parakeetSampleRate
             let rtf = audioDuration > 0 ? elapsed / audioDuration : 0
 
-            TranscriptedCore.AppLogger.transcription.info("NEMOTRON | \(Self.model.title) transcribed \(sourceDescription) in \(String(format: "%.2f", elapsed))s, chars=\(trimmed.count)")
+            AppLogger.transcription.info("NEMOTRON | \(Self.model.title) transcribed \(sourceDescription) in \(String(format: "%.2f", elapsed))s, chars=\(trimmed.count)")
             EventReporter.shared.capture(
                 level: .info,
                 engine: Self.model.engineName,
@@ -194,7 +194,7 @@ final class NemotronEngine: ObservableObject {
         // cache on first use, then loads from disk. There is no per-file
         // progress callback, so publish a coarse downloading → ready state.
         modelDownloadState = .downloading(progress: 0)
-        TranscriptedCore.AppLogger.transcription.info("NEMOTRON | preparing \(Self.model.title)...")
+        AppLogger.transcription.info("NEMOTRON | preparing \(Self.model.title)...")
 
         do {
             try await manager.loadModels()
@@ -210,7 +210,7 @@ final class NemotronEngine: ObservableObject {
             )
         } catch {
             let friendlyMessage = "Couldn't load \(Self.model.title): \(error.localizedDescription)"
-            TranscriptedCore.AppLogger.transcription.error("NEMOTRON | \(friendlyMessage)")
+            AppLogger.transcription.error("NEMOTRON | \(friendlyMessage)")
             modelDownloadState = .failed(friendlyMessage)
             EventReporter.shared.capture(
                 level: .error,

--- a/Sources/Speech/ParakeetAudioEngineSupport.swift
+++ b/Sources/Speech/ParakeetAudioEngineSupport.swift
@@ -20,7 +20,7 @@ func unregisterDefaultInputDeviceListener(_ listener: AudioObjectPropertyListene
     )
 
     if status != noErr {
-        TranscriptedCore.AppLogger.audioMic.warning("PARAKEET | failed to remove default input listener (\(status))")
+        AppLogger.audioMic.warning("PARAKEET | failed to remove default input listener (\(status))")
     }
 }
 

--- a/Sources/Speech/ParakeetDeviceRecovery.swift
+++ b/Sources/Speech/ParakeetDeviceRecovery.swift
@@ -85,7 +85,7 @@ extension ParakeetEngine {
     private func handleDefaultInputDeviceChange(selection: DictationInputDeviceSelection) {
         cachedInputDeviceName = selection.selectedInput.name
         cachedInputDeviceSelection = selection
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | default input changed → \(selection.defaultInput.name); dictation input → \(selection.selectedInput.name)")
+        AppLogger.transcription.info("PARAKEET | default input changed → \(selection.defaultInput.name); dictation input → \(selection.selectedInput.name)")
         EventReporter.shared.capture(
             level: .info,
             engine: "parakeet",
@@ -310,7 +310,7 @@ extension ParakeetEngine {
                 guard let snapshot = readySnapshot else { return }
                 self.updateNativeSampleRate(snapshot.outputFormat.sampleRate)
                 self.prewarmRetryCount = 0
-                TranscriptedCore.AppLogger.transcription.info("PARAKEET | audio device changed → \(self.inputDeviceName) (\(self.safeNativeSampleRate())Hz), input ready")
+                AppLogger.transcription.info("PARAKEET | audio device changed → \(self.inputDeviceName) (\(self.safeNativeSampleRate())Hz), input ready")
 
                 guard !Task.isCancelled else { return }
                 guard self.recoveryState.finishRecovery(success: true, generation: myGeneration) else { return }
@@ -341,7 +341,7 @@ extension ParakeetEngine {
                         guard !self.recoveryState.isStale(generation: myGeneration) else { return }
                         if await self.startRecording() {
                             restarted = true
-                            TranscriptedCore.AppLogger.transcription.info("PARAKEET | recording recovered on new device (\(self.inputDeviceName)) after \(attempt) attempt(s)")
+                            AppLogger.transcription.info("PARAKEET | recording recovered on new device (\(self.inputDeviceName)) after \(attempt) attempt(s)")
                             EventReporter.shared.capture(level: .info, engine: "parakeet",
                                 event: "recording_recovered_device_change",
                                 message: "Recording recovered after device change",

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -467,7 +467,7 @@ class ParakeetEngine: ObservableObject {
 
         prewarmRetryCount = 0
         markFormatReadyAndPublish()
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | input ready (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
+        AppLogger.transcription.info("PARAKEET | input ready (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
     }
 
     private func canContinuePrewarm(generation: Int) -> Bool {
@@ -1317,7 +1317,7 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func handleSystemWake() async {
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | system wake detected, resetting audio engine")
+        AppLogger.transcription.info("PARAKEET | system wake detected, resetting audio engine")
         EventReporter.shared.capture(level: .info, engine: "parakeet", event: "system_wake",
             message: "System woke from sleep, resetting audio engine",
             context: ["was_recording": "\(isRecording)", "was_prewarmed": "\(isEnginePrewarmed)"])
@@ -1432,7 +1432,7 @@ class ParakeetEngine: ObservableObject {
               lastInputSelectionReportKey != reportKey else { return }
 
         lastInputSelectionReportKey = reportKey
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | using \(selection.selectedInput.name) instead of \(selection.defaultInput.name) to avoid Bluetooth headset mode")
+        AppLogger.transcription.info("PARAKEET | using \(selection.selectedInput.name) instead of \(selection.defaultInput.name) to avoid Bluetooth headset mode")
         EventReporter.shared.capture(
             level: .info,
             engine: "parakeet",
@@ -1669,7 +1669,7 @@ class ParakeetEngine: ObservableObject {
                     for: readiness.startFailureReason ?? .invalidAudioFormat,
                     isRecoveryAttempt: isRecoveryAttempt
                 )
-                TranscriptedCore.AppLogger.transcription.warning("PARAKEET | input format unavailable (\(readiness.rawValue)): output=\(snapshot.outputFormat.sampleRate)Hz/\(snapshot.outputFormat.channelCount)ch hw=\(snapshot.hwFormat.sampleRate)Hz/\(snapshot.hwFormat.channelCount)ch")
+                AppLogger.transcription.warning("PARAKEET | input format unavailable (\(readiness.rawValue)): output=\(snapshot.outputFormat.sampleRate)Hz/\(snapshot.outputFormat.channelCount)ch hw=\(snapshot.hwFormat.sampleRate)Hz/\(snapshot.hwFormat.channelCount)ch")
                 var context = audioStartContext(
                     attempt: attempt,
                     isRecoveryAttempt: isRecoveryAttempt,
@@ -1797,7 +1797,7 @@ class ParakeetEngine: ObservableObject {
 
                 if shouldRetry {
                     startGeneration = audioGraphGeneration
-                    TranscriptedCore.AppLogger.transcription.warning("PARAKEET | audio engine start failed, resetting graph and retrying once: \(error.localizedDescription)")
+                    AppLogger.transcription.warning("PARAKEET | audio engine start failed, resetting graph and retrying once: \(error.localizedDescription)")
                     EventReporter.shared.capture(
                         level: .warning,
                         engine: "parakeet",
@@ -1809,7 +1809,7 @@ class ParakeetEngine: ObservableObject {
                 }
 
                 if failureReason == .audioRouteNotSettled {
-                    TranscriptedCore.AppLogger.transcription.warning("PARAKEET | audio route format unsupported while starting; waiting for CoreAudio to settle")
+                    AppLogger.transcription.warning("PARAKEET | audio route format unsupported while starting; waiting for CoreAudio to settle")
                     EventReporter.shared.capture(
                         level: .warning,
                         engine: "parakeet",
@@ -1827,7 +1827,7 @@ class ParakeetEngine: ObservableObject {
                 }
 
                 if operationTimedOut {
-                    TranscriptedCore.AppLogger.transcription.error("PARAKEET | audio engine start timed out after \(attempt) attempt(s): \(error.localizedDescription)")
+                    AppLogger.transcription.error("PARAKEET | audio engine start timed out after \(attempt) attempt(s): \(error.localizedDescription)")
                     EventReporter.shared.capture(
                         level: .error,
                         engine: "parakeet",
@@ -1844,7 +1844,7 @@ class ParakeetEngine: ObservableObject {
                     return await failAudioStart()
                 }
 
-                TranscriptedCore.AppLogger.transcription.error("PARAKEET | audio engine failed after \(attempt) attempt(s): \(error.localizedDescription)")
+                AppLogger.transcription.error("PARAKEET | audio engine failed after \(attempt) attempt(s): \(error.localizedDescription)")
                 reportAudioStartFailureIfNeeded(message: error.localizedDescription, context: context)
                 if startFailureAction.markFormatUnready {
                     markStartFailedAndPublish()
@@ -1885,7 +1885,7 @@ class ParakeetEngine: ObservableObject {
             }
             Task { await eouManager?.reset() }
         }
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | recording started (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
+        AppLogger.transcription.info("PARAKEET | recording started (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
 
         // Watchdog: detect zombie audio engine (running but no usable signal after sleep/wake).
         // Only on first attempt — recovery attempt doesn't re-watchdog to prevent infinite loops.
@@ -1995,11 +1995,11 @@ class ParakeetEngine: ObservableObject {
 
             // Retry once — isRecoveryAttempt prevents another watchdog
             if await self.startRecording(isRecoveryAttempt: true) {
-                TranscriptedCore.AppLogger.transcription.info("PARAKEET | zombie engine recovered — recording restarted")
+                AppLogger.transcription.info("PARAKEET | zombie engine recovered — recording restarted")
                 EventReporter.shared.capture(level: .info, engine: "parakeet", event: "zombie_engine_recovered",
                     message: "Audio engine recovered after reset")
             } else {
-                TranscriptedCore.AppLogger.transcription.error("PARAKEET | zombie engine recovery failed")
+                AppLogger.transcription.error("PARAKEET | zombie engine recovery failed")
                 EventReporter.shared.capture(level: .error, engine: "parakeet", event: "zombie_engine_recovery_failed",
                     message: "Audio engine could not recover after reset",
                     context: ["audio_device": self.inputDeviceName])
@@ -2061,7 +2061,7 @@ class ParakeetEngine: ObservableObject {
         isRecording = false
         audioLevel = 0
         let stopSampleRate = safeNativeSampleRate()
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | recording stopped (\(sampleBuffer.count) samples, \(String(format: "%.1f", Double(sampleBuffer.count) / stopSampleRate))s)")
+        AppLogger.transcription.info("PARAKEET | recording stopped (\(sampleBuffer.count) samples, \(String(format: "%.1f", Double(sampleBuffer.count) / stopSampleRate))s)")
     }
 
     // MARK: - EOU Streaming (live display)
@@ -2230,7 +2230,7 @@ class ParakeetEngine: ObservableObject {
         }
         let nativeCount = recorded.nativeSampleCount
         let resampled = recorded.samples16k
-        TranscriptedCore.AppLogger.transcription.info("\(engineName.uppercased()) | resampled \(nativeCount) → \(resampled.count) samples")
+        AppLogger.transcription.info("\(engineName.uppercased()) | resampled \(nativeCount) → \(resampled.count) samples")
 
         let shortAudioDecision = ParakeetShortAudioGate.dictation(
             nativeSampleCount: nativeCount,
@@ -2239,7 +2239,7 @@ class ParakeetEngine: ObservableObject {
         guard shortAudioDecision.shouldTranscribe else {
             lastEmptyTranscriptionReason = .recordingTooShort
             let audioDuration = shortAudioDecision.context["audio_duration_s"] ?? "0.00"
-            TranscriptedCore.AppLogger.transcription.warning("\(engineName.uppercased()) | skipping transcription for short audio (\(audioDuration)s)")
+            AppLogger.transcription.warning("\(engineName.uppercased()) | skipping transcription for short audio (\(audioDuration)s)")
             EventReporter.shared.capture(
                 level: .warning,
                 engine: engineName,
@@ -2353,7 +2353,7 @@ class ParakeetEngine: ObservableObject {
             return nil
         }
         guard let manager = asrManager, asrManagerReady else {
-            TranscriptedCore.AppLogger.transcription.error("PARAKEET | ASR manager not available")
+            AppLogger.transcription.error("PARAKEET | ASR manager not available")
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "asr_manager_unavailable",
                 message: "ASR manager not available for transcription")
             return nil
@@ -2368,7 +2368,7 @@ class ParakeetEngine: ObservableObject {
         }
         let nativeCount = recorded.nativeSampleCount
         let resampled = recorded.samples16k
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | resampled \(nativeCount) → \(resampled.count) samples")
+        AppLogger.transcription.info("PARAKEET | resampled \(nativeCount) → \(resampled.count) samples")
 
         let shortAudioDecision = ParakeetShortAudioGate.dictation(
             nativeSampleCount: nativeCount,
@@ -2377,7 +2377,7 @@ class ParakeetEngine: ObservableObject {
         guard shortAudioDecision.shouldTranscribe else {
             lastEmptyTranscriptionReason = .recordingTooShort
             let audioDuration = shortAudioDecision.context["audio_duration_s"] ?? "0.00"
-            TranscriptedCore.AppLogger.transcription.warning("PARAKEET | skipping transcription for short audio (\(audioDuration)s)")
+            AppLogger.transcription.warning("PARAKEET | skipping transcription for short audio (\(audioDuration)s)")
             EventReporter.shared.capture(
                 level: .warning,
                 engine: "parakeet",
@@ -2400,7 +2400,7 @@ class ParakeetEngine: ObservableObject {
 
             let audioDuration = Double(resampled.count) / TranscriptedConstants.parakeetSampleRate
             let rtf = audioDuration > 0 ? elapsed / audioDuration : 0
-            TranscriptedCore.AppLogger.transcription.info("PARAKEET | transcribed in \(String(format: "%.2f", elapsed))s, chars=\(corrected.count)")
+            AppLogger.transcription.info("PARAKEET | transcribed in \(String(format: "%.2f", elapsed))s, chars=\(corrected.count)")
 
             if trimmed.isEmpty {
                 let analysis = DictationAudioRecovery.analyze(
@@ -2511,7 +2511,7 @@ class ParakeetEngine: ObservableObject {
                 return nil
             }
 
-            TranscriptedCore.AppLogger.transcription.error("PARAKEET | transcription failed: \(error.localizedDescription)")
+            AppLogger.transcription.error("PARAKEET | transcription failed: \(error.localizedDescription)")
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "transcription_failed",
                 message: error.localizedDescription,
                 context: ["samples": "\(nativeCount)", "elapsed": String(format: "%.2f", elapsed)])

--- a/Sources/Speech/ParakeetModelLifecycle.swift
+++ b/Sources/Speech/ParakeetModelLifecycle.swift
@@ -68,7 +68,7 @@ extension ParakeetEngine {
         // not surprise users with a hidden or out-of-context prompt.
 
         modelDownloadState = .loading
-        TranscriptedCore.AppLogger.transcription.info("PARAKEET | initializing models...")
+        AppLogger.transcription.info("PARAKEET | initializing models...")
 
         var failureStage: ParakeetModelInitStage = .authorizationRequest
         var loadSource: ParakeetModelLoadSource = .unresolved
@@ -87,7 +87,7 @@ extension ParakeetEngine {
             if let bundlePath = bundledModelPath {
                 failureStage = .bundleLoad
                 loadSource = .bundle
-                TranscriptedCore.AppLogger.transcription.info("PARAKEET | loading from bundle: \(bundlePath.path)")
+                AppLogger.transcription.info("PARAKEET | loading from bundle: \(bundlePath.path)")
                 models = try await AsrModels.load(from: bundlePath, version: .v3)
                 guard !Task.isCancelled, !isShuttingDown else { return }
                 loadSourceName = loadSource.rawValue
@@ -111,7 +111,7 @@ extension ParakeetEngine {
                 loadSource = .download
                 let downloadedPath: URL
                 if let modelFilePrefetchTask {
-                    TranscriptedCore.AppLogger.transcription.info("PARAKEET | waiting for background Parakeet model cache...")
+                    AppLogger.transcription.info("PARAKEET | waiting for background Parakeet model cache...")
                     modelDownloadState = .downloading(progress: 0.0)
                     downloadedPath = try await modelFilePrefetchTask.value
                     prefetchedModelPath = downloadedPath
@@ -122,14 +122,14 @@ extension ParakeetEngine {
                     prefetchedModelPath = cachedModelPath
                     downloadedPath = cachedModelPath
                 } else {
-                    TranscriptedCore.AppLogger.transcription.info("PARAKEET | models not bundled, downloading (~600MB)...")
+                    AppLogger.transcription.info("PARAKEET | models not bundled, downloading (~600MB)...")
                     modelDownloadState = .downloading(progress: 0.0)
                     downloadedPath = try await AsrModels.download(version: .v3)
                     prefetchedModelPath = downloadedPath
                 }
                 guard !Task.isCancelled, !isShuttingDown else { return }
                 modelDownloadState = .loading
-                TranscriptedCore.AppLogger.transcription.info("PARAKEET | loading downloaded models from: \(downloadedPath.path)")
+                AppLogger.transcription.info("PARAKEET | loading downloaded models from: \(downloadedPath.path)")
                 models = try await AsrModels.load(from: downloadedPath, version: .v3)
                 guard !Task.isCancelled, !isShuttingDown else { return }
                 loadSourceName = loadSource.rawValue
@@ -146,7 +146,7 @@ extension ParakeetEngine {
             asrManager = manager
             asrManagerReady = true
             modelDownloadState = .ready
-            TranscriptedCore.AppLogger.transcription.info("PARAKEET | TDT V3 models loaded (source: \(loadSourceName))")
+            AppLogger.transcription.info("PARAKEET | TDT V3 models loaded (source: \(loadSourceName))")
             EventReporter.shared.capture(level: .info, engine: "parakeet", event: "models_loaded",
                 message: "Parakeet ASR models initialized successfully",
                 context: ["load_source": loadSourceName])
@@ -161,7 +161,7 @@ extension ParakeetEngine {
             prefetchedModelPath = nil
             let friendlyMessage = ModelDownloadService.classifyError(error).detail
             modelDownloadState = .failed(friendlyMessage)
-            TranscriptedCore.AppLogger.transcription.error("PARAKEET | model initialization failed: \(error.localizedDescription)")
+            AppLogger.transcription.error("PARAKEET | model initialization failed: \(error.localizedDescription)")
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "model_init_failed",
                 message: error.localizedDescription,
                 context: ParakeetModelInitDiagnostics.failureContext(
@@ -264,13 +264,13 @@ extension ParakeetEngine {
 
             let modelDir: URL
             if let bundlePath = bundledModelPath(subdirectory: "parakeet-eou-120m-coreml", checkFile: "streaming_encoder.mlmodelc") {
-                TranscriptedCore.AppLogger.transcription.info("PARAKEET EOU | loading from bundle: \(bundlePath.path)")
+                AppLogger.transcription.info("PARAKEET EOU | loading from bundle: \(bundlePath.path)")
                 modelDir = bundlePath
             } else {
                 // Download from HuggingFace (~120MB) and cache locally
                 // DownloadUtils nests inside <directory>/<repo.folderName>/, so we use the parent
                 guard let appSupportRoot = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-                    TranscriptedCore.AppLogger.transcription.warning("PARAKEET EOU | application support directory unavailable")
+                    AppLogger.transcription.warning("PARAKEET EOU | application support directory unavailable")
                     EventReporter.shared.capture(
                         level: .warning,
                         engine: "parakeet",
@@ -283,10 +283,10 @@ extension ParakeetEngine {
                 let expectedDir = cacheBase.appendingPathComponent("parakeet-eou-streaming/320ms", isDirectory: true)
                 let checkFile = expectedDir.appendingPathComponent("streaming_encoder.mlmodelc")
                 if FileManager.default.fileExists(atPath: checkFile.path) {
-                    TranscriptedCore.AppLogger.transcription.info("PARAKEET EOU | loading from cache: \(expectedDir.path)")
+                    AppLogger.transcription.info("PARAKEET EOU | loading from cache: \(expectedDir.path)")
                     modelDir = expectedDir
                 } else {
-                    TranscriptedCore.AppLogger.transcription.warning("PARAKEET EOU | streaming model download unavailable with current FluidAudio API")
+                    AppLogger.transcription.warning("PARAKEET EOU | streaming model download unavailable with current FluidAudio API")
                     EventReporter.shared.capture(
                         level: .warning,
                         engine: "parakeet",
@@ -324,12 +324,12 @@ extension ParakeetEngine {
             }
 
             eouManager = eou
-            TranscriptedCore.AppLogger.transcription.info("PARAKEET EOU | streaming model ready")
+            AppLogger.transcription.info("PARAKEET EOU | streaming model ready")
             EventReporter.shared.capture(level: .info, engine: "parakeet", event: "eou_model_loaded",
                 message: "Parakeet EOU streaming model initialized")
         } catch {
             // Non-fatal — live display will just stay empty until batch result arrives
-            TranscriptedCore.AppLogger.transcription.warning("PARAKEET EOU | model load failed (live display disabled): \(error.localizedDescription)")
+            AppLogger.transcription.warning("PARAKEET EOU | model load failed (live display disabled): \(error.localizedDescription)")
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "eou_model_failed",
                 message: error.localizedDescription)
         }
@@ -350,11 +350,11 @@ extension ParakeetEngine {
               !fileManager.fileExists(atPath: newDir.path) else { return }
         do {
             try fileManager.moveItem(at: legacyDir, to: newDir)
-            TranscriptedCore.AppLogger.transcription.info("PARAKEET | migrated legacy model cache to \(newDir.lastPathComponent)")
+            AppLogger.transcription.info("PARAKEET | migrated legacy model cache to \(newDir.lastPathComponent)")
             EventReporter.shared.capture(level: .info, engine: "parakeet", event: "model_cache_migrated",
                 message: "Renamed pre-0.15 FluidAudio model cache folder")
         } catch {
-            TranscriptedCore.AppLogger.transcription.warning("PARAKEET | legacy model cache migration failed: \(error.localizedDescription)")
+            AppLogger.transcription.warning("PARAKEET | legacy model cache migration failed: \(error.localizedDescription)")
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "model_cache_migration_failed",
                 message: error.localizedDescription)
         }
@@ -399,7 +399,7 @@ extension ParakeetEngine {
         if cleanupDecision == .cleanupNow {
             Task { await mgr?.cleanup() }
         } else {
-            TranscriptedCore.AppLogger.transcription.info("PARAKEET | deferring ASR manager cleanup while transcription is active")
+            AppLogger.transcription.info("PARAKEET | deferring ASR manager cleanup while transcription is active")
         }
     }
 }

--- a/Sources/Speech/WhisperEngine.swift
+++ b/Sources/Speech/WhisperEngine.swift
@@ -123,7 +123,7 @@ final class WhisperEngine: ObservableObject {
             let audioDuration = Double(samples.count) / TranscriptedConstants.parakeetSampleRate
             let rtf = audioDuration > 0 ? elapsed / audioDuration : 0
 
-            TranscriptedCore.AppLogger.transcription.info("WHISPER | \(model.title) transcribed \(sourceDescription) in \(String(format: "%.2f", elapsed))s, chars=\(trimmed.count)")
+            AppLogger.transcription.info("WHISPER | \(model.title) transcribed \(sourceDescription) in \(String(format: "%.2f", elapsed))s, chars=\(trimmed.count)")
             EventReporter.shared.capture(
                 level: .info,
                 engine: model.engineName,
@@ -185,7 +185,7 @@ final class WhisperEngine: ObservableObject {
         }
 
         modelDownloadState = .downloading(progress: 0)
-        TranscriptedCore.AppLogger.transcription.info("WHISPER | preparing \(model.title) (\(variant))...")
+        AppLogger.transcription.info("WHISPER | preparing \(model.title) (\(variant))...")
 
         do {
             let downloadBase = FileManager.default.transcriptedWhisperModelsDir
@@ -203,7 +203,7 @@ final class WhisperEngine: ObservableObject {
 
             guard !Task.isCancelled else { return }
             modelDownloadState = .loading
-            TranscriptedCore.AppLogger.transcription.info("WHISPER | loading \(model.title) from \(modelFolder.path)")
+            AppLogger.transcription.info("WHISPER | loading \(model.title) from \(modelFolder.path)")
 
             let config = WhisperKitConfig(
                 model: variant,
@@ -241,7 +241,7 @@ final class WhisperEngine: ObservableObject {
             )
         } catch {
             let friendlyMessage = "Couldn't load \(model.title): \(error.localizedDescription)"
-            TranscriptedCore.AppLogger.transcription.error("WHISPER | \(friendlyMessage)")
+            AppLogger.transcription.error("WHISPER | \(friendlyMessage)")
             modelDownloadState = .failed(friendlyMessage)
             EventReporter.shared.capture(
                 level: .error,

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -411,7 +411,7 @@ private struct FocusedTextPasteConfirmation {
         // compiled directly into the fast-test binary without the TranscriptedCore
         // module's search path (see APP_SOURCES in run-tests.sh), so importing that
         // module here isn't an option — this follows the same fputs(..., stderr)
-        // idiom Sources/Observability/AppLogger.swift itself falls back to for
+        // idiom Sources/Observability/AppLogSink.swift itself falls back to for
         // internal diagnostics.
         guard CFGetTypeID(focusedElement) == AXUIElementGetTypeID() else {
             fputs("⚠️ ClipboardRestoringTextPaster | focused UI element attribute returned an unexpected CF type (expected AXUIElement)\n", stderr)

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -8,7 +8,7 @@ import TranscriptedCore
 class TranscriptedAppState: ObservableObject {
     private static let wakeHotkeyRetryAttempts = 3
     private static let wakeHotkeyRetryDelay: UInt64 = 500_000_000
-    let logger = AppLogger()
+    let logger = AppLogSink()
     let sparkleUpdater = SparkleUpdaterController()
     let contextCapture = ContextCaptureEngine()
     let sttRouter = STTRouter()

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -7,7 +7,7 @@
 ## Subsystems (80 Swift files)
 
 - `Audio/` (21 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, Bluetooth-input avoidance for meetings, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, merge helpers, and privacy-safe pipeline diagnostics snapshots
-- `Logging/` (3 files) — shared app logger, JSONL file logger, and log privacy sanitizer
+- `Logging/` (4 files) — shared app logger (`AppLogger`, subsystem-scoped, os.Logger + JSONL), JSONL file logger (`FileLogger`), log privacy sanitizer, and `LogTailTrimmer` (shared truncate-in-place rotation used by `FileLogger` and by the app target's `AppLogSink`); see `docs/observability.md` for the full sink map, including how this `AppLogger` differs from `Sources/Observability/AppLogSink.swift`
 - `Models/` (5 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, `SpeakerMapping`, and recording-health metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
 - `Protocols/` (7 files) — host-injected seams: `SpeechToTextEngine`, `DiarizationEngine`, `SpeakerStore`, `TranscriptNotifier`, `AudioCaptureEngine`, `StatsStore`, `TranscriptStorage`

--- a/Sources/TranscriptedCore/Logging/FileLogger.swift
+++ b/Sources/TranscriptedCore/Logging/FileLogger.swift
@@ -131,24 +131,17 @@ final class FileLogger: @unchecked Sendable {
         flock(lockFd, LOCK_EX)
         defer { flock(lockFd, LOCK_UN); close(lockFd) }
 
-        guard let data = try? Data(contentsOf: logFileURL),
-              let content = String(data: data, encoding: .utf8) else { return }
+        let didTrim = LogTailTrimmer.trimIfNeeded(
+            at: logFileURL.path,
+            maxLines: maxEntries,
+            keepLines: trimTarget,
+            filterEmptyLines: true,
+            appendsTrailingNewline: true
+        )
+        guard didTrim else { return }
 
-        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
-        guard lines.count > maxEntries else { return }
-
-        // Keep the most recent entries
-        let trimmed = Array(lines.suffix(trimTarget))
-        let newContent = trimmed.joined(separator: "\n") + "\n"
-
-        // Close handle, rewrite file, reopen
+        // Close handle, reopen against the rewritten file
         try? fileHandle?.close()
-
-        try? newContent.write(to: logFileURL, atomically: true, encoding: .utf8)
-        // Security: atomic rewrite creates a replacement inode that may inherit default
-        // permissions (for example 0644). Re-tighten after every trim so sensitive logs
-        // never drift from owner-only access.
-        FileManager.default.restrictToOwnerOnly(atPath: logFileURL.path)
 
         fileHandle = try? FileHandle(forWritingTo: logFileURL)
         if fileHandle == nil {

--- a/Sources/TranscriptedCore/Logging/LogTailTrimmer.swift
+++ b/Sources/TranscriptedCore/Logging/LogTailTrimmer.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Shared truncate-in-place rotation for growing plain-text/JSONL log files.
+///
+/// This is the "keep only the most recent N lines" strategy: read the whole
+/// file, drop everything but the newest `keepLines`, and atomically rewrite
+/// it under the same path (no renamed generation, unlike
+/// `ObservabilityLogRotation`'s rename-to-`.1` strategy). Both `FileLogger`
+/// (line-count gated, checked periodically during writes) and the app-log
+/// sink (byte-size gated, checked once at session start) used to hand-roll
+/// this same read/filter/suffix/rewrite/re-chmod sequence independently;
+/// this type is the single implementation both now call.
+///
+/// Callers own the "should I trim" decision — pass `maxLines` when the
+/// caller wants that decision made here (by line count, matching
+/// `FileLogger`'s original behavior), or leave it `nil` when the caller has
+/// already gated on a different signal (e.g. byte size) and just wants the
+/// unconditional tail-rewrite performed.
+public enum LogTailTrimmer {
+    /// Rewrites the file at `path` to keep only its most recent `keepLines`
+    /// lines, if trimming is needed.
+    ///
+    /// - Parameters:
+    ///   - path: Path to the log file. No-op if the file cannot be read.
+    ///   - maxLines: If non-nil, trimming only happens once the (optionally
+    ///     filtered) line count exceeds this value — matching a periodic,
+    ///     count-gated caller. If nil, the rewrite always happens, for
+    ///     callers that already decided trimming is needed via their own
+    ///     threshold (e.g. file size) before calling.
+    ///   - keepLines: Number of trailing lines to retain.
+    ///   - filterEmptyLines: Whether to drop empty lines before counting/
+    ///     keeping (matches `FileLogger`'s behavior; the app-log sink does
+    ///     not filter).
+    ///   - appendsTrailingNewline: Whether the rewritten content ends with a
+    ///     trailing newline (matches `FileLogger`'s JSONL format; the
+    ///     app-log sink's plain-text format does not add one).
+    /// - Returns: `true` if the file was rewritten.
+    @discardableResult
+    public static func trimIfNeeded(
+        at path: String,
+        maxLines: Int?,
+        keepLines: Int,
+        filterEmptyLines: Bool,
+        appendsTrailingNewline: Bool
+    ) -> Bool {
+        guard let data = FileManager.default.contents(atPath: path),
+              let content = String(data: data, encoding: .utf8) else {
+            return false
+        }
+
+        var lines = content.components(separatedBy: "\n")
+        if filterEmptyLines {
+            lines = lines.filter { !$0.isEmpty }
+        }
+
+        if let maxLines, lines.count <= maxLines {
+            return false
+        }
+
+        let kept = Array(lines.suffix(keepLines))
+        let newContent = appendsTrailingNewline
+            ? kept.joined(separator: "\n") + "\n"
+            : kept.joined(separator: "\n")
+
+        do {
+            try newContent.write(toFile: path, atomically: true, encoding: .utf8)
+        } catch {
+            fputs("⚠️ LOGGER | log tail trim write failed: \(error.localizedDescription)\n", stderr)
+            return false
+        }
+
+        // Security: atomic rewrite creates a replacement inode that may inherit
+        // default permissions (for example 0644). Re-tighten after every trim
+        // so sensitive logs never drift from owner-only access.
+        FileManager.default.restrictToOwnerOnly(atPath: path)
+
+        return true
+    }
+}

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -14,7 +14,7 @@ struct TranscriptedSettingsView: View {
     @ObservedObject private var statsService: StatsService = .shared
 
     private let actions: TranscriptedSettingsActions
-    private let appLogger: AppLogger
+    private let appLogger: AppLogSink
 
     @State private var dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
         for: PhysicalDictationTriggerPreferences.pushToTalkBinding()

--- a/Sources/UI/Shared/TranscriptedSupportActions.swift
+++ b/Sources/UI/Shared/TranscriptedSupportActions.swift
@@ -10,7 +10,7 @@ enum TranscriptedSupportActions {
         NSWorkspace.shared.open(url)
     }
 
-    static func sendFeedback(logger: AppLogger?) {
+    static func sendFeedback(logger: AppLogSink?) {
         guard let url = FeedbackIssueBuilder.emailURL(rawLogLines: logger?.entries) else { return }
         NSWorkspace.shared.open(url)
     }
@@ -34,7 +34,7 @@ enum TranscriptedSupportActions {
         return CrashReporter.shared.captureSupportDiagnosticEvent(extra: context)
     }
 
-    static func feedbackEmailURL(logger: AppLogger?) -> URL? {
+    static func feedbackEmailURL(logger: AppLogSink?) -> URL? {
         FeedbackIssueBuilder.emailURL(rawLogLines: logger?.entries)
     }
 

--- a/Tests/ObservabilityLogWriterTests.swift
+++ b/Tests/ObservabilityLogWriterTests.swift
@@ -150,11 +150,11 @@ func testObservabilityLogWriter() {
         assertEqual(sanitized.context?["trigger"], "physical_key", "coarse diagnostics should stay useful")
     }
 
-    runSuite("AppLogger routes direct debug-log messages through the shared redactor") {
-        let appLoggerSource = readObservabilityTestRepoTextFile("Sources/Observability/AppLogger.swift")
+    runSuite("AppLogSink routes direct debug-log messages through the shared redactor") {
+        let appLoggerSource = readObservabilityTestRepoTextFile("Sources/Observability/AppLogSink.swift")
         assertTrue(
             appLoggerSource.contains("ObservabilityTextRedactor.redact(message)"),
-            "AppLogger.log should scrub direct debug messages before storing or writing"
+            "AppLogSink.log should scrub direct debug messages before storing or writing"
         )
 
         let sanitized = ObservabilityTextRedactor.redact(
@@ -239,7 +239,7 @@ func testObservabilityLogWriter() {
             "Sources/Observability/LockedFileAppender.swift",
             "Sources/Observability/EventReporter.swift",
             "Sources/Observability/ReliabilityPacketRecorder.swift",
-            "Sources/Observability/AppLogger.swift",
+            "Sources/Observability/AppLogSink.swift",
             "Sources/TranscriptedCore/Logging/FileLogger.swift",
             "Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift",
         ]

--- a/Tests/TranscriptedCoreTests/LogTailTrimmerTests.swift
+++ b/Tests/TranscriptedCoreTests/LogTailTrimmerTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import TranscriptedCore
+
+final class LogTailTrimmerTests: XCTestCase {
+    private func makeTempFile(contents: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LogTailTrimmerTests-\(UUID().uuidString).log")
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    func testMaxLinesGateSkipsTrimBelowThreshold() throws {
+        let url = try makeTempFile(contents: "one\ntwo\nthree\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let didTrim = LogTailTrimmer.trimIfNeeded(
+            at: url.path,
+            maxLines: 10,
+            keepLines: 2,
+            filterEmptyLines: true,
+            appendsTrailingNewline: true
+        )
+
+        XCTAssertFalse(didTrim)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "one\ntwo\nthree\n")
+    }
+
+    func testMaxLinesGateTrimsToKeepLinesWithTrailingNewline() throws {
+        let lines = (0..<10).map { "line-\($0)" }
+        let url = try makeTempFile(contents: lines.joined(separator: "\n") + "\n")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let didTrim = LogTailTrimmer.trimIfNeeded(
+            at: url.path,
+            maxLines: 5,
+            keepLines: 3,
+            filterEmptyLines: true,
+            appendsTrailingNewline: true
+        )
+
+        XCTAssertTrue(didTrim)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertEqual(content, "line-7\nline-8\nline-9\n")
+    }
+
+    func testNilMaxLinesAlwaysTrimsForCallersThatAlreadyGated() throws {
+        // No trailing newline, matching AppLogSink's on-disk shape (see the
+        // next test): a trailing "\n" would split into a trailing empty
+        // "line" that a naive suffix() would keep instead of "b".
+        let url = try makeTempFile(contents: "a\nb")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let didTrim = LogTailTrimmer.trimIfNeeded(
+            at: url.path,
+            maxLines: nil,
+            keepLines: 1,
+            filterEmptyLines: false,
+            appendsTrailingNewline: false
+        )
+
+        XCTAssertTrue(didTrim, "a nil maxLines gate always trims — the caller already decided trimming was needed")
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "b")
+    }
+
+    func testNoTrailingNewlineAndNoEmptyLineFilterMatchesAppLogSinkShape() throws {
+        // AppLogSink's on-disk debug log has no trailing newline convention and
+        // does not filter blank lines — mirror that shape here.
+        let url = try makeTempFile(contents: "a\n\nb\nc")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let didTrim = LogTailTrimmer.trimIfNeeded(
+            at: url.path,
+            maxLines: nil,
+            keepLines: 3,
+            filterEmptyLines: false,
+            appendsTrailingNewline: false
+        )
+
+        XCTAssertTrue(didTrim)
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "\nb\nc")
+    }
+
+    func testMissingFileIsANoOp() {
+        let missingPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LogTailTrimmerTests-missing-\(UUID().uuidString).log")
+            .path
+
+        let didTrim = LogTailTrimmer.trimIfNeeded(
+            at: missingPath,
+            maxLines: 1,
+            keepLines: 1,
+            filterEmptyLines: true,
+            appendsTrailingNewline: true
+        )
+
+        XCTAssertFalse(didTrim)
+    }
+
+    func testRestrictsPermissionsToOwnerOnlyAfterRewrite() throws {
+        let url = try makeTempFile(contents: "a\nb\nc\n")
+        try FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o644)], ofItemAtPath: url.path)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let didTrim = LogTailTrimmer.trimIfNeeded(
+            at: url.path,
+            maxLines: nil,
+            keepLines: 1,
+            filterEmptyLines: true,
+            appendsTrailingNewline: true
+        )
+
+        XCTAssertTrue(didTrim)
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber)
+        XCTAssertEqual(permissions, NSNumber(value: 0o600))
+    }
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,97 @@
+# Observability sink map
+
+Transcripted writes diagnostics to disk through five distinct sinks. They
+overlap in name and in shape (JSONL-ish, size- or count-bounded, owner-only
+permissions) but serve different audiences and have different retention
+policies. This page is the map. For the privacy/redaction contract (what may
+never reach Sentry/PostHog), see `docs/privacy-first-observability.md`.
+
+| Sink | Lives in | Writes to | Rotation |
+| --- | --- | --- | --- |
+| `AppLogger` | `Sources/TranscriptedCore/Logging/AppLogger.swift` | `~/Library/Application Support/Transcripted/logs/app.jsonl` (via `FileLogger`) + `os.Logger`/Console.app | Line-count gated: trims to 1500 lines once past 2000, checked every 100 writes |
+| `AppLogSink` | `Sources/Observability/AppLogSink.swift` | `~/Library/Application Support/Transcripted/logs/debug.log` + in-app debug panel (`entries`) | Byte-size gated: trims to 1000 lines once past 500 KB, checked once at session start |
+| `FileLogger` | `Sources/TranscriptedCore/Logging/FileLogger.swift` | `app.jsonl` (this is `AppLogger`'s file backend, not a separate log) | Same as `AppLogger` above — it's the same file |
+| `EventReporter` | `Sources/Observability/EventReporter.swift` | `~/Library/Application Support/Transcripted/logs/events.jsonl` + optional Sentry forwarding (errors only, allowlisted) | Rename-based: `ObservabilityLogRotation` renames the active file to `events.jsonl.1` once past the shared JSONL threshold (`TranscriptedConstants.jsonlLogRotationThreshold`) |
+| `ReliabilityPacketRecorder` | `Sources/Observability/ReliabilityPacketRecorder.swift` | `~/Library/Application Support/Transcripted/logs/reliability.jsonl` | Same rename-based `ObservabilityLogRotation` strategy as `EventReporter`, same threshold |
+
+## Why there are two `AppLogger`-shaped types
+
+`TranscriptedCore.AppLogger` and (the former) `Observability.AppLogger` were
+two unrelated classes that happened to share a name, because they were built
+independently for different audiences:
+
+- **`AppLogger`** (`TranscriptedCore`) is the general-purpose, subsystem-scoped
+  logger used throughout the engine and pipeline code (`AppLogger.transcription.info(...)`,
+  `AppLogger.pipeline.error(...)`, etc). It fans out to `os.Logger` (so it shows
+  up live in Console.app) and to `FileLogger`'s `app.jsonl` (so an agent or a
+  support engineer can grep structured records after the fact).
+- **`AppLogSink`** (`Sources/Observability/`, renamed from `AppLogger` in the
+  2026-07 observability cleanup) is a `@MainActor` `ObservableObject` that
+  backs the in-app debug panel and feeds recent log lines into user-submitted
+  feedback emails (`TranscriptedSupportActions.feedbackEmailURL`). It writes a
+  plain-text `debug.log`, not JSONL, and it is UI-observable — engine code
+  should prefer `TranscriptedCore.AppLogger`; `AppLogSink` is for
+  user-visible/user-submittable diagnostics.
+
+Because both types lived in the same app target (no module boundary between
+`Sources/Observability/` and `Sources/TranscriptedCore/`'s consumers), any
+unqualified `AppLogger` reference in app-target code was ambiguous — Swift
+resolves the same-target/local declaration first, so call sites that actually
+wanted `TranscriptedCore.AppLogger` had to spell out the qualifier
+(`Sources/Speech/*.swift`, `Sources/Meeting/MeetingModelDownloader.swift`).
+The rename removes the collision; those call sites no longer need the
+`TranscriptedCore.` prefix.
+
+## Shared rotation code
+
+Two different rotation strategies exist on purpose, not by accident, and both
+are now implemented once:
+
+- **Truncate-in-place** (`LogTailTrimmer`, `Sources/TranscriptedCore/Logging/LogTailTrimmer.swift`,
+  public): read the file, keep only the newest N lines, atomically rewrite
+  the same path, re-chmod to owner-only. Used by `FileLogger` (gated on line
+  count, checked periodically during writes) and `AppLogSink` (gated on byte
+  size, checked once at session start). The gating decision (when to trim)
+  stays with each caller since the two sinks trigger on different signals;
+  the mechanical read/keep-tail/rewrite/re-chmod step is the one shared
+  implementation both call, replacing what used to be two hand-rolled copies
+  of the same logic.
+- **Rename-based** (`ObservabilityLogRotation`, `Sources/Observability/ObservabilityLogRotation.swift`):
+  rename the active file to `<name>.1` once it exceeds a byte threshold. O(1),
+  no read/rewrite of file contents, safe under a concurrent writer holding
+  the old descriptor. Used by `EventReporter` and `ReliabilityPacketRecorder`,
+  both append-only JSONL logs where a rename-and-keep-one-generation policy is
+  a better fit than a truncate-and-rewrite.
+
+Don't merge these two strategies — they were evaluated together during the
+2026-07 observability cleanup and kept separate deliberately (truncate-in-place
+suits the two line-oriented sinks that already special-case trimming as part of
+a size-bounded "recent activity" log; rename-based suits the two append-only
+JSONL sinks where a second on-disk generation is acceptable and cheaper to keep
+correct under concurrent writers).
+
+## `EventReporter` → `ReliabilityPacketRecorder`
+
+`ReliabilityPacketRecorder` does not have its own capture call sites. Every
+reliability packet is derived from an already-captured, already-sanitized
+`ObservabilityEvent`: `EventReporter.capture(...)` calls
+`ReliabilityPacketRecorder.record(event:)` directly as part of handling every
+event (see `Sources/Observability/EventReporter.swift`). `ReliabilityPacketRecorder`
+then re-shapes a subset of events (via its own coarse, bucketed allowlist —
+see `Sources/Observability/CLAUDE.md`) into `reliability.jsonl`, which is what
+gets attached to user-submitted support diagnostics. If you're looking for
+where reliability packets come from, start at `EventReporter.capture`, not at
+`ReliabilityPacketRecorder`.
+
+## Practical guidance
+
+- Writing engine/pipeline code in `TranscriptedCore` or elsewhere in the app
+  target? Use `AppLogger.<subsystem>.info/warning/error(...)`.
+- Need something a user can see in a debug panel or attach to a feedback
+  email? Use `AppLogSink` (via `TranscriptedAppState.logger`).
+- Recording a structured, privacy-reviewed event for local diagnostics and
+  possible Sentry forwarding? Use `EventReporter.shared.capture(...)` (often
+  via `DiagnosticsTrail.record(...)`, which does both the `AppLogSink` line
+  and the `EventReporter` capture in one call).
+- Reliability packets are a derived view — don't write to `reliability.jsonl`
+  directly; go through `EventReporter.capture`.

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -51,6 +51,7 @@ SWIFT_SOURCES=(
     "Sources/TranscriptedCore/Audio/WAVHeaderRepair.swift"
     "Sources/TranscriptedCore/Logging/AppLogger.swift"
     "Sources/TranscriptedCore/Logging/FileLogger.swift"
+    "Sources/TranscriptedCore/Logging/LogTailTrimmer.swift"
     "Sources/TranscriptedCore/Logging/LogPrivacySanitizer.swift"
     "Sources/TranscriptedCore/Utilities/FilePermissions.swift"
     "Sources/UI/Shared/MeetingAudioArchiveResolver.swift"


### PR DESCRIPTION
## What / why

Codebase audit 2026-07-08 wave 3 flagged four observability problems:

1. **`AppLogger` name collision.** `Sources/Observability/AppLogger.swift` (app-target, in-app debug panel + feedback-email log) and `Sources/TranscriptedCore/Logging/AppLogger.swift` (subsystem-scoped engine logger) were two unrelated classes sharing a name in the same target. Any unqualified `AppLogger` reference in app-target code resolved to the app-target's own declaration, so call sites that actually wanted Core's logger had to spell out `TranscriptedCore.AppLogger` — wave 1 PR #1512 had to do exactly this in `Sources/Speech/*.swift` and `Sources/Meeting/MeetingModelDownloader.swift`.
2. **Duplicated rotation logic.** `Observability`'s log writer hand-rolled the same "read file, keep last N lines, atomically rewrite, re-chmod" sequence that `FileLogger` already implemented independently in Core.
3. **Undocumented derive relationship.** `ReliabilityPacketRecorder` derives every packet from `EventReporter.capture`, but that was only written down in a CLAUDE.md.
4. **No single sink map.** Four (now five, counting the renamed logger) log sinks with no page explaining what each captures, where it writes, and its rotation policy.

## What changed

- **Renamed** `Sources/Observability/AppLogger` → `AppLogSink` (the *less*-referenced of the two, per the design: ~6 external call sites vs. Core's ~55). `TranscriptedCore.AppLogger` is untouched. Removed the now-unnecessary `TranscriptedCore.` qualifier from the 7 call sites in `Sources/Speech/` and `Sources/Meeting/MeetingModelDownloader.swift` that needed it only because of the collision.
- **Extracted `LogTailTrimmer`** (`Sources/TranscriptedCore/Logging/LogTailTrimmer.swift`, public) — the one shared "read / optionally filter empty lines / keep last N / atomically rewrite / re-chmod owner-only" implementation. `FileLogger` and `AppLogSink` each keep their own trigger (`FileLogger`: line-count gated, checked every 100 writes, matching its existing 2000/1500 thresholds; `AppLogSink`: byte-size gated, checked once at session start, matching its existing 500KB/1000-line thresholds) and call the shared trimmer for the mechanical rewrite step. Behavior-identical — same thresholds, same trigger points, same on-disk shape for both logs. `ObservabilityLogRotation` (the rename-to-`.1` strategy used by `EventReporter`/`ReliabilityPacketRecorder`) is intentionally left as a separate implementation; it solves a different problem (append-only JSONL, O(1) rotation safe under a concurrent writer) for a different sink family, and the two strategies were evaluated together and kept apart deliberately.
- **Added `docs/observability.md`** — the sink map: what each of `AppLogger`(Core)/`AppLogSink`/`FileLogger`/`EventReporter`/`ReliabilityPacketRecorder` captures, where it writes, its rotation policy, and the `EventReporter` → `ReliabilityPacketRecorder` derive relationship (lifted out of `Sources/Observability/CLAUDE.md`, which now links to it, as does `Sources/TranscriptedCore/CLAUDE.md`).
- Per spec: **no runtime facade type** this wave — the audit's refuted finding showed the sinks have genuinely distinct purposes, so the deliverable stops at the rename + shared rotation + doc.

## Deviations from spec

- Also renamed the private `AppLogFileWriter` actor inside the renamed file to `AppLogSinkFileWriter` for naming consistency. Mechanical, no external references (it was already `private`).
- Added `Tests/TranscriptedCoreTests/LogTailTrimmerTests.swift` — not explicitly requested, but `LogTailTrimmer` is now public API shared by two callers, so it seemed worth locking its behavior directly rather than relying only on `FileLoggerTests`/`ObservabilityLogWriterTests` coverage.

## Test plan

- [x] `swift test --filter FileLoggerTests --filter LogTailTrimmerTests` (Core package) — 14/14 passed
- [x] `bash run-tests.sh` (fast suite, includes `ObservabilityLogWriterTests`, `ObservabilityLogRotationTests`, `ObservabilityTextRedactorTests`, etc.) — 12,883/12,883 passed
- [x] `bash build-deps.sh --force` then `bash build.sh --no-open` — clean build, launch smoke check passed (920.8ms, budget 3000ms)
- [x] Duplicate-declaration sweep on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)