### PR TITLE
docs: refresh CLAUDE.md files against post-cleanup layout, add hotspots + naming-trap notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Verification rules (mirror `.agents/test-matrix.yml`; if a change matches multip
 
 ### Running a single test
 
-Fast tests are top-level functions, not XCTest cases. To run one in isolation, use `bash run-tests.sh --filter <entryFn|File>` (e.g. `bash run-tests.sh --filter testJSONLWriter`); the selector matches an entry function, a file name, or a case-insensitive substring of either, and `bash run-tests.sh --list` prints the known entry functions. For the SPM target use `swift test --filter <TestName>` (e.g. `swift test --filter MicRecordingFileMergerTests`).
+Fast tests are top-level functions, not XCTest cases. To run one in isolation, use `bash run-tests.sh --filter <entryFn|File>` (e.g. `bash run-tests.sh --filter testPayloadSanitizationCore`); the selector matches an entry function, a file name, or a case-insensitive substring of either, and `bash run-tests.sh --list` prints the known entry functions. For the SPM target use `swift test --filter <TestName>` (e.g. `swift test --filter MicRecordingFileMergerTests`).
 
 ### Scoped test loops (`Tests/TranscriptedCoreTests/`)
 
@@ -104,7 +104,6 @@ Subsystem boundaries (each has a local `CLAUDE.md`):
 | Path | Owns |
 |------|------|
 | `Sources/Accessibility/` | focused-editor AX metadata, overlay placement, paste-back context |
-| `Sources/Beta/` | beta-build configuration |
 | `Sources/Capture/` | physical dictation trigger capture, meeting hotkey routing, `ContextCaptureEngine` |
 | `Sources/Dictation/` | dictation transcript persistence, daily Markdown files, timeout helpers |
 | `Sources/Meeting/` | app-side bridge into `TranscriptedCore`; live capture, imported-audio/video prep, queued meeting transcription, `MeetingSTTAdapter` |
@@ -123,13 +122,18 @@ Subsystem boundaries (each has a local `CLAUDE.md`):
 
 Keep `Sources/TranscriptedCore/` a library boundary — meetings reuse the app's STT path through `Sources/Meeting/MeetingSTTAdapter.swift`. Sources/Speech/ owns dictation STT.
 
+Naming traps (confirmed by the 2026-07-08 audit):
+
+- `Sources/Support/CaptureLibrary*.swift` is capture-**library** migration/relocation logic (the user-relocatable folder of saved meeting/dictation Markdown and audio) — it is not `Sources/Capture/`, which is screen/audio capture triggering. See `Sources/Support/CLAUDE.md`.
+- `Sources/Support/ModelCacheInventory.swift` inventories `Sources/Speech/` STT model caches even though it lives in `Support/`.
+
 ## Storage layout
 
 App-owned state lives under `~/Library/Application Support/Transcripted/`:
 
 - `captures/meetings/` — saved meeting Markdown + audio
 - `captures/dictations/` — daily dictation Markdown
-- `logs/app.jsonl`, `logs/events.jsonl`, `logs/debug.log`
+- `logs/app.jsonl`, `logs/events.jsonl`, `logs/debug.log` (see `docs/observability.md` for the full sink map)
 
 Users can relocate the capture library via `transcriptSaveLocation` in Settings; app state/cache/logs/tmp stay under Application Support. Historic `Draft`-named paths still exist for migration and standalone-tool fallback. Canonical map: `docs/storage-paths.md`.
 
@@ -161,6 +165,23 @@ Treat as reference, not current runtime truth:
 - `docs/archive/`
 - `.claude/` (older planning)
 - references to `Sources/Text/` or `Sources/Style/` in older docs
+
+## Hotspots
+
+Files still over 1500 lines after the 2026-07 god-file splits (measured with `wc -l`). These are dense, high-blast-radius files — read the whole file and the relevant subsystem `CLAUDE.md` before editing; do not casually append another responsibility to any of them:
+
+- `Sources/UI/Settings/TranscriptedSettingsView.swift` (~5.6k) — settings shell, navigation, and page routing for every settings surface; most page bodies have already moved to `Sources/UI/Settings/Pages/` and sibling files, but the shell itself stays huge because it wires all of them together
+- `Sources/Meeting/MeetingSessionController.swift` (~3.1k) — the meeting state machine; failed-meeting and queue bookkeeping were split into `FailedMeetingStore.swift`/`TranscriptionQueueCoordinator.swift`, but permission gating, capture start/stop, and transcript-save handoff still live here
+- `Sources/Speech/ParakeetEngine.swift` (~2.8k) — the dictation STT engine; device recovery and model lifecycle already moved to `ParakeetDeviceRecovery.swift`/`ParakeetModelLifecycle.swift`, this file is still the public-API owner and `@MainActor` home for recording state
+- `Sources/UI/Overlay/MeetingOverlayController.swift` (~2.7k) — the non-activating meeting-prompt/recording panel controller; touches capture state, live-transcript drawer, and prompt UI all at once
+- `Sources/UI/Settings/PermissionsOnboardingView.swift` (~2.4k) — first-run onboarding walkthrough; sequences several distinct permission/setup stages in one view
+- `Sources/UI/Settings/HomeView.swift` (~2.4k) — the Home canvas (greeting, stats, capture lists, preview/feedback sheets); most small formatting/policy helpers already live in sibling files (`HomePresentation.swift`, `HomeCanvasGreeting.swift`, etc.), this is the view assembly itself
+- `Sources/UI/Overlay/DictationSessionController.swift` (~2.2k) — dictation session orchestration
+- `Sources/Meeting/LocalMeetingSummarizer.swift` (~1.9k) — opt-in local AI meeting-summary runners for both providers (Gemma MLX, Apple Foundation Models)
+- `Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift` (~1.7k) — the MCP server's SQLite index; schema DDL already split into `TranscriptIndex+Schema.swift`, this file is still the query/reconcile surface
+- `Sources/TranscriptedCore/Speaker/SpeakerNamingSimulationRunner.swift` (~1.7k) — offline speaker-naming simulation harness
+- `Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift` (~1.7k) — the single-flight transcription queue/orchestrator
+- `Sources/UI/Settings/SpeakerPeopleSettingsSection.swift` (~1.6k) — the speakers settings surface (voice-to-name queue, duplicate suggestions, searchable list)
 
 ## Response voice
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -37,7 +37,6 @@ Important entry points:
 ## Directory map
 
 - `Accessibility/` — AX helpers for overlay positioning
-- `Beta/` — beta-only config currently; older API docs are historical
 - `Capture/` — physical dictation trigger capture, meeting trigger routing, context parsing, and capture routing
 - `Dictation/` — dictation transcript persistence and timeout helpers
 - `Meeting/` — app-side meeting bridge, prompts, imported-audio prep, storage, and transcript restyling
@@ -69,7 +68,7 @@ app target entirely. If a historical doc still mentions `Sources/Text/` or
 - touching overlay, menubar, onboarding, settings, or agent-connect UI: `Sources/UI/CLAUDE.md`
 - touching hotkeys or physical dictation trigger routing: `Sources/Capture/CLAUDE.md`
 - touching focused-editor AX metadata, overlay placement, or paste-back context: `Sources/Accessibility/CLAUDE.md`
-- touching beta-build configuration: `Sources/Beta/CLAUDE.md`
+- touching beta-gated model/summary opt-ins: `Sources/Support/SpeechModelBetaPreferences.swift` / `Sources/Support/LocalMeetingSummaryPreferences.swift` (`Sources/Beta/` no longer exists — beta preferences now live in `Sources/Support/`)
 - touching wake / sleep recovery or hotkey recovery: `Sources/Reliability/CLAUDE.md`
 - touching crash reporting, analytics, logs, diagnostics, or Sparkle updates: `Sources/Observability/CLAUDE.md`
 - touching tests or package boundaries: `Tests/README.md`

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -7,6 +7,12 @@
 ## Files
 
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles, retained-audio URLs, and retry metadata
+- `FailedMeetingStore.swift` — failed-meeting queue/persistence/retry bookkeeping split out of `MeetingSessionController` (audit 2026-07-08 wave 2). Plain owned object, not an `ObservableObject`; the controller still owns the published `failedMeetings` surface and lends this store callback access for state it doesn't own
+- `TranscriptionQueueCoordinator.swift` — background-transcription queue/dispatch bookkeeping split out of `MeetingSessionController` (audit 2026-07-08 wave 2). Drives the controller's state/display-status transitions via callbacks; job dispatch reaches back into the controller for `taskManager` and live-sidecar bookkeeping
+- `MeetingCaptureHealthTelemetry.swift` — coarse, privacy-safe telemetry for capture-health signals (mic/system audio dropouts, recovery outcomes) surfaced during a recording
+- `MeetingPromptTelemetry.swift` — `MeetingPromptCallTelemetry` and the bucketed funnel-event emission for detected-call/prompt outcomes
+- `MeetingQuickSummaryExtractor.swift` — extracts the quick-summary candidate text/metadata from a saved transcript for the opt-in local AI summary flow
+- `MeetingQuickSummaryWriter.swift` — writes the quick-summary sidecar file alongside a saved meeting transcript
 - `MeetingAudioStorageManager.swift` — compresses retained meeting WAVs to M4A, compresses queue-tracked failed-meeting WAVs without deleting untracked orphans, applies audio-retention cleanup, and backfills existing retained audio after launch or Settings changes
 - `MeetingAudioInactivityDetector.swift` — detects prolonged audio silence during meetings and emits warning/cleared events so the UI can prompt the user to confirm the recording is still needed
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio` that converts start/stop into async flows, waits for both live capture and system-audio-file readiness, and mirrors live levels for the UI
@@ -89,7 +95,8 @@
 - `MeetingFailureKind` is the canonical place for stable failed-meeting categories used by presentation and metadata. Keep new classification rules centralized there.
 - `MeetingFailureCopy` is the canonical place for human-facing failed-meeting titles and details. Keep retry messaging centralized there.
 - `MeetingSessionUIPolicy` is the canonical place for deciding whether background meeting work should still surface as an active transcribing/saving state. Speaker review alone should not keep that state visible.
-- `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
+- `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `TranscriptionQueueCoordinator` (called by `MeetingSessionController`), not in ad hoc background tasks.
+- Failed-meeting queue/persistence/retry bookkeeping belongs in `FailedMeetingStore`, not scattered back into `MeetingSessionController`. Both extracted objects are plain code-motion splits (audit 2026-07-08 wave 2): they still reach back into the controller via a `controller` callback for state they don't own, and legacy nested-type references (`FailedMeetingItem`, `QueuedTranscriptionJob`, `BackgroundTranscriptionWorkSnapshot`) stay resolvable as typealiases on the controller.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
 - Local meeting summaries rewrite the saved transcript after a slow local model run. Always re-read the transcript before writing and fail closed if transcript text changed while generation was in flight. Keep provider-specific setup and metadata explicit so Gemma MLX and Apple Foundation Models summaries remain distinguishable.
 
@@ -120,7 +127,7 @@ their available recording audio there while keeping scratch files available for
 retry. Explicit discard still removes the scratch recording without saving a
 transcript or retained audio.
 
-Core logging for the embedded meeting pipeline is redirected to `~/Library/Application Support/Transcripted/logs/`.
+Core logging for the embedded meeting pipeline is redirected to `~/Library/Application Support/Transcripted/logs/`. See `docs/observability.md` for the full sink map.
 
 See `docs/storage-paths.md` for the full map.
 

--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -23,10 +23,13 @@ anonymous analytics, and Sparkle update plumbing.
 - `AnalyticsPreferences.swift` — Settings-backed anonymous analytics preference
 - `AnalyticsEventPolicy.swift` — compiles the explicit PostHog event/property allowlist from `Resources/analytics-events.psv`
 - `ActivationTelemetry.swift` — centralized activation analytics helpers for artifact actions, agent prompt/setup CTAs, and saved-recent artifact return-proxy buckets
+- `FeatureDiscoveryTelemetry.swift` — tracks which Settings features (agent setup, beta summaries, capture library, permissions, speaker review, support, update settings) a user has already discovered, keyed off a shared `settingsFeatureDiscovered.` preference prefix
 - `SpeakerRecognitionTelemetry.swift` — similarity/margin bucketing for speaker-recognition accuracy analytics, aligned with the matcher's decision thresholds
 - `AnalyticsPayloadSanitizer.swift` — strips sensitive analytics properties before send
 - `TimelineAnalyticsTelemetry.swift` — centralized timeline analytics helper with coarse enum/bucket payloads only
+- `WorkflowRecoveryTelemetry.swift` — bucketed analytics for recovery flows (attempted/succeeded/failed) across workflow kind, failure kind, retry source, and artifact-retained outcome
 - `EventFileWritePolicy.swift` — buffering policy for info-level event writes so routine telemetry does not hammer local JSONL files
+- `ObservabilityLogRotation.swift` — rename-based, O(1) rotation for append-only JSONL observability logs once they exceed a size threshold; keeps one rotated generation
 - `ObservabilityTextRedactor.swift` — shared text redactor for support-facing and diagnostic strings before they leave local-only surfaces
 - `SentryEventPolicy.swift` — explicit allowlist of non-fatal events permitted to reach Sentry
 - `SentryPayloadSanitizer.swift` — strips obvious sensitive values before Sentry sends
@@ -34,6 +37,7 @@ anonymous analytics, and Sparkle update plumbing.
 - `SentryRuntimeConfiguration.swift` — resolves Sentry DSN, environment, release, and dist from `Info.plist` or process environment
 - `SparkleUpdaterController.swift` — live Sparkle update controller used by the menubar app, including update-state telemetry and ready-to-install restart flows
 - `UpdateFailureKind.swift` — canonical Sparkle/update failure taxonomy used to normalize network, appcast, download, signature, install, and busy-session errors for analytics
+- `UpdateActionSafetyPolicy.swift` — gates the Settings "check for updates" action against in-flight capture/processing work, with the user-facing help copy for why the action is blocked
 
 ## Current Notes
 

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -12,6 +12,7 @@
 - `AgentMCPConnector.swift` — per-agent MCP connect seam: detection, connection state, and config writers for Claude Code (via the `claude` CLI), Codex (`~/.codex/config.toml`), and Cursor (`~/.cursor/mcp.json`), all pointing at the shared installed helper
 - `CaptureLibraryChangeBroadcaster.swift` — single source of truth for the debounced `.meetingCaptureArtifactsDidChange` notification; coalesces background WAV→M4A recompression and transcript-rename file mutations so Home can re-resolve its cached transcript/audio URLs (empty id set means a library-wide change of unknown scope)
 - `CaptureLibraryMigrationPlanner.swift` — copy-only planning and execution for capture-library relocation: detects captures in the old folder, enumerates meeting Markdown plus retained `audio/*_audio/` directories plus dictation day files, skips destination collisions, and never deletes originals
+- `CaptureLibrarySize.swift` — once-per-launch on-disk size measurement/bucketing for the capture library, reported next to the retention setting so unbounded retained-audio growth is visible in the event log
 - `ClaudeDesktopIntegrationInstaller.swift` — installs the bundled read-only MCP helper for Claude Desktop, safely merges `mcpServers` JSON configs, runs the helper self-test, and silently refreshes a stale installed helper at app launch
 - `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app
 - `CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements plus text post-processing helpers
@@ -32,7 +33,9 @@
 - `MeetingOverlayPillPreferences.swift` — persisted "keep controls visible" pin that opts the meeting pill out of resting to its compact capsule
 - `MenuBarVisibilityPreferences.swift` — persisted Home toggles for optional menubar popover rows
 - `MicrophoneProcessingPreferences.swift` — persisted mic processing mode, toggling between raw/off input, default software AGC, and optional Apple voice processing (VPIO) for users who need the WebRTC-specific recovery path in meetings or dictation
-- `ModelCacheInventory.swift` — scans and cleans known local model cache roots for Settings storage controls
+- `ModelCacheInventory.swift` — scans and cleans known local model cache roots for Settings storage controls; despite living in `Support/`, it inventories `Sources/Speech/` STT model caches (Parakeet/Whisper/Nemotron), not app-wide caches
+- `SpeakerEmbedderFactory.swift` — app-layer resolution of the optional speaker-embedding model; keeps `Bundle.main`/filesystem lookups out of `TranscriptedCore` and hands the meeting controller a ready `SpeakerSegmentEmbedder` or nil
+- `SpeakerEmbedderPreferences.swift` — persisted choice between the diarizer's built-in WeSpeaker embedder and the optional ERes2Net model used for same-voice consolidation and cross-call speaker matching; mirrors `TranscriptionModelPreferences`
 - `OnboardingDictationShortcutPolicy.swift` — first-run shortcut policy that keeps dictation setup copy aligned with trigger preferences
 - `PermissionsOnboardingPreferences.swift` — persisted completion and forced-rerun state for the first-run permissions onboarding flow
 - `PhysicalDictationTriggerPreferences.swift` — canonical physical key / modifier trigger bindings for push-to-talk, hands-free dictation, paste-last-dictation, and meeting shortcuts, including migration from older right-Option settings
@@ -49,6 +52,8 @@
 
 ## Current notes
 
+- Naming trap: `Support/CaptureLibrary*.swift` (`CaptureLibraryChangeBroadcaster`, `CaptureLibraryMigrationPlanner`, `CaptureLibrarySize`) is capture-**library** migration/relocation/change-broadcast logic — the user-relocatable folder of saved meeting/dictation Markdown and audio. It is unrelated to `Sources/Capture/`, which is screen/audio capture triggering (`ContextCaptureEngine`, physical hotkey routing). Same "capture" word, different subsystem — do not conflate them when searching or routing changes.
+- Naming trap: `ModelCacheInventory.swift` lives in `Support/` but inventories `Sources/Speech/` STT model caches, not a generic app cache. If you're looking for Speech model cache logic, check here first.
 - Keep preference keys and notification names centralized here so UI and controllers do not drift.
 - `PhysicalDictationTriggerPreferences` is the canonical binding layer for push-to-talk, hands-free dictation, paste-last-dictation, and meeting shortcuts. Avoid reintroducing ad hoc keycode logic or special-case right-Option handling in UI or capture code.
 - `TranscriptionModelPreferences` is the shared switch between `Parakeet`, the available local Whisper variants, and the beta-gated Nemotron streaming model (`SpeechModelBetaPreferences` controls its availability; `effectiveModel()` falls back to the default while the gate is off). Model-specific runtime behavior still belongs in `Sources/Speech/` and `Sources/Meeting/`.

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,17 +4,17 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (80 Swift files)
+## Subsystems (90 Swift files)
 
-- `Audio/` (21 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, Bluetooth-input avoidance for meetings, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, merge helpers, and privacy-safe pipeline diagnostics snapshots
+- `Audio/` (22 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, Bluetooth-input avoidance for meetings, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, merge helpers, and privacy-safe pipeline diagnostics snapshots
 - `Logging/` (4 files) — shared app logger (`AppLogger`, subsystem-scoped, os.Logger + JSONL), JSONL file logger (`FileLogger`), log privacy sanitizer, and `LogTailTrimmer` (shared truncate-in-place rotation used by `FileLogger` and by the app target's `AppLogSink`); see `docs/observability.md` for the full sink map, including how this `AppLogger` differs from `Sources/Observability/AppLogSink.swift`
 - `Models/` (5 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, `SpeakerMapping`, and recording-health metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
 - `Protocols/` (7 files) — host-injected seams: `SpeechToTextEngine`, `DiarizationEngine`, `SpeakerStore`, `TranscriptNotifier`, `AudioCaptureEngine`, `StatsStore`, `TranscriptStorage`
 - `Services/` (7 files) — DI container (`AppServices`), model bundle / download management, path indirection, recording validation, diarization, and failed-transcription persistence
-- `Speaker/` (21 files) — speaker DB, embedding matching / clustering, embedding thresholds and segment re-embedding, clip extraction, naming policy / coordinator, people-review policy, profile merging + provenance, simulation, retroactive transcript updates, and the recognition lifeline: match-outcome store, profile-health demotion, and review prioritization (see `docs/speaker-recognition-metrics.md`)
+- `Speaker/` (28 files) — speaker DB (`SpeakerDatabase`, instance-based, injected via `AppServices`; no `.shared` singleton), embedding matching / clustering, embedding thresholds and segment re-embedding, clip extraction, naming policy / coordinator, people-review policy, profile merging + provenance, simulation, retroactive transcript updates, negative-exemplar policy/store, write-path policy, and the recognition lifeline: match-outcome store, profile-health demotion, and review prioritization (see `docs/speaker-recognition-metrics.md`)
 - `Stats/` (4 files) — recording stats database, models, queries, and service
-- `Storage/` (6 files) — transcript save, scanner, formatter, format options, shared frontmatter parsing, and retained-recording audio archiving
+- `Storage/` (7 files) — transcript save, scanner, formatter, format options, shared frontmatter parsing, retained-recording audio archiving, and `SQLiteHandle` (shared low-level SQLite open/prepare/step wrapper used by `SpeakerDatabase` and `StatsDatabase`)
 - `Utilities/` (2 files) — date formatting and file permission helpers
 
 ## The seams embedders should know
@@ -84,50 +84,52 @@ Also run when the package seam changes:
 
 - `swift test`
 
-Current direct core coverage includes:
+Current direct core coverage includes (paths reflect the five per-subsystem
+SPM test targets — `AudioTests`, `SpeakerTests`, `PipelineTests`,
+`StorageTests`, `UtilitiesTests` — see root `CLAUDE.md` "Scoped test loops"):
 
-- `Tests/TranscriptedCoreTests/AudioInitializationTests.swift`
-- `Tests/TranscriptedCoreTests/AudioDiagnosticsSnapshotTests.swift`
-- `Tests/TranscriptedCoreTests/AudioLevelMonitorSilenceTests.swift`
-- `Tests/TranscriptedCoreTests/AudioLevelPublishGateTests.swift`
-- `Tests/TranscriptedCoreTests/AudioPipelineDiagnosticsSnapshotShapeTests.swift`
-- `Tests/TranscriptedCoreTests/AudioResamplerTests.swift`
-- `Tests/TranscriptedCoreTests/AudioSignalRecoveryTests.swift`
-- `Tests/TranscriptedCoreTests/BluetoothMeetingRouteContractTests.swift`
-- `Tests/TranscriptedCoreTests/CoreStoragePathsTests.swift`
-- `Tests/TranscriptedCoreTests/DatabaseFilePermissionsTests.swift`
-- `Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift`
-- `Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift`
-- `Tests/TranscriptedCoreTests/FileLoggerTests.swift`
-- `Tests/TranscriptedCoreTests/MeetingInputDeviceSelectionPolicyTests.swift`
-- `Tests/TranscriptedCoreTests/MeetingRecordingJournalTests.swift`
-- `Tests/TranscriptedCoreTests/MeetingRouteArtifactFixtureTests.swift`
-- `Tests/TranscriptedCoreTests/DiarizationSpeakerIdParsingTests.swift`
-- `Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/AudioDiagnosticsSnapshotTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/AudioLevelMonitorSilenceTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/AudioLevelPublishGateTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/AudioPipelineDiagnosticsSnapshotShapeTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/AudioResamplerTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/AudioSignalRecoveryTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/BluetoothMeetingRouteContractTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/CoreStoragePathsTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/DatabaseFilePermissionsTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/EmbeddingClustererTests.swift`
+- `Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift`
+- `Tests/TranscriptedCoreTests/UtilitiesTests/FileLoggerTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/MeetingInputDeviceSelectionPolicyTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/MeetingRecordingJournalTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/MeetingRouteArtifactFixtureTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/DiarizationSpeakerIdParsingTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/MicRecordingFileMergerTests.swift`
 - `Tests/MicRecordingMergePlanTests.swift`
-- `Tests/TranscriptedCoreTests/QuietMicAttenuationDetectorTests.swift`
-- `Tests/TranscriptedCoreTests/RealtimeAGCTests.swift`
-- `Tests/TranscriptedCoreTests/RecordingAudioArchiverTests.swift`
-- `Tests/TranscriptedCoreTests/RecordingHealthInfoOverrideTests.swift`
-- `Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift`
-- `Tests/TranscriptedCoreTests/SpeakerMatchingServiceTests.swift`
-- `Tests/TranscriptedCoreTests/SpeakerEmbeddingMatcherTests.swift`
-- `Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift`
-- `Tests/TranscriptedCoreTests/SpeakerNamingSimulationRunnerTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/QuietMicAttenuationDetectorTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/RealtimeAGCTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/RecordingAudioArchiverTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/RecordingHealthInfoOverrideTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/SpeakerMatchingServiceTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/SpeakerEmbeddingMatcherTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingCoordinatorTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingSimulationRunnerTests.swift`
 - `Tests/SpeakerPeopleReviewPolicyTests.swift`
-- `Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift`
-- `Tests/TranscriptedCoreTests/SpeakerProfileProvenanceTests.swift`
-- `Tests/TranscriptedCoreTests/SpeakerProvenanceTests.swift`
-- `Tests/TranscriptedCoreTests/StatsDatabaseTests.swift`
-- `Tests/TranscriptedCoreTests/StatsDatabaseQueriesTests.swift`
-- `Tests/TranscriptedCoreTests/StatsDatabaseModelsTests.swift`
-- `Tests/TranscriptedCoreTests/StatsServiceTests.swift`
-- `Tests/TranscriptedCoreTests/LogPrivacySanitizerTests.swift`
-- `Tests/TranscriptedCoreTests/TranscriptFormatVersionTests.swift`
-- `Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift`
-- `Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift`
-- `Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift`
-- `Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/SpeakerProfileMergerTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/SpeakerProfileProvenanceTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerTests/SpeakerProvenanceTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/StatsDatabaseTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/StatsDatabaseQueriesTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/StatsDatabaseModelsTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/StatsServiceTests.swift`
+- `Tests/TranscriptedCoreTests/UtilitiesTests/LogPrivacySanitizerTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/TranscriptFormatVersionTests.swift`
+- `Tests/TranscriptedCoreTests/StorageTests/TranscriptFrontmatterTests.swift`
+- `Tests/TranscriptedCoreTests/AudioTests/TranscriptMetadataBuilderTests.swift`
+- `Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineHelpersTests.swift`
+- `Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerMetadataTests.swift`
 - `Tests/Integration/AppCoreIntegrationSmoke.swift`
 
 Core coverage spans the package seam, audio initialization, speaker reconciliation, transcript metadata, stats, storage-path behavior, file-permission enforcement, failed-transcription persistence, file logging, recording archiving, and task-manager metadata.

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -17,7 +17,7 @@ Draft-mode UI is not an active product path in this worktree.
 surface. Touching it means also reading `Sources/UI/Timeline/CLAUDE.md` and the
 engine boundary in `Sources/Timeline/CLAUDE.md`.
 
-## Files (82 Swift files)
+## Files (97 Swift files across Overlay/MenuBar/Settings/Shared; Timeline/ is still empty scaffolding)
 
 ### Overlay/
 
@@ -106,6 +106,14 @@ onboarding connect stage. Both keep one mental model:
 - `Settings/TranscriptedSettingsView.swift` — main settings view
 - `Settings/TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 - `Settings/TypingTimeSavedFormatter.swift` — Foundation-pure formatter for Home's typing-time-saved stat
+- `Settings/Pages/` — one file per settings tab-strip page split out of `TranscriptedSettingsView` (About, Dictations, People, Privacy, Support)
+
+This list is not exhaustive for `Settings/` — it has grown past 40 files, several
+of them small extracted presentation/policy helpers (`FailedMeetingRecoveryPresentation.swift`,
+`HomeMeetingPreviewSheet.swift`, `HomeScanWarningPolicy.swift`, `HomeSearchMatching.swift`,
+`AgentSetupFailureCopy.swift`, `OnboardingAbandonmentReasonPolicy.swift`,
+`SettingsActionFailureCopy.swift`, `TranscriptedSettingsSupportViews.swift`).
+See `Sources/UI/Settings/CLAUDE.md` for the file list that directory keeps current.
 
 ### Shared/
 

--- a/Sources/UI/Settings/CLAUDE.md
+++ b/Sources/UI/Settings/CLAUDE.md
@@ -41,6 +41,13 @@ settings-side agent connection flow.
 - `SpeakerNamingSheet.swift` - completed-meeting speaker review sheet.
 - `TypingTimeSavedFormatter.swift` - Foundation-pure formatter for Home's
   typing-time-saved stat.
+- `Pages/` - one file per settings tab-strip page split out of
+  `TranscriptedSettingsView` (`AboutSettingsPage.swift`,
+  `DictationsSettingsPage.swift`, `PeopleSettingsPage.swift`,
+  `PrivacySettingsPage.swift`, `SupportSettingsPage.swift`). New settings
+  pages should land here as their own file instead of growing the shell.
+- `TranscriptedSettingsSupportViews.swift` - shared small SwiftUI views used
+  across multiple settings pages (support/diagnostics-adjacent rows).
 
 ## Guardrails
 

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -35,11 +35,11 @@ When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 that mode the SQLite index also defaults to the shared root unless
 `TRANSCRIPTED_INDEX_DIR` is set.
 
-## Package Layout (24 Swift files)
+## Package Layout (37 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
-- `Sources/TranscriptedMCP/` — 13 source files for server startup, directory resolution, path validation, indexing, telemetry, semantic search, and tool handlers
-- `Tests/TranscriptedMCPTests/` — 11 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, tool handlers, markdown loading, logging, telemetry, name variants, semantic search, and shared fixtures
+- `Sources/TranscriptedMCP/` — 23 source files for server startup, directory resolution, path validation, indexing, telemetry, semantic search, tool handlers (split by tool family), and the MCP Apps widget surface
+- `Tests/TranscriptedMCPTests/` — 14 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, tool handlers, markdown loading, logging, telemetry, name variants, semantic search, the recent-meetings widget, audio-directory naming, frontmatter corpus parity, and shared fixtures
 
 ## File Index
 
@@ -47,8 +47,18 @@ that mode the SQLite index also defaults to the shared root unless
 |------|---------|
 | `Main.swift` | `@main` entry point; resolves directories, builds the index (with an `NLEmbeddingProvider` for semantic search), starts file watchers, then starts the MCP stdio server |
 | `DataDirectories.swift` | Index-dir resolution plus a thin wrapper over `TranscriptedCaptureKit`'s shared capture-library resolver |
-| `ToolHandlers.swift` | Registers every MCP tool and routes requests to the correct loader or index method |
+| `ToolHandlers.swift` | Registers every MCP tool and routes requests to the correct handler; the tool bodies themselves live in the `ToolHandlers+*.swift` files below |
+| `ToolHandlers+Meetings.swift` | `list_meetings` / `read_meeting` handlers |
+| `ToolHandlers+Dictations.swift` | `list_dictations` / `read_dictation` handlers |
+| `ToolHandlers+Search.swift` | `search` / `search_context` / `recent_context` / `who_is` handlers |
+| `ToolHandlers+Rollups.swift` | `recap` / `list_action_items` / `list_decisions` / `digest` handlers |
+| `ToolHandlers+Receipts.swift` | `decisions` / `commitments` / `open_questions` / `search_meetings` WS2.3 receipt-API handlers; they share a common `handleReceiptQuery` tail |
+| `UIResourceHandlers.swift` | MCP Apps (SEP-1865, `io.modelcontextprotocol/ui`) surface: the `ui://` HTML resource and the `show_recent_meetings` tool that returns it |
+| `RecentMeetingsWidget.swift` | Widget data model for one meeting card, shared by the widget builder and the HTML renderer / `structuredContent` payload |
+| `RecentMeetingsWidgetBuilder.swift` | Builds the recent-meetings widget model from the local capture library, reusing the same read-tool data access rather than re-plumbing it |
 | `TranscriptIndex.swift` | SQLite-backed index, incremental updates, and query methods across meetings and dictations; routes `lexical`/`semantic`/`hybrid` search modes |
+| `TranscriptIndex+Schema.swift` | Declarative DDL: table, FTS5 virtual table, trigger, and index definitions for the index database, split out of `TranscriptIndex.swift` |
+| `SQLiteHelpers.swift` | Shared free-function SQLite plumbing used by both `TranscriptIndex` and `EmbeddingStore`'s independent connections |
 | `EmbeddingProvider.swift` | `EmbeddingProvider` protocol, the default `NLEmbeddingProvider` (Apple NaturalLanguage, zero-bundle on-device), `SearchMode`, and `VectorMath` helpers |
 | `EmbeddingStore.swift` | Vector store on its own SQLite connection; embeds rows, stores Float32 vectors, and runs cosine semantic search over utterances and dictation entries |
 | `SemanticSearchFusion.swift` | Reciprocal-rank fusion that merges lexical (FTS) and semantic result lists for hybrid search |
@@ -67,12 +77,15 @@ that mode the SQLite index also defaults to the shared root unless
 | `TranscriptIndexTests.swift` | Full index lifecycle: reconcile, query, date filters, speaker search, and mixed-context indexing |
 | `SummaryItemIndexTests.swift` | Structured summary parse→index→query: decisions/action-items/open-questions, owner + unassigned rollup, reindex/delete, sidecar-not-a-meeting |
 | `TranscriptLoaderTests.swift` | Markdown and YAML frontmatter parsing edge cases, including path-safety checks |
+| `FrontmatterCorpusParityTests.swift` | Checks the kit's frontmatter parsing stays in parity across a corpus of real saved transcripts |
 | `LoggingTests.swift` | JSON log emission coverage for MCP startup and indexing diagnostics |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
 | `SummaryRollupTests.swift` | Cross-meeting rollups: action items by owner/status/date, decisions, digest, write-seam idempotency |
 | `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error, read pagination windows and size guard |
 | `AgentCaptureQueryTelemetryTests.swift` | Bucketing and payload coverage for agent capture-query telemetry |
 | `SemanticSearchTests.swift` | Semantic + hybrid search via a deterministic stub provider, graceful fallback, model-change re-embed, vector-math, and RRF fusion |
+| `RecentMeetingsWidgetTests.swift` | Widget-model and builder coverage for the `show_recent_meetings` MCP Apps surface |
+| `AudioDirectoryNamingTests.swift` | Retained-audio directory naming/resolution coverage |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |
 
 ## MCP Tools
@@ -98,6 +111,7 @@ All tools are read-only.
 | `open_questions` | WS2.3 receipt API for local open-question lookup by project/range |
 | `search_meetings` | WS2.3 receipt API for local keyword search over meeting utterances |
 | `status` | Server version, resolved capture directories and which resolution rule selected them, index location, and indexed counts |
+| `show_recent_meetings` | MCP Apps (SEP-1865) tool: returns a `ui://` HTML resource that renders a recent-meetings widget inline in a rendering-capable client, plus the same data as `structuredContent`. See `Sources/TranscriptedMCP/UIResourceHandlers.swift` |
 
 The rollup and WS2.3 tools are cross-meeting reads over local structured summary
 fields and raw utterance FTS. They query the same `meeting_summary_items` index


### PR DESCRIPTION
## What / why

Closing docs pass for codebase audit 2026-07-08 wave 3, run against final merged main after the dead-code removal, logging migration, and god-file-split waves (Settings `Pages/`, `FailedMeetingStore`/`TranscriptionQueueCoordinator`, `ParakeetDeviceRecovery`/`ModelLifecycle`, MCP `ToolHandlers+*.swift`, `SQLiteHandle`, the `TranscriptedCoreTests` per-subsystem target split).

Diffed each target CLAUDE.md against the actual tree and fixed stale facts — surgical edits, existing voice/format preserved:

- **root `CLAUDE.md`** — removed the now-nonexistent `Sources/Beta/` subsystem row, added a **Hotspots** section (files still >1500 lines after the splits, one line each on why they're sensitive), added the two confirmed naming-trap notes, fixed a stale `testJSONLWriter` example (that test/type is gone), linked `docs/observability.md`
- **`Sources/CLAUDE.md`** — same `Sources/Beta/` removal; redirected the beta-config pointer to where those preferences actually live now (`Sources/Support/`)
- **`Sources/Meeting/CLAUDE.md`** — documented `FailedMeetingStore.swift` / `TranscriptionQueueCoordinator.swift` (split out of `MeetingSessionController`, wave 2) plus `MeetingCaptureHealthTelemetry`, `MeetingPromptTelemetry`, and the two `MeetingQuickSummary*` files; linked `docs/observability.md`
- **`Sources/TranscriptedCore/CLAUDE.md`** — corrected subsystem file counts (80→90 total; Audio 21→22, Speaker 21→28, Storage 6→7), documented `SQLiteHandle` and confirmed `SpeakerDatabase` has no `.shared` singleton, rewrote the whole test-coverage path list to the five per-subsystem SPM test targets instead of stale flat paths
- **`Sources/Observability/CLAUDE.md`** — added `FeatureDiscoveryTelemetry`, `ObservabilityLogRotation`, `UpdateActionSafetyPolicy`, `WorkflowRecoveryTelemetry` (existed, weren't listed)
- **`Sources/Support/CLAUDE.md`** — added `CaptureLibrarySize`, `SpeakerEmbedderFactory`, `SpeakerEmbedderPreferences`; added the two confirmed naming traps
- **`Sources/UI/CLAUDE.md` + `Sources/UI/Settings/CLAUDE.md`** — corrected UI file count (82→97), documented the new `Settings/Pages/` split, flagged extracted Settings helper files the catalog hadn't caught up to
- **`Tools/TranscriptedMCP/CLAUDE.md`** — corrected file counts (24→37), documented the `ToolHandlers+*.swift` split, `TranscriptIndex+Schema.swift`, `SQLiteHelpers.swift`, the MCP Apps recent-meetings widget files, and the new `show_recent_meetings` tool

`Sources/Speech/CLAUDE.md` was already accurate against the tree (file-by-file diff matched exactly), so it's untouched.

Verified every backtick-quoted path across the edited files against the live tree with a small script (see PR discussion for method); fixed the two real hits (`Sources/Beta/CLAUDE.md` reference to a deleted dir, and the `TranscriptedCoreTests` paths missing their new subsystem-target subfolder).

## Deviations

The `Sources/UI/CLAUDE.md` and `Sources/UI/Settings/` per-file catalogs have drifted further than a surgical pass can fully re-enumerate without becoming a rewrite (Settings/ alone grew from ~33 to 44 files across several small waves). Rather than guess at one-liners for every extracted helper, both docs now name the extracted files/dirs that matter (`Pages/`, `TranscriptedSettingsSupportViews.swift`, etc.) and point at each other, so an agent knows to verify the live tree instead of trusting an exhaustive list. A full re-catalog of `Sources/UI/Settings/` file-by-file is flagged as a good follow-up but out of scope here.

## Test plan

- [x] Docs-only change, no build required per task scope
- [x] `bash scripts/dev/agent-preflight.sh` run for the changed doc paths (repo-hygiene-adjacent check; no dedicated doc-validation script exists)
- [x] Scripted existence check of every backtick-quoted path in the ten edited files against the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)