### PR TITLE
Require both meeting audio sources before ready

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -107,7 +107,9 @@ final class MeetingCaptureBridge: ObservableObject {
                 guard let self,
                       let continuation = self.startAttempt.resetIfCurrent(attemptID) else { return }
                 self.errorMessage = AudioCaptureStartState.timeoutFailureMessage(
-                    existingErrorMessage: self.errorMessage
+                    existingErrorMessage: self.errorMessage,
+                    micAudioStreaming: self.audio.micAudioStreaming,
+                    systemAudioStreaming: self.audio.systemAudioStreaming
                 )
                 self.audio.stop()
                 continuation.resume(returning: false)
@@ -196,6 +198,8 @@ final class MeetingCaptureBridge: ObservableObject {
     private func finishPendingStartAttemptIfPossible() {
         switch AudioCaptureStartState.meetingCaptureOutcome(
             isRecording: audio.isRecording,
+            micAudioFileURL: audio.micAudioFileURL,
+            micAudioStreaming: audio.micAudioStreaming,
             systemAudioFileURL: audio.systemAudioFileURL,
             systemAudioStreaming: audio.systemAudioStreaming,
             errorMessage: errorMessage
@@ -300,11 +304,13 @@ final class MeetingCaptureBridge: ObservableObject {
             .store(in: &cancellables)
 
         sinkStartAttemptTriggers(from: audio.$isRecording)
+        sinkStartAttemptTriggers(from: audio.$micAudioFileURL)
         sinkStartAttemptTriggers(from: audio.$systemAudioFileURL)
-        // A tap can install (file URL assigned, isRecording true) yet never
-        // stream. Re-evaluate readiness when the first system buffer arrives so
-        // a silent-death tap stays `.waiting` and fails the start deadline
-        // instead of being reported as recording.
+        // Either tap can install (file URL assigned, isRecording true) yet
+        // never stream. Re-evaluate readiness when each first buffer arrives
+        // so a one-sided recording stays `.waiting` and fails the start
+        // deadline instead of being reported as recording.
+        sinkStartAttemptTriggers(from: audio.$micAudioStreaming)
         sinkStartAttemptTriggers(from: audio.$systemAudioStreaming)
     }
 

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -184,6 +184,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
     @Published public var micAudioFileURL: URL?
     @Published public var systemAudioFileURL: URL?
 
+    /// True once the microphone tap has actually delivered its first nonempty
+    /// buffer for the current recording. A mic WAV can be created before the
+    /// input tap has delivered anything, so meeting readiness must not treat a
+    /// file URL or a running engine as proof that microphone capture works.
+    /// The flag is generation-guarded from the mic callback and reset for each
+    /// fresh recording start.
+    @Published public internal(set) var micAudioStreaming: Bool = false
+
     /// True once the system-audio tap has actually delivered its first buffer
     /// for the current recording. Meeting-capture readiness
     /// (`AudioCaptureStartState`) must not promote `.waiting` → `.ready` on
@@ -505,6 +513,23 @@ public class Audio: ObservableObject, @unchecked Sendable {
             systemBufferCountLock.lock()
             defer { systemBufferCountLock.unlock() }
             _systemBufferCount = newValue
+        }
+    }
+
+    // Track nonempty mic buffers separately so the first-frame readiness
+    // latch only schedules one main-thread publication per recording.
+    private var _micBufferCount: Int = 0
+    private let micBufferCountLock = NSLock()
+    var micBufferCount: Int {
+        get {
+            micBufferCountLock.lock()
+            defer { micBufferCountLock.unlock() }
+            return _micBufferCount
+        }
+        set {
+            micBufferCountLock.lock()
+            defer { micBufferCountLock.unlock() }
+            _micBufferCount = newValue
         }
     }
 
@@ -958,6 +983,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
         error = nil
         isMicRecovering = false
         systemBufferCount = 0  // Reset debug counter (lock-protected)
+        micBufferCount = 0
+        micAudioStreaming = false  // Re-gate readiness on a fresh first buffer
         systemAudioStreaming = false  // Re-gate readiness on a fresh first buffer
         resetSignalDiagnostics()
         // Fresh instance = clean one-shot latch per recording.
@@ -1159,6 +1186,16 @@ public class Audio: ObservableObject, @unchecked Sendable {
         DispatchQueue.main.async { [weak self] in
             guard let self, self.recordingSessionGeneration == sessionGeneration else { return }
             self.systemAudioStreaming = true
+        }
+    }
+
+    /// Records that the microphone tap delivered a usable buffer for this
+    /// recording. Like the system-side latch, this is published on main and
+    /// guarded against callbacks that outlive their recording generation.
+    func markMicAudioStreamingIfCurrent(sessionGeneration: UInt64) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.recordingSessionGeneration == sessionGeneration else { return }
+            self.micAudioStreaming = true
         }
     }
 

--- a/Sources/TranscriptedCore/Audio/AudioCaptureStartState.swift
+++ b/Sources/TranscriptedCore/Audio/AudioCaptureStartState.swift
@@ -2,16 +2,12 @@ import Foundation
 
 /// Start-state policy for meeting capture.
 ///
-/// Meeting recordings are only valid once the mic is running, the system-audio
-/// file has been created, AND the system-audio tap has actually delivered its
-/// first buffer. Returning success on "I/O proc started + file URL assigned"
-/// alone can leave a long mic-only recording that later fails in the
-/// multichannel pipeline — or, worse, mark a tap that silently never streams as
-/// "recording," losing the entire remote side of a call with no recovery (the
-/// device-change watchdog is gated on the first buffer and never fires). Gating
-/// readiness on `systemAudioStreaming` makes a never-streaming tap stay
-/// `.waiting` so it misses the start deadline and fails (the existing
-/// start-timeout teardown then stops it) instead of masquerading as recording.
+/// Meeting recordings are only valid once both source files exist and both the
+/// microphone and system-audio taps have actually delivered their first frame.
+/// Returning success on "I/O proc started + file URL assigned" alone can leave
+/// a header-only mic WAV or a never-streaming system tap while the UI claims to
+/// be recording. Both latches keep capture in `.waiting` until the start
+/// deadline fails it and tears it down honestly.
 public enum AudioCaptureStartState {
     public enum Outcome: Equatable {
         case waiting
@@ -21,6 +17,8 @@ public enum AudioCaptureStartState {
 
     public static func meetingCaptureOutcome(
         isRecording: Bool,
+        micAudioFileURL: URL?,
+        micAudioStreaming: Bool,
         systemAudioFileURL: URL?,
         systemAudioStreaming: Bool,
         errorMessage: String?
@@ -29,16 +27,34 @@ public enum AudioCaptureStartState {
             return .failed(errorMessage)
         }
 
-        if isRecording, systemAudioFileURL != nil, systemAudioStreaming {
+        if isRecording,
+           micAudioFileURL != nil,
+           micAudioStreaming,
+           systemAudioFileURL != nil,
+           systemAudioStreaming {
             return .ready
         }
 
         return .waiting
     }
 
-    public static func timeoutFailureMessage(existingErrorMessage: String?) -> String {
+    public static func timeoutFailureMessage(
+        existingErrorMessage: String?,
+        micAudioStreaming: Bool,
+        systemAudioStreaming: Bool
+    ) -> String {
         if let existingErrorMessage, !existingErrorMessage.isEmpty {
             return existingErrorMessage
+        }
+
+        if !micAudioStreaming, systemAudioStreaming {
+            return "Microphone capture did not become ready in time. Check your input device, then try again."
+        }
+        if micAudioStreaming, !systemAudioStreaming {
+            return "System audio capture did not become ready in time."
+        }
+        if !micAudioStreaming, !systemAudioStreaming {
+            return "Microphone and system audio capture did not become ready in time."
         }
 
         return "System audio capture did not become ready in time."

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -272,7 +272,7 @@ extension Audio {
                     operation: "device_recovery_restart"
                 )
                 newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-                    self?.handleMicBuffer(buffer)
+                    self?.handleMicBuffer(buffer, sessionGeneration: sessionGeneration)
                 }
                 do {
                     engine.prepare()

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -303,7 +303,7 @@ extension Audio {
 
             // Install tap on microphone
             inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-                self?.handleMicBuffer(buffer)
+                self?.handleMicBuffer(buffer, sessionGeneration: sessionGeneration)
             }
 
             do {
@@ -343,7 +343,16 @@ extension Audio {
     /// activity and the silence/inactivity detector still fires when the
     /// room is genuinely quiet. (AGC would otherwise amplify ambient noise
     /// up to "speech-looking" levels and defeat the inactivity prompt.)
-    func handleMicBuffer(_ buffer: AVAudioPCMBuffer) {
+    func handleMicBuffer(_ buffer: AVAudioPCMBuffer, sessionGeneration: UInt64) {
+        guard sessionGeneration == recordingSessionGeneration else { return }
+        // Empty callbacks do not prove the input route can deliver audio. Let
+        // the start gate and watchdog keep waiting for a real mic frame.
+        guard buffer.frameLength > 0 else { return }
+
+        micBufferCount += 1
+        if micBufferCount == 1 {
+            markMicAudioStreamingIfCurrent(sessionGeneration: sessionGeneration)
+        }
         lastBufferTime = CACurrentMediaTime()
         let rawPeak = linearPeak(buffer: buffer)
 

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioCaptureStartStateTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioCaptureStartStateTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+@testable import TranscriptedCore
+
+final class AudioCaptureStartStateTests: XCTestCase {
+    private let micURL = URL(fileURLWithPath: "/tmp/mic.wav")
+    private let systemURL = URL(fileURLWithPath: "/tmp/system.wav")
+
+    func testSystemFramesWithoutMicFramesStayWaiting() {
+        let outcome = AudioCaptureStartState.meetingCaptureOutcome(
+            isRecording: true,
+            micAudioFileURL: micURL,
+            micAudioStreaming: false,
+            systemAudioFileURL: systemURL,
+            systemAudioStreaming: true,
+            errorMessage: nil
+        )
+
+        XCTAssertEqual(
+            outcome,
+            .waiting,
+            "A system stream must not make a header-only mic file look like a valid meeting recording."
+        )
+    }
+
+    func testBothSourcesMustStreamBeforeCaptureIsReady() {
+        let outcome = AudioCaptureStartState.meetingCaptureOutcome(
+            isRecording: true,
+            micAudioFileURL: micURL,
+            micAudioStreaming: true,
+            systemAudioFileURL: systemURL,
+            systemAudioStreaming: true,
+            errorMessage: nil
+        )
+
+        XCTAssertEqual(outcome, .ready)
+    }
+
+    func testMicReadinessTimeoutNamesTheMissingSource() {
+        XCTAssertEqual(
+            AudioCaptureStartState.timeoutFailureMessage(
+                existingErrorMessage: nil,
+                micAudioStreaming: false,
+                systemAudioStreaming: true
+            ),
+            "Microphone capture did not become ready in time. Check your input device, then try again."
+        )
+    }
+}

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioDiagnosticsSnapshotTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioDiagnosticsSnapshotTests.swift
@@ -44,6 +44,17 @@ final class AudioDiagnosticsSnapshotTests: XCTestCase {
         XCTAssertNotNil(snapshot.privacySafeContext["captured_input_volume_during"])
     }
 
+    func testFreshRecordingStartResetsMicFrameReadiness() {
+        let audio = makeAudio()
+        audio.micAudioStreaming = true
+        audio.micBufferCount = 3
+
+        audio.prepareForNewRecordingStart()
+
+        XCTAssertFalse(audio.micAudioStreaming)
+        XCTAssertEqual(audio.micBufferCount, 0)
+    }
+
     func testHandleMicBufferAppliesAGCBeforeMicCallbackAndDiagnostics() throws {
         let audio = makeAudio()
         audio.prepareForNewRecordingStart()
@@ -63,7 +74,7 @@ final class AudioDiagnosticsSnapshotTests: XCTestCase {
         for _ in 0..<40 {
             let buffer = try makeMonoSineBuffer(peak: rawPeak)
             let originalPeak = audio.linearPeak(buffer: buffer)
-            audio.handleMicBuffer(buffer)
+            audio.handleMicBuffer(buffer, sessionGeneration: audio.recordingSessionGeneration)
 
             XCTAssertEqual(
                 audio.linearPeak(buffer: buffer),
@@ -104,7 +115,7 @@ final class AudioDiagnosticsSnapshotTests: XCTestCase {
 
         let rawPeak: Float = 0.04
         let buffer = try makeMonoSineBuffer(peak: rawPeak)
-        audio.handleMicBuffer(buffer)
+        audio.handleMicBuffer(buffer, sessionGeneration: audio.recordingSessionGeneration)
 
         let processedPeak = try XCTUnwrap(callbackPeaks.last)
         XCTAssertEqual(processedPeak, rawPeak, accuracy: 0.002, "raw/off mode should not boost the mic copy")

--- a/Tests/TranscriptedCoreTests/AudioTests/LiveCaptureSmokeTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/LiveCaptureSmokeTests.swift
@@ -127,6 +127,8 @@ final class LiveCaptureSmokeTests: XCTestCase {
         while Date() < deadline {
             let outcome = AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: audio.isRecording,
+                micAudioFileURL: audio.micAudioFileURL,
+                micAudioStreaming: audio.micAudioStreaming,
                 systemAudioFileURL: audio.systemAudioFileURL,
                 systemAudioStreaming: audio.systemAudioStreaming,
                 errorMessage: audio.error

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineHelpersTests.swift
@@ -88,6 +88,8 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
+                micAudioFileURL: readyURL,
+                micAudioStreaming: true,
                 systemAudioFileURL: nil,
                 systemAudioStreaming: true,
                 errorMessage: nil
@@ -98,6 +100,8 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
+                micAudioFileURL: readyURL,
+                micAudioStreaming: true,
                 systemAudioFileURL: readyURL,
                 systemAudioStreaming: true,
                 errorMessage: nil
@@ -108,6 +112,8 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
+                micAudioFileURL: readyURL,
+                micAudioStreaming: true,
                 systemAudioFileURL: readyURL,
                 systemAudioStreaming: true,
                 errorMessage: "System audio unavailable"
@@ -124,6 +130,8 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
+                micAudioFileURL: URL(fileURLWithPath: "/tmp/mic.wav"),
+                micAudioStreaming: true,
                 systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
                 systemAudioStreaming: false,
                 errorMessage: nil

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineStateTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineStateTests.swift
@@ -94,6 +94,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: false,
+                micAudioFileURL: url,
+                micAudioStreaming: true,
                 systemAudioFileURL: url,
                 systemAudioStreaming: true,
                 errorMessage: nil
@@ -110,6 +112,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
+                micAudioFileURL: URL(fileURLWithPath: "/tmp/mic.wav"),
+                micAudioStreaming: true,
                 systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
                 systemAudioStreaming: false,
                 errorMessage: nil
@@ -124,6 +128,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
+                micAudioFileURL: URL(fileURLWithPath: "/tmp/mic.wav"),
+                micAudioStreaming: true,
                 systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
                 systemAudioStreaming: true,
                 errorMessage: ""
@@ -137,6 +143,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         XCTAssertEqual(
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
+                micAudioFileURL: URL(fileURLWithPath: "/tmp/mic.wav"),
+                micAudioStreaming: true,
                 systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
                 systemAudioStreaming: true,
                 errorMessage: "permission denied"
@@ -147,11 +155,19 @@ final class TranscriptionPipelineStateTests: XCTestCase {
 
     func testTimeoutFailureMessageFallsBackToCanonicalCopy() {
         XCTAssertEqual(
-            AudioCaptureStartState.timeoutFailureMessage(existingErrorMessage: nil),
+            AudioCaptureStartState.timeoutFailureMessage(
+                existingErrorMessage: nil,
+                micAudioStreaming: true,
+                systemAudioStreaming: false
+            ),
             "System audio capture did not become ready in time."
         )
         XCTAssertEqual(
-            AudioCaptureStartState.timeoutFailureMessage(existingErrorMessage: ""),
+            AudioCaptureStartState.timeoutFailureMessage(
+                existingErrorMessage: "",
+                micAudioStreaming: true,
+                systemAudioStreaming: false
+            ),
             "System audio capture did not become ready in time."
         )
     }
@@ -159,7 +175,9 @@ final class TranscriptionPipelineStateTests: XCTestCase {
     func testTimeoutFailureMessagePreservesExistingError() {
         XCTAssertEqual(
             AudioCaptureStartState.timeoutFailureMessage(
-                existingErrorMessage: "screen recording denied"
+                existingErrorMessage: "screen recording denied",
+                micAudioStreaming: true,
+                systemAudioStreaming: true
             ),
             "screen recording denied"
         )


### PR DESCRIPTION
## Summary
- Require both mic and system-audio files plus a first nonempty frame from each before a meeting is reported as recording.
- If only system audio arrives, stop at the existing start deadline and surface a microphone/input-device failure instead of silently saving a one-sided meeting.
- Add deterministic regression coverage for system frames with absent mic frames.

## Incident provenance
Public v1.1.49 is the current `origin/main` commit. This Mac’s `/Applications/Transcripted.app` and privacy-safe local event entries report 1.1.48, so the reported binary version is unconfirmed. No user transcript or audio content was accessed, and nothing was installed or overwritten.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (12,918 passed)
- `bash run-integration-smoke.sh`
- `swift test` (753 passed, 13 skipped)
- `bash scripts/ops/transcripted-qa-bench.sh --mode full` (PASS; 18 checks, one non-blocking local-artifact warning)
- `codex review --base origin/main` (no actionable findings)

## Manual/hardware boundary
No real microphone, Bluetooth, or customer-session capture was run. Those checks remain YELLOW/UNKNOWN.