### PR TITLE
Bound system audio permission requests

### DIFF
--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -80,6 +80,12 @@ enum TranscriptedConstants {
     /// neither the success nor error publisher has fired.
     static let meetingStartTimeout: UInt64 = 5_000_000_000  // 5 seconds
 
+    /// Bounds the ScreenCaptureKit probe used to verify System Audio Recording
+    /// access before meeting capture. A stalled TCC/ScreenCaptureKit callback
+    /// must return an honest denied result instead of leaving the meeting UI
+    /// in its starting state forever.
+    static let systemAudioPermissionRequestTimeout: UInt64 = 12_000_000_000  // 12 seconds
+
     /// Base timeout for waiting on meeting capture file-close callbacks after
     /// stop. Long recordings can need more time to flush and merge audio, so
     /// call `meetingStopTimeout(forRecordingDuration:)` for live capture.

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -18,7 +18,6 @@ enum TranscriptedPermissionAccess {
 
     private static let systemAudioRecordingGrantedKey = "systemAudioRecordingPermissionGranted"
     private static let systemAudioRecordingKnownKey = "systemAudioRecordingPermissionKnown"
-    @MainActor private static var activeSystemAudioRequester: SystemAudioPermissionRequester?
     @MainActor private static var activeSystemAudioRevalidator: Task<Bool, Never>?
 
     static func isGranted(_ kind: TranscriptedPermissionKind) -> Bool {
@@ -269,16 +268,17 @@ enum TranscriptedPermissionAccess {
 
     @MainActor
     private static func performSystemAudioRecordingAccessRequest() async -> Bool {
-        return await withCheckedContinuation { continuation in
-            let requester = SystemAudioPermissionRequester()
-            activeSystemAudioRequester = requester
-            requester.requestAccess { granted in
-                Task { @MainActor in
-                    activeSystemAudioRequester = nil
-                    continuation.resume(returning: granted)
-                }
+        let requester = SystemAudioPermissionRequester()
+        let attempt = SystemAudioPermissionRequestAttempt()
+
+        return await attempt.awaitResult(
+            start: { completion in
+                requester.requestAccess(completion: completion)
+            },
+            cleanup: {
+                requester.cancel()
             }
-        }
+        )
     }
 
     @MainActor
@@ -302,67 +302,197 @@ extension Notification.Name {
     static let transcriptedPermissionsDidChange = Notification.Name("transcriptedPermissionsDidChange")
 }
 
+/// Bounds one callback-driven System Audio Recording permission request.
+///
+/// ScreenCaptureKit has no completion guarantee for every TCC or daemon state.
+/// This main-actor gate makes timeout, caller cancellation, and real callbacks
+/// race through one terminal result so a late callback cannot resume a checked
+/// continuation twice or revive a finished request.
+@MainActor
+final class SystemAudioPermissionRequestAttempt {
+    typealias Completion = (Bool) -> Void
+    typealias TimeoutScheduler = @MainActor (@escaping @MainActor () -> Void) -> @MainActor () -> Void
+
+    private let scheduleTimeout: TimeoutScheduler
+    private let onTimeout: () -> Void
+    private let onResolved: (Bool) -> Void
+    private var continuation: CheckedContinuation<Bool, Never>?
+    private var cancelTimeout: (() -> Void)?
+    private var cleanup: (() -> Void)?
+    private var result: Bool?
+
+    init(
+        scheduleTimeout: @escaping TimeoutScheduler = SystemAudioPermissionRequestAttempt.liveTimeoutScheduler,
+        onTimeout: @escaping () -> Void = {},
+        onResolved: @escaping (Bool) -> Void = { _ in }
+    ) {
+        self.scheduleTimeout = scheduleTimeout
+        self.onTimeout = onTimeout
+        self.onResolved = onResolved
+    }
+
+    func awaitResult(
+        start: @escaping (@escaping Completion) -> Void,
+        cleanup: @escaping () -> Void
+    ) async -> Bool {
+        await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { continuation in
+                if let result {
+                    continuation.resume(returning: result)
+                    return
+                }
+
+                self.continuation = continuation
+                self.cleanup = cleanup
+                self.cancelTimeout = scheduleTimeout { [weak self] in
+                    self?.timeout()
+                }
+                start { [weak self] granted in
+                    Task { @MainActor [weak self] in
+                        self?.finish(granted)
+                    }
+                }
+            }
+        }, onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.finish(false)
+            }
+        })
+    }
+
+    private func timeout() {
+        guard result == nil else { return }
+        onTimeout()
+        finish(false)
+    }
+
+    private func finish(_ granted: Bool) {
+        guard result == nil else { return }
+        result = granted
+
+        let continuation = continuation
+        self.continuation = nil
+        let cancelTimeout = cancelTimeout
+        self.cancelTimeout = nil
+        let cleanup = cleanup
+        self.cleanup = nil
+
+        cancelTimeout?()
+        cleanup?()
+        onResolved(granted)
+        continuation?.resume(returning: granted)
+    }
+
+    private static func liveTimeoutScheduler(
+        _ action: @escaping @MainActor () -> Void
+    ) -> @MainActor () -> Void {
+        let task = Task { @MainActor in
+            do {
+                try await Task.sleep(nanoseconds: TranscriptedConstants.systemAudioPermissionRequestTimeout)
+            } catch {
+                return
+            }
+            action()
+        }
+        return {
+            task.cancel()
+        }
+    }
+}
+
 @available(macOS 26.0, *)
+@MainActor
 private final class SystemAudioPermissionRequester: NSObject, SCStreamOutput {
     private var stream: SCStream?
     private let sampleHandlerQueue = DispatchQueue(label: "Transcripted.SystemAudioPermission")
     private var completion: ((Bool) -> Void)?
+    private var stopCaptureRequested = false
 
     func requestAccess(completion: @escaping (Bool) -> Void) {
         self.completion = completion
 
         SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) { [weak self] content, error in
-            guard let self else { return }
-
-            if error != nil {
-                self.finish(granted: false)
-                return
-            }
-
-            guard let display = content?.displays.first else {
-                self.finish(granted: false)
-                return
-            }
-
-            let filter = SCContentFilter(display: display, excludingWindows: [])
-            let config = SCStreamConfiguration()
-            config.capturesAudio = true
-            config.excludesCurrentProcessAudio = true
-            config.sampleRate = 48000
-            config.channelCount = 2
-            config.width = 2
-            config.height = 2
-            config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
-
-            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
-            self.stream = stream
-
-            do {
-                try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: self.sampleHandlerQueue)
-            } catch {
-                self.finish(granted: false)
-                return
-            }
-
-            stream.startCapture { [weak self] error in
-                guard let self else { return }
-
-                if error != nil {
-                    self.finish(granted: false)
-                    return
-                }
-
-                stream.stopCapture { [weak self] _ in
-                    self?.finish(granted: true)
-                }
+            Task { @MainActor [weak self] in
+                self?.handleShareableContent(content, error: error)
             }
         }
     }
 
-    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {}
+    func cancel() {
+        completion = nil
+        guard let stream else { return }
+
+        self.stream = nil
+        guard !stopCaptureRequested else { return }
+        stopCaptureRequested = true
+        stream.stopCapture { _ in }
+    }
+
+    nonisolated func stream(
+        _ stream: SCStream,
+        didOutputSampleBuffer sampleBuffer: CMSampleBuffer,
+        of type: SCStreamOutputType
+    ) {}
+
+    private func handleShareableContent(_ content: SCShareableContent?, error: Error?) {
+        guard completion != nil else { return }
+
+        if error != nil {
+            finish(granted: false)
+            return
+        }
+
+        guard let display = content?.displays.first else {
+            finish(granted: false)
+            return
+        }
+
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+        let config = SCStreamConfiguration()
+        config.capturesAudio = true
+        config.excludesCurrentProcessAudio = true
+        config.sampleRate = 48000
+        config.channelCount = 2
+        config.width = 2
+        config.height = 2
+        config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+
+        let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+        self.stream = stream
+        stopCaptureRequested = false
+
+        do {
+            try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: sampleHandlerQueue)
+        } catch {
+            finish(granted: false)
+            return
+        }
+
+        stream.startCapture { [weak self] error in
+            Task { @MainActor [weak self] in
+                self?.handleStartCapture(error: error)
+            }
+        }
+    }
+
+    private func handleStartCapture(error: Error?) {
+        guard let stream, completion != nil else { return }
+
+        if error != nil {
+            finish(granted: false)
+            return
+        }
+
+        stopCaptureRequested = true
+        stream.stopCapture { [weak self] error in
+            Task { @MainActor [weak self] in
+                guard let self, self.stream != nil, self.completion != nil else { return }
+                self.finish(granted: error == nil)
+            }
+        }
+    }
 
     private func finish(granted: Bool) {
-        stream = nil
         let completion = completion
         self.completion = nil
         completion?(granted)

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -7,6 +7,40 @@ private final class PermissionRequestBox {
 }
 
 @MainActor
+private final class SystemAudioPermissionAttemptDriver {
+    var completion: ((Bool) -> Void)?
+    var timeoutAction: (() -> Void)?
+    var cleanupCount = 0
+    var timeoutCancellationCount = 0
+
+    func start(_ completion: @escaping (Bool) -> Void) {
+        self.completion = completion
+    }
+
+    func scheduleTimeout(_ action: @escaping () -> Void) -> () -> Void {
+        timeoutAction = action
+        return { [weak self] in
+            self?.timeoutCancellationCount += 1
+        }
+    }
+
+    func fireTimeout() {
+        timeoutAction?()
+    }
+}
+
+@MainActor
+private func waitForSystemAudioPermissionAttemptStart(
+    _ driver: SystemAudioPermissionAttemptDriver
+) async -> Bool {
+    for _ in 0..<20 {
+        if driver.completion != nil { return true }
+        await Task.yield()
+    }
+    return driver.completion != nil
+}
+
+@MainActor
 func testTranscriptedPermissionAccess() async {
     let knownKey = "systemAudioRecordingPermissionKnown"
     let grantedKey = "systemAudioRecordingPermissionGranted"
@@ -18,6 +52,129 @@ func testTranscriptedPermissionAccess() async {
         } else {
             UserDefaults.standard.removeObject(forKey: key)
         }
+    }
+
+    await runSuite("SystemAudioPermissionRequestAttempt — stalled requester times out with one denied result") {
+        let driver = SystemAudioPermissionAttemptDriver()
+        var timeoutCount = 0
+        var resolved: [Bool] = []
+        let attempt = SystemAudioPermissionRequestAttempt(
+            scheduleTimeout: driver.scheduleTimeout,
+            onTimeout: { timeoutCount += 1 },
+            onResolved: { resolved.append($0) }
+        )
+        let resultTask = Task { @MainActor in
+            await attempt.awaitResult(
+                start: driver.start,
+                cleanup: { driver.cleanupCount += 1 }
+            )
+        }
+
+        assertTrue(
+            await waitForSystemAudioPermissionAttemptStart(driver),
+            "the deterministic requester should start before its timeout is fired"
+        )
+        driver.fireTimeout()
+        let granted = await resultTask.value
+
+        assertFalse(granted, "a stalled permission requester must resolve as denied")
+        assertEqual(timeoutCount, 1, "the timeout diagnostic hook should fire once")
+        assertEqual(resolved, [false], "timeout should resolve the request exactly once")
+        assertEqual(driver.cleanupCount, 1, "timeout should clean up the in-flight requester")
+        assertEqual(driver.timeoutCancellationCount, 1, "timeout should cancel its pending timer once")
+    }
+
+    await runSuite("SystemAudioPermissionRequestAttempt — ignores a late success after timeout") {
+        let driver = SystemAudioPermissionAttemptDriver()
+        var resolved: [Bool] = []
+        let attempt = SystemAudioPermissionRequestAttempt(
+            scheduleTimeout: driver.scheduleTimeout,
+            onResolved: { resolved.append($0) }
+        )
+        let resultTask = Task { @MainActor in
+            await attempt.awaitResult(
+                start: driver.start,
+                cleanup: { driver.cleanupCount += 1 }
+            )
+        }
+
+        assertTrue(await waitForSystemAudioPermissionAttemptStart(driver), "the requester should start")
+        driver.fireTimeout()
+        let granted = await resultTask.value
+        driver.completion?(true)
+        await Task.yield()
+
+        assertFalse(granted, "a timeout must not be upgraded to a late success")
+        assertEqual(resolved, [false], "a late ScreenCaptureKit callback must be harmless")
+        assertEqual(driver.cleanupCount, 1, "late callbacks must not repeat cleanup")
+    }
+
+    await runSuite("SystemAudioPermissionRequestAttempt — returns real success and failure") {
+        let successDriver = SystemAudioPermissionAttemptDriver()
+        let successAttempt = SystemAudioPermissionRequestAttempt(scheduleTimeout: successDriver.scheduleTimeout)
+        let successTask = Task { @MainActor in
+            await successAttempt.awaitResult(
+                start: successDriver.start,
+                cleanup: { successDriver.cleanupCount += 1 }
+            )
+        }
+        assertTrue(await waitForSystemAudioPermissionAttemptStart(successDriver), "the success requester should start")
+        successDriver.completion?(true)
+        assertTrue(await successTask.value, "a successful ScreenCaptureKit probe should be granted")
+
+        let failureDriver = SystemAudioPermissionAttemptDriver()
+        let failureAttempt = SystemAudioPermissionRequestAttempt(scheduleTimeout: failureDriver.scheduleTimeout)
+        let failureTask = Task { @MainActor in
+            await failureAttempt.awaitResult(
+                start: failureDriver.start,
+                cleanup: { failureDriver.cleanupCount += 1 }
+            )
+        }
+        assertTrue(await waitForSystemAudioPermissionAttemptStart(failureDriver), "the failure requester should start")
+        failureDriver.completion?(false)
+        assertFalse(await failureTask.value, "a failed ScreenCaptureKit probe should stay denied")
+        assertEqual(successDriver.cleanupCount, 1, "success should clean up the probe stream")
+        assertEqual(failureDriver.cleanupCount, 1, "failure should clean up the probe stream")
+    }
+
+    await runSuite("SystemAudioPermissionRequestAttempt — duplicate callbacks and cancellation resolve once") {
+        let duplicateDriver = SystemAudioPermissionAttemptDriver()
+        var duplicateResolved: [Bool] = []
+        let duplicateAttempt = SystemAudioPermissionRequestAttempt(
+            scheduleTimeout: duplicateDriver.scheduleTimeout,
+            onResolved: { duplicateResolved.append($0) }
+        )
+        let duplicateTask = Task { @MainActor in
+            await duplicateAttempt.awaitResult(
+                start: duplicateDriver.start,
+                cleanup: { duplicateDriver.cleanupCount += 1 }
+            )
+        }
+        assertTrue(await waitForSystemAudioPermissionAttemptStart(duplicateDriver), "the duplicate-callback requester should start")
+        duplicateDriver.completion?(true)
+        assertTrue(await duplicateTask.value, "the first callback should win")
+        duplicateDriver.completion?(false)
+        await Task.yield()
+        assertEqual(duplicateResolved, [true], "duplicate callbacks must not resume twice")
+        assertEqual(duplicateDriver.cleanupCount, 1, "duplicate callbacks must not repeat cleanup")
+
+        let cancellationDriver = SystemAudioPermissionAttemptDriver()
+        var cancellationResolved: [Bool] = []
+        let cancellationAttempt = SystemAudioPermissionRequestAttempt(
+            scheduleTimeout: cancellationDriver.scheduleTimeout,
+            onResolved: { cancellationResolved.append($0) }
+        )
+        let cancellationTask = Task { @MainActor in
+            await cancellationAttempt.awaitResult(
+                start: cancellationDriver.start,
+                cleanup: { cancellationDriver.cleanupCount += 1 }
+            )
+        }
+        assertTrue(await waitForSystemAudioPermissionAttemptStart(cancellationDriver), "the cancellable requester should start")
+        cancellationTask.cancel()
+        assertFalse(await cancellationTask.value, "cancelling a request should return an honest denied result")
+        assertEqual(cancellationResolved, [false], "cancellation must resolve exactly once")
+        assertEqual(cancellationDriver.cleanupCount, 1, "cancellation should clean up the probe stream")
     }
 
     runSuite("TranscriptedPermissionAccess.systemAudioRecordingGranted — old onboarding completion no longer implies a real grant") {


### PR DESCRIPTION
## Summary
- bound force-refresh system-audio permission revalidation so a stalled ScreenCaptureKit request returns false instead of leaving meeting start loading forever
- make timeout, cancellation, and callbacks resolve exactly once; ignore late callbacks and clean up the probe stream/requester
- add deterministic coverage for timeout, late completion, success, failure, duplicate callback, and cancellation paths

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 12,942 passed
- `bash run-integration-smoke.sh`
- `swift test` — 749 passed, 13 skipped
- `bash scripts/ops/transcripted-qa-bench.sh --mode full` — PASS; 18 checks, one non-blocking local-artifact warning
- Independent `codex review --base origin/main` — no actionable findings

## Manual hold
- Real Zoom/ScreenCaptureKit permission revalidation on Justin's Mac is still YELLOW and required before any release decision. This PR does not merge or release anything.

## Compatibility
- Reviewed against the current open #1530 and #1531 work; this Support-only change does not overlap their Meeting-flow edits.