### PR TITLE
Guard meetings against unusable local audio

### DIFF
--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -22,6 +22,11 @@ struct MeetingFailureCopy: Equatable {
                 title: "Turn on Microphone",
                 detail: "Turn on Microphone access in System Settings, then retry the meeting."
             )
+        case .microphoneAudioUnusable:
+            return MeetingFailureCopy(
+                title: "Microphone audio was not captured",
+                detail: "Transcripted kept the meeting audio, but the microphone track had no usable signal. Check the selected microphone and record the meeting again."
+            )
         case .recordingTooShort:
             return MeetingFailureCopy(
                 title: "Recording ended too soon",

--- a/Sources/Meeting/MeetingFailureExplanation.swift
+++ b/Sources/Meeting/MeetingFailureExplanation.swift
@@ -159,6 +159,7 @@ struct MeetingFailureExplanation: Equatable {
              .modelNotLoaded,
              .pipelineFailed,
              .transcriptionInferenceFailed,
+             .microphoneAudioUnusable,
              .emptyAudio,
              .noSpeechDetected,
              .invalidAudioFormat,

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -4,6 +4,7 @@ enum MeetingFailureKind: String {
     case systemAudioPermission = "system_audio_permission"
     case microphonePermission = "microphone_permission"
     case microphoneMissing = "microphone_missing"
+    case microphoneAudioUnusable = "microphone_audio_unusable"
     case audioDeviceUnavailable = "audio_device_unavailable"
     case recordingTooShort = "recording_too_short"
     case emptyAudio = "empty_audio"
@@ -94,6 +95,14 @@ enum MeetingFailureKind: String {
 
         if normalized.contains("no microphone found") {
             return .microphoneMissing
+        }
+
+        if normalized.contains(anyOf: [
+            "microphone audio was not usable",
+            "microphone audio was unusable",
+            "microphone artifact had no usable capture signal",
+        ]) {
+            return .microphoneAudioUnusable
         }
 
         if normalized.contains(anyOf: [

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -772,7 +772,8 @@ final class MeetingSessionController: ObservableObject {
         clearSharedDictationMicRelay()
         await sttRouter.resumeRegularRecordingAfterSharedMeetingMicEndedIfNeeded()
         let files = (micURL: stopResult.micURL, systemURL: stopResult.systemURL)
-        let shouldAwaitFinalLiveCodexTranscript = files.micURL != nil && !stopResult.didTimeOut
+        let shouldAwaitFinalLiveCodexTranscript =
+            files.micURL != nil && files.systemURL != nil && !stopResult.didTimeOut
         finishLiveCodexSessionForActiveRecording(
             status: shouldAwaitFinalLiveCodexTranscript ? .stopped : .failed,
             shouldAwaitFinalTranscript: shouldAwaitFinalLiveCodexTranscript
@@ -932,6 +933,32 @@ final class MeetingSessionController: ObservableObject {
             return
         }
 
+        guard let systemURL = files.systemURL else {
+            let preserved = failedMeetingStore.preserveFailedMeetingForRetry(
+                micAudioURL: micURL,
+                systemAudioURL: nil,
+                errorMessage: "Recording stopped without system audio.",
+                meetingTitle: recordingSnapshot.suggestedTitle,
+                recordingDate: recordingSnapshot.recordingStartedAt
+            )
+            DiagnosticsTrail.record(
+                level: .error,
+                engine: "meeting",
+                event: "meeting_recording_missing_system_audio",
+                message: "Meeting recording stopped without a system-audio file",
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "reason": reason.rawValue,
+                        "mic_file_present": boolString(true),
+                        "preserved_for_retry": boolString(preserved)
+                    ]
+                )
+            )
+            Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "missing_system_audio")
+            state = .error("System audio was missing. Open Transcripted Home to retry the saved meeting.")
+            return
+        }
+
         // Issue #500: when stop diagnostics classified an unrecovered
         // voice-processed quiet mic, ride the facts into the saved transcript
         // frontmatter so Home can surface the enable-for-next-time hint.
@@ -952,7 +979,7 @@ final class MeetingSessionController: ObservableObject {
 
         let outcome = transcriptionQueue.enqueueTranscriptionJob(
             micURL: micURL,
-            systemURL: files.systemURL,
+            systemURL: systemURL,
             healthInfo: healthInfoForSave,
             captureDiagnostics: stopCaptureDiagnostics,
             meetingTitle: recordingSnapshot.suggestedTitle,

--- a/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
@@ -47,6 +47,12 @@ enum AudioSignalRecovery {
     static let parakeetSampleRate: Double = 16_000
     static let parakeetMinimumInferenceSamples = 16_000
     static let legacySpeechDetectionThreshold: Float = 0.010
+    // This is a capture-health floor, not a speech detector. It is deliberately
+    // lower than hasSpeechCandidate so quiet but valid microphone input is kept.
+    static let minimumCapturePeak: Float = 0.0008
+    static let minimumCaptureActiveDuration: Double = 0.20
+    private static let captureFrameDuration: Double = 0.10
+    private static let minimumCaptureFrameRMS: Float = 0.0001
 
     static func analyze(samples: [Float], sampleRate: Double) -> AudioSignalAnalysis {
         guard !samples.isEmpty, AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else {
@@ -81,6 +87,39 @@ enum AudioSignalRecovery {
             rms: rms,
             activeRatio: Double(activeCount) / Double(samples.count)
         )
+    }
+
+    /// Returns whether the finished microphone artifact contains a sustained,
+    /// low-level capture signal. This deliberately does not claim that speech
+    /// was spoken or understood; it only prevents an all-silent/one-buffer mic
+    /// artifact from being saved as a healthy two-source meeting.
+    static func hasUsableCaptureSignal(samples: [Float], sampleRate: Double) -> Bool {
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate),
+              samples.count >= Int(sampleRate * minimumCaptureActiveDuration) else {
+            return false
+        }
+
+        let frameSize = max(1, Int(sampleRate * captureFrameDuration))
+        var peak: Float = 0
+        var activeDuration = 0.0
+        for start in stride(from: 0, to: samples.count, by: frameSize) {
+            let end = min(samples.count, start + frameSize)
+            let frame = samples[start..<end]
+            guard !frame.isEmpty else { continue }
+            var sumOfSquares = 0.0
+            for sample in frame {
+                peak = max(peak, abs(sample))
+                sumOfSquares += Double(sample * sample)
+            }
+            let frameRMS = Float(sqrt(sumOfSquares / Double(frame.count)))
+            if frameRMS >= minimumCaptureFrameRMS {
+                activeDuration += Double(frame.count) / sampleRate
+            }
+            if activeDuration >= minimumCaptureActiveDuration {
+                return peak >= minimumCapturePeak
+            }
+        }
+        return peak >= minimumCapturePeak && activeDuration >= minimumCaptureActiveDuration
     }
 
     static func normalizeForSpeech(

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -84,6 +84,9 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         if normalized.contains("no samples recorded") || normalized.contains("empty audio file") {
             return .emptyAudioFile
         }
+        if normalized.contains("microphone audio was not usable") {
+            return .microphoneAudioUnusable
+        }
         if normalized.contains("no speech detected") || normalized.contains("no speech was found") {
             return .noSpeechDetected
         }

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -119,6 +119,7 @@ public struct TranscriptionResult: Sendable {
 public enum PipelineError: LocalizedError {
     // Audio errors (permanent — bad data won't improve on retry)
     case emptyAudioFile
+    case microphoneAudioUnusable
     case noSpeechDetected
     case recordingTooShort(duration: TimeInterval)
     case invalidAudioFormat(detail: String)
@@ -140,6 +141,8 @@ public enum PipelineError: LocalizedError {
         switch self {
         case .emptyAudioFile:
             return "Empty audio file — no samples recorded."
+        case .microphoneAudioUnusable:
+            return "Microphone audio was not usable. Open Transcripted Home to retry the saved meeting."
         case .noSpeechDetected:
             return "No speech detected in the audio."
         case .recordingTooShort(let duration):
@@ -163,7 +166,7 @@ public enum PipelineError: LocalizedError {
     /// Audio data errors are permanent. Model/storage errors may be transient.
     public var isRetryable: Bool {
         switch self {
-        case .emptyAudioFile, .noSpeechDetected, .recordingTooShort, .invalidAudioFormat, .missingSystemAudio:
+        case .emptyAudioFile, .microphoneAudioUnusable, .noSpeechDetected, .recordingTooShort, .invalidAudioFormat, .missingSystemAudio:
             return false
         case .modelNotLoaded, .modelInferenceFailed, .saveFailed, .unknown:
             return true

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -67,7 +67,11 @@ extension Transcription {
             var systemSamples = try AudioResampler.loadAndResample(url: systemURL, targetRate: 16000)
             var micSamples: [Float]
             if let micURL {
-                micSamples = try AudioResampler.loadAndResample(url: micURL, targetRate: 16000)
+                do {
+                    micSamples = try AudioResampler.loadAndResample(url: micURL, targetRate: 16000)
+                } catch PipelineError.emptyAudioFile {
+                    throw PipelineError.microphoneAudioUnusable
+                }
             } else {
                 micSamples = []
             }
@@ -89,6 +93,10 @@ extension Transcription {
                 context["suggested_gain"] = String(format: "%.2f", AudioSignalRecovery.normalizationGain(for: rawMicAnalysis))
                 AppLogger.transcription.info("Analyzed meeting mic signal", context)
                 micSignalAnalysis = rawMicAnalysis
+                guard AudioSignalRecovery.hasUsableCaptureSignal(samples: micSamples, sampleRate: 16000) else {
+                    AppLogger.transcription.error("Microphone artifact had no usable capture signal", context)
+                    throw PipelineError.microphoneAudioUnusable
+                }
             } else {
                 micSignalAnalysis = nil
             }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -511,6 +511,8 @@ public class TranscriptionTaskManager: ObservableObject {
             switch pipelineError {
             case .emptyAudioFile:
                 return "Empty audio file"
+            case .microphoneAudioUnusable:
+                return "Microphone audio was not usable"
             case .noSpeechDetected:
                 return "No speech detected"
             case .recordingTooShort:

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -83,6 +83,21 @@ func testFailedMeetingPresentation() {
         )
     }
 
+    runSuite("FailedMeetingPresentation unusable mic artifacts point to recording repair") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "Microphone audio was not usable",
+            shortErrorMessage: "Microphone audio was not usable",
+            isRetryable: false
+        )
+
+        assertEqual(copy.title, "Microphone audio was not captured", "unusable mic artifacts should name the failed source")
+        assertEqual(
+            copy.detail,
+            "Transcripted kept the meeting audio, but the microphone track had no usable signal. Check the selected microphone and record the meeting again.",
+            "unusable mic artifacts should give deterministic recovery guidance"
+        )
+    }
+
     runSuite("MeetingSessionController surfaces skipped no-speech outcomes visibly") {
         let source = (try? String(
             contentsOf: repoFixtureURL("Sources/Meeting/MeetingSessionController.swift"),

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -70,6 +70,14 @@ func testMeetingFailureKind() {
         assertEqual(kind, .noSpeechDetected, "audio with no spoken content should get a direct user-facing bucket")
     }
 
+    runSuite("MeetingFailureKind classifies unusable microphone artifacts") {
+        let kind = MeetingFailureKind.classify(
+            message: "Microphone audio was not usable"
+        )
+
+        assertEqual(kind, .microphoneAudioUnusable, "mic artifact failures should stay source-specific")
+    }
+
     runSuite("MeetingFailureKind marks expected empty transcript outcomes as skipped") {
         assertTrue(
             MeetingFailureKind.recordingTooShort.shouldReportAsSkippedTranscript,

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2670,6 +2670,18 @@ func testRepoCommandContract() {
             "normal stop should switch to transcribing and enqueue the captured audio instead of deleting scratch files"
         )
         assertTrue(
+            stopBlock.contains("guard let systemURL = files.systemURL else")
+                && stopBlock.contains("event: \"meeting_recording_missing_system_audio\"")
+                && stopBlock.contains("systemURL: systemURL"),
+            "a live meeting must not fall back to mic-only transcription when the finished system-audio source is missing"
+        )
+        let pipelineContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift")
+        assertTrue(
+            pipelineContents.contains("hasUsableCaptureSignal(samples: micSamples, sampleRate: 16000)")
+                && pipelineContents.contains("throw PipelineError.microphoneAudioUnusable"),
+            "multichannel transcription must reject a missing or unusable mic artifact before saving system-only output"
+        )
+        assertTrue(
             cancelBlock.contains("capture.stopAndDiscardFiles()")
                 && cancelBlock.contains("restoreStateAfterRecordingEndedWithoutNewWork()"),
             "explicit discard should use the discard path and restore idle/ready state without queueing transcription"

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioSignalRecoveryTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioSignalRecoveryTests.swift
@@ -37,6 +37,51 @@ final class AudioSignalRecoveryTests: XCTestCase {
         XCTAssertFalse(analysis.hasSpeechCandidate, "pure silence should never look like a speech candidate")
     }
 
+    // MARK: - finished microphone artifact validation
+
+    func testUsableCaptureSignalRejectsAnEmptyArtifact() {
+        XCTAssertFalse(
+            AudioSignalRecovery.hasUsableCaptureSignal(samples: [], sampleRate: 16_000),
+            "an empty microphone artifact must not pass source validation"
+        )
+    }
+
+    func testUsableCaptureSignalRejectsFirstFrameThenStall() {
+        let firstFrameOnly = [Float](repeating: 0.02, count: 1_600)
+
+        XCTAssertFalse(
+            AudioSignalRecovery.hasUsableCaptureSignal(samples: firstFrameOnly, sampleRate: 16_000),
+            "one 100ms frame must not count as sustained microphone capture"
+        )
+    }
+
+    func testUsableCaptureSignalRejectsAllSilentSamples() {
+        let silent = [Float](repeating: 0, count: 32_000)
+
+        XCTAssertFalse(
+            AudioSignalRecovery.hasUsableCaptureSignal(samples: silent, sampleRate: 16_000),
+            "a non-empty but silent microphone WAV must not look healthy"
+        )
+    }
+
+    func testUsableCaptureSignalKeepsQuietButValidInput() {
+        let quiet = [Float](repeating: 0.002, count: 32_000)
+
+        XCTAssertTrue(
+            AudioSignalRecovery.hasUsableCaptureSignal(samples: quiet, sampleRate: 16_000),
+            "quiet input above the capture floor must not be rejected as missing"
+        )
+    }
+
+    func testUsableCaptureSignalRejectsBelowFloorNoise() {
+        let inaudible = [Float](repeating: 0.0004, count: 32_000)
+
+        XCTAssertFalse(
+            AudioSignalRecovery.hasUsableCaptureSignal(samples: inaudible, sampleRate: 16_000),
+            "below-floor input must not be accepted as a usable mic artifact"
+        )
+    }
+
     func testAnalyzeComputesPeakAndFullActiveRatioForUniformLoudSamples() {
         let analysis = AudioSignalRecovery.analyze(samples: [0.1, -0.1, 0.1, -0.1], sampleRate: 16_000)
 

--- a/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
@@ -473,6 +473,16 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertFalse(failure.isRetryable)
     }
 
+    func testFailedTranscriptionRetryabilityKeepsUnusableMicrophonePermanent() {
+        let failure = FailedTranscription(
+            micAudioURL: testRoot.appendingPathComponent("mic.wav"),
+            systemAudioURL: testRoot.appendingPathComponent("system.wav"),
+            errorMessage: "Microphone audio was not usable. Open Transcripted Home to retry the saved meeting."
+        )
+
+        XCTAssertFalse(failure.isRetryable)
+    }
+
     func testLoadHealsMissingMicAudioToMergedSibling() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
@@ -24,6 +24,10 @@ final class TranscriptionPipelineErrorPolicyTests: XCTestCase {
             TranscriptionTaskManager.safeFailureDiagnosticMessage(for: PipelineError.invalidAudioFormat(detail: "bad")),
             "Invalid audio format"
         )
+        XCTAssertEqual(
+            TranscriptionTaskManager.safeFailureDiagnosticMessage(for: PipelineError.microphoneAudioUnusable),
+            "Microphone audio was not usable"
+        )
     }
 
     func testSafeFailureDiagnosticMessageRoutesTypedSystemAndModelErrors() {

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineStateTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineStateTests.swift
@@ -187,6 +187,7 @@ final class TranscriptionPipelineStateTests: XCTestCase {
 
     func testPipelineErrorMarksAudioErrorsAsNonRetryable() {
         XCTAssertFalse(PipelineError.emptyAudioFile.isRetryable)
+        XCTAssertFalse(PipelineError.microphoneAudioUnusable.isRetryable)
         XCTAssertFalse(PipelineError.noSpeechDetected.isRetryable)
         XCTAssertFalse(PipelineError.recordingTooShort(duration: 0.5).isRetryable)
         XCTAssertFalse(PipelineError.invalidAudioFormat(detail: "x").isRetryable)
@@ -204,6 +205,13 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         let description = PipelineError.recordingTooShort(duration: 1.234).errorDescription ?? ""
         XCTAssertTrue(description.contains("1.2"), "Expected duration in description, got: \(description)")
         XCTAssertTrue(description.contains("At least 2 seconds"), description)
+    }
+
+    func testPipelineErrorIdentifiesUnusableMicrophoneAudioWithoutUserData() {
+        XCTAssertEqual(
+            PipelineError.microphoneAudioUnusable.localizedDescription,
+            "Microphone audio was not usable. Open Transcripted Home to retry the saved meeting."
+        )
     }
 
     // MARK: - SpeakerNamingPolicy seam used by the runner


### PR DESCRIPTION
## Summary
- Preserve #1530 two-source first-frame readiness and add final microphone-artifact validation for sustained capture signal.
- Prevent the live meeting stop path from enqueueing or saving a meeting when system audio is missing.
- Add source-specific failure classification, deterministic UI copy, privacy-safe diagnostics, and persisted retryability coverage.

## Lineage
Follow-up to merged #1530. This PR does not duplicate its first-frame readiness gate; it closes the residual final-artifact and missing-system-source paths.

## Proof
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
- `bash scripts/ops/transcripted-qa-bench.sh --mode full`
- Focused synthetic signal, failure classification, retryability, UI, and privacy contract tests

All deterministic checks passed. Manual Bluetooth/meeting hardware proof was not performed and remains YELLOW/UNKNOWN.