### PR TITLE
[bug-hunter] Preserve ownership across delayed and cancelled work

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -100,10 +100,10 @@ private final class PhysicalShortcutDetector {
     private var activePushToTalkKeyCode: UInt32?
     private var consumedKeyCodes: Set<UInt32> = []
     private var pendingModifierShortcut: PendingModifierShortcut?
+    private var pendingModifierGeneration: UInt64 = 0
 
     private struct PendingModifierShortcut {
-        let keyCode: UInt32
-        let action: PhysicalShortcutAction
+        let press: DelayedModifierShortcutPress
         let workItem: DispatchWorkItem?
     }
 
@@ -291,12 +291,12 @@ private final class PhysicalShortcutDetector {
             return Unmanaged.passUnretained(event)
 
         case .flagsChanged:
-            if pendingModifierShortcut?.keyCode == keyCode,
+            if pendingModifierShortcut?.press.keyCode == keyCode,
                let pending = pendingModifierShortcut,
-               matchesRelease(for: pending.action, in: shortcutBindings, keyCode: keyCode, modifiers: modifiers) {
+               matchesRelease(for: pending.press.action, in: shortcutBindings, keyCode: keyCode, modifiers: modifiers) {
                 cancelPendingModifierShortcut()
-                if pending.action != .dictationPushToTalk {
-                    onShortcut?(pending.action, .press)
+                if pending.press.action != .dictationPushToTalk {
+                    onShortcut?(pending.press.action, .press)
                 }
                 return nil
             }
@@ -388,20 +388,33 @@ private final class PhysicalShortcutDetector {
 
     private func schedulePendingModifierShortcut(keyCode: UInt32, action: PhysicalShortcutAction) {
         cancelPendingModifierShortcut()
+        pendingModifierGeneration &+= 1
+        let press = DelayedModifierShortcutPress(
+            generation: pendingModifierGeneration,
+            keyCode: keyCode,
+            action: action
+        )
 
         let workItem: DispatchWorkItem?
         if action == .dictationPushToTalk {
             let delayedWorkItem = DispatchWorkItem { [weak self] in
-                guard let self,
-                      self.pendingModifierShortcut?.keyCode == keyCode,
-                      self.pendingModifierShortcut?.action == action else {
-                    return
-                }
+                guard let self else { return }
 
                 self.stateLock.lock()
-                self.pendingModifierShortcut = nil
+                defer { self.stateLock.unlock() }
+                let currentPress = self.pendingModifierShortcut?.press
+                let shouldActivate = PhysicalShortcutMatcher.shouldActivateDelayedModifierPress(
+                    current: currentPress,
+                    expected: press,
+                    isPhysicallyDown: Self.isExactPhysicalKeyDown(keyCode)
+                )
+                if currentPress == press {
+                    self.pendingModifierShortcut = nil
+                }
+                guard shouldActivate else { return }
                 self.activePushToTalkKeyCode = keyCode
-                self.stateLock.unlock()
+                // Keep press delivery inside the same lock-protected transition as
+                // ownership. Otherwise a release can enqueue before this press.
                 self.onShortcut?(action, .press)
             }
             workItem = delayedWorkItem
@@ -411,8 +424,7 @@ private final class PhysicalShortcutDetector {
         }
 
         pendingModifierShortcut = PendingModifierShortcut(
-            keyCode: keyCode,
-            action: action,
+            press: press,
             workItem: workItem
         )
     }
@@ -447,6 +459,10 @@ private final class PhysicalShortcutDetector {
         }
 
         return CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
+    }
+
+    private static func isExactPhysicalKeyDown(_ keyCode: UInt32) -> Bool {
+        CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
     }
 }
 

--- a/Sources/Capture/PhysicalShortcutMatcher.swift
+++ b/Sources/Capture/PhysicalShortcutMatcher.swift
@@ -24,7 +24,21 @@ struct PhysicalShortcutBinding {
     let binding: PhysicalDictationTriggerBinding
 }
 
+struct DelayedModifierShortcutPress: Equatable {
+    let generation: UInt64
+    let keyCode: UInt32
+    let action: PhysicalShortcutAction
+}
+
 enum PhysicalShortcutMatcher {
+    static func shouldActivateDelayedModifierPress(
+        current: DelayedModifierShortcutPress?,
+        expected: DelayedModifierShortcutPress,
+        isPhysicallyDown: Bool
+    ) -> Bool {
+        current == expected && isPhysicallyDown
+    }
+
     static func shouldSynthesizePushToTalkRelease(
         activeKeyCode: UInt32?,
         isPhysicallyDown: (UInt32) -> Bool

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -211,7 +211,7 @@ final class MeetingSessionController: ObservableObject {
     }
 
     var shouldConfirmQuitForBackgroundTranscription: Bool {
-        taskManager.hasPreservableActiveTranscriptionAudio
+        taskManager.hasActiveTranscriptionWorkRequiringQuitConfirmation
             || transcriptionQueue.isPreparingQueuedTranscriptionStart
             || !transcriptionQueue.queuedTranscriptionJobs.isEmpty
     }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -211,7 +211,9 @@ final class MeetingSessionController: ObservableObject {
     }
 
     var shouldConfirmQuitForBackgroundTranscription: Bool {
-        hasBackgroundTranscriptionWork
+        taskManager.hasPreservableActiveTranscriptionAudio
+            || transcriptionQueue.isPreparingQueuedTranscriptionStart
+            || !transcriptionQueue.queuedTranscriptionJobs.isEmpty
     }
 
     var shouldBlockDictationForActiveMeetingCapture: Bool {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -47,6 +47,19 @@ public class TranscriptionTaskManager: ObservableObject {
         activeTaskAudio.values.contains { $0.micURL != nil || $0.systemURL != nil }
     }
 
+    /// Active pipeline work that should keep quit confirmation enabled.
+    ///
+    /// Saved-audio retranscriptions and failed-row retries use already-retained
+    /// source files, so they intentionally do not enter `activeTaskAudio`. They
+    /// still need the background-work quit warning while inference is running.
+    /// Conversely, `cancelAll()` leaves non-cooperative model work in
+    /// `activeTasks` for single-flight occupancy, but marks it intentionally
+    /// cancelled after discarding any owned scratch audio. That cancelled
+    /// occupancy must not revive a misleading save-audio prompt.
+    public var hasActiveTranscriptionWorkRequiringQuitConfirmation: Bool {
+        activeTasks.keys.contains { !intentionallyCancelledTaskIds.contains($0) }
+    }
+
     public init(
         failedTranscriptionManager: FailedTranscriptionManager,
         speechToText: any SpeechToTextEngine,

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -43,6 +43,10 @@ public class TranscriptionTaskManager: ObservableObject {
     /// (tests, CLI tools) and embedders that prefer their own in-app presentation.
     public let notifier: TranscriptNotifier?
 
+    public var hasPreservableActiveTranscriptionAudio: Bool {
+        activeTaskAudio.values.contains { $0.micURL != nil || $0.systemURL != nil }
+    }
+
     public init(
         failedTranscriptionManager: FailedTranscriptionManager,
         speechToText: any SpeechToTextEngine,
@@ -1334,13 +1338,15 @@ public class TranscriptionTaskManager: ObservableObject {
                 removeManagedCleanupFile(audio.micURL, label: "cancelled live mic scratch")
                 removeManagedCleanupFile(audio.systemURL, label: "cancelled live system scratch")
             }
+            activeTaskAudio.removeValue(forKey: taskId)
             AppLogger.pipeline.info("Cancelled task", ["taskId": "\(taskId)"])
         }
-        activeTasks.removeAll()
-        activeTaskAudio.removeAll()
+        // Keep cancelled tasks in the occupancy map and counters until their task bodies exit.
+        // CoreML calls are not guaranteed to observe cancellation immediately; clearing
+        // these signals here would let a new pipeline enter the same single-instance models.
+        // Audio ownership is cleared above because cancellation deliberately discarded it;
+        // finishCancelledTaskIfNeeded removes each task from the occupancy map on exit.
         preservedTaskIdsForShutdown.removeAll()
-        activeCount = 0
-        backgroundTaskCount = 0
         publishNonFailureStatus(.idle)
     }
 

--- a/Tests/ContextCaptureEnginePolicyTests.swift
+++ b/Tests/ContextCaptureEnginePolicyTests.swift
@@ -111,6 +111,25 @@ func testContextCaptureEnginePolicy() {
         )
     }
 
+    runSuite("ContextCaptureEngine delayed modifier — exact key state and ordered delivery") {
+        let source = readContextCaptureEngineSource()
+
+        assertTrue(
+            source.contains("isPhysicallyDown: Self.isExactPhysicalKeyDown(keyCode)"),
+            "delayed modifier activation must check the bound side, not an aggregate modifier family flag"
+        )
+        assertTrue(
+            source.contains("private static func isExactPhysicalKeyDown")
+                && source.contains("CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))"),
+            "the exact-key check should query the bound virtual key state"
+        )
+        assertTrue(
+            source.contains("defer { self.stateLock.unlock() }")
+                && source.contains("self.onShortcut?(action, .press)"),
+            "delayed press ownership and delivery should remain one lock-protected transition"
+        )
+    }
+
     // MARK: - Notification.Name.hotkeysDidChange
     // The engine subscribes to this notification to re-register hotkeys when
     // HotkeyRecorderView writes new bindings. Renaming the notification would

--- a/Tests/PhysicalShortcutMatcherTests.swift
+++ b/Tests/PhysicalShortcutMatcherTests.swift
@@ -161,4 +161,51 @@ func testPhysicalShortcutMatcher() {
             "a released push-to-talk key must synthesize release if macOS dropped keyUp while the tap was disabled"
         )
     }
+
+    runSuite("PhysicalShortcutMatcher — delayed modifier press requires current ownership and a held key") {
+        let current = DelayedModifierShortcutPress(
+            generation: 2,
+            keyCode: UInt32(kVK_RightOption),
+            action: .dictationPushToTalk
+        )
+        let stale = DelayedModifierShortcutPress(
+            generation: 1,
+            keyCode: UInt32(kVK_RightOption),
+            action: .dictationPushToTalk
+        )
+
+        assertTrue(
+            PhysicalShortcutMatcher.shouldActivateDelayedModifierPress(
+                current: current,
+                expected: current,
+                isPhysicallyDown: true
+            ),
+            "the current delayed press may activate while its modifier is still held"
+        )
+        assertFalse(
+            PhysicalShortcutMatcher.shouldActivateDelayedModifierPress(
+                current: current,
+                expected: stale,
+                isPhysicallyDown: true
+            ),
+            "a cancelled or superseded work item must not consume the current pending press"
+        )
+        assertFalse(
+            PhysicalShortcutMatcher.shouldActivateDelayedModifierPress(
+                current: current,
+                expected: current,
+                isPhysicallyDown: false
+            ),
+            "a modifier released at the debounce deadline must not start push-to-talk"
+        )
+        let physicallyDownKeyCodes: Set<UInt32> = [UInt32(kVK_Option)]
+        assertFalse(
+            PhysicalShortcutMatcher.shouldActivateDelayedModifierPress(
+                current: current,
+                expected: current,
+                isPhysicallyDown: physicallyDownKeyCodes.contains(current.keyCode)
+            ),
+            "left Option staying down must not activate a released right-side bound key"
+        )
+    }
 }

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
@@ -348,6 +348,10 @@ extension TranscriptionTaskManagerMetadataTests {
         }
 
         XCTAssertTrue(manager.hasPreservableActiveTranscriptionAudio)
+        XCTAssertTrue(
+            manager.hasActiveTranscriptionWorkRequiringQuitConfirmation,
+            "live transcription should require quit confirmation before cancellation"
+        )
         manager.cancelAll()
         XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "cancelled live mic scratch audio should be deleted")
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "cancelled live system scratch audio should be deleted")
@@ -361,6 +365,10 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertFalse(
             manager.hasPreservableActiveTranscriptionAudio,
             "cancelled occupancy must not promise that already-discarded audio can be saved on quit"
+        )
+        XCTAssertFalse(
+            manager.hasActiveTranscriptionWorkRequiringQuitConfirmation,
+            "intentionally cancelled occupancy must not revive the background-work quit prompt"
         )
         XCTAssertEqual(
             manager.preserveActiveTranscriptionsForShutdown(errorMessage: "App quit during cancellation"),

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
@@ -347,9 +347,26 @@ extension TranscriptionTaskManagerMetadataTests {
             speech.didStart
         }
 
+        XCTAssertTrue(manager.hasPreservableActiveTranscriptionAudio)
         manager.cancelAll()
         XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "cancelled live mic scratch audio should be deleted")
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "cancelled live system scratch audio should be deleted")
+        XCTAssertEqual(
+            manager.activeTasks.count,
+            1,
+            "a cancelled blocking model call must keep the single-flight gate occupied until it exits"
+        )
+        XCTAssertEqual(manager.activeCount, 1, "queued work must still observe the cancelling pipeline as occupied")
+        XCTAssertEqual(manager.backgroundTaskCount, 1, "background occupancy must clear only after the model call exits")
+        XCTAssertFalse(
+            manager.hasPreservableActiveTranscriptionAudio,
+            "cancelled occupancy must not promise that already-discarded audio can be saved on quit"
+        )
+        XCTAssertEqual(
+            manager.preserveActiveTranscriptionsForShutdown(errorMessage: "App quit during cancellation"),
+            0,
+            "cancel then quit must not create a failed entry for audio that was already discarded"
+        )
         speech.release()
 
         try await waitUntil {

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
@@ -93,7 +93,10 @@ extension TranscriptionTaskManagerMetadataTests {
 
     func testSavedAudioRetranscriptionRequiresQuitConfirmationWithoutClaimingScratchOwnership() async throws {
         let speech = BlockingMetadataStubSpeechToTextEngine(transcript: "Saved audio retry completed.")
-        let manager = makeManager(speechToText: speech)
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments(duration: 2.5))
+        )
         let savedAudioDirectory = tempDirectory.appendingPathComponent("saved-meeting-audio", isDirectory: true)
         try FileManager.default.createDirectory(at: savedAudioDirectory, withIntermediateDirectories: true)
         let systemURL = savedAudioDirectory.appendingPathComponent("system_audio.wav")

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
@@ -91,6 +91,43 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertEqual(message, "Another transcript is already running. Wait for it to finish, then try again.")
     }
 
+    func testSavedAudioRetranscriptionRequiresQuitConfirmationWithoutClaimingScratchOwnership() async throws {
+        let speech = BlockingMetadataStubSpeechToTextEngine(transcript: "Saved audio retry completed.")
+        let manager = makeManager(speechToText: speech)
+        let savedAudioDirectory = tempDirectory.appendingPathComponent("saved-meeting-audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: savedAudioDirectory, withIntermediateDirectories: true)
+        let systemURL = savedAudioDirectory.appendingPathComponent("system_audio.wav")
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.startSavedAudioRetranscription(
+            micURL: nil,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Saved customer call"
+        )
+
+        try await waitUntil {
+            speech.didStart
+        }
+
+        XCTAssertTrue(
+            manager.hasActiveTranscriptionWorkRequiringQuitConfirmation,
+            "retained-audio retranscription should keep the background-work quit warning enabled"
+        )
+        XCTAssertFalse(
+            manager.hasPreservableActiveTranscriptionAudio,
+            "retained source audio must not be misclassified as app-owned scratch audio"
+        )
+
+        manager.cancelAll()
+        try await waitUntil {
+            manager.activeTasks.isEmpty
+        }
+
+        XCTAssertFalse(manager.hasActiveTranscriptionWorkRequiringQuitConfirmation)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path), "cancellation must keep retained source audio")
+    }
+
     func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileAfterSuccess() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "Imported meeting artifact."),

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRetryTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRetryTests.swift
@@ -150,8 +150,16 @@ extension TranscriptionTaskManagerMetadataTests {
             speech.didStart
         }
         XCTAssertNotNil(manager.activeTasks[failedId], "retry must register its work in activeTasks")
+        XCTAssertTrue(
+            manager.hasActiveTranscriptionWorkRequiringQuitConfirmation,
+            "an in-flight failed-meeting retry should keep the background-work quit warning enabled"
+        )
 
         manager.cancelAll()
+        XCTAssertFalse(
+            manager.hasActiveTranscriptionWorkRequiringQuitConfirmation,
+            "cancelled retry occupancy should no longer require a quit warning"
+        )
 
         // No release(): the only way the blocked engine can unwind is real task
         // cancellation reaching the in-flight inference.


### PR DESCRIPTION
## Summary

- Prevent delayed modifier push-to-talk work from starting after release, being consumed by a stale debounce generation, or delivering release before press.
- Keep a cancelled non-cooperative transcription task in the single-flight occupancy gate until its body really exits.
- Separate model occupancy from preservable audio ownership so cancel-then-quit does not create a ghost failed meeting or a misleading save-audio prompt.

## Evidence

- Modifier-only push-to-talk is delayed for chord disambiguation. The old closure checked pending state before locking, never rechecked the physical key, and unlocked before delivering press.
- cancelAll previously cleared activeTasks and counters immediately even though CoreML calls may ignore cancellation temporarily, allowing a second pipeline into single-instance models.
- Independent adversarial review found press/release ordering, left/right modifier conflation, and false quit-prompt edge cases; all were fixed and re-reviewed with no remaining patch finding.

## Verification

- bash build-deps.sh --force
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open
  - signed bundle and signature verification passed
  - launch smoke passed at 992.5 ms against a 3000 ms budget
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
  - 13,196 passed, 0 failed
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
  - core, wake recovery, and recovery merge smoke passed
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test
  - 764 executed, 13 skipped, 0 failures

## Proof boundary

- Deterministic and synthetic proof is green.
- Exact physical modifier timing on real hardware remains manual-proof unknown, so this stays draft.
- Existing build warnings about FluidAudio Sendable conformance and one unhandled fixture remain pre-existing.
- Open PR #1537 owns the separate Zoom/Bluetooth microphone contention lane.

lanes used: Codex=baseline, four subsystem audits, reproduction, implementation, adversarial rereview, full verification, PR; Claude=skipped because the local Claude lane was not authenticated; Local=skipped because LM Studio was unavailable; Windows=skipped because the worker was unavailable.