### PR TITLE
Fix release health and prompt telemetry

### DIFF
--- a/Sources/Meeting/MeetingPromptTelemetry.swift
+++ b/Sources/Meeting/MeetingPromptTelemetry.swift
@@ -13,17 +13,18 @@ enum MeetingPromptTelemetry {
         case record
         case dismiss
         case remindLater = "remind_later"
-        case expired
     }
 
     enum OutcomeKind: String {
+        case dismissed
+        case expired
+        case remindedLater = "reminded_later"
         case recordingStarted = "recording_started"
         case recordingStartFailed = "recording_start_failed"
         case transcriptSaved = "transcript_saved"
         case transcriptFailed = "transcript_failed"
         case transcriptSkipped = "transcript_skipped"
         case speakerFinalizationFailed = "speaker_finalization_failed"
-        case ignored
         case suppressed
     }
 

--- a/Sources/Observability/ActivationTelemetry.swift
+++ b/Sources/Observability/ActivationTelemetry.swift
@@ -73,10 +73,7 @@ enum ActivationTelemetry {
         case cancelled
         case deleted
         case dismissed
-        case expired
         case failed
-        case remindedLater = "reminded_later"
-        case suppressed
         case unavailable
         case windowClosed = "window_closed"
     }

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -210,13 +210,23 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             let dismissPrompt: (MeetingPromptDetector.Candidate) -> Void = { [weak self] candidate in
                 guard let self else { return }
                 let readiness = self.meetingPromptTelemetryReadiness()
+                let elapsedSeconds = self.consumeMeetingPromptShownElapsedSeconds(candidateID: candidate.id)
                 AnalyticsReporter.track(
                     "meeting_prompt_choice_made",
                     properties: MeetingPromptTelemetry.choiceProperties(
                         for: candidate,
                         readiness: readiness,
                         choiceKind: .dismiss,
-                        elapsedSeconds: self.consumeMeetingPromptShownElapsedSeconds(candidateID: candidate.id)
+                        elapsedSeconds: elapsedSeconds
+                    )
+                )
+                AnalyticsReporter.track(
+                    "meeting_prompt_outcome_recorded",
+                    properties: MeetingPromptTelemetry.outcomeProperties(
+                        for: candidate,
+                        readiness: readiness,
+                        outcomeKind: .dismissed,
+                        elapsedSeconds: elapsedSeconds
                     )
                 )
                 let backoffDecision = self.meetingPromptDetector.dismiss(candidate: candidate)
@@ -245,11 +255,26 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 let readiness = self.meetingPromptTelemetryReadiness()
                 let elapsedSeconds = self.consumeMeetingPromptShownElapsedSeconds(candidateID: candidate.id)
                 AnalyticsReporter.track(
+                    "meeting_prompt_outcome_recorded",
+                    properties: MeetingPromptTelemetry.outcomeProperties(
+                        for: candidate,
+                        readiness: readiness,
+                        outcomeKind: .expired,
+                        elapsedSeconds: elapsedSeconds
+                    )
+                )
+                _ = self.meetingPromptDetector.expire(candidate: candidate)
+            }
+            let remindPrompt: (MeetingPromptDetector.Candidate) -> Void = { [weak self] candidate in
+                guard let self else { return }
+                let readiness = self.meetingPromptTelemetryReadiness()
+                let elapsedSeconds = self.consumeMeetingPromptShownElapsedSeconds(candidateID: candidate.id)
+                AnalyticsReporter.track(
                     "meeting_prompt_choice_made",
                     properties: MeetingPromptTelemetry.choiceProperties(
                         for: candidate,
                         readiness: readiness,
-                        choiceKind: .expired,
+                        choiceKind: .remindLater,
                         elapsedSeconds: elapsedSeconds
                     )
                 )
@@ -258,61 +283,11 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                     properties: MeetingPromptTelemetry.outcomeProperties(
                         for: candidate,
                         readiness: readiness,
-                        outcomeKind: .ignored,
+                        outcomeKind: .remindedLater,
                         elapsedSeconds: elapsedSeconds
                     )
                 )
-                let backoffDecision = self.meetingPromptDetector.expire(candidate: candidate)
-                AnalyticsReporter.track(
-                    "meeting_prompt_dismissed",
-                    properties: MeetingPromptTelemetry.properties(
-                        for: candidate,
-                        readiness: readiness,
-                        backoffKind: backoffDecision.kind,
-                        signals: self.meetingPromptDetector.currentSignalSnapshot()
-                    )
-                )
-                ActivationTelemetry.trackWorkflowAbandoned(
-                    workflowKind: .meetingPrompt,
-                    stage: "prompt_shown",
-                    reasonKind: .expired,
-                    surface: .meetingOverlay,
-                    priorReadyState: MeetingPromptTelemetry.readyState(
-                        readiness: readiness
-                    )
-                )
-            }
-            let remindPrompt: (MeetingPromptDetector.Candidate) -> Void = { [weak self] candidate in
-                guard let self else { return }
-                let readiness = self.meetingPromptTelemetryReadiness()
-                AnalyticsReporter.track(
-                    "meeting_prompt_choice_made",
-                    properties: MeetingPromptTelemetry.choiceProperties(
-                        for: candidate,
-                        readiness: readiness,
-                        choiceKind: .remindLater,
-                        elapsedSeconds: self.consumeMeetingPromptShownElapsedSeconds(candidateID: candidate.id)
-                    )
-                )
-                let backoffDecision = self.meetingPromptDetector.remindSoon(candidate: candidate)
-                AnalyticsReporter.track(
-                    "meeting_prompt_dismissed",
-                    properties: MeetingPromptTelemetry.properties(
-                        for: candidate,
-                        readiness: readiness,
-                        backoffKind: backoffDecision.kind,
-                        signals: self.meetingPromptDetector.currentSignalSnapshot()
-                    )
-                )
-                ActivationTelemetry.trackWorkflowAbandoned(
-                    workflowKind: .meetingPrompt,
-                    stage: "prompt_shown",
-                    reasonKind: .remindedLater,
-                    surface: .meetingOverlay,
-                    priorReadyState: MeetingPromptTelemetry.readyState(
-                        readiness: readiness
-                    )
-                )
+                _ = self.meetingPromptDetector.remindSoon(candidate: candidate)
             }
             meetingOverlayController.onPromptRecord = recordPrompt
             meetingOverlayController.onPromptDismiss = dismissPrompt
@@ -340,15 +315,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                         for: suppression,
                         readiness: readiness,
                         signals: self.meetingPromptDetector.currentSignalSnapshot()
-                    )
-                )
-                ActivationTelemetry.trackWorkflowAbandoned(
-                    workflowKind: .meetingPrompt,
-                    stage: "pre_prompt",
-                    reasonKind: .suppressed,
-                    surface: .meetingOverlay,
-                    priorReadyState: MeetingPromptTelemetry.readyState(
-                        readiness: readiness
                     )
                 )
             }

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -1745,13 +1745,18 @@ func testAnalyticsEventPolicy() {
         )
         assertEqual(
             analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_choice_made\"", in: appSource),
-            4,
-            "choice telemetry should cover record, dismiss, remind-later, and expiry actions without counting shown inventory"
+            3,
+            "choice telemetry should cover record, dismiss, and remind-later actions; automatic expiry is an outcome, not a user choice"
         )
         assertEqual(
             analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_outcome_recorded\"", in: appSource),
-            2,
-            "app-level outcomes should cover ignored expiry and pre-prompt suppression only"
+            4,
+            "app-level outcomes should cover dismiss, expiry, remind-later, and pre-prompt suppression exactly once"
+        )
+        assertEqual(
+            analyticsPolicyOccurrenceCount(of: "ActivationTelemetry.trackWorkflowAbandoned(", in: appSource),
+            1,
+            "only an explicit user dismissal should be classified as prompt abandonment"
         )
         assertEqual(
             analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_outcome_recorded\"", in: meetingSessionSource),

--- a/Tests/MeetingPromptTelemetryTests.swift
+++ b/Tests/MeetingPromptTelemetryTests.swift
@@ -229,5 +229,20 @@ func testMeetingPromptTelemetry() async {
         assertEqual(suppressed["outcome_kind"], "suppressed", "suppression should be an outcome enum")
         assertEqual(suppressed["suppression_reason"], "own_capture_active", "suppression reason should stay enum-shaped")
         assertEqual(suppressed["elapsed_bucket"], "unknown", "missing anchors should report unknown instead of raw time")
+
+        for (kind, expected) in [
+            (MeetingPromptTelemetry.OutcomeKind.dismissed, "dismissed"),
+            (.expired, "expired"),
+            (.remindedLater, "reminded_later"),
+        ] {
+            let terminal = MeetingPromptTelemetry.outcomeProperties(
+                for: candidate,
+                readiness: readiness,
+                outcomeKind: kind,
+                elapsedSeconds: 4
+            )
+            assertEqual(terminal["outcome_kind"], expected, "prompt terminal decisions should remain distinct")
+            assertEqual(terminal["elapsed_bucket"], "lt_10s", "prompt terminal latency should stay bucketed")
+        }
     }
 }

--- a/docs/activation-lane.md
+++ b/docs/activation-lane.md
@@ -73,14 +73,19 @@ For the dashboard-to-product-task loop, use:
 
 ```bash
 python3 scripts/ops/posthog-product-dashboard-summary.py --days 30
+python3 scripts/ops/posthog-product-dashboard-summary.py --days 7 --app-version 1.1.50 --build-channel release --build-revision <revision>
 ```
 
 That script reads the five dashboard families (`100 WAU Operating`,
-`Activation`, `Reliability`, `Feature Adoption`, and `Release Health`) and
+`Activation`, `Reliability`, `Feature Adoption`, and exact-build `Release Health`) and
 outputs the biggest activation leak, biggest reliability leak, strongest
-adoption signal, under-discovered feature, release regression watch, and top
+adoption signal, under-discovered feature, current release health, and top
 three PR/task candidates. It has fixture and self-test modes so CI can check
 the ranking logic without PostHog credentials.
+
+Current release health stays `UNKNOWN` unless all three public-build fields are
+provided from confirmed release truth. Fixture mode is aggregate-only and does
+not accept exact-build filters.
 
 ## PostHog Product Context Pack
 

--- a/docs/auto-call-detection-spec.md
+++ b/docs/auto-call-detection-spec.md
@@ -480,11 +480,11 @@ falls back to the normal `dismiss` backoff so an ignored call eventually goes
 quiet. Net: up to 3 offers per call (~t+0, ~t+3.5min, ~t+7min), then silence.
 Explicit × dismissals and remind-soon behave exactly as before.
 
-**Analytics:** no new event names. Expiry reuses `meeting_prompt_dismissed` with
-`backoff_kind`/`cooldown_reason` = `expired_reoffer` and `workflow_abandoned`
-`reason_kind` = `expired`, so dashboards can now separate "user said no" from
-"user never saw it" — the number that tells us whether the prompt surface itself
-needs to be louder.
+**Analytics:** no new event names. Automatic expiry records
+`meeting_prompt_outcome_recorded.outcome_kind = expired`; it is not a user choice,
+dismissal, or abandoned workflow. Explicit dismissals keep
+`meeting_prompt_dismissed` and the conservative abandonment signal, while
+remind-later remains an explicit choice plus `outcome_kind = reminded_later`.
 
 **Coverage:** new `MicActivityMonitorTests` (output attribution + self-exclusion),
 `MeetingPromptHeuristicsTests` (output provider mapping, expiry policy),

--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -95,7 +95,12 @@ For the normal health lane's product-task loop, run:
 
 ```bash
 python3 scripts/ops/posthog-product-dashboard-summary.py --days 30
+python3 scripts/ops/posthog-product-dashboard-summary.py --days 7 --app-version 1.1.50 --build-channel release --build-revision <revision>
 ```
+
+The first command reports product behavior but leaves current release health
+`UNKNOWN`. Supply all three confirmed public-build fields for a release claim;
+fixture mode intentionally rejects exact-build filters.
 
 `health-probe.sh posthog` runs this helper automatically when credentials are
 present. The report summarizes the five product-learning dashboard families

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -166,9 +166,9 @@ aggregate reliability sizing and should not be expanded to raw device names.
 | `meeting_recording_started` | `trigger` |
 | `meeting_recording_start_failed` | `failure_kind`, `trigger` |
 | `meeting_prompt_shown` | `app_signal`, `calendar_confidence`, `call_state`, `missing_permission`, `prompt_reason`, `provider`, `route_ready`, `source` |
-| `meeting_prompt_choice_made` | `calendar_confidence`, `call_state`, `choice_kind`, `elapsed_bucket`, `prompt_reason`, `provider`, `route_ready`, `source` |
-| `meeting_prompt_dismissed` | prompt fields plus `backoff_kind`, `cooldown_reason` |
-| `meeting_prompt_outcome_recorded` | prompt fields plus `elapsed_bucket`, `outcome_kind`, optional `suppression_reason` |
+| `meeting_prompt_choice_made` | Explicit user choices only (`record`, `dismiss`, `remind_later`) plus `calendar_confidence`, `call_state`, `choice_kind`, `elapsed_bucket`, `prompt_reason`, `provider`, `route_ready`, `source` |
+| `meeting_prompt_dismissed` | Explicit dismissals only; prompt fields plus `backoff_kind`, `cooldown_reason` |
+| `meeting_prompt_outcome_recorded` | One funnel outcome (`dismissed`, `expired`, `reminded_later`, `suppressed`, or a recording/transcript terminal result) plus prompt fields, `elapsed_bucket`, and optional `suppression_reason` |
 | `meeting_prompt_record_selected` | prompt fields |
 | `meeting_prompt_suppressed` | prompt fields plus `capture_activity`, `cooldown_reason`, `suppression_reason` |
 | `meeting_mic_boost_prompt_shown` | `duration_bucket`, `trigger` |
@@ -247,7 +247,7 @@ Prefer a small number of lifecycle events over broad click tracking.
 | `meeting_speaker_review_shown` | A saved meeting has review work surfaced | `review_item_bucket`, `local_voice_bucket`, `remote_voice_bucket`, `match_suggestion_bucket`, `known_people_bucket`, `review_reason`, `surface` |
 | `meeting_speaker_review_submitted` | User saves or defers speaker review | `review_item_bucket`, `local_voice_bucket`, `remote_voice_bucket`, `match_suggestion_bucket`, `known_people_bucket`, `review_reason`, `completion_kind`, `result`, `updates_submitted_bucket`, `surface` |
 | `settings_feature_discovered` | A high-leverage feature panel is first viewed | `feature_area`, `page_id`, `source` |
-| `workflow_abandoned` | App can confidently infer abandonment without content | `workflow_kind`, `stage`, `reason_kind`, `elapsed_bucket`, `surface`, optional `prior_ready_state` |
+| `workflow_abandoned` | App can confidently infer abandonment without content; invisible suppression, automatic expiry, and remind-later are not abandonment | `workflow_kind`, `stage`, `reason_kind`, `elapsed_bucket`, `surface`, optional `prior_ready_state` |
 
 Do not add generic "button clicked" for every control. Track buttons only when
 they answer a product question: did the user start capture, grant permission,
@@ -272,10 +272,15 @@ HogQL specs behind these dashboard families. Use `--json-only` when
 dashboard-to-product-task loop. It reads aggregate PostHog signal for this
 dashboard plus Activation, Reliability, Feature Adoption, and Release Health,
 then outputs the biggest activation leak, biggest reliability leak, strongest
-adoption signal, under-discovered feature, release regression watch, and top
+adoption signal, under-discovered feature, current release health, and top
 three PR/task candidates. Fixture mode uses
 `Tests/Fixtures/posthog-product-dashboard-summary.json` so CI can verify the
 ranking logic without credentials.
+
+The helper does not infer the public release from observed build rows. Current
+release health remains `UNKNOWN` until the caller supplies the confirmed
+`app_version`, `build_channel`, and `build_revision`; fixture mode cannot apply
+those filters because its other aggregate rows do not carry build identity.
 
 ### Activation Funnel
 
@@ -287,8 +292,9 @@ permission ready -> `dictation_started` / `meeting_recording_started` ->
 -> `agent_capture_query_observed` -> `activation_return_proxy_observed`.
 
 Break out `workflow_abandoned` by `workflow_kind`, `stage`, `reason_kind`, and
-`prior_ready_state` beside the ordered funnel. Treat it as an exit map, not a
-click stream.
+`prior_ready_state` beside the ordered funnel. Treat it as a confident exit map,
+not a click stream; meeting-prompt suppression, expiry, and remind-later stay in
+the prompt outcome funnel instead.
 
 ### Dictation Reliability Funnel
 
@@ -301,9 +307,9 @@ Break down by trigger, delivery, route shape, input/output class,
 
 ### Meeting Reliability Funnel
 
-`meeting_prompt_shown` -> `meeting_prompt_choice_made` ->
-`meeting_prompt_record_selected` -> `meeting_recording_started` ->
-`meeting_prompt_outcome_recorded` -> `meeting_recording_stopped` ->
+`meeting_prompt_shown` -> explicit `meeting_prompt_choice_made` or terminal
+`meeting_prompt_outcome_recorded` -> `meeting_prompt_record_selected` ->
+`meeting_recording_started` -> `meeting_prompt_outcome_recorded` -> `meeting_recording_stopped` ->
 `meeting_transcript_saved` / failed / skipped -> speaker review ->
 summary requested -> summary finished.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,9 +86,11 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Fixture taxonomy check: `python3 scripts/ops/posthog-dashboard-queries.py --taxonomy-check --observed-fixture Tests/Fixtures/posthog-observed-event-taxonomy.json --json-only`
   - CI/offline proof: `python3 scripts/ops/posthog-dashboard-queries.py --self-test`
   - Machine output for health agents: `python3 scripts/ops/posthog-dashboard-queries.py --family all --json-only`
-- `scripts/ops/posthog-product-dashboard-summary.py` — turn the five PostHog product-learning dashboard families into ranked product tasks, with release-regression watch rows grouped by full build identity
+- `scripts/ops/posthog-product-dashboard-summary.py` — turn the five PostHog product-learning dashboard families into ranked product tasks, with current-release rows scoped by full build identity
   - Usage: `python3 scripts/ops/posthog-product-dashboard-summary.py --days 30`
+  - Exact shipped build: `python3 scripts/ops/posthog-product-dashboard-summary.py --days 7 --app-version 1.1.50 --build-channel release --build-revision <revision>`
   - Fixture usage: `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json`
+  - Release health stays `UNKNOWN` without all three confirmed public-build fields; fixture mode rejects exact-build filters
   - Writes local Markdown and JSON under `/tmp/transcripted-posthog-product-tasks/<run-id>/`
   - Self-test: `python3 scripts/ops/posthog-product-dashboard-summary.py --self-test`
 - `scripts/ops/daily-audio-reliability-check.sh` — interactive daily audio reliability loop for launch, wake, Bluetooth/device-change, meeting recovery, retry, and stop-race checks

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -132,7 +132,7 @@ class Finding:
 load_env = posthog.load_env
 sql_quote = posthog.sql_quote
 sql_list = posthog.sql_list
-app_version_filter = posthog.app_version_filter
+app_build_filter = posthog.app_build_filter
 
 
 def posthog_config() -> tuple[str, str, str]:
@@ -147,31 +147,46 @@ def rows_as_dicts(response: dict[str, Any]) -> list[dict[str, Any]]:
     return posthog.rows_as_dicts(response, DISALLOWED_OUTPUT_COLUMNS, ProductTaskReportError)
 
 
-def event_counts_query(days: int, app_version: str | None) -> str:
+def event_counts_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT event, count() AS events, uniq(distinct_id) AS devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ({sql_list(CORE_EVENTS)})
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY event
 ORDER BY event ASC
 """
 
 
-def daily_active_query(days: int, app_version: str | None) -> str:
+def daily_active_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT toDate(timestamp) AS day, uniq(distinct_id) AS active_devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ({sql_list(WORKFLOW_EVENTS)})
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY day
 ORDER BY day ASC
 """
 
 
-def reliability_breakdown_query(days: int, app_version: str | None) -> str:
+def reliability_breakdown_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   event,
@@ -182,14 +197,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ('dictation_start_failed', 'dictation_no_speech', 'dictation_audio_route_recovery_timeout', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped', 'meeting_file_import_failed', 'meeting_speaker_finalization_failed', 'local_summary_failed', 'local_meeting_summary_failed', 'workflow_recovery_failed', 'workflow_recovery_finished')
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY event, failure_kind, trigger
 ORDER BY events DESC
 LIMIT 30
 """
 
 
-def recovery_outcomes_query(days: int, app_version: str | None) -> str:
+def recovery_outcomes_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   properties['workflow_kind'] AS workflow_kind,
@@ -202,14 +222,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event = 'workflow_recovery_finished'
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY workflow_kind, failure_kind, retry_source, recovery_attempt_bucket, result
 ORDER BY events DESC
 LIMIT 30
 """
 
 
-def abandonment_breakdown_query(days: int, app_version: str | None) -> str:
+def abandonment_breakdown_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   properties['workflow_kind'] AS workflow_kind,
@@ -221,14 +246,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event = 'workflow_abandoned'
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY workflow_kind, stage, reason_kind, elapsed_bucket
 ORDER BY events DESC
 LIMIT 30
 """
 
 
-def adoption_breakdown_query(days: int, app_version: str | None) -> str:
+def adoption_breakdown_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   event,
@@ -247,14 +277,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ('activation_artifact_action_clicked', 'activation_agent_prompt_action_clicked', 'activation_agent_setup_cta_clicked', 'activation_habit_loop_actioned', 'onboarding_agent_cta_clicked', 'settings_page_viewed', 'settings_action_clicked', 'meeting_prompt_record_selected', 'meeting_file_imported', 'meeting_saved_audio_retranscription_requested', 'meeting_live_transcript_drawer_actioned', 'activation_second_artifact_saved', 'agent_capture_query_observed', 'timeline_viewed', 'timeline_card_opened', 'local_summary_requested', 'local_summary_finished', 'local_summary_failed', 'local_summary_cancelled', 'local_meeting_summary_started', 'local_meeting_summary_completed', 'local_meeting_summary_failed')
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY event, surface, artifact_kind, action_kind, agent_target, client_family, tool_kind, capture_kind, source_count_bucket, result, page_id
 ORDER BY devices DESC, events DESC
 LIMIT 50
 """
 
 
-def meeting_prompt_quality_query(days: int, app_version: str | None) -> str:
+def meeting_prompt_quality_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   properties['provider'] AS provider,
@@ -275,14 +310,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ('meeting_prompt_shown', 'meeting_prompt_choice_made', 'meeting_prompt_record_selected', 'meeting_prompt_outcome_recorded', 'meeting_prompt_dismissed', 'meeting_prompt_suppressed', 'meeting_missed_call_nudge')
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY provider, source, prompt_reason, route_ready, choice_kind, outcome_kind, elapsed_bucket
 ORDER BY shown_events DESC, devices DESC
 LIMIT 50
 """
 
 
-def speaker_trust_query(days: int, app_version: str | None) -> str:
+def speaker_trust_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   event,
@@ -297,14 +337,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ('meeting_speaker_review_shown', 'meeting_speaker_review_submitted', 'meeting_speaker_match_reviewed', 'meeting_speaker_auto_recognized', 'meeting_speaker_finalization_failed')
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY event, review_action, completion_kind, result, had_suggestion, similarity_bucket, margin_bucket
 ORDER BY events DESC
 LIMIT 50
 """
 
 
-def onboarding_friction_query(days: int, app_version: str | None) -> str:
+def onboarding_friction_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   event,
@@ -317,14 +362,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ('onboarding_permission_cta_clicked', 'onboarding_permission_status_changed', 'onboarding_primary_cta_clicked', 'product_friction_observed', 'workflow_abandoned')
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY event, step_id, stage, reason_kind, permission_kind
 ORDER BY events DESC
 LIMIT 50
 """
 
 
-def timeline_dayflow_query(days: int, app_version: str | None) -> str:
+def timeline_dayflow_query(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   event,
@@ -336,14 +386,19 @@ SELECT
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ('timeline_onboarding_completed', 'timeline_viewed', 'timeline_mode_changed', 'timeline_card_opened', 'timeline_provider_selected', 'timeline_chat_question_asked', 'timeline_batch_completed', 'timeline_batch_failed')
-  {app_version_filter(app_version)}
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY event, provider, mode, result
 ORDER BY events DESC
 LIMIT 50
 """
 
 
-def release_breakdown_query(days: int) -> str:
+def release_breakdown_query(
+    days: int,
+    app_version: str | None = None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
     return f"""
 SELECT
   properties['app_version'] AS app_version,
@@ -361,32 +416,40 @@ FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
   AND event IN ({sql_list(CORE_EVENTS)})
   AND properties['app_version'] IS NOT NULL
+  {app_build_filter(app_version, build_channel, build_revision)}
 GROUP BY app_version, build_version, build_channel, build_revision
 ORDER BY launch_devices DESC, launch_events DESC, last_seen DESC
 LIMIT 20
 """
 
 
-def fetch_report_data(days: int, app_version: str | None) -> dict[str, Any]:
+def fetch_report_data(
+    days: int,
+    app_version: str | None,
+    build_channel: str | None,
+    build_revision: str | None,
+) -> dict[str, Any]:
     load_env()
     host, project_id, token = posthog_config()
     queries = {
-        "event_counts": event_counts_query(days, app_version),
-        "daily_active": daily_active_query(days, app_version),
-        "reliability_breakdown": reliability_breakdown_query(days, app_version),
-        "recovery_outcomes": recovery_outcomes_query(days, app_version),
-        "abandonment_breakdown": abandonment_breakdown_query(days, app_version),
-        "adoption_breakdown": adoption_breakdown_query(days, app_version),
-        "meeting_prompt_quality": meeting_prompt_quality_query(days, app_version),
-        "speaker_trust": speaker_trust_query(days, app_version),
-        "onboarding_friction": onboarding_friction_query(days, app_version),
-        "timeline_dayflow": timeline_dayflow_query(days, app_version),
-        "release_breakdown": release_breakdown_query(days),
+        "event_counts": event_counts_query(days, app_version, build_channel, build_revision),
+        "daily_active": daily_active_query(days, app_version, build_channel, build_revision),
+        "reliability_breakdown": reliability_breakdown_query(days, app_version, build_channel, build_revision),
+        "recovery_outcomes": recovery_outcomes_query(days, app_version, build_channel, build_revision),
+        "abandonment_breakdown": abandonment_breakdown_query(days, app_version, build_channel, build_revision),
+        "adoption_breakdown": adoption_breakdown_query(days, app_version, build_channel, build_revision),
+        "meeting_prompt_quality": meeting_prompt_quality_query(days, app_version, build_channel, build_revision),
+        "speaker_trust": speaker_trust_query(days, app_version, build_channel, build_revision),
+        "onboarding_friction": onboarding_friction_query(days, app_version, build_channel, build_revision),
+        "timeline_dayflow": timeline_dayflow_query(days, app_version, build_channel, build_revision),
+        "release_breakdown": release_breakdown_query(days, app_version, build_channel, build_revision),
     }
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "window_days": days,
         "app_version": app_version,
+        "build_channel": build_channel,
+        "build_revision": build_revision,
         "source": {
             "kind": "posthog_hogql_aggregate",
             "host": host,
@@ -410,6 +473,8 @@ def load_fixture(path: Path) -> dict[str, Any]:
     data.setdefault("source", {"kind": "fixture", "privacy": "aggregate fixture counts only"})
     data.setdefault("window_days", 30)
     data.setdefault("app_version", None)
+    data.setdefault("build_channel", None)
+    data.setdefault("build_revision", None)
     return data
 
 
@@ -738,20 +803,35 @@ def build_timeline_dayflow(data: dict[str, Any]) -> Finding:
 
 def build_release_watch(data: dict[str, Any]) -> Finding:
     rows = [row for row in data["results"].get("release_breakdown", []) if row.get("app_version")]
+    requested = {
+        "app_version": data.get("app_version"),
+        "build_channel": data.get("build_channel"),
+        "build_revision": data.get("build_revision"),
+    }
+    for key, value in requested.items():
+        if value:
+            rows = [row for row in rows if row.get(key) == value]
+    if not all(requested.values()):
+        return Finding(
+            "Current release health",
+            f"UNKNOWN: exact public-release identity was not supplied; {len(rows)} matching build rows were observed but none is treated as current.",
+            "Pass the confirmed GitHub release app_version, build_channel, and build_revision before making a release-health claim.",
+            "low",
+            0,
+        )
     if not rows:
         return Finding(
-            "Release regression watch",
-            "No app-version rows in this window.",
-            "Keep release-health UNKNOWN until PostHog app_version rows appear.",
+            "Current release health",
+            "No rows matched the requested release identity in this window.",
+            "Keep release health UNKNOWN until PostHog reports the exact version, channel, and revision.",
             "low",
             0,
         )
     watched = max(
         rows,
         key=lambda row: (
-            as_int(row.get("failure_events")) / max(as_int(row.get("launch_devices")), 1),
-            as_int(row.get("failure_events")),
             str(row.get("last_seen") or ""),
+            as_int(row.get("launch_devices")),
         ),
     )
     launches = as_int(watched.get("launch_devices"))
@@ -770,7 +850,7 @@ def build_release_watch(data: dict[str, Any]) -> Finding:
     if str(build_channel).lower() in {"local", "dev", "debug", "main", "nightly"}:
         recommendation = "Treat this as current-main/local telemetry, not shipped-release proof. Keep it separate from shipped app_version rows."
     return Finding(
-        "Release regression watch",
+        "Current release health",
         f"{version} ({build_version}, {build_channel}, {build_revision}): launches={launches}, success_devices={successes}, failure_events={failures}.",
         recommendation,
         "medium" if launches < 10 or failures else "high",
@@ -779,7 +859,7 @@ def build_release_watch(data: dict[str, Any]) -> Finding:
 
 
 def task_priority_score(finding: Finding) -> float:
-    if finding.title == "Release regression watch":
+    if finding.title == "Current release health":
         return min(finding.score / 50, 20)
     if finding.title == "Under-discovered feature":
         return min(finding.score, 20)
@@ -838,6 +918,8 @@ def render_json(data: dict[str, Any], findings: dict[str, Finding]) -> dict[str,
         "generated_at": data["generated_at"],
         "window_days": data["window_days"],
         "app_version": data.get("app_version"),
+        "build_channel": data.get("build_channel"),
+        "build_revision": data.get("build_revision"),
         "source": data.get("source", {}),
         "dashboards": dashboard_lines(data, findings),
         "findings": {
@@ -849,6 +931,7 @@ def render_json(data: dict[str, Any], findings: dict[str, Finding]) -> dict[str,
             "speaker_trust": findings["speaker"].__dict__,
             "onboarding_friction": findings["onboarding"].__dict__,
             "timeline_dayflow": findings["timeline"].__dict__,
+            # Preserve the established machine-readable key for automation consumers.
             "release_regression_watch": findings["release"].__dict__,
         },
         "top_recommended_tasks": [finding.__dict__ for finding in task_candidates(findings)],
@@ -858,11 +941,16 @@ def render_json(data: dict[str, Any], findings: dict[str, Finding]) -> dict[str,
 def render_markdown(data: dict[str, Any], findings: dict[str, Finding]) -> str:
     result = render_json(data, findings)
     tasks = result["top_recommended_tasks"]
+    scope = data.get("app_version") or "all app versions"
+    if data.get("build_channel"):
+        scope += f", channel={data['build_channel']}"
+    if data.get("build_revision"):
+        scope += f", revision={data['build_revision']}"
     lines = [
         "# Transcripted PostHog Product Task Report",
         "",
         f"Generated: {data['generated_at']}",
-        f"Window: last {data['window_days']} days, {data.get('app_version') or 'all app versions'}",
+        f"Window: last {data['window_days']} days, {scope}",
         "",
         "Source: aggregate PostHog signal only. This report writes counts and enum buckets, not user rows, transcript text, audio references, file paths, meeting titles, URLs, or raw payloads.",
         "",
@@ -880,7 +968,7 @@ def render_markdown(data: dict[str, Any], findings: dict[str, Finding]) -> str:
         f"- Speaker trust: {findings['speaker'].metric} {findings['speaker'].recommendation}",
         f"- Onboarding friction: {findings['onboarding'].metric} {findings['onboarding'].recommendation}",
         f"- Timeline Dayflow: {findings['timeline'].metric} {findings['timeline'].recommendation}",
-        f"- Release regression watch: {findings['release'].metric} {findings['release'].recommendation}",
+        f"- Current release health: {findings['release'].metric} {findings['release'].recommendation}",
         "",
         "## Top 3 Recommended PR/Task Candidates",
         "",
@@ -940,7 +1028,7 @@ def run_self_test() -> int:
         "Speaker trust",
         "Onboarding friction",
         "Timeline Dayflow",
-        "Release regression watch",
+        "Current release health",
         "Top 3 Recommended PR/Task Candidates",
     )
     missing = [item for item in required if item not in markdown]
@@ -988,17 +1076,36 @@ def run_self_test() -> int:
         if "SELECT *" in query.upper():
             print("self-test failed: query uses SELECT *", file=sys.stderr)
             return 1
-    release_query = release_breakdown_query(30)
+    release_query = release_breakdown_query(30, "1.1.50", "release", "release123")
     if "GROUP BY app_version, build_version, build_channel, build_revision" not in release_query:
         print("self-test failed: release breakdown must group by full build identity", file=sys.stderr)
         return 1
+    for expected_filter in (
+        "properties['app_version'] = '1.1.50'",
+        "properties['build_channel'] = 'release'",
+        "properties['build_revision'] = 'release123'",
+    ):
+        if expected_filter not in release_query:
+            print(f"self-test failed: release breakdown missing exact identity filter: {expected_filter}", file=sys.stderr)
+            return 1
     release_rows = data["results"].get("release_breakdown", [])
     if not any(row.get("build_channel") == "release" for row in release_rows) or not any(row.get("build_channel") == "local" for row in release_rows):
         print("self-test failed: release fixture must include shipped and local/current-main build rows", file=sys.stderr)
         return 1
     release_metric = findings["release"].metric
-    if "localmain" not in release_metric:
-        print("self-test failed: release watch must print selected build revision/channel", file=sys.stderr)
+    if "UNKNOWN" not in release_metric or "releaseabc" in release_metric or "localmain" in release_metric:
+        print("self-test failed: release health must stay unknown without a confirmed exact public-build identity", file=sys.stderr)
+        return 1
+    exact_release_data = json.loads(json.dumps(data))
+    exact_release_data["app_version"] = "1.1.47"
+    exact_release_data["build_channel"] = "release"
+    exact_release_data["build_revision"] = "oldrelease"
+    exact_release_metric = build_release_watch(exact_release_data).metric
+    if "oldrelease" not in exact_release_metric or "releaseabc" in exact_release_metric:
+        print("self-test failed: release health did not honor the requested exact build identity", file=sys.stderr)
+        return 1
+    if "release_regression_watch" not in summary["findings"]:
+        print("self-test failed: established release summary JSON key changed", file=sys.stderr)
         return 1
     print("self-test passed")
     return 0
@@ -1007,7 +1114,9 @@ def run_self_test() -> int:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--days", type=int, default=30, help="Lookback window in days.")
-    parser.add_argument("--app-version", help="Optional app_version filter for non-release queries, e.g. 1.1.48.")
+    parser.add_argument("--app-version", help="Optional exact app_version filter, e.g. 1.1.50.")
+    parser.add_argument("--build-channel", help="Optional exact build_channel filter, normally release for shipped health.")
+    parser.add_argument("--build-revision", help="Optional exact build_revision filter for a published artifact.")
     parser.add_argument("--fixture", type=Path, help="Read aggregate fixture JSON instead of querying PostHog.")
     parser.add_argument("--write-dir", type=Path, help="Directory for product-task-report.md and product-task-report.json.")
     parser.add_argument("--json-only", action="store_true", help="Print the JSON summary instead of Markdown.")
@@ -1023,8 +1132,19 @@ def main() -> int:
     if args.days <= 0:
         print("ERROR: --days must be positive", file=sys.stderr)
         return 2
+    if args.build_revision and not args.app_version:
+        print("ERROR: --build-revision requires --app-version", file=sys.stderr)
+        return 2
+    if args.fixture and (args.app_version or args.build_channel or args.build_revision):
+        print("ERROR: exact-build filters cannot be applied to aggregate fixture rows", file=sys.stderr)
+        return 2
     try:
-        data = load_fixture(args.fixture) if args.fixture else fetch_report_data(args.days, args.app_version)
+        data = load_fixture(args.fixture) if args.fixture else fetch_report_data(
+            args.days,
+            args.app_version,
+            args.build_channel,
+            args.build_revision,
+        )
         findings = analyze(data)
         markdown = render_markdown(data, findings)
         summary = render_json(data, findings)

--- a/scripts/ops/posthog_common.py
+++ b/scripts/ops/posthog_common.py
@@ -89,9 +89,22 @@ def event_filter(events: tuple[str, ...]) -> str:
 
 
 def app_version_filter(app_version: str | None) -> str:
-    if not app_version:
-        return ""
-    return f"AND properties['app_version'] = {sql_quote(app_version)}"
+    return app_build_filter(app_version=app_version)
+
+
+def app_build_filter(
+    app_version: str | None = None,
+    build_channel: str | None = None,
+    build_revision: str | None = None,
+) -> str:
+    predicates = []
+    if app_version:
+        predicates.append(f"properties['app_version'] = {sql_quote(app_version)}")
+    if build_channel:
+        predicates.append(f"properties['build_channel'] = {sql_quote(build_channel)}")
+    if build_revision:
+        predicates.append(f"properties['build_revision'] = {sql_quote(build_revision)}")
+    return "\n  ".join(f"AND {predicate}" for predicate in predicates)
 
 
 def version_or_app_version_filter(app_version: str | None) -> str:


### PR DESCRIPTION
## Summary
- require confirmed app version, build channel, and build revision before calling PostHog rows current-release health
- keep unscoped release health UNKNOWN and reject misleading fixture filters
- classify prompt expiry, reminders, and suppression as outcomes instead of abandonment; keep explicit dismiss as the only abandonment
- preserve the existing machine-readable release summary key

## Proof
- `bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (13,196 passed)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh`
- focused prompt telemetry tests (58 passed)
- analytics policy tests (6,212 passed)
- Python compile, dashboard self-test, fixture render, and fixture-filter rejection
- `bash scripts/dev/agent-preflight.sh`

## Review
Independent review found two P2 scoping bugs in the first draft: inferred release identity and silently ignored fixture filters. Both were fixed. Final independent risk review reported no actionable findings. Proof: `/Users/redbars/.codex/maestro/runs/20260717T030843Z-telemetry-review-claude`.

## Manual boundary
No release, appcast, Homebrew, notarization, deploy, or publish action was performed. Live PostHog exact-build output remains a production-credential check; the deterministic query/fixture contract is proven here.