### PR TITLE
Remove dormant dictation live display

### DIFF
--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -8,9 +8,9 @@
 
 - `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, final dictation transcription, permission-aware input-readiness checks, short-audio gating, live level metering, and sanitized failure reporting for model init errors. Device-change recovery and model load/download/warmup/teardown are split into the two files below — ParakeetEngine remains the public-API owner and `@MainActor` home for that state; the split files are internal collaborator extensions.
 - `ParakeetDeviceRecovery.swift` — `ParakeetEngine` extension: device-change detection (CoreAudio default-input listener, `AVAudioEngineConfigurationChange` observer) and the `attemptDeviceRecovery` / `scheduleConfigRecoveryTimeout` executor that rewarms the audio graph after a route change. The pure decision tables it consults (`ParakeetDeviceRecoveryReadinessPolicy`, `ParakeetDeviceRecoveryFailurePolicy`, `ParakeetDeviceRecoveryTimeoutPolicy`) live in `ParakeetStartRecordingFailurePolicy.swift`, not here.
-- `ParakeetModelLifecycle.swift` — `ParakeetEngine` extension: model load/download/warmup/teardown paths (`initialize`, `performInitialize`, `prefetchModelFilesIfNeeded`, `initializeEouModel`, `cancelModelWork`, `teardownModel`)
+- `ParakeetModelLifecycle.swift` — `ParakeetEngine` extension: model load/download/warmup/teardown paths (`initialize`, `performInitialize`, `prefetchModelFilesIfNeeded`, `cancelModelWork`, `teardownModel`)
 - `ParakeetAudioDeviceLookup.swift` — CoreAudio default-input lookup and dictation input selection descriptors used before Parakeet starts recording
-- `ParakeetAudioEngineSupport.swift` — support types for Parakeet engine startup snapshots, retired-engine retention, default-input listener teardown, and the disabled live-display shim
+- `ParakeetAudioEngineSupport.swift` — support types for Parakeet engine startup snapshots, retired-engine retention, and default-input listener teardown
 - `WhisperEngine.swift` — app-owned WhisperKit STT engine used when advanced users select a Whisper model
 - `NemotronEngine.swift` — app-owned FluidAudio Nemotron streaming STT engine, beta-gated behind `SpeechModelBetaPreferences`; transcribes buffered samples only (recording stays in `ParakeetEngine`)
 - `DictationAudioLevelMeter.swift` — normalizes live PCM buffers into a 0...1 level used by the dictation waveform UI
@@ -36,7 +36,7 @@
 - `ParakeetEngine` consults `ParakeetStartRecordingFailurePolicy` when startup fails so format-reset, engine rebuild, and prewarm-retry behavior stay consistent across direct starts and recovery attempts.
 - `ParakeetEngine` stays `@MainActor` for app state, published UI state, and event reporting, but all `AVAudioEngine` graph work runs through its private serial audio-engine queue. Keep recording start/stop/readiness APIs async so callers do not block the main actor while CoreAudio settles, starts, stops, or rebuilds.
 - `ParakeetEngine` reports model-init failures with `ParakeetModelInitDiagnostics.failureContext(...)`, which keeps diagnostics useful for packaging/download/debugging issues without shipping raw transcript or device content.
-- Live transcript display is currently disabled in `ParakeetEngine`; the product favors stable capture and final transcription over provisional live text. Do not promise live transcript UI behavior unless that path is re-enabled and verified.
+- Dictation intentionally exposes only final transcription. The abandoned provisional-text/EOU path was removed rather than kept behind a false feature flag. A future live dictation experience must add a real streaming engine and end-to-end tests instead of reviving dormant audio-tap branches.
 - `DictationAudioLevelMeter` converts live audio buffers into normalized meter levels using `TranscriptedConstants` floor and ceiling thresholds. Keep waveform calibration changes here instead of burying them in overlay code.
 - `DictationAudioRecovery` analyzes buffered audio for usable speech signal (peak, RMS, active ratio) and can produce a focused, gain-normalized retry segment. `ParakeetEngine` uses it to retry transcription when an initial attempt returns empty rather than silently dropping audio that contained real speech.
 - The meeting pipeline reuses the same app-owned `STTRouter` through `Sources/Meeting/MeetingSTTAdapter.swift`.
@@ -55,7 +55,7 @@ Manual checks:
 
 - dictation can start and stop cleanly
 - very short recordings follow the expected drop / empty-result / transcribe behavior
-- final dictation text appears after stop/transcribe; live text remains disabled unless explicitly re-enabled
+- final dictation text appears after stop/transcribe; provisional live text is not shown
 - device changes do not leave the app stuck or force a Bluetooth headset mic when a safer built-in fallback exists
 - wake / resume does not strand buffered audio or leave recovery state hanging
 

--- a/Sources/Speech/ParakeetAudioEngineSupport.swift
+++ b/Sources/Speech/ParakeetAudioEngineSupport.swift
@@ -24,29 +24,6 @@ func unregisterDefaultInputDeviceListener(_ listener: AudioObjectPropertyListene
     }
 }
 
-// No-op shim for the dormant live-display path (liveDisplayEnabled = false).
-// FluidAudio 0.15.x ships a real `StreamingEouAsrManager` again with a different
-// API; this local declaration deliberately shadows it so the disabled code path
-// keeps compiling unchanged. Delete this shim when live display is rewired to
-// the real streaming API (phase 3 of docs/voices-model-upgrade-plan.md).
-actor StreamingEouAsrManager {
-    enum ChunkSize {
-        case ms320
-    }
-
-    init(chunkSize: ChunkSize, eouDebounceMs: Int) {}
-
-    func loadModels(modelDir: URL) async throws {}
-
-    func setPartialCallback(_ callback: @escaping @Sendable (String) -> Void) async {}
-
-    func setEouCallback(_ callback: @escaping @Sendable (String) -> Void) async {}
-
-    func process(audioBuffer: AVAudioPCMBuffer) async throws -> String { "" }
-
-    func reset() async {}
-}
-
 enum ParakeetModelState {
     case notLoaded
     case downloading(progress: Double)

--- a/Sources/Speech/ParakeetDeviceRecovery.swift
+++ b/Sources/Speech/ParakeetDeviceRecovery.swift
@@ -155,8 +155,6 @@ extension ParakeetEngine {
 
         if isRecording {
             preserveCurrentRecordingBuffersForRecovery()
-            streamingSamplesLock.withLock { streamingSampleBuffer.removeAll(keepingCapacity: true) }
-            Task { await eouManager?.reset() }
             await removeRecordingTap()
             isRecording = false
             audioLevel = 0

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -16,7 +16,6 @@ class ParakeetEngine: ObservableObject {
     @Published var isRecording = false
     @Published var isTranscribing = false
     @Published var audioLevel: Float = 0
-    @Published var liveTranscript: String = ""
     @Published var modelDownloadState: ParakeetModelState = .notLoaded
     @Published var recordingInterrupted = false
     @Published var isRecovering = false
@@ -50,19 +49,6 @@ class ParakeetEngine: ObservableObject {
     private var recentAudioEngineRebuildTimestamps: [CFAbsoluteTime] = []
     private var didReportAudioEngineRebuildChurn = false
 
-    // Live streaming text is intentionally disabled — the product focuses on
-    // stable capture and final transcription rather than provisional text.
-    nonisolated let liveDisplayEnabled = false
-    nonisolated(unsafe) var eouManager: StreamingEouAsrManager?
-    var committedStreamText: String = ""
-    // Protected by streamingSamplesLock — accessed from both the audio render thread and MainActor.
-    let streamingSamplesLock = NSLock()
-    var streamingSampleBuffer: [Float] = []
-    // Feed EOU in ~320ms chunks (shift size). The manager buffers internally and processes
-    // when it has a full chunk (10240 samples = 64 mel frames at hop=160).
-    private let eouChunkSamples: Int = 5120
-    // Cached format for makePCMBuffer — always 16kHz mono, no need to recreate per chunk
-    private let eouPCMFormat = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)
     var configChangeObserver: NSObjectProtocol?
     var configChangeDebounceTask: Task<Void, Never>?
     var configRecoveryTask: Task<Void, Never>?
@@ -1073,24 +1059,6 @@ class ParakeetEngine: ObservableObject {
                     }
                 }
 
-                if self.liveDisplayEnabled, let eou = self.eouManager {
-                    let resampled = AudioResampler.resample(monoSamples, from: effectiveSampleRate, to: 16000)
-                    let chunk: [Float]? = self.streamingSamplesLock.withLock {
-                        self.streamingSampleBuffer.append(contentsOf: resampled)
-                        guard self.streamingSampleBuffer.count >= self.eouChunkSamples else { return nil }
-                        let ready = self.streamingSampleBuffer
-                        self.streamingSampleBuffer = []
-                        return ready
-                    }
-                    if let chunk = chunk, let pcm = self.makePCMBuffer(from: chunk) {
-                        Task {
-                            do { _ = try await eou.process(audioBuffer: pcm) }
-                            catch { EventReporter.shared.capture(level: .warning, engine: "parakeet",
-                                event: "eou_process_error", message: error.localizedDescription) }
-                        }
-                    }
-                }
-
                 let truncatedSamples: Int = self.pendingSamplesLock.withLock {
                     self.pendingSamples.append(contentsOf: monoSamples)
                     let maxSamples = ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
@@ -1331,10 +1299,6 @@ class ParakeetEngine: ObservableObject {
         cancelAudioWatchdog()
         if isRecording {
             preserveCurrentRecordingBuffersForRecovery()
-            streamingSamplesLock.withLock {
-                streamingSampleBuffer.removeAll(keepingCapacity: true)
-            }
-            Task { await eouManager?.reset() }
             await removeRecordingTap()
             isRecording = false
             audioLevel = 0
@@ -1881,14 +1845,6 @@ class ParakeetEngine: ObservableObject {
 
         isRecording = true
         markFormatReadyAndPublish()
-        liveTranscript = ""
-        committedStreamText = ""
-        if liveDisplayEnabled {
-            streamingSamplesLock.withLock {
-                streamingSampleBuffer.removeAll(keepingCapacity: true)
-            }
-            Task { await eouManager?.reset() }
-        }
         AppLogger.transcription.info("PARAKEET | recording started (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
 
         // Watchdog: detect zombie audio engine (running but no usable signal after sleep/wake).
@@ -1913,14 +1869,6 @@ class ParakeetEngine: ObservableObject {
         }
         sampleBuffer.removeAll(keepingCapacity: true)
         clearRecoveredRecordingTimeline(keepingCapacity: true)
-        liveTranscript = ""
-        committedStreamText = ""
-        if liveDisplayEnabled {
-            streamingSamplesLock.withLock {
-                streamingSampleBuffer.removeAll(keepingCapacity: true)
-            }
-            Task { await eouManager?.reset() }
-        }
         sharedMeetingMicRecorder.begin()
         sharedMeetingMicTransition.beginSharedRecording()
         sharedMeetingMicRecording = true
@@ -1938,34 +1886,7 @@ class ParakeetEngine: ObservableObject {
 
     /// Called from MeetingCaptureBridge's off-tap relay queue.
     nonisolated func appendSharedMeetingMicBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard let chunk = sharedMeetingMicRecorder.append(buffer), liveDisplayEnabled else { return }
-        let resampled = AudioResampler.resample(chunk.samples, from: chunk.sampleRate, to: 16000)
-        Task { @MainActor [weak self] in
-            self?.consumeSharedMeetingMicLiveDisplaySamples(resampled)
-        }
-    }
-
-    private func consumeSharedMeetingMicLiveDisplaySamples(_ samples: [Float]) {
-        guard sharedMeetingMicRecording, let eou = eouManager else { return }
-        let chunk: [Float]? = streamingSamplesLock.withLock {
-            streamingSampleBuffer.append(contentsOf: samples)
-            guard streamingSampleBuffer.count >= eouChunkSamples else { return nil }
-            let ready = streamingSampleBuffer
-            streamingSampleBuffer = []
-            return ready
-        }
-        guard let chunk, let pcm = makePCMBuffer(from: chunk) else { return }
-        Task {
-            do { _ = try await eou.process(audioBuffer: pcm) }
-            catch {
-                EventReporter.shared.capture(
-                    level: .warning,
-                    engine: "parakeet",
-                    event: "eou_process_error",
-                    message: error.localizedDescription
-                )
-            }
-        }
+        sharedMeetingMicRecorder.append(buffer)
     }
 
     func updateSharedMeetingMicAudioLevel(_ level: Float) {
@@ -2097,9 +2018,6 @@ class ParakeetEngine: ObservableObject {
                     "sample_signal_started": "\(self.didReceiveNonZeroAudioSamples)",
                 ])
 
-            self.streamingSamplesLock.withLock {
-                self.streamingSampleBuffer.removeAll(keepingCapacity: true)
-            }
             self.pendingSamplesLock.withLock {
                 self.pendingSamples.removeAll(keepingCapacity: true)
                 self.didReportPendingSampleTruncation = false
@@ -2110,7 +2028,6 @@ class ParakeetEngine: ObservableObject {
             self.configChangeWasRecording = false
             self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent()
                 + TranscriptedConstants.selfInducedConfigChangeIgnoreWindow
-            await self.eouManager?.reset()
             await self.removeRecordingTap()
             await self.stopAudioEngine()
             self.isEnginePrewarmed = false
@@ -2182,20 +2099,6 @@ class ParakeetEngine: ObservableObject {
         }
         audioGraphGeneration += 1
         cancelAudioWatchdog()
-        if liveDisplayEnabled {
-            let remainingEou: [Float] = streamingSamplesLock.withLock {
-                let remainingEou = streamingSampleBuffer
-                streamingSampleBuffer.removeAll(keepingCapacity: true)
-                return remainingEou
-            }
-            if let eou = eouManager, !remainingEou.isEmpty, let pcm = makePCMBuffer(from: remainingEou) {
-                Task {
-                    do { _ = try await eou.process(audioBuffer: pcm) }
-                    catch { EventReporter.shared.capture(level: .warning, engine: "parakeet",
-                        event: "eou_process_error", message: error.localizedDescription) }
-                }
-            }
-        }
         await removeRecordingTap()
         await stopAudioEngine()
         await restorePendingSystemInputAfterRecording(operation: "stop_recording")
@@ -2207,10 +2110,7 @@ class ParakeetEngine: ObservableObject {
         AppLogger.transcription.info("PARAKEET | recording stopped (\(sampleBuffer.count) samples, \(String(format: "%.1f", Double(sampleBuffer.count) / stopSampleRate))s)")
     }
 
-    // MARK: - EOU Streaming (live display)
-    // Live display is driven by StreamingEouAsrManager fed via the audio tap (see startRecording).
-    // EOU callback in initializeEouModel() updates committedStreamText → liveTranscript.
-    // No explicit start/stop methods needed — tap feeds the manager, reset() clears state.
+    // MARK: - Recorded Audio Buffering
 
     private func drainPendingSamplesIntoSampleBuffer() {
         pendingSamplesLock.withLock {
@@ -2322,21 +2222,6 @@ class ParakeetEngine: ObservableObject {
             )
         }.value
         return (nativeSampleCount, resampled)
-    }
-
-    /// Convert [Float] samples to AVAudioPCMBuffer for StreamingEouAsrManager.
-    private func makePCMBuffer(from samples: [Float]) -> AVAudioPCMBuffer? {
-        guard let format = eouPCMFormat,
-              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
-        else { return nil }
-        buffer.frameLength = AVAudioFrameCount(samples.count)
-        if let dest = buffer.floatChannelData?[0] {
-            samples.withUnsafeBufferPointer { src in
-                guard let baseAddress = src.baseAddress else { return }
-                dest.update(from: baseAddress, count: samples.count)
-            }
-        }
-        return buffer
     }
 
     // MARK: - Transcription
@@ -2667,7 +2552,7 @@ class ParakeetEngine: ObservableObject {
     // MARK: - Pure-Sample Transcription (for Meeting pipeline)
 
     /// Transcribe pre-resampled 16kHz mono Float32 samples directly, bypassing
-    /// ParakeetEngine's recording lifecycle (audioEngine, sampleBuffer, EOU streaming).
+    /// ParakeetEngine's recording lifecycle and audio buffering.
     ///
     /// Used by `MeetingSTTAdapter` to satisfy Core's `SpeechToTextEngine` protocol:
     /// Core's TranscriptionPipeline owns its own recording (mic + system audio files via
@@ -2771,10 +2656,6 @@ class ParakeetEngine: ObservableObject {
         pendingSamplesLock.withLock {
             pendingSamples.removeAll(keepingCapacity: true)
         }
-        streamingSamplesLock.withLock {
-            streamingSampleBuffer.removeAll(keepingCapacity: true)
-        }
-        await eouManager?.reset()
         isRecording = false
         isTranscribing = false
         audioLevel = 0
@@ -2783,8 +2664,6 @@ class ParakeetEngine: ObservableObject {
         recordingStartedOnLikelyBluetoothHandsFreeRoute = false
         sampleBuffer.removeAll(keepingCapacity: true)
         clearRecoveredRecordingTimeline(keepingCapacity: true)
-        liveTranscript = ""
-        committedStreamText = ""
         audioGraphGeneration += 1
         let cleanupGeneration = audioGraphGeneration
         await releaseIdleAudioHardware(removeTap: true, expectedGeneration: cleanupGeneration)
@@ -2810,10 +2689,6 @@ class ParakeetEngine: ObservableObject {
         pendingSamplesLock.withLock {
             pendingSamples.removeAll(keepingCapacity: true)
         }
-        streamingSamplesLock.withLock {
-            streamingSampleBuffer.removeAll(keepingCapacity: true)
-        }
-        Task { await eouManager?.reset() }
         isRecording = false
         isTranscribing = false
         audioStartInProgress = false
@@ -2823,8 +2698,6 @@ class ParakeetEngine: ObservableObject {
         recordingStartedOnLikelyBluetoothHandsFreeRoute = false
         sampleBuffer.removeAll(keepingCapacity: true)
         clearRecoveredRecordingTimeline(keepingCapacity: true)
-        liveTranscript = ""
-        committedStreamText = ""
         schedulePendingSystemInputRestore(operation: "abandon_blocked_recording_start")
         abandonBlockedAudioEngine(reason: reason)
     }
@@ -2848,12 +2721,6 @@ class ParakeetEngine: ObservableObject {
             pendingSamples.removeAll(keepingCapacity: true)
         }
         if isRecording {
-            if liveDisplayEnabled {
-                streamingSamplesLock.withLock {
-                    streamingSampleBuffer.removeAll(keepingCapacity: true)
-                }
-                Task { await eouManager?.reset() }
-            }
             isRecording = false
             audioLevel = 0
         }
@@ -2866,8 +2733,6 @@ class ParakeetEngine: ObservableObject {
         sampleBuffer.removeAll()
         clearRecoveredRecordingTimeline(keepingCapacity: false)
         isTranscribing = false
-        liveTranscript = ""
-        committedStreamText = ""
     }
 
     private func releaseIdleAudioHardware(removeTap: Bool, expectedGeneration: Int? = nil) async {
@@ -2943,6 +2808,5 @@ class ParakeetEngine: ObservableObject {
         ParakeetRetiredAudioEngineStore.shared.retire(audioEngine, reason: "deinit")
         let mgr = asrManager
         Task { await mgr?.cleanup() }
-        eouManager = nil
     }
 }

--- a/Sources/Speech/ParakeetModelLifecycle.swift
+++ b/Sources/Speech/ParakeetModelLifecycle.swift
@@ -151,10 +151,6 @@ extension ParakeetEngine {
                 message: "Parakeet ASR models initialized successfully",
                 context: ["load_source": loadSourceName])
 
-            if liveDisplayEnabled {
-                await initializeEouModel()
-            }
-
         } catch {
             guard !Task.isCancelled, !isShuttingDown else { return }
             modelFilePrefetchTask = nil
@@ -256,85 +252,6 @@ extension ParakeetEngine {
         return true
     }
 
-    /// Load Parakeet EOU 120M for streaming live display.
-    /// Non-fatal — if EOU fails, live transcript stays empty but batch result still works.
-    private func initializeEouModel() async {
-        do {
-            let eou = StreamingEouAsrManager(chunkSize: .ms320, eouDebounceMs: 1280)
-
-            let modelDir: URL
-            if let bundlePath = bundledModelPath(subdirectory: "parakeet-eou-120m-coreml", checkFile: "streaming_encoder.mlmodelc") {
-                AppLogger.transcription.info("PARAKEET EOU | loading from bundle: \(bundlePath.path)")
-                modelDir = bundlePath
-            } else {
-                // Download from HuggingFace (~120MB) and cache locally
-                // DownloadUtils nests inside <directory>/<repo.folderName>/, so we use the parent
-                guard let appSupportRoot = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-                    AppLogger.transcription.warning("PARAKEET EOU | application support directory unavailable")
-                    EventReporter.shared.capture(
-                        level: .warning,
-                        engine: "parakeet",
-                        event: "eou_app_support_unavailable",
-                        message: "Application support directory lookup returned no results; cannot resolve EOU model cache"
-                    )
-                    return
-                }
-                let cacheBase = appSupportRoot.appendingPathComponent("FluidAudio/Models", isDirectory: true)
-                let expectedDir = cacheBase.appendingPathComponent("parakeet-eou-streaming/320ms", isDirectory: true)
-                let checkFile = expectedDir.appendingPathComponent("streaming_encoder.mlmodelc")
-                if FileManager.default.fileExists(atPath: checkFile.path) {
-                    AppLogger.transcription.info("PARAKEET EOU | loading from cache: \(expectedDir.path)")
-                    modelDir = expectedDir
-                } else {
-                    AppLogger.transcription.warning("PARAKEET EOU | streaming model download unavailable with current FluidAudio API")
-                    EventReporter.shared.capture(
-                        level: .warning,
-                        engine: "parakeet",
-                        event: "eou_model_unavailable",
-                        message: "Streaming EOU model download is unavailable with the current FluidAudio version"
-                    )
-                    return
-                }
-            }
-            try await eou.loadModels(modelDir: modelDir)
-
-            // Partial callback fires on every chunk with new tokens — live "ghost text" display
-            await eou.setPartialCallback { [weak self] partial in
-                Task { @MainActor [weak self] in
-                    guard let self = self else { return }
-                    let trimmed = partial.trimmingCharacters(in: .whitespaces)
-                    guard !trimmed.isEmpty else { return }
-                    self.liveTranscript = self.committedStreamText.isEmpty
-                        ? trimmed
-                        : self.committedStreamText + " " + trimmed
-                }
-            }
-
-            // EOU callback fires after silence — commits the utterance so partial text resets
-            await eou.setEouCallback { [weak self] transcript in
-                Task { @MainActor [weak self] in
-                    guard let self = self else { return }
-                    let trimmed = transcript.trimmingCharacters(in: .whitespaces)
-                    guard !trimmed.isEmpty else { return }
-                    self.committedStreamText = self.committedStreamText.isEmpty
-                        ? trimmed
-                        : self.committedStreamText + " " + trimmed
-                    self.liveTranscript = self.committedStreamText
-                }
-            }
-
-            eouManager = eou
-            AppLogger.transcription.info("PARAKEET EOU | streaming model ready")
-            EventReporter.shared.capture(level: .info, engine: "parakeet", event: "eou_model_loaded",
-                message: "Parakeet EOU streaming model initialized")
-        } catch {
-            // Non-fatal — live display will just stay empty until batch result arrives
-            AppLogger.transcription.warning("PARAKEET EOU | model load failed (live display disabled): \(error.localizedDescription)")
-            EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "eou_model_failed",
-                message: error.localizedDescription)
-        }
-    }
-
     /// FluidAudio 0.15.x renamed the v3 cache folder from `parakeet-tdt-0.6b-v3-coreml`
     /// to `parakeet-tdt-0.6b-v3` (ModelNames.folderName strips the suffix). Rename a
     /// 0.7.9-era cache in place so existing users keep their ~600MB download; FluidAudio
@@ -381,7 +298,7 @@ extension ParakeetEngine {
         modelFilePrefetchTask = nil
     }
 
-    /// Tear down the loaded ASR/EOU model state. Deferred (instead of an
+    /// Tear down the loaded ASR model state. Deferred (instead of an
     /// immediate `asrManager = nil`) while transcription work is still
     /// in-flight, so an active `AsrManager.transcribe()` call doesn't get its
     /// backing object released out from under it. Called from `cleanup()`.
@@ -394,7 +311,6 @@ extension ParakeetEngine {
             asrManager = nil
         }
         asrManagerReady = false
-        eouManager = nil
         modelDownloadState = .notLoaded
         if cleanupDecision == .cleanupNow {
             Task { await mgr?.cleanup() }

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -16,7 +16,6 @@ class STTRouter: ObservableObject {
     @Published var isRecording = false
     @Published var isTranscribing = false
     @Published var audioLevel: Float = 0
-    @Published var liveTranscript: String = ""
     @Published var recordingInterrupted = false
     @Published var isRecovering = false
     @Published var inputFormatReady = true
@@ -58,7 +57,6 @@ class STTRouter: ObservableObject {
         parakeetEngine.$isRecording.assign(to: &$isRecording)
         parakeetEngine.$isTranscribing.assign(to: &$isTranscribing)
         parakeetEngine.$audioLevel.assign(to: &$audioLevel)
-        parakeetEngine.$liveTranscript.assign(to: &$liveTranscript)
         parakeetEngine.$recordingInterrupted.assign(to: &$recordingInterrupted)
         parakeetEngine.$isRecovering.assign(to: &$isRecovering)
         parakeetEngine.$inputFormatReady.assign(to: &$inputFormatReady)

--- a/Sources/Speech/SharedMeetingMicRecorder.swift
+++ b/Sources/Speech/SharedMeetingMicRecorder.swift
@@ -1,11 +1,6 @@
 @preconcurrency import AVFoundation
 import Foundation
 
-struct SharedMeetingMicChunk: Sendable {
-    let samples: [Float]
-    let sampleRate: Double
-}
-
 /// Thread-safe storage for dictation samples borrowed from an active meeting.
 /// MeetingCaptureBridge delivers buffers on its relay queue, never on the
 /// CoreAudio tap thread. Synchronization makes MainActor start/stop atomic with
@@ -22,16 +17,14 @@ final class SharedMeetingMicRecorder: @unchecked Sendable {
         }
     }
 
-    @discardableResult
-    func append(_ buffer: AVAudioPCMBuffer) -> SharedMeetingMicChunk? {
-        guard let monoSamples = Self.extractMonoSamples(from: buffer), !monoSamples.isEmpty else { return nil }
+    func append(_ buffer: AVAudioPCMBuffer) {
+        guard let monoSamples = Self.extractMonoSamples(from: buffer), !monoSamples.isEmpty else { return }
         let sampleRate = ParakeetTapSampleRatePolicy.effectiveSampleRate(
             bufferSampleRate: buffer.format.sampleRate
         )
-        return lock.withLock {
-            guard isActive else { return nil }
+        lock.withLock {
+            guard isActive else { return }
             timeline.append(monoSamples, sampleRate: sampleRate)
-            return SharedMeetingMicChunk(samples: monoSamples, sampleRate: sampleRate)
         }
     }
 

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -29,7 +29,7 @@ engine boundary in `Sources/Timeline/CLAUDE.md`.
 - `Overlay/DictationSessionController.swift` — dictation session orchestration
 - `Overlay/FloatingOverlayController.swift` — owns the dictation overlay panel lifecycle and Combine subscriptions
 - `Overlay/FloatingOverlayPanel.swift` — non-activating NSPanel for the dictation overlay
-- `Overlay/OverlayDraftingView.swift` — legacy-named dictation processing and error state view
+- `Overlay/OverlayDraftingView.swift` — legacy-named dictation clipboard-notice and error state view
 - `Overlay/OverlayHeaderView.swift` — overlay title bar with centered listening layout, live waveform host, and inline stop control for active dictation
 - `Overlay/OverlayRootView.swift` — top-level AppKit view that keeps dictation compact in normal listening mode and only expands for loading or error/recovery content
 - `Overlay/OverlayTokens.swift` — design tokens (colors, spacing, sizing) for overlay views

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -220,12 +220,6 @@ class FloatingOverlayController {
             }
             .store(in: &subscriptions)
 
-        sttRouter.$isTranscribing
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                self?.pushStateToViews()
-            }
-            .store(in: &subscriptions)
     }
 
     // MARK: - State → View Push
@@ -249,11 +243,9 @@ class FloatingOverlayController {
             loadingPresentation: loadingPresentation,
             loadingElapsedSeconds: loadingElapsedSeconds,
             successTitle: successTitle,
-            isTranscribing: sttRouter?.isTranscribing ?? false,
             isRecording: sttRouter?.isRecording ?? false,
             isMiniCursorMode: isCursorMiniPanelMode,
-            audioLevel: sttRouter?.audioLevel ?? 0,
-            liveTranscript: sttRouter?.liveTranscript ?? ""
+            audioLevel: sttRouter?.audioLevel ?? 0
         )
         updatePanelMouseBehavior()
         updatePanelCornerRadius()

--- a/Sources/UI/Overlay/OverlayDraftingView.swift
+++ b/Sources/UI/Overlay/OverlayDraftingView.swift
@@ -1,5 +1,5 @@
 // OverlayDraftingView.swift
-// Content view during drafting/processing state — spinner + status or error
+// Legacy-named content view for actionable dictation errors and clipboard notices.
 
 import AppKit
 
@@ -62,17 +62,11 @@ private final class OverlaySecondaryButton: NSButton {
 
 @MainActor
 final class OverlayDraftingView: NSView {
-    private let spinner = NSProgressIndicator()
-    private let statusLabel = NSTextField(labelWithString: "")
     private let errorIcon = NSImageView()
     private let errorLabel = NSTextField(wrappingLabelWithString: "")
     private let errorActionButton = OverlaySecondaryButton(frame: .zero)
     private let errorDismissButton = NSButton(frame: .zero)
 
-    // Secondary state: dimmed transcript + "Refining..." spinner
-    private let dimmedTranscript = NSTextField(wrappingLabelWithString: "")
-    private let refiningSpinner = NSProgressIndicator()
-    private let refiningLabel = NSTextField(labelWithString: "")
     private var errorAction: (() -> Void)?
     private var errorDismiss: (() -> Void)?
 
@@ -85,25 +79,6 @@ final class OverlayDraftingView: NSView {
     required init?(coder: NSCoder) { fatalError() }
 
     private func setupViews() {
-        // Main spinner
-        spinner.style = .spinning
-        spinner.controlSize = .small
-        spinner.isIndeterminate = true
-        addSubview(spinner)
-
-        // Status text
-        statusLabel.font = NSFont.systemFont(ofSize: 12)
-        // The loading/processing status is the sole readable message in this
-        // state, so it tracks the secondary text token (matching the error and
-        // "Refining…" labels) instead of the weakest muted token, which kept it
-        // a notch under contrast on the translucent overlay over bright windows.
-        statusLabel.textColor = OverlayTokens.textSecondary
-        statusLabel.isBezeled = false
-        statusLabel.isEditable = false
-        statusLabel.drawsBackground = false
-        statusLabel.alignment = .center
-        addSubview(statusLabel)
-
         // Error icon
         applyMessageIcon(isNotice: false)
         errorIcon.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 18, weight: .regular)
@@ -140,33 +115,6 @@ final class OverlayDraftingView: NSView {
         errorDismissButton.setAccessibilityLabel("Dismiss error")
         addSubview(errorDismissButton)
 
-        // Dimmed transcript (for showing text at reduced opacity during processing)
-        dimmedTranscript.font = NSFont.systemFont(ofSize: 13)
-        dimmedTranscript.textColor = OverlayTokens.textPrimary
-        dimmedTranscript.alphaValue = 0.45
-        dimmedTranscript.isBezeled = false
-        dimmedTranscript.isEditable = false
-        dimmedTranscript.drawsBackground = false
-        dimmedTranscript.lineBreakMode = .byWordWrapping
-        dimmedTranscript.maximumNumberOfLines = 0
-        dimmedTranscript.isHidden = true
-        addSubview(dimmedTranscript)
-
-        // Refining spinner + label
-        refiningSpinner.style = .spinning
-        refiningSpinner.controlSize = .mini
-        refiningSpinner.isIndeterminate = true
-        refiningSpinner.isHidden = true
-        addSubview(refiningSpinner)
-
-        refiningLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
-        refiningLabel.textColor = OverlayTokens.textSecondary
-        refiningLabel.stringValue = "Refining..."
-        refiningLabel.isBezeled = false
-        refiningLabel.isEditable = false
-        refiningLabel.drawsBackground = false
-        refiningLabel.isHidden = true
-        addSubview(refiningLabel)
     }
 
     override func layout() {
@@ -175,66 +123,44 @@ final class OverlayDraftingView: NSView {
         let centerX = bounds.midX
         let centerY = bounds.midY
 
-        if !errorIcon.isHidden {
-            // Error mode: icon + label centered
-            let iconSize: CGFloat = 24
-            errorLabel.preferredMaxLayoutWidth = bounds.width - pad * 2
-            let labelSize = errorLabel.fittingSize
-            let buttonSize = errorActionButton.isHidden ? .zero : errorActionButton.fittingSize
-            let hasAction = !errorActionButton.isHidden
-            let buttonSpacing: CGFloat = hasAction ? 10 : 0
-            let totalHeight = iconSize + 8 + labelSize.height + buttonSpacing + buttonSize.height
-            let startY = centerY - totalHeight / 2
-            let dismissSize: CGFloat = 22
+        let iconSize: CGFloat = 24
+        errorLabel.preferredMaxLayoutWidth = bounds.width - pad * 2
+        let labelSize = errorLabel.fittingSize
+        let buttonSize = errorActionButton.isHidden ? .zero : errorActionButton.fittingSize
+        let hasAction = !errorActionButton.isHidden
+        let buttonSpacing: CGFloat = hasAction ? 10 : 0
+        let totalHeight = iconSize + 8 + labelSize.height + buttonSpacing + buttonSize.height
+        let startY = centerY - totalHeight / 2
+        let dismissSize: CGFloat = 22
 
-            errorDismissButton.frame = NSRect(
-                x: bounds.width - pad - dismissSize,
-                y: bounds.height - pad - dismissSize,
-                width: dismissSize,
-                height: dismissSize
-            )
+        errorDismissButton.frame = NSRect(
+            x: bounds.width - pad - dismissSize,
+            y: bounds.height - pad - dismissSize,
+            width: dismissSize,
+            height: dismissSize
+        )
 
-            errorIcon.frame = NSRect(
-                x: centerX - iconSize / 2,
-                y: startY + buttonSize.height + buttonSpacing + labelSize.height + 8,
-                width: iconSize,
-                height: iconSize
+        errorIcon.frame = NSRect(
+            x: centerX - iconSize / 2,
+            y: startY + buttonSize.height + buttonSpacing + labelSize.height + 8,
+            width: iconSize,
+            height: iconSize
+        )
+        errorLabel.frame = NSRect(
+            x: pad,
+            y: startY + buttonSize.height + buttonSpacing,
+            width: bounds.width - pad * 2,
+            height: labelSize.height
+        )
+        if hasAction {
+            errorActionButton.frame = NSRect(
+                x: centerX - buttonSize.width / 2,
+                y: startY,
+                width: buttonSize.width,
+                height: buttonSize.height
             )
-            errorLabel.frame = NSRect(
-                x: pad,
-                y: startY + buttonSize.height + buttonSpacing,
-                width: bounds.width - pad * 2,
-                height: labelSize.height
-            )
-            if hasAction {
-                errorActionButton.frame = NSRect(
-                    x: centerX - buttonSize.width / 2,
-                    y: startY,
-                    width: buttonSize.width,
-                    height: buttonSize.height
-                )
-            } else {
-                errorActionButton.frame = .zero
-            }
-        } else if !dimmedTranscript.isHidden {
-            // Dimmed transcript mode
-            dimmedTranscript.preferredMaxLayoutWidth = bounds.width - pad * 2
-            let transcriptSize = dimmedTranscript.fittingSize
-            dimmedTranscript.frame = NSRect(x: pad, y: bounds.height - pad - transcriptSize.height, width: bounds.width - pad * 2, height: transcriptSize.height)
-
-            // Refining label at bottom
-            let refSize = refiningLabel.fittingSize
-            let spinSize: CGFloat = 14
-            let refTotalWidth = spinSize + 6 + refSize.width
-            refiningSpinner.frame = NSRect(x: centerX - refTotalWidth / 2, y: pad, width: spinSize, height: spinSize)
-            refiningLabel.frame = NSRect(x: refiningSpinner.frame.maxX + 6, y: pad, width: refSize.width, height: refSize.height)
         } else {
-            // Default spinner + status
-            let spinSize: CGFloat = 20
-            let labelSize = statusLabel.fittingSize
-            let totalHeight = spinSize + 8 + labelSize.height
-            spinner.frame = NSRect(x: centerX - spinSize / 2, y: centerY - totalHeight / 2 + labelSize.height + 8, width: spinSize, height: spinSize)
-            statusLabel.frame = NSRect(x: pad, y: centerY - totalHeight / 2, width: bounds.width - pad * 2, height: labelSize.height)
+            errorActionButton.frame = .zero
         }
     }
 
@@ -250,67 +176,24 @@ final class OverlayDraftingView: NSView {
     }
 
     func update(
-        error: String?,
+        message: String,
         errorActionTitle: String?,
         onErrorAction: (() -> Void)?,
         isNotice: Bool = false,
-        onErrorDismiss: (() -> Void)?,
-        isTranscribing: Bool,
-        transcriptText: String,
-        statusText: String
+        onErrorDismiss: (() -> Void)?
     ) {
-        if let error = error, !error.isEmpty {
-            // Error mode
-            errorAction = onErrorAction
-            applyMessageIcon(isNotice: isNotice)
-            errorDismiss = onErrorDismiss
-            errorIcon.isHidden = false
-            errorLabel.isHidden = false
-            errorLabel.stringValue = error
-            errorDismissButton.isHidden = false
-            if let errorActionTitle, !errorActionTitle.isEmpty {
-                errorActionButton.title = errorActionTitle
-                errorActionButton.isHidden = false
-            } else {
-                errorActionButton.isHidden = true
-            }
-            spinner.isHidden = true
-            spinner.stopAnimation(nil)
-            statusLabel.isHidden = true
-            dimmedTranscript.isHidden = true
-            refiningSpinner.isHidden = true
-            refiningLabel.isHidden = true
-        } else if isTranscribing, !transcriptText.isEmpty {
-            // Dimmed transcript + refining
-            errorAction = nil
-            errorDismiss = nil
-            dimmedTranscript.isHidden = false
-            dimmedTranscript.stringValue = transcriptText
-            refiningSpinner.isHidden = false
-            refiningSpinner.startAnimation(nil)
-            refiningLabel.isHidden = false
-            spinner.isHidden = true
-            spinner.stopAnimation(nil)
-            statusLabel.isHidden = true
-            errorIcon.isHidden = true
-            errorLabel.isHidden = true
-            errorActionButton.isHidden = true
-            errorDismissButton.isHidden = true
+        errorAction = onErrorAction
+        applyMessageIcon(isNotice: isNotice)
+        errorDismiss = onErrorDismiss
+        errorIcon.isHidden = false
+        errorLabel.isHidden = false
+        errorLabel.stringValue = message
+        errorDismissButton.isHidden = false
+        if let errorActionTitle, !errorActionTitle.isEmpty {
+            errorActionButton.title = errorActionTitle
+            errorActionButton.isHidden = false
         } else {
-            // Default: spinner + status
-            errorAction = nil
-            errorDismiss = nil
-            spinner.isHidden = false
-            spinner.startAnimation(nil)
-            statusLabel.isHidden = false
-            statusLabel.stringValue = statusText
-            errorIcon.isHidden = true
-            errorLabel.isHidden = true
-            dimmedTranscript.isHidden = true
-            refiningSpinner.isHidden = true
-            refiningLabel.isHidden = true
             errorActionButton.isHidden = true
-            errorDismissButton.isHidden = true
         }
         needsLayout = true
     }

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -138,11 +138,9 @@ final class OverlayRootView: NSView {
         loadingPresentation: FloatingOverlayController.LoadingPresentation,
         loadingElapsedSeconds: Int,
         successTitle: String,
-        isTranscribing: Bool,
         isRecording: Bool,
         isMiniCursorMode: Bool,
-        audioLevel: Float,
-        liveTranscript: String
+        audioLevel: Float
     ) {
         currentState = state
         currentErrorMessage = errorMessage
@@ -185,16 +183,12 @@ final class OverlayRootView: NSView {
 
         if showMessage {
             draftingView.isHidden = false
-            let statusText = isTranscribing ? "Transcribing..." : "Processing..."
             draftingView.update(
-                error: errorMessage.isEmpty ? nil : errorMessage,
+                message: errorMessage,
                 errorActionTitle: errorActionTitle,
                 onErrorAction: onErrorAction,
                 isNotice: isNotice,
-                onErrorDismiss: onErrorDismiss,
-                isTranscribing: isTranscribing,
-                transcriptText: liveTranscript,
-                statusText: statusText
+                onErrorDismiss: onErrorDismiss
             )
         }
 

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -327,20 +327,24 @@ func testBluetoothRouteContract() {
         assertEqual(timeline.segments.first?.sampleRate, 48_000, "recorded timeline should preserve the pinned tap rate")
     }
 
-    runSuite("Bluetooth route contract - engine tap wiring keeps sample-rate pinning") {
+    runSuite("Bluetooth route contract - engine tap and final inference keep sample-rate pinning") {
         let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetEngine.swift")
         guard let tapStart = source.range(of: "private func installTapAndStartEngine"),
-              let tapEnd = source.range(of: "func removeRecordingTap", range: tapStart.upperBound..<source.endIndex) else {
-            assertTrue(false, "test should find dictation tap wiring")
+              let tapEnd = source.range(of: "func removeRecordingTap", range: tapStart.upperBound..<source.endIndex),
+              let inferenceStart = source.range(of: "private func drainRecordedSamplesForInference"),
+              let inferenceEnd = source.range(of: "// MARK: - Transcription", range: inferenceStart.upperBound..<source.endIndex) else {
+            assertTrue(false, "test should find dictation tap and final inference wiring")
             return
         }
         let tapBody = String(source[tapStart.lowerBound..<tapEnd.lowerBound])
+        let inferenceBody = String(source[inferenceStart.lowerBound..<inferenceEnd.lowerBound])
 
         guard let installTap = tapBody.range(of: "inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil)"),
               let bufferFormat = tapBody.range(of: "Self.audioFormatSummary(buffer.format)"),
               let effectiveRate = tapBody.range(of: "ParakeetTapSampleRatePolicy.effectiveSampleRate"),
               let nativeRate = tapBody.range(of: "self.nativeSampleRate = effectiveSampleRate"),
-              let resampleRate = tapBody.range(of: "from: effectiveSampleRate") else {
+              let inputRate = inferenceBody.range(of: "let inputRate = safeNativeSampleRate()"),
+              let resampleRate = inferenceBody.range(of: "from: inputRate") else {
             assertTrue(false, "dictation tap should use the delivered buffer format for sample-rate bookkeeping")
             return
         }
@@ -348,7 +352,7 @@ func testBluetoothRouteContract() {
         assertTrue(installTap.lowerBound < bufferFormat.lowerBound, "tap should be installed with CoreAudio's delivered buffer format")
         assertTrue(bufferFormat.lowerBound < effectiveRate.lowerBound, "buffer.format should feed the sample-rate policy")
         assertTrue(effectiveRate.lowerBound < nativeRate.lowerBound, "nativeSampleRate should track the effective tap-buffer rate")
-        assertTrue(nativeRate.lowerBound < resampleRate.lowerBound, "downstream resampling should use the pinned tap-buffer rate")
+        assertTrue(inputRate.lowerBound < resampleRate.lowerBound, "final inference should resample from the pinned tap-buffer rate")
     }
 
     runSuite("Bluetooth route contract - input override happens before format reads") {
@@ -388,7 +392,7 @@ func testBluetoothRouteContract() {
               let cleanupStart = source.range(of: "// MARK: - Cleanup"),
               let cleanupEnd = source.range(of: "deinit", range: cleanupStart.upperBound..<source.endIndex),
               let stopStart = source.range(of: "func stopRecording() async"),
-              let stopEnd = source.range(of: "// MARK: - EOU Streaming", range: stopStart.upperBound..<source.endIndex) else {
+              let stopEnd = source.range(of: "// MARK: - Recorded Audio Buffering", range: stopStart.upperBound..<source.endIndex) else {
             assertTrue(false, "test should find dictation audioInputSnapshot and stopRecording")
             return
         }

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -855,7 +855,7 @@ func testParakeetStartRecordingFailurePolicy() {
     runSuite("ParakeetEngine stopRecording cancels pending zombie restart while idle") {
         let source = readParakeetEngineSource()
         guard let stopStart = source.range(of: "func stopRecording()"),
-              let stopEnd = source.range(of: "// MARK: - EOU Streaming", range: stopStart.upperBound..<source.endIndex),
+              let stopEnd = source.range(of: "// MARK: - Recorded Audio Buffering", range: stopStart.upperBound..<source.endIndex),
               let cancelStart = source.range(of: "func cancelAudioWatchdog()") else {
             assertTrue(false, "test should find stopRecording and watchdog cancellation bodies")
             return
@@ -885,7 +885,7 @@ func testParakeetStartRecordingFailurePolicy() {
         guard let wakeStart = source.range(of: "private func handleSystemWake()"),
               let wakeEnd = source.range(of: "// MARK: - Recording", range: wakeStart.upperBound..<source.endIndex),
               let stopStart = source.range(of: "func stopRecording()"),
-              let stopEnd = source.range(of: "// MARK: - EOU Streaming", range: stopStart.upperBound..<source.endIndex) else {
+              let stopEnd = source.range(of: "// MARK: - Recorded Audio Buffering", range: stopStart.upperBound..<source.endIndex) else {
             assertTrue(false, "test should find wake and stopRecording bodies")
             return
         }

--- a/Tests/RecordedAudioTimelineTests.swift
+++ b/Tests/RecordedAudioTimelineTests.swift
@@ -90,19 +90,25 @@ func testRecordedAudioTimeline() {
         assertTrue(recorder.finish().isEmpty, "buffers after finish should be ignored")
     }
 
-    runSuite("Shared meeting mic path preserves live display feeding contract") {
+    runSuite("Shared meeting mic path always records borrowed PCM") {
         let source = (try? String(
             contentsOfFile: "Sources/Speech/ParakeetEngine.swift",
             encoding: .utf8
         )) ?? ""
         guard let start = source.range(of: "nonisolated func appendSharedMeetingMicBuffer"),
-              let end = source.range(of: "private func consumeSharedMeetingMicLiveDisplaySamples", range: start.upperBound..<source.endIndex) else {
-            assertTrue(false, "shared meeting mic live-display methods should remain present")
+              let end = source.range(of: "func updateSharedMeetingMicAudioLevel", range: start.upperBound..<source.endIndex) else {
+            assertTrue(false, "shared meeting mic append method should remain present")
             return
         }
-        let appendBody = String(source[start.lowerBound..<end.upperBound])
-        assertTrue(appendBody.contains("AudioResampler.resample"), "borrowed meeting PCM should be resampled for live display")
-        assertTrue(appendBody.contains("consumeSharedMeetingMicLiveDisplaySamples"), "borrowed meeting PCM should feed the EOU buffer")
+        let appendBody = String(source[start.lowerBound..<end.lowerBound])
+        assertTrue(
+            appendBody.contains("sharedMeetingMicRecorder.append(buffer)"),
+            "borrowed meeting PCM should always reach the recorder"
+        )
+        assertFalse(
+            appendBody.contains("liveDisplayEnabled"),
+            "recording borrowed meeting PCM must not depend on a provisional-text feature gate"
+        )
     }
 
     runSuite("SharedMeetingMicRecorder downmixes stereo and preserves route sample-rate changes") {

--- a/docs/voices-model-upgrade-plan.md
+++ b/docs/voices-model-upgrade-plan.md
@@ -71,12 +71,11 @@ existing users unless they opt in.
   and transcribed after the user stops talking.
 - Whisper Large V3 / Turbo via WhisperKit are the alternate choices
   (`Sources/Support/TranscriptionModelPreferences.swift`).
-- FluidAudio is pinned at **0.7.9**
-  (`scripts/entrypoints/build-deps.sh:52`). Upstream is at **0.15.4**
-  (June 16, 2026). That pin is why live display is dead: 0.7.9 dropped
-  the old streaming EOU manager, so `ParakeetAudioEngineSupport.swift`
-  carries a no-op `StreamingEouAsrManager` stub and
-  `ParakeetEngine.liveDisplayEnabled` is hardcoded `false`.
+- FluidAudio is pinned at **0.15.4**
+  (`scripts/entrypoints/build-deps.sh`). Dictation still uses the stable
+  batch Parakeet path and publishes only the final result. The old no-op
+  streaming EOU shim and its permanently-disabled audio-tap branches were
+  removed; live dictation now requires a deliberate end-to-end implementation.
 - Diarization is offline PyAnnote through `OfflineDiarizerManager`
   (`Sources/TranscriptedCore/Services/DiarizationService.swift`), with an
   unused Sortformer streaming path.
@@ -192,17 +191,15 @@ Capture the numbers we'll compare against:
 - Record model cache disk usage via `ModelCacheInventory` for the
   storage-settings story.
 
-### Phase 1 — FluidAudio 0.7.9 → 0.15.x, behavior-neutral
+### Phase 1 — FluidAudio 0.7.9 → 0.15.x, behavior-neutral (complete)
 
 The riskiest step, so it ships alone.
 
 - Bump `FLUID_AUDIO_VERSION` in `scripts/entrypoints/build-deps.sh`;
   rebuild deps (`bash build-deps.sh --force`).
 - Fix API breaks in `ParakeetEngine` / `DiarizationService` /
-  `MeetingSTTAdapter`. Expect changes around `AsrManager` init, model
-  download entry points, and diarizer config types. Keep the EOU stub in
-  `ParakeetAudioEngineSupport.swift` for now — deleting it belongs to
-  phase 3.
+  `MeetingSTTAdapter`. The obsolete EOU compatibility stub was later
+  removed because no shipped path used it.
 - Confirm model cache layout under
   `~/Library/Application Support/Transcripted/FluidAudio/Models/` is
   unchanged, or add a migration shim in `ModelCacheInventory` +
@@ -241,14 +238,12 @@ The riskiest step, so it ships alone.
 
 ### Phase 3 — live streaming display
 
-- Replace the `StreamingEouAsrManager` stub with the real FluidAudio
-  0.15.x streaming manager; delete the 0.7.9 workaround comment block.
+- Add a real FluidAudio 0.15.x streaming manager as a new, tested path.
 - Wire partial-hypothesis callbacks into the dictation overlay
   (`Sources/UI/Overlay/DictationSessionController.swift`): show gray
-  provisional text, replace with the final pass on EoU. Flip
-  `liveDisplayEnabled` into a computed property: on when the selected
-  model streams, off for batch models — Parakeet/Whisper users see
-  exactly today's behavior.
+  provisional text, replace with the final pass on EoU. Keep the
+  streaming state owned by the selected streaming engine so batch
+  Parakeet/Whisper users see exactly today's behavior.
 - Meeting drawer: feed rolling partials into the existing live transcript
   drawer. Keep CoreAudio threading rules — partials hop off the capture
   queue via deep-copied buffers before touching `@MainActor` UI state.


### PR DESCRIPTION
## Summary

- remove the disabled Parakeet EOU/provisional dictation display pipeline
- simplify the overlay to actionable error and clipboard notices
- keep final batch transcription, Bluetooth recovery, and meeting microphone forwarding unchanged

## Preserved behavior

- borrowed meeting microphone PCM is still appended unconditionally
- meeting live transcripts remain owned by the meeting pipeline
- final dictation inference still uses the pinned native sample rate
- Bluetooth input recovery and restoration paths are untouched

## Proof

- signed build and launch smoke: PASS
- full fast suite: 13,189 / 13,189
- full QA bench: PASS, 18 checks with one expected warnings-only local artifact check
- report: `/tmp/transcripted-qa-bench/qa-20260716-222503/qa-report.md`
- `git diff --check`: PASS
- independent Codex review: no actionable findings

## Manual boundary

Automated proof does not replace hardware QA. Before merging into a release candidate, manually dictate during an active meeting and end the meeting mid-dictation, confirming the dictation meter, final text, and meeting audio artifact.
