### PR TITLE
[bug-hunter] Prevent SCK recovery from undoing stop

### DIFF
--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -88,6 +88,22 @@ final class SCKRecoverySessionGate: @unchecked Sendable {
     }
 }
 
+enum SCKOfficialStopPolicy {
+    static func captureStateToStop(
+        isCapturing: Bool,
+        isWaitingForTimedOutStopCallback: Bool
+    ) -> Bool? {
+        guard !isWaitingForTimedOutStopCallback else { return nil }
+        return isCapturing
+    }
+}
+
+enum SCKStartErrorPolicy {
+    static func shouldPublish(_ error: Error, isRecoverySessionCurrent: Bool) -> Bool {
+        isRecoverySessionCurrent || !(error is AudioCaptureStaleSessionError)
+    }
+}
+
 @available(macOS 26.0, *)
 final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngine, SCStreamDelegate, @unchecked Sendable {
     @Published var errorMessage: String?
@@ -319,7 +335,11 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             } else {
                 cleanupStreamReference(stream)
             }
-            if !(error is AudioCaptureStaleSessionError) {
+            let isRecoverySessionCurrent = (try? recoverySessionGate.check(recoveryToken)) != nil
+            if SCKStartErrorPolicy.shouldPublish(
+                error,
+                isRecoverySessionCurrent: isRecoverySessionCurrent
+            ) {
                 publishErrorMessage(error.localizedDescription)
             }
             throw error
@@ -327,7 +347,10 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     }
 
     func stop() {
-        let wasCapturing = invalidateRecoverySessionAndTransitionToStopped()
+        guard let wasCapturing = invalidateRecoverySessionAndTransitionToStopped() else {
+            AppLogger.audioSystem.warning("SCKAudioCapture: previous stop still pending")
+            return
+        }
         guard let stream = stream else { return }
         let stopGeneration = currentGeneration()
         guard wasCapturing else {
@@ -345,7 +368,10 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     }
 
     func stopSync() {
-        let wasCapturing = invalidateRecoverySessionAndTransitionToStopped()
+        guard let wasCapturing = invalidateRecoverySessionAndTransitionToStopped() else {
+            AppLogger.audioSystem.warning("SCKAudioCapture: previous stop still pending")
+            return
+        }
         stopCurrentStreamSynchronously(wasCapturing: wasCapturing)
     }
 
@@ -386,10 +412,18 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         }
     }
 
-    private func invalidateRecoverySessionAndTransitionToStopped() -> Bool {
+    private func invalidateRecoverySessionAndTransitionToStopped() -> Bool? {
         captureStateLock.lock()
         recoverySessionGate.invalidate()
-        let wasCapturing = _isCapturing
+        guard let wasCapturing = SCKOfficialStopPolicy.captureStateToStop(
+            isCapturing: _isCapturing,
+            isWaitingForTimedOutStopCallback: isWaitingForTimedOutStopCallback
+        ) else {
+            isRecovering = false
+            recoveringToken = nil
+            captureStateLock.unlock()
+            return nil
+        }
         _isCapturing = false
         isRecovering = false
         recoveringToken = nil
@@ -484,8 +518,10 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             return
         }
 
-        setCapturing(true)
+        captureStateLock.lock()
+        _isCapturing = true
         isWaitingForTimedOutStopCallback = true
+        captureStateLock.unlock()
         startWatchdog(generation: currentGeneration())
         AppLogger.audioSystem.warning("SCKAudioCapture: keeping stream reference after stop timeout")
     }

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -44,6 +44,50 @@ private final class SCKStopCallbackState {
     }
 }
 
+struct SCKRecoverySessionToken: Equatable, Sendable {
+    fileprivate let generation: UInt64
+}
+
+final class SCKRecoverySessionGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var generation: UInt64 = 0
+
+    func beginSession() -> SCKRecoverySessionToken {
+        lock.lock()
+        defer { lock.unlock() }
+        generation &+= 1
+        return SCKRecoverySessionToken(generation: generation)
+    }
+
+    func currentToken() -> SCKRecoverySessionToken {
+        lock.lock()
+        defer { lock.unlock() }
+        return SCKRecoverySessionToken(generation: generation)
+    }
+
+    func invalidate() {
+        lock.lock()
+        generation &+= 1
+        lock.unlock()
+    }
+
+    func check(_ token: SCKRecoverySessionToken) throws {
+        lock.lock()
+        let isCurrent = generation == token.generation
+        lock.unlock()
+        guard isCurrent else { throw AudioCaptureStaleSessionError() }
+    }
+
+    func runPhase(
+        token: SCKRecoverySessionToken,
+        _ phase: () throws -> Void
+    ) throws {
+        try check(token)
+        try phase()
+        try check(token)
+    }
+}
+
 @available(macOS 26.0, *)
 final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngine, SCStreamDelegate, @unchecked Sendable {
     @Published var errorMessage: String?
@@ -58,6 +102,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     private var isWaitingForTimedOutStopCallback = false
     private var recoveryAttempts = 0
     private var isRecovering = false
+    private var recoveringToken: SCKRecoverySessionToken?
     // Guards `_isCapturing`, `recoveryAttempts`, and `isRecovering` so the
     // buffer-stall watchdog (`checkWatchdog`, on `watchdogQueue`), the
     // `SCStreamDelegate` callback (on ScreenCaptureKit's delegate queue), and
@@ -65,9 +110,8 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     // cannot race each other's guard-check-then-set of these fields — e.g.
     // both a buffer-stall and a `didStopWithError` callback observing
     // "not yet recovering" and both kicking off a recovery attempt.
-    // NOTE: this does not yet give full cross-file coordination with
-    // `Audio.swift`'s stop path — see the recovery block below.
     private let captureStateLock = NSLock()
+    private let recoverySessionGate = SCKRecoverySessionGate()
     private static let callbackTimeoutSeconds = 8
     private static let permissionPromptCallbackTimeoutSeconds = 120
     private static let callbackTimeout: DispatchTimeInterval = .seconds(callbackTimeoutSeconds)
@@ -104,8 +148,15 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     // MARK: - Lifecycle
 
     func prepare() throws {
+        let sessionToken = recoverySessionGate.beginSession()
+        try prepare(recoveryToken: sessionToken)
+    }
+
+    private func prepare(recoveryToken: SCKRecoverySessionToken) throws {
+        try recoverySessionGate.check(recoveryToken)
         AppLogger.audioSystem.info("SCKAudioCapture: preparing ScreenCaptureKit audio stream")
         try stopCurrentStreamBeforePrepare()
+        try recoverySessionGate.check(recoveryToken)
         let prepareGeneration = incrementGeneration()
 
         // Fetch shareable content. On first use this can be held by the macOS
@@ -125,6 +176,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             timeout: Self.permissionPromptCallbackTimeout,
             timeoutSeconds: Self.permissionPromptCallbackTimeoutSeconds
         )
+        try recoverySessionGate.check(recoveryToken)
 
         if let error = fetchError {
             AppLogger.audioSystem.error("SCKAudioCapture: failed to get shareable content", ["error": error.localizedDescription])
@@ -169,6 +221,12 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             stopStreamSynchronously(preparedStream)
             throw AudioCaptureStaleSessionError()
         }
+        do {
+            try recoverySessionGate.check(recoveryToken)
+        } catch {
+            stopStreamSynchronously(preparedStream)
+            throw error
+        }
         _audioFormat = audioFormat
         stream = preparedStream
 
@@ -179,6 +237,14 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     }
 
     func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {
+        try start(bufferCallback: bufferCallback, recoveryToken: recoverySessionGate.currentToken())
+    }
+
+    private func start(
+        bufferCallback: @escaping (AVAudioPCMBuffer) -> Void,
+        recoveryToken: SCKRecoverySessionToken
+    ) throws {
+        try recoverySessionGate.check(recoveryToken)
         guard !isWaitingForTimedOutStopCallback else {
             AppLogger.audioSystem.warning("SCKAudioCapture: refusing to start stream while previous stop is still pending")
             throw SCKCaptureTimeoutError(operation: "previous stop cleanup")
@@ -189,9 +255,10 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         }
         guard let stream = stream else {
             AppLogger.audioSystem.info("SCKAudioCapture: auto-preparing in start()")
-            try prepare()
+            let preparedToken = recoverySessionGate.beginSession()
+            try prepare(recoveryToken: preparedToken)
             guard self.stream != nil else { throw "SCKAudioCapture: prepare failed silently" }
-            return try start(bufferCallback: bufferCallback)
+            return try start(bufferCallback: bufferCallback, recoveryToken: preparedToken)
         }
         let startGeneration = currentGeneration()
 
@@ -221,6 +288,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         var didRequestStart = false
         do {
             try stream.addStreamOutput(output, type: .audio, sampleHandlerQueue: queue)
+            try recoverySessionGate.check(recoveryToken)
 
             // Start capture — synchronous wait since we're on a background thread.
             let semaphore = DispatchSemaphore(value: 0)
@@ -231,6 +299,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
                 semaphore.signal()
             }
             try Self.waitForCallback(semaphore, operation: "start capture")
+            try recoverySessionGate.check(recoveryToken)
 
             if let error = startError {
                 throw error
@@ -239,8 +308,8 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             guard currentGeneration() == startGeneration, self.stream === stream else {
                 throw AudioCaptureStaleSessionError()
             }
-            setCapturing(true)
             startWatchdog(generation: startGeneration)
+            try transitionToCapturing(recoveryToken: recoveryToken)
             AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
         } catch {
             AppLogger.audioSystem.error("SCKAudioCapture: start failed", ["error": error.localizedDescription])
@@ -250,15 +319,18 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             } else {
                 cleanupStreamReference(stream)
             }
-            publishErrorMessage(error.localizedDescription)
+            if !(error is AudioCaptureStaleSessionError) {
+                publishErrorMessage(error.localizedDescription)
+            }
             throw error
         }
     }
 
     func stop() {
+        let wasCapturing = invalidateRecoverySessionAndTransitionToStopped()
         guard let stream = stream else { return }
         let stopGeneration = currentGeneration()
-        guard transitionToStopped() else {
+        guard wasCapturing else {
             cleanupIfCurrent(generation: stopGeneration, stream: stream)
             return
         }
@@ -273,13 +345,19 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     }
 
     func stopSync() {
+        let wasCapturing = invalidateRecoverySessionAndTransitionToStopped()
+        stopCurrentStreamSynchronously(wasCapturing: wasCapturing)
+    }
+
+    private func stopCurrentStreamSynchronously(wasCapturing: Bool? = nil) {
         guard let stream = stream else { return }
         guard !isWaitingForTimedOutStopCallback else {
             AppLogger.audioSystem.warning("SCKAudioCapture: previous stop still pending")
             return
         }
         let stopGeneration = currentGeneration()
-        guard transitionToStopped() else {
+        let shouldStopCapture = wasCapturing ?? transitionToStopped()
+        guard shouldStopCapture else {
             cleanupIfCurrent(generation: stopGeneration, stream: stream)
             return
         }
@@ -300,12 +378,23 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             throw SCKCaptureTimeoutError(operation: "previous stop cleanup")
         }
 
-        stopSync()
+        stopCurrentStreamSynchronously()
 
         guard !isWaitingForTimedOutStopCallback, stream == nil else {
             AppLogger.audioSystem.warning("SCKAudioCapture: refusing to prepare new stream because previous stream is still stopping")
             throw SCKCaptureTimeoutError(operation: "previous stop cleanup")
         }
+    }
+
+    private func invalidateRecoverySessionAndTransitionToStopped() -> Bool {
+        captureStateLock.lock()
+        recoverySessionGate.invalidate()
+        let wasCapturing = _isCapturing
+        _isCapturing = false
+        isRecovering = false
+        recoveringToken = nil
+        captureStateLock.unlock()
+        return wasCapturing
     }
 
     private func incrementGeneration() -> UInt64 {
@@ -339,6 +428,13 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         captureStateLock.lock()
         _isCapturing = value
         captureStateLock.unlock()
+    }
+
+    private func transitionToCapturing(recoveryToken: SCKRecoverySessionToken) throws {
+        captureStateLock.lock()
+        defer { captureStateLock.unlock() }
+        try recoverySessionGate.check(recoveryToken)
+        _isCapturing = true
     }
 
     /// Atomically checks that capture is currently active and flips it to
@@ -561,37 +657,44 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         // `didStopWithError`) cannot both observe "not yet recovering" and
         // both kick off a recovery attempt.
         captureStateLock.lock()
-        guard recoveryAttempts < Self.maxRecoveryAttempts, !isRecovering else {
+        guard _isCapturing,
+              recoveryAttempts < Self.maxRecoveryAttempts,
+              !isRecovering else {
             captureStateLock.unlock()
             return
         }
         recoveryAttempts += 1
         isRecovering = true
+        let recoveryToken = recoverySessionGate.currentToken()
+        recoveringToken = recoveryToken
         captureStateLock.unlock()
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
             defer {
                 self.captureStateLock.lock()
-                self.isRecovering = false
+                if self.recoveringToken == recoveryToken {
+                    self.isRecovering = false
+                    self.recoveringToken = nil
+                }
                 self.captureStateLock.unlock()
             }
-            // NOTE: this only prevents two recovery attempts from racing each
-            // other (above). It does not yet fully coordinate with an
-            // official stop initiated from Audio.swift's stop()/stopSync()
-            // path — if such a stop completes while this recovery is between
-            // its own stopSync()/prepare()/start() calls, the recovery can
-            // still restart capture after the caller believed capture had
-            // stopped. Full cross-file coordination with Audio.swift's stop
-            // path is a larger follow-up.
             do {
                 AppLogger.audioSystem.info("SCKAudioCapture: attempting stream recovery", [
                     "attempt": "\(self.recoveryAttempts)"
                 ])
-                self.stopSync()
-                try self.prepare()
-                try self.start(bufferCallback: callback)
+                try self.recoverySessionGate.runPhase(token: recoveryToken) {
+                    self.stopCurrentStreamSynchronously()
+                }
+                try self.recoverySessionGate.runPhase(token: recoveryToken) {
+                    try self.prepare(recoveryToken: recoveryToken)
+                }
+                try self.recoverySessionGate.runPhase(token: recoveryToken) {
+                    try self.start(bufferCallback: callback, recoveryToken: recoveryToken)
+                }
                 AppLogger.audioSystem.info("SCKAudioCapture: stream recovery succeeded")
+            } catch is AudioCaptureStaleSessionError {
+                AppLogger.audioSystem.info("SCKAudioCapture: recovery cancelled by stop")
             } catch {
                 AppLogger.audioSystem.error("SCKAudioCapture: stream recovery failed", [
                     "error": error.localizedDescription

--- a/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureRecoveryTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureRecoveryTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import TranscriptedCore
+
+final class SCKAudioCaptureRecoveryTests: XCTestCase {
+    func testStopBeforeQueuedRecoveryPreventsEveryPhase() throws {
+        let gate = SCKRecoverySessionGate()
+        let token = gate.beginSession()
+        gate.invalidate()
+        var phases: [String] = []
+
+        XCTAssertThrowsError(try gate.runPhase(token: token) { phases.append("stop") })
+        XCTAssertEqual(phases, [], "An official stop must cancel recovery before its first queued action.")
+    }
+
+    func testStopDuringRecoveryStopPreventsPrepareAndStart() throws {
+        let gate = SCKRecoverySessionGate()
+        let token = gate.beginSession()
+        var phases: [String] = []
+
+        XCTAssertThrowsError(
+            try gate.runPhase(token: token) {
+                phases.append("stop")
+                gate.invalidate()
+            }
+        )
+        XCTAssertThrowsError(try gate.runPhase(token: token) { phases.append("prepare") })
+        XCTAssertThrowsError(try gate.runPhase(token: token) { phases.append("start") })
+        XCTAssertEqual(phases, ["stop"], "Stop invalidation must prevent recovery from preparing or restarting SCK.")
+    }
+
+    func testStopDuringRecoveryPreparePreventsStart() throws {
+        let gate = SCKRecoverySessionGate()
+        let token = gate.beginSession()
+        var phases: [String] = []
+
+        try gate.runPhase(token: token) { phases.append("stop") }
+        XCTAssertThrowsError(
+            try gate.runPhase(token: token) {
+                phases.append("prepare")
+                gate.invalidate()
+            }
+        )
+        XCTAssertThrowsError(try gate.runPhase(token: token) { phases.append("start") })
+        XCTAssertEqual(phases, ["stop", "prepare"], "A stop racing prepare must prevent the later SCK start.")
+    }
+
+    func testStopDuringRecoveryStartPreventsSuccess() throws {
+        let gate = SCKRecoverySessionGate()
+        let token = gate.beginSession()
+        var reportedRecovered = false
+
+        XCTAssertThrowsError(
+            try gate.runPhase(token: token) {
+                gate.invalidate()
+            }
+        )
+        if (try? gate.check(token)) != nil {
+            reportedRecovered = true
+        }
+
+        XCTAssertFalse(reportedRecovered, "A stop racing start must keep recovery from reporting capture restarted.")
+    }
+}

--- a/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureRecoveryTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureRecoveryTests.swift
@@ -2,6 +2,44 @@ import XCTest
 @testable import TranscriptedCore
 
 final class SCKAudioCaptureRecoveryTests: XCTestCase {
+    func testOrdinaryStaleGenerationStartErrorStillPublishes() {
+        XCTAssertTrue(
+            SCKStartErrorPolicy.shouldPublish(
+                AudioCaptureStaleSessionError(),
+                isRecoverySessionCurrent: true
+            )
+        )
+    }
+
+    func testOfficialStopCancellationKeepsStaleStartErrorSilent() {
+        XCTAssertFalse(
+            SCKStartErrorPolicy.shouldPublish(
+                AudioCaptureStaleSessionError(),
+                isRecoverySessionCurrent: false
+            )
+        )
+    }
+
+    func testRepeatedStopPreservesTimedOutStreamCaptureState() {
+        XCTAssertNil(
+            SCKOfficialStopPolicy.captureStateToStop(
+                isCapturing: true,
+                isWaitingForTimedOutStopCallback: true
+            ),
+            "a repeated stop must not clear the retained live-stream state while the first callback is pending"
+        )
+    }
+
+    func testFirstStopTransitionsActiveCapture() {
+        XCTAssertEqual(
+            SCKOfficialStopPolicy.captureStateToStop(
+                isCapturing: true,
+                isWaitingForTimedOutStopCallback: false
+            ),
+            true
+        )
+    }
+
     func testStopBeforeQueuedRecoveryPreventsEveryPhase() throws {
         let gate = SCKRecoverySessionGate()
         let token = gate.beginSession()


### PR DESCRIPTION
## Summary

- give each ScreenCaptureKit lifecycle a recovery session token
- invalidate recovery synchronously when official stop begins
- guard recovery stop, prepare, start, and capturing-state transitions
- cover stop races before and during every recovery phase

## Proof

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-integration-smoke.sh`
- focused recovery tests (4 passed)
- full `swift test` (768 passed, 13 external-fixture skips)
- `bash run-tests.sh` (13,189 passed)
- `git diff --check`

## Manual boundary

Real macOS ScreenCaptureKit/TCC recovery hardware behavior was not exercised.
