### PR TITLE
[bug-hunter] Keep microphone recovery generation-owned

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -577,7 +577,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     // Audio file recording
     var systemAudioFile: AVAudioFile?
-    var micAudioFile: AVAudioFile?
+    var micAudioFileOwnership = MicWriterOwnership<AVAudioFile>()
     let systemAudioFileQueue = DispatchQueue(label: "SystemAudioFileWrite", qos: .utility)
     let micAudioFileQueue = DispatchQueue(label: "MicAudioFileWrite", qos: .utility)
 
@@ -1328,7 +1328,9 @@ public class Audio: ObservableObject, @unchecked Sendable {
         let engineRef = self.engine
         let inputNodeRef = self.inputNode
         let systemCaptureRef = self.systemAudioCapture
-        let micAudioFileRef = micAudioFileQueue.sync { self.micAudioFile }
+        let micAudioFileRef = micAudioFileQueue.sync {
+            self.micAudioFileOwnership.takeWriterAndInvalidate(for: stopGeneration)
+        }
         let systemAudioFileRef = systemAudioFileQueue.sync { self.systemAudioFile }
         // Use the original mic URL (set at recording start), not the potentially-overwritten
         // recovery URL. Device recovery creates a new WAV segment but the original file
@@ -1422,9 +1424,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
             cleanupGroup.enter()
             self.micAudioFileQueue.async { [weak self] in
                 if let self, let micAudioFileRef {
-                    if let currentMicFile = self.micAudioFile, currentMicFile === micAudioFileRef {
-                        self.micAudioFile = nil
-                    }
                     // Close explicitly so the WAV header is finalized here on
                     // the serial queue before cleanupGroup.notify hands the
                     // file to the merger. Waiting for deinit is racy: other

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -13,6 +13,50 @@ enum MicCaptureRestartReason {
     case processingChange
 }
 
+/// Queue-confined ownership for the shared microphone writer. Recovery is a
+/// two-step retire/install operation, so the generation stays claimed while
+/// the old file is closed and the replacement is created. A newer recording
+/// can replace that claim, causing the stale recovery install to fail.
+struct MicWriterOwnership<Writer: AnyObject> {
+    private(set) var writer: Writer?
+    private(set) var generation: UInt64?
+
+    @discardableResult
+    mutating func installSessionWriter(_ writer: Writer, generation: UInt64) -> Writer? {
+        let displacedWriter = self.writer
+        self.writer = writer
+        self.generation = generation
+        return displacedWriter
+    }
+
+    mutating func takeWriterOwned(by generation: UInt64) -> Writer? {
+        guard self.generation == generation, let writer else { return nil }
+        self.writer = nil
+        return writer
+    }
+
+    mutating func installRecoveryWriter(_ writer: Writer, generation: UInt64) -> Bool {
+        guard self.generation == generation, self.writer == nil else { return false }
+        self.writer = writer
+        return true
+    }
+
+    mutating func takeWriterAndInvalidate(for generation: UInt64) -> Writer? {
+        let writer = self.writer
+        self.writer = nil
+        self.generation = generation
+        return writer
+    }
+
+    @discardableResult
+    mutating func removeIfOwned(_ writer: Writer, generation: UInt64) -> Bool {
+        guard self.generation == generation, self.writer === writer else { return false }
+        self.writer = nil
+        return true
+    }
+
+}
+
 /// Extension handling mic device recovery, watchdog timer, and sleep/wake resilience.
 /// Runs on background threads — NOT @MainActor.
 extension Audio {
@@ -201,13 +245,20 @@ extension Audio {
 
         let channelCountChanged = oldChannelCount != recordingSnapshot.channelCount
         var recoverySegmentURL: URL?
+        var recoveryWriter: AVAudioFile?
+        var recoveryWriterWasInstalled = false
         var shouldKeepRecoverySegment = false
         defer {
             if let recoverySegmentURL, !shouldKeepRecoverySegment {
-                micAudioFileQueue.sync {
-                    if micAudioFile?.url == recoverySegmentURL {
-                        micAudioFile?.close()
-                        micAudioFile = nil
+                if let recoveryWriter {
+                    let shouldCloseWriter = !recoveryWriterWasInstalled || micAudioFileQueue.sync {
+                        micAudioFileOwnership.removeIfOwned(
+                            recoveryWriter,
+                            generation: sessionGeneration
+                        )
+                    }
+                    if shouldCloseWriter {
+                        recoveryWriter.close()
                     }
                 }
                 try? FileManager.default.removeItem(at: recoverySegmentURL)
@@ -225,10 +276,16 @@ extension Audio {
         // Close explicitly so the retiring segment's WAV header is finalized
         // before the merger can ever read it. Even same-rate device switches
         // need a new segment so the missing-buffer interval can be padded.
-        micAudioFileQueue.sync {
-            micAudioFile?.close()
-            micAudioFile = nil
+        guard let retiringWriter = micAudioFileQueue.sync(execute: {
+            micAudioFileOwnership.takeWriterOwned(by: sessionGeneration)
+        }) else {
+            AppLogger.audioMic.info("Skipping recovery because mic writer ownership changed", [
+                "expectedSession": "\(sessionGeneration)",
+                "currentSession": "\(recordingSessionGeneration)"
+            ])
+            return
         }
+        retiringWriter.close()
 
         let captureDir = self.paths.audioCaptures
         try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
@@ -249,7 +306,21 @@ extension Audio {
                 interleaved: monoFormat.isInterleaved
             )
             FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
-            micAudioFileQueue.sync { micAudioFile = newFile }
+            recoveryWriter = newFile
+            let installed = micAudioFileQueue.sync {
+                micAudioFileOwnership.installRecoveryWriter(
+                    newFile,
+                    generation: sessionGeneration
+                )
+            }
+            guard installed else {
+                AppLogger.audioMic.info("Skipping stale recovery writer replacement", [
+                    "expectedSession": "\(sessionGeneration)",
+                    "currentSession": "\(recordingSessionGeneration)"
+                ])
+                return
+            }
+            recoveryWriterWasInstalled = true
             AppLogger.audioMic.info("Created recovery audio file", ["file": fileURL.lastPathComponent])
         } catch {
             AppLogger.audioMic.error("Failed to create recovery audio file", ["error": error.localizedDescription])

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -277,12 +277,19 @@ extension Audio {
             }
 
             // Save as mono WAV file
-            micAudioFile = try AVAudioFile(
+            let newMicAudioFile = try AVAudioFile(
                 forWriting: fileURL,
                 settings: monoFormat.settings,
                 commonFormat: monoFormat.commonFormat,
                 interleaved: monoFormat.isInterleaved
             )
+            let displacedMicAudioFile = micAudioFileQueue.sync {
+                micAudioFileOwnership.installSessionWriter(
+                    newMicAudioFile,
+                    generation: sessionGeneration
+                )
+            }
+            displacedMicAudioFile?.close()
             FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
             journalSession = recordingJournal.begin(primaryMicURL: fileURL)
             AppLogger.audioMic.info("Saving as mono", ["sampleRate": "\(recordingSnapshot.sampleRate)"])
@@ -390,7 +397,7 @@ extension Audio {
         micAudioFileQueue.async { [weak self] in
             guard let self = self,
                   self.consecutiveMicWriteErrors < self.maxConsecutiveWriteErrors,
-                  let audioFile = self.micAudioFile,
+                  let audioFile = self.micAudioFileOwnership.writer,
                   let monoFormat = self.monoOutputFormat else { return }
 
             do {

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -329,7 +329,12 @@ final class AudioInitializationTests: XCTestCase {
         audio.micSegments = [MicRecordingSegment(url: oldMicURL)]
         audio.micAudioFileURL = oldMicURL
         audio.systemAudioFileURL = oldSystemURL
-        audio.micAudioFileQueue.sync { audio.micAudioFile = oldMicFile }
+        _ = audio.micAudioFileQueue.sync {
+            audio.micAudioFileOwnership.installSessionWriter(
+                oldMicFile,
+                generation: audio.recordingSessionGeneration
+            )
+        }
         audio.systemAudioFileQueue.sync { audio.systemAudioFile = oldSystemFile }
 
         let lockHeld = expectation(description: "audio graph lock held")
@@ -358,7 +363,12 @@ final class AudioInitializationTests: XCTestCase {
         audio.micSegments = [MicRecordingSegment(url: newMicURL)]
         audio.micAudioFileURL = newMicURL
         audio.systemAudioFileURL = newSystemURL
-        audio.micAudioFileQueue.sync { audio.micAudioFile = newMicFile }
+        _ = audio.micAudioFileQueue.sync {
+            audio.micAudioFileOwnership.installSessionWriter(
+                newMicFile,
+                generation: audio.recordingSessionGeneration
+            )
+        }
         audio.systemAudioFileQueue.sync { audio.systemAudioFile = newSystemFile }
 
         releaseLock.signal()
@@ -371,7 +381,9 @@ final class AudioInitializationTests: XCTestCase {
         XCTAssertEqual(audio.micAudioFileURL, newMicURL)
         XCTAssertEqual(audio.systemAudioFileURL, newSystemURL)
 
-        let activeMicFile = audio.micAudioFileQueue.sync { audio.micAudioFile }
+        let activeMicFile = audio.micAudioFileQueue.sync {
+            audio.micAudioFileOwnership.writer
+        }
         let activeSystemFile = audio.systemAudioFileQueue.sync { audio.systemAudioFile }
         XCTAssertNotNil(activeMicFile)
         XCTAssertNotNil(activeSystemFile)

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioStateTransitionTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioStateTransitionTests.swift
@@ -5,6 +5,8 @@ import XCTest
 @available(macOS 14.0, *)
 final class AudioStateTransitionTests: XCTestCase {
 
+    private final class TestMicWriter {}
+
     private var rootURL: URL!
 
     override func setUp() {
@@ -200,6 +202,42 @@ final class AudioStateTransitionTests: XCTestCase {
         XCTAssertNil(audio.lastRecoveryTime)
         XCTAssertEqual(audio.systemAudioStatus, .healthy)
         XCTAssertNil(audio.systemAudioSilenceStart)
+    }
+
+    func testStaleRecoveryCannotReplaceNewRecordingMicWriter() {
+        var ownership = MicWriterOwnership<TestMicWriter>()
+        let oldWriter = TestMicWriter()
+        let recoveryWriter = TestMicWriter()
+        let newRecordingWriter = TestMicWriter()
+
+        ownership.installSessionWriter(oldWriter, generation: 1)
+        XCTAssertTrue(ownership.takeWriterOwned(by: 1) === oldWriter)
+
+        // Deterministic race: a new recording claims the shared slot after
+        // stale recovery retired its own writer but before it can replace it.
+        ownership.installSessionWriter(newRecordingWriter, generation: 2)
+
+        XCTAssertFalse(ownership.installRecoveryWriter(recoveryWriter, generation: 1))
+        XCTAssertFalse(ownership.removeIfOwned(recoveryWriter, generation: 1))
+        XCTAssertTrue(ownership.writer === newRecordingWriter)
+        XCTAssertEqual(ownership.generation, 2)
+    }
+
+    func testStopInvalidationPreventsStaleRecoveryWriterInstall() {
+        var ownership = MicWriterOwnership<TestMicWriter>()
+        let oldWriter = TestMicWriter()
+        let recoveryWriter = TestMicWriter()
+
+        ownership.installSessionWriter(oldWriter, generation: 7)
+        XCTAssertTrue(ownership.takeWriterOwned(by: 7) === oldWriter)
+
+        // Official stop wins the queue after recovery retires the writer but
+        // before it creates and installs the replacement segment.
+        XCTAssertNil(ownership.takeWriterAndInvalidate(for: 8))
+
+        XCTAssertFalse(ownership.installRecoveryWriter(recoveryWriter, generation: 7))
+        XCTAssertNil(ownership.writer)
+        XCTAssertEqual(ownership.generation, 8)
     }
 
     // MARK: - AudioGap description


### PR DESCRIPTION
## Summary

- bind the shared microphone writer to the recording generation that created it
- let recovery retire and replace only a writer it still owns
- invalidate ownership synchronously on official stop
- cover stale recovery versus newer recording and stop races

## Proof

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-integration-smoke.sh`
- ownership race tests (46 passed)
- Audio package tests (221 passed, 1 skipped)
- full `swift test` (766 passed, 13 external-fixture skips)
- `bash run-tests.sh` (13,189 passed)
- `git diff --check`

## Manual boundary

Real microphone/device-switch hardware recovery was not exercised.
