### PR TITLE
Decouple failed meeting retry storage

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -7,7 +7,7 @@
 ## Files
 
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles, retained-audio URLs, and retry metadata
-- `FailedMeetingStore.swift` — failed-meeting queue/persistence/retry bookkeeping split out of `MeetingSessionController` (audit 2026-07-08 wave 2). Plain owned object, not an `ObservableObject`; the controller still owns the published `failedMeetings` surface and lends this store callback access for state it doesn't own
+- `FailedMeetingStore.swift` — failed-meeting queue/persistence/retry bookkeeping split out of `MeetingSessionController` (audit 2026-07-08 wave 2). Plain owned object, not an `ObservableObject`; the controller still owns the published `failedMeetings` surface and injects managers plus narrow weak callbacks for readiness, refresh, and diagnostics
 - `TranscriptionQueueCoordinator.swift` — background-transcription queue/dispatch bookkeeping split out of `MeetingSessionController` (audit 2026-07-08 wave 2). Drives the controller's state/display-status transitions via callbacks; job dispatch reaches back into the controller for `taskManager` and live-sidecar bookkeeping
 - `MeetingCaptureHealthTelemetry.swift` — coarse, privacy-safe telemetry for capture-health signals (mic/system audio dropouts, recovery outcomes) surfaced during a recording
 - `MeetingPromptTelemetry.swift` — `MeetingPromptCallTelemetry` and the bucketed funnel-event emission for detected-call/prompt outcomes
@@ -96,7 +96,7 @@
 - `MeetingFailureCopy` is the canonical place for human-facing failed-meeting titles and details. Keep retry messaging centralized there.
 - `MeetingSessionUIPolicy` is the canonical place for deciding whether background meeting work should still surface as an active transcribing/saving state. Speaker review alone should not keep that state visible.
 - `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `TranscriptionQueueCoordinator` (called by `MeetingSessionController`), not in ad hoc background tasks.
-- Failed-meeting queue/persistence/retry bookkeeping belongs in `FailedMeetingStore`, not scattered back into `MeetingSessionController`. Both extracted objects are plain code-motion splits (audit 2026-07-08 wave 2): they still reach back into the controller via a `controller` callback for state they don't own, and legacy nested-type references (`FailedMeetingItem`, `QueuedTranscriptionJob`, `BackgroundTranscriptionWorkSnapshot`) stay resolvable as typealiases on the controller.
+- Failed-meeting queue/persistence/retry bookkeeping belongs in `FailedMeetingStore`, not scattered back into `MeetingSessionController`. The failed store receives its managers plus narrow weak callbacks and must not regain a controller back-reference. `TranscriptionQueueCoordinator` still reaches back into the controller for queue-owned state transitions. Legacy nested-type references (`FailedMeetingItem`, `QueuedTranscriptionJob`, `BackgroundTranscriptionWorkSnapshot`) stay resolvable as typealiases on the controller.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
 - Local meeting summaries rewrite the saved transcript after a slow local model run. Always re-read the transcript before writing and fail closed if transcript text changed while generation was in flight. Keep provider-specific setup and metadata explicit so Gemma MLX and Apple Foundation Models summaries remain distinguishable.
 

--- a/Sources/Meeting/FailedMeetingStore.swift
+++ b/Sources/Meeting/FailedMeetingStore.swift
@@ -1,10 +1,9 @@
 // FailedMeetingStore.swift
 // Failed-meeting queue/persistence/retry bookkeeping extracted from
-// MeetingSessionController (audit 2026-07-08 wave 2, W2-B). Pure code motion —
-// no behavior change. This is a plain owned object (not an ObservableObject);
+// MeetingSessionController (audit 2026-07-08 wave 2, W2-B). This is a plain
+// owned object (not an ObservableObject); runtime behavior stays unchanged.
 // MeetingSessionController still owns the `@Published var failedMeetings`
-// surface and calls back into the controller for state it doesn't itself own
-// (`taskManager`, `failedManager`, diagnostics helpers) via `controller`.
+// surface and supplies narrow callbacks for the state transitions it owns.
 //
 // MeetingSessionController.FailedMeetingItem stays resolvable via a typealias
 // on the controller so every existing call site (Settings/Home UI,
@@ -29,29 +28,49 @@ final class FailedMeetingStore {
         let audioURLs: [URL]
     }
 
-    unowned let controller: MeetingSessionController
+    private let taskManager: TranscriptionTaskManager
+    private let failedManager: FailedTranscriptionManager
+    private let canRetry: () -> Bool
+    private let prepareModelsForRetry: () async -> Bool
+    private let markRetryStarted: () -> Void
+    private let publishRefresh: () -> Void
+    private let diagnosticsContext: ([String: String]) -> [String: String]
 
     private var retryingFailedMeetingIDs: Set<UUID> = []
     private var failedAudioCompressionTask: Task<Void, Never>?
     private var failedAudioCompressionNeedsReschedule = false
 
-    init(controller: MeetingSessionController) {
-        self.controller = controller
+    init(
+        taskManager: TranscriptionTaskManager,
+        failedManager: FailedTranscriptionManager,
+        canRetry: @escaping () -> Bool,
+        prepareModelsForRetry: @escaping () async -> Bool,
+        markRetryStarted: @escaping () -> Void,
+        publishRefresh: @escaping () -> Void,
+        diagnosticsContext: @escaping ([String: String]) -> [String: String]
+    ) {
+        self.taskManager = taskManager
+        self.failedManager = failedManager
+        self.canRetry = canRetry
+        self.prepareModelsForRetry = prepareModelsForRetry
+        self.markRetryStarted = markRetryStarted
+        self.publishRefresh = publishRefresh
+        self.diagnosticsContext = diagnosticsContext
     }
 
     @discardableResult
     func retryFailedMeeting(id: UUID) -> Bool {
-        guard !controller.isRecording, !controller.hasBackgroundTranscriptionWork, !controller.isSpeakerReviewPending else { return false }
+        guard canRetry() else { return false }
         guard !retryingFailedMeetingIDs.contains(id) else { return false }
-        guard controller.failedManager.failedTranscriptions.contains(where: { $0.id == id }) else {
-            controller.refreshFailedMeetings()
+        guard failedManager.failedTranscriptions.contains(where: { $0.id == id }) else {
+            publishRefresh()
             return false
         }
 
         failedAudioCompressionTask?.cancel()
         retryingFailedMeetingIDs.insert(id)
-        controller.activeTranscriptionTrigger = .unknown
-        controller.refreshFailedMeetings()
+        markRetryStarted()
+        publishRefresh()
         let retryStartedAt = CFAbsoluteTimeGetCurrent()
         WorkflowRecoveryTelemetry.attempted(
             workflowKind: "meeting_transcription",
@@ -63,17 +82,16 @@ final class FailedMeetingStore {
 
         Task { [weak self] in
             guard let self else { return }
-            await self.controller.prepareModels()
-            guard case .ready = self.controller.state else {
+            guard await self.prepareModelsForRetry() else {
                 DiagnosticsTrail.record(
                     level: .warning,
                     engine: "meeting",
                     event: "meeting_failed_retry_blocked_models",
                     message: "Failed meeting retry blocked because models were not ready",
-                    context: self.controller.baseDiagnosticsContext(extra: ["failed_id": id.uuidString])
+                    context: self.diagnosticsContext(["failed_id": id.uuidString])
                 )
                 self.retryingFailedMeetingIDs.remove(id)
-                self.controller.refreshFailedMeetings()
+                self.publishRefresh()
                 WorkflowRecoveryTelemetry.finished(
                     workflowKind: "meeting_transcription",
                     failureKind: "failed_meeting",
@@ -86,12 +104,12 @@ final class FailedMeetingStore {
                 return
             }
 
-            let retryPublished = await self.controller.taskManager.retryFailedTranscription(
+            let retryPublished = await self.taskManager.retryFailedTranscription(
                 failedId: id,
                 outputFolder: MeetingStoragePaths.transcriptsFolder
             )
             self.retryingFailedMeetingIDs.remove(id)
-            self.controller.refreshFailedMeetings()
+            self.publishRefresh()
             WorkflowRecoveryTelemetry.finished(
                 workflowKind: "meeting_transcription",
                 failureKind: "failed_meeting",
@@ -108,17 +126,17 @@ final class FailedMeetingStore {
     @discardableResult
     func dismissFailedMeeting(id: UUID) -> Bool {
         retryingFailedMeetingIDs.remove(id)
-        let didDismiss = controller.failedManager.removeFailedTranscription(id: id)
-        controller.refreshFailedMeetings()
-        return didDismiss || !controller.failedManager.failedTranscriptions.contains(where: { $0.id == id })
+        let didDismiss = failedManager.removeFailedTranscription(id: id)
+        publishRefresh()
+        return didDismiss || !failedManager.failedTranscriptions.contains(where: { $0.id == id })
     }
 
     @discardableResult
     func deleteFailedMeeting(id: UUID) -> Bool {
         retryingFailedMeetingIDs.remove(id)
-        let didDelete = controller.failedManager.deleteFailedTranscription(id: id)
-        controller.refreshFailedMeetings()
-        return didDelete || !controller.failedManager.failedTranscriptions.contains(where: { $0.id == id })
+        let didDelete = failedManager.deleteFailedTranscription(id: id)
+        publishRefresh()
+        return didDelete || !failedManager.failedTranscriptions.contains(where: { $0.id == id })
     }
 
     @discardableResult
@@ -131,7 +149,7 @@ final class FailedMeetingStore {
         recordingDate: Date? = nil,
         archiveAudio: Bool = true
     ) -> Bool {
-        let preserved = controller.taskManager.addFailedTranscriptionRetainingAvailableAudio(
+        let preserved = taskManager.addFailedTranscriptionRetainingAvailableAudio(
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
             errorMessage: errorMessage,
@@ -141,20 +159,20 @@ final class FailedMeetingStore {
             archiveAudio: archiveAudio
         )
         if preserved {
-            controller.refreshFailedMeetings()
+            publishRefresh()
         }
         return preserved
     }
 
     func refreshTimedOutFailedMeetingAudio(id: UUID, result: CaptureStopResult) {
-        let existingFailure = controller.failedManager.failedTranscriptions
+        let existingFailure = failedManager.failedTranscriptions
             .first(where: { $0.id == id })
         let existingMicURL = existingFailure?.micAudioURL
         let existingSystemURL = existingFailure?.systemAudioURL
         guard let micURL = result.micURL ?? existingMicURL else { return }
         let systemURL = result.systemURL ?? existingSystemURL
 
-        let updated = controller.taskManager.promoteFinalizedFailedTranscriptionAudio(
+        let updated = taskManager.promoteFinalizedFailedTranscriptionAudio(
             id: id,
             micAudioURL: micURL,
             systemAudioURL: systemURL
@@ -166,16 +184,14 @@ final class FailedMeetingStore {
             message: updated
                 ? "Timed-out meeting audio finalized and failed queue was refreshed"
                 : "Timed-out meeting audio finalized but failed queue entry was not found",
-            context: controller.baseDiagnosticsContext(
-                extra: [
-                    "failed_id": id.uuidString,
-                    "mic_file_present": controller.boolString(FileManager.default.fileExists(atPath: micURL.path)),
-                    "system_file_present": controller.boolString(systemURL.map { FileManager.default.fileExists(atPath: $0.path) } ?? false)
-                ]
-            )
+            context: diagnosticsContext([
+                "failed_id": id.uuidString,
+                "mic_file_present": boolString(FileManager.default.fileExists(atPath: micURL.path)),
+                "system_file_present": boolString(systemURL.map { FileManager.default.fileExists(atPath: $0.path) } ?? false)
+            ])
         )
         if updated {
-            controller.refreshFailedMeetings()
+            publishRefresh()
         }
     }
 
@@ -184,7 +200,7 @@ final class FailedMeetingStore {
     /// its own `@Published var failedMeetings` (kept on the controller —
     /// this store never touches the published surface directly).
     func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) -> [FailedMeetingItem] {
-        let failedTranscriptions = updatedFailedTranscriptions ?? controller.failedManager.failedTranscriptions
+        let failedTranscriptions = updatedFailedTranscriptions ?? failedManager.failedTranscriptions
         retryingFailedMeetingIDs.formIntersection(Set(failedTranscriptions.map(\.id)))
 
         let items = failedTranscriptions
@@ -234,7 +250,7 @@ final class FailedMeetingStore {
                               !self.retryingFailedMeetingIDs.contains(update.id) else {
                             return false
                         }
-                        return self.controller.failedManager.updateFailedTranscriptionAudio(
+                        return self.failedManager.updateFailedTranscriptionAudio(
                             id: update.id,
                             micAudioURL: update.micAudioURL,
                             systemAudioURL: update.systemAudioURL
@@ -247,9 +263,13 @@ final class FailedMeetingStore {
                 self?.failedAudioCompressionTask = nil
                 self?.failedAudioCompressionNeedsReschedule = false
                 if shouldReschedule, let self {
-                    self.scheduleFailedAudioCompression(for: self.controller.failedManager.failedTranscriptions)
+                    self.scheduleFailedAudioCompression(for: self.failedManager.failedTranscriptions)
                 }
             }
         }
+    }
+
+    private func boolString(_ value: Bool) -> String {
+        value ? "true" : "false"
     }
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -151,7 +151,7 @@ final class MeetingSessionController: ObservableObject {
     let liveTranscriptFeed = LiveMeetingTranscriptFeed()
     let services: AppServices
     let taskManager: TranscriptionTaskManager
-    let failedManager: FailedTranscriptionManager
+    private let failedManager: FailedTranscriptionManager
     let diarization: DiarizationService
     let sttAdapter: MeetingSTTAdapter
     private let speakerDatabase: SpeakerDatabase
@@ -162,13 +162,10 @@ final class MeetingSessionController: ObservableObject {
     /// Failed-meeting queue/persistence/retry bookkeeping (audit 2026-07-08
     /// wave 2, W2-B). Plain owned object — this controller stays the single
     /// ObservableObject; `failedMeetings` below is still published here.
-    /// Implicitly-unwrapped: `FailedMeetingStore` holds an `unowned` back
-    /// reference to this controller, so it can only be constructed with
-    /// `self` — which Swift only allows once every OTHER stored property is
-    /// set. A plain `let` here would make `self` unusable for its own
-    /// assignment; this is constructed once, immediately, in `init` and
-    /// never nil afterward.
-    private(set) var failedMeetingStore: FailedMeetingStore!
+    /// Laziness lets the store receive narrow weak callbacks after this
+    /// controller has finished initializing, without an unowned back-reference
+    /// or an implicitly-unwrapped stored property.
+    private(set) lazy var failedMeetingStore = makeFailedMeetingStore()
     /// Background-transcription queue/dispatch bookkeeping (audit 2026-07-08
     /// wave 2, W2-B). Plain owned object, same rationale as above.
     private(set) var transcriptionQueue: TranscriptionQueueCoordinator!
@@ -340,12 +337,10 @@ final class MeetingSessionController: ObservableObject {
         // Model downloader — coordinates selected STT + PyAnnote readiness.
         self.downloader = MeetingModelDownloader(stt: sttAdapter, diarization: diarization)
 
-        // Failed-meeting and transcription-queue bookkeeping (audit
-        // 2026-07-08 wave 2, W2-B). Constructed last, after every other
-        // stored property, since each holds an `unowned` back-reference to
-        // this controller. `wireSubscriptions()` below calls into
-        // `failedMeetingStore` synchronously, so both must exist first.
-        self.failedMeetingStore = FailedMeetingStore(controller: self)
+        // Transcription-queue bookkeeping (audit 2026-07-08 wave 2, W2-B).
+        // Constructed last because it still holds an unowned controller
+        // reference. `failedMeetingStore` initializes lazily when
+        // `wireSubscriptions()` first needs it.
         self.transcriptionQueue = TranscriptionQueueCoordinator(controller: self)
 
         capture.onUnexpectedRecordingComplete = { [weak self] result in
@@ -2511,9 +2506,7 @@ final class MeetingSessionController: ObservableObject {
         refreshWarmupStatus()
     }
 
-    // Was `private`; FailedMeetingStore lives in a sibling file and needs
-    // module-internal access (audit 2026-07-08 wave 2, W2-B).
-    var hasBackgroundTranscriptionWork: Bool {
+    private var hasBackgroundTranscriptionWork: Bool {
         taskManager.activeCount > 0
             || transcriptionQueue.isPreparingQueuedTranscriptionStart
             || !transcriptionQueue.queuedTranscriptionJobs.isEmpty
@@ -3099,9 +3092,8 @@ final class MeetingSessionController: ObservableObject {
         )
     }
 
-    // Was `private`; FailedMeetingStore / TranscriptionQueueCoordinator live
-    // in sibling files and need module-internal access (audit 2026-07-08
-    // wave 2, W2-B).
+    // TranscriptionQueueCoordinator lives in a sibling file and needs
+    // module-internal access.
     func baseDiagnosticsContext(extra: [String: String] = [:]) -> [String: String] {
         var context: [String: String] = [
             "session_state": state.diagnosticName,
@@ -3124,10 +3116,36 @@ final class MeetingSessionController: ObservableObject {
         MeetingSystemAudioStatusCopy.message(for: status)
     }
 
-    // Was `private`; FailedMeetingStore lives in a sibling file and needs
-    // module-internal access (audit 2026-07-08 wave 2, W2-B).
-    func boolString(_ value: Bool) -> String {
+    private func boolString(_ value: Bool) -> String {
         value ? "true" : "false"
+    }
+
+    private func makeFailedMeetingStore() -> FailedMeetingStore {
+        FailedMeetingStore(
+            taskManager: taskManager,
+            failedManager: failedManager,
+            canRetry: { [weak self] in
+                guard let self else { return false }
+                return !self.isRecording
+                    && !self.hasBackgroundTranscriptionWork
+                    && !self.isSpeakerReviewPending
+            },
+            prepareModelsForRetry: { [weak self] in
+                guard let self else { return false }
+                await self.prepareModels()
+                guard case .ready = self.state else { return false }
+                return true
+            },
+            markRetryStarted: { [weak self] in
+                self?.activeTranscriptionTrigger = .unknown
+            },
+            publishRefresh: { [weak self] in
+                self?.refreshFailedMeetings()
+            },
+            diagnosticsContext: { [weak self] extra in
+                self?.baseDiagnosticsContext(extra: extra) ?? extra
+            }
+        )
     }
 
     // preserveFailedMeetingForRetry, refreshTimedOutFailedMeetingAudio, and
@@ -3139,10 +3157,7 @@ final class MeetingSessionController: ObservableObject {
     /// controller (rather than moved wholesale) because `failedMeetings` is
     /// `@Published` here — the store computes the list, the controller owns
     /// the publish.
-    // Was `private`; FailedMeetingStore lives in a sibling file and calls
-    // back into this method after every mutation (audit 2026-07-08 wave 2,
-    // W2-B).
-    func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) {
+    private func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) {
         failedMeetings = failedMeetingStore.refreshFailedMeetings(updatedFailedTranscriptions)
     }
 }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2388,7 +2388,7 @@ func testRepoCommandContract() {
             "an active compression pass should mark that the failed queue needs another scan"
         )
         assertTrue(
-            storeContents.contains("self.scheduleFailedAudioCompression(for: self.controller.failedManager.failedTranscriptions)"),
+            storeContents.contains("self.scheduleFailedAudioCompression(for: self.failedManager.failedTranscriptions)"),
             "compression completion should re-check the latest failed queue before going idle"
         )
         assertTrue(
@@ -2433,7 +2433,7 @@ func testRepoCommandContract() {
             to: "func refreshFailedMeetings("
         )
         assertTrue(
-            refreshTimedOutAudioBlock.contains("let existingFailure = controller.failedManager.failedTranscriptions")
+            refreshTimedOutAudioBlock.contains("let existingFailure = failedManager.failedTranscriptions")
                 && refreshTimedOutAudioBlock.contains("let existingMicURL = existingFailure?.micAudioURL")
                 && refreshTimedOutAudioBlock.contains("guard let micURL = result.micURL ?? existingMicURL"),
             "late finalization should still promote system-only failed audio by reusing the failed queue mic placeholder"
@@ -2444,7 +2444,7 @@ func testRepoCommandContract() {
         )
         assertTrue(
             helperBlock.contains("taskManager.addFailedTranscriptionRetainingAvailableAudio(")
-                && helperBlock.contains("if preserved {\n            controller.refreshFailedMeetings()"),
+                && helperBlock.contains("if preserved {\n            publishRefresh()"),
             "retained failed-meeting audio should refresh MeetingSessionController.failedMeetings immediately"
         )
         assertTrue(
@@ -2463,6 +2463,20 @@ func testRepoCommandContract() {
             ),
             1,
             "direct failed-queue writes should stay centralized in FailedMeetingStore's refresh helper"
+        )
+        assertFalse(
+            storeContents.contains("unowned let controller")
+                || storeContents.contains("controller."),
+            "FailedMeetingStore should depend on injected managers and narrow callbacks, not a controller back-reference"
+        )
+        assertTrue(
+            controllerContents.contains("private(set) lazy var failedMeetingStore = makeFailedMeetingStore()")
+                && controllerContents.contains("canRetry: { [weak self] in")
+                && controllerContents.contains("prepareModelsForRetry: { [weak self] in")
+                && controllerContents.contains("markRetryStarted: { [weak self] in")
+                && controllerContents.contains("publishRefresh: { [weak self] in")
+                && controllerContents.contains("diagnosticsContext: { [weak self] extra in"),
+            "MeetingSessionController should lazily inject weak retry, refresh, and diagnostics callbacks"
         )
     }
 


### PR DESCRIPTION
## Summary

- remove the FailedMeetingStore back-reference to MeetingSessionController
- inject only the managers and weak callbacks the store needs
- keep retry gating, diagnostics, refresh, and failed-audio compression behavior unchanged
- strengthen the source contract so every injected callback stays weak

## Verification

- focused RepoCommandContractTests: 681/681
- full fast suite: 13,191/13,191
- signed app build and launch smoke
- integration smoke
- full QA bench: 18 checks passed, with the expected warnings-only local artifact warning
- independent Codex exact-diff review; two narrow hardening findings fixed before final QA

## Proof boundary

This is queue/store architecture only. It does not change capture, microphone, Bluetooth, or system-audio routing, so no new hardware claim is made.