### PR TITLE
Make speaker finalization retry-safe

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -15,6 +15,12 @@ extension TranscriptionTaskManager {
         let mutations: [PlannedSpeakerMutation]
     }
 
+    private enum NamingFlowFinishOutcome {
+        case completed
+        case transcriptFinalizationFailed
+        case metadataPublicationFailed
+    }
+
     private enum PlannedSpeakerMutation {
         case merge(sourceId: UUID, into: UUID)
         case setDisplayName(id: UUID, name: String)
@@ -77,29 +83,6 @@ extension TranscriptionTaskManager {
         let newlyCreatedMicProfileIds = transcriptionResult.newlyCreatedMicProfileIds
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
-            guard let resolvedURL = TranscriptSaver.resolveTranscriptURL(
-                transcriptURL,
-                transcriptId: transcriptId
-            ) else {
-                self?.cleanupNamingArtifacts(
-                    clips: clips,
-                    micURL: micURL,
-                    systemURL: systemURL,
-                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && sourceFailedTranscriptionId == nil
-                )
-
-                Task { @MainActor in
-                    self?.finishNamingFlow(
-                        didFinalizeTranscript: false,
-                        updatesCount: updates.count,
-                        transcriptId: transcriptId,
-                        resolvedURL: transcriptURL,
-                        sourceFailedTranscriptionId: sourceFailedTranscriptionId
-                    )
-                }
-                return
-            }
-
             guard let plannedChanges = Self.planNamingUpdates(
                 regularUpdates,
                 clipsBySpeakerId: clipsBySpeakerId,
@@ -113,13 +96,17 @@ extension TranscriptionTaskManager {
                 )
 
                 Task { @MainActor in
-                    self?.finishNamingFlow(
+                    guard let self else { return }
+                    _ = self.finishNamingFlow(
                         didFinalizeTranscript: false,
                         updatesCount: updates.count,
                         transcriptId: transcriptId,
-                        resolvedURL: resolvedURL,
+                        resolvedURL: transcriptURL,
+                        micURL: micURL,
+                        systemURL: systemURL,
                         sourceFailedTranscriptionId: sourceFailedTranscriptionId
                     )
+                    self.clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
                 }
                 return
             }
@@ -131,34 +118,50 @@ extension TranscriptionTaskManager {
             let transcriptUpdates = plannedChanges.resolvedUpdates.filter {
                 Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) > 0
             }
-            var didFinalizeTranscript = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
-                transcriptURL: resolvedURL,
-                updates: transcriptUpdates,
-                transcriptionResult: transcriptionResult,
-                speakerStore: speakerDB
-            )
+            // Resolve and mutate under the same serializer used by transcript styling/title
+            // renames. Otherwise the styler can move the canonical file after resolution but
+            // before the first speaker rewrite, leaving finalization pointed at a stale path.
+            let finalization = TranscriptSaver.serializeTranscriptFileUpdate {
+                guard let resolvedURL = TranscriptSaver.resolveTranscriptURL(
+                    transcriptURL,
+                    transcriptId: transcriptId
+                ) else {
+                    return (didFinalize: false, resolvedURL: transcriptURL)
+                }
 
-            if didFinalizeTranscript, let deferredReviewPlan {
-                didFinalizeTranscript = TranscriptSaver.markSpeakerReviewDeferred(
+                var didFinalize = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
                     transcriptURL: resolvedURL,
-                    entries: clips,
-                    redirectedSpeakerIdsByKey: deferredReviewPlan.redirectedSpeakerIdsByKey
+                    updates: transcriptUpdates,
+                    transcriptionResult: transcriptionResult,
+                    speakerStore: speakerDB
                 )
-            }
 
-            if didFinalizeTranscript && !collapsedUpdates.isEmpty {
-                didFinalizeTranscript = TranscriptSaver.collapseMicSpeakersToYou(
-                    transcriptURL: resolvedURL,
-                    collapsedUpdates: collapsedUpdates
-                )
-            }
+                if didFinalize, let deferredReviewPlan {
+                    didFinalize = TranscriptSaver.markSpeakerReviewDeferred(
+                        transcriptURL: resolvedURL,
+                        entries: clips,
+                        redirectedSpeakerIdsByKey: deferredReviewPlan.redirectedSpeakerIdsByKey
+                    )
+                }
 
-            if didFinalizeTranscript && !discardedUpdates.isEmpty {
-                didFinalizeTranscript = TranscriptSaver.discardSpeakerDatabaseLinks(
-                    transcriptURL: resolvedURL,
-                    discardedUpdates: discardedUpdates
-                )
+                if didFinalize && !collapsedUpdates.isEmpty {
+                    didFinalize = TranscriptSaver.collapseMicSpeakersToYou(
+                        transcriptURL: resolvedURL,
+                        collapsedUpdates: collapsedUpdates
+                    )
+                }
+
+                if didFinalize && !discardedUpdates.isEmpty {
+                    didFinalize = TranscriptSaver.discardSpeakerDatabaseLinks(
+                        transcriptURL: resolvedURL,
+                        discardedUpdates: discardedUpdates
+                    )
+                }
+
+                return (didFinalize: didFinalize, resolvedURL: resolvedURL)
             }
+            let didFinalizeTranscript = finalization.didFinalize
+            let resolvedURL = finalization.resolvedURL
 
             if didFinalizeTranscript {
                 Self.applyPlannedNamingMutations(plannedChanges.mutations, speakerDB: speakerDB)
@@ -201,23 +204,49 @@ extension TranscriptionTaskManager {
                 )
             }
 
-            let shouldKeepAudioForFailedRetry = !didFinalizeTranscript && sourceFailedTranscriptionId != nil
-            self?.cleanupNamingArtifacts(
-                clips: clips,
-                micURL: micURL,
-                systemURL: systemURL,
-                shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && !shouldKeepAudioForFailedRetry
-            )
+            if !didFinalizeTranscript {
+                let shouldKeepAudioForFailedRetry = sourceFailedTranscriptionId != nil
+                self?.cleanupNamingArtifacts(
+                    clips: clips,
+                    micURL: micURL,
+                    systemURL: systemURL,
+                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && !shouldKeepAudioForFailedRetry
+                )
+            }
 
             Task { @MainActor in
-                self?.finishNamingFlow(
+                guard let self else { return }
+                let outcome = self.finishNamingFlow(
                     didFinalizeTranscript: didFinalizeTranscript,
                     updatesCount: updates.count,
                     transcriptId: transcriptId,
                     resolvedURL: resolvedURL,
+                    micURL: micURL,
+                    systemURL: systemURL,
                     sourceFailedTranscriptionId: sourceFailedTranscriptionId,
                     shouldDeleteSourceFailedAudio: shouldRemoveTemporaryAudio
                 )
+                switch outcome {
+                case .completed:
+                    self.cleanupNamingArtifacts(
+                        clips: clips,
+                        micURL: micURL,
+                        systemURL: systemURL,
+                        shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio
+                    )
+                case .metadataPublicationFailed:
+                    // The speaker clips are no longer needed, but retry audio must remain
+                    // available through the failed-transcription queue.
+                    self.cleanupNamingArtifacts(
+                        clips: clips,
+                        micURL: micURL,
+                        systemURL: systemURL,
+                        shouldRemoveTemporaryAudio: false
+                    )
+                case .transcriptFinalizationFailed:
+                    break
+                }
+                self.clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
             }
         }
     }
@@ -801,13 +830,61 @@ extension TranscriptionTaskManager {
         updatesCount: Int,
         transcriptId: UUID,
         resolvedURL: URL,
+        micURL: URL?,
+        systemURL: URL,
         sourceFailedTranscriptionId: UUID? = nil,
         shouldDeleteSourceFailedAudio: Bool = true
-    ) {
+    ) -> NamingFlowFinishOutcome {
         if didFinalizeTranscript {
+            // A title/style rename can queue behind transcript finalization and move the file
+            // before this MainActor handoff runs. Resolve and consume metadata in one serialized
+            // transaction so UI bookkeeping never publishes the stale pre-rename URL.
+            let metadataPublication: (resolvedURL: URL, didAlreadyPublish: Bool)? =
+                TranscriptSaver.serializeTranscriptFileUpdate {
+                    guard let currentURL = TranscriptSaver.resolveTranscriptURL(
+                        resolvedURL,
+                        transcriptId: transcriptId
+                    ) else {
+                        return nil
+                    }
+
+                    let didAlreadyPublish = lastSavedTranscriptId == transcriptId
+                        || lastSavedTranscriptURL == currentURL
+                    populateSavedMetadata(from: currentURL)
+                    return (resolvedURL: currentURL, didAlreadyPublish: didAlreadyPublish)
+                }
+
+            guard let metadataPublication else {
+                AppLogger.pipeline.error("Speaker naming metadata publication failed", [
+                    "transcriptId": transcriptId.uuidString,
+                    "transcript": resolvedURL.lastPathComponent
+                ])
+                let retryError = "Speaker names were saved, but the finalized transcript could not be found. Retry audio was preserved."
+                let retryId = sourceFailedTranscriptionId ?? transcriptId
+                let didPersistRetry = persistMetadataPublicationFailureRetry(
+                    id: retryId,
+                    micURL: micURL,
+                    systemURL: systemURL,
+                    errorMessage: retryError
+                )
+                if didPersistRetry {
+                    displayStatus = .failed(message: "Final transcript could not be found. Retry audio was kept.")
+                } else {
+                    AppLogger.pipeline.error("Speaker naming retry queue persistence failed", [
+                        "transcriptId": transcriptId.uuidString,
+                        "retryId": retryId.uuidString
+                    ])
+                    displayStatus = .failed(
+                        message: "Final transcript could not be found. Retry could not be saved; audio was left in place."
+                    )
+                }
+                scheduleStatusReset(delay: 8)
+                return .metadataPublicationFailed
+            }
+
             AppLogger.pipeline.info("Speaker naming complete", [
                 "named": "\(updatesCount)",
-                "transcript": resolvedURL.lastPathComponent
+                "transcript": metadataPublication.resolvedURL.lastPathComponent
             ])
             if let sourceFailedTranscriptionId {
                 if shouldDeleteSourceFailedAudio {
@@ -816,13 +893,11 @@ extension TranscriptionTaskManager {
                     failedTranscriptionManager.removeFailedTranscription(id: sourceFailedTranscriptionId)
                 }
             }
-            let didAlreadyPublishSavedTranscript = lastSavedTranscriptId == transcriptId
-                || lastSavedTranscriptURL == resolvedURL
-            populateSavedMetadata(from: resolvedURL)
-            if !didAlreadyPublishSavedTranscript {
+            if !metadataPublication.didAlreadyPublish {
                 displayStatus = .transcriptSaved
                 scheduleStatusReset(delay: 8)
             }
+            return .completed
         } else {
             AppLogger.pipeline.error("Speaker naming finalization failed", [
                 "transcriptId": transcriptId.uuidString,
@@ -836,8 +911,37 @@ extension TranscriptionTaskManager {
             }
             displayStatus = .failed(message: "Failed to finalize speaker names")
             scheduleStatusReset(delay: 8)
+            return .transcriptFinalizationFailed
+        }
+    }
+
+    @MainActor private func persistMetadataPublicationFailureRetry(
+        id: UUID,
+        micURL: URL?,
+        systemURL: URL,
+        errorMessage: String
+    ) -> Bool {
+        if failedTranscriptionManager.failedTranscriptions.contains(where: { $0.id == id }) {
+            let didUpdate = failedTranscriptionManager.updateFailedTranscriptionError(
+                id: id,
+                errorMessage: errorMessage
+            )
+            if !didUpdate {
+                // The pre-existing durable row remains actionable even if its diagnostic
+                // could not be refreshed. Treating it as absent would create duplicates.
+                AppLogger.pipeline.warning("Speaker naming retry diagnostic update failed", [
+                    "retryId": id.uuidString
+                ])
+            }
+            return true
         }
 
-        clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
+        return addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: errorMessage,
+            taskId: id,
+            archiveAudio: false
+        )
     }
 }

--- a/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingCoordinatorTests.swift
@@ -2215,6 +2215,316 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleNamingCompleteReconcilesRenameThatOccursDuringFinalizationPlanning() async throws {
+        var blockingStore: BlockingSpeakerStore?
+        let harness = try makeHarness { speakerDB in
+            let store = BlockingSpeakerStore(base: speakerDB, blockPoint: .planning)
+            blockingStore = store
+            return store
+        }
+        let store = try XCTUnwrap(blockingStore)
+        let transcriptId = UUID()
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.3, count: 256),
+            existingId: nil
+        ).id
+        let originalTranscriptURL = harness.paths.transcripts.appendingPathComponent("Call_2026-04-10_15-01-23.md")
+        let renamedTranscriptURL = harness.paths.transcripts.appendingPathComponent("2026-04-10 Planning Sync.md")
+        let clipURL = harness.paths.speakerClips.appendingPathComponent("speaker-planning-rename.wav")
+        let micURL = harness.paths.audioCaptures.appendingPathComponent("mic-planning-rename.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("system-planning-rename.wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "System",
+                label: "Speaker 1",
+                text: "Thanks for joining."
+            )
+        ]
+
+        try sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: [
+                BreakdownEntry(name: "Speaker 1", utterances: 1, wordCount: 3, duration: "00:03")
+            ],
+            totalWords: 3
+        ).write(to: originalTranscriptURL, atomically: true, encoding: .utf8)
+        let originalTranscript = try String(contentsOf: originalTranscriptURL, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: clipURL)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: originalTranscriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Sarah Graham",
+                    previousName: nil,
+                    action: .named
+                )
+            ],
+            transcriptURL: originalTranscriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "Thanks for joining.",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: [Float](repeating: 0.3, count: 256)
+                )
+            ]
+        )
+
+        try await waitUntil {
+            store.hasReachedBlockPoint
+        }
+        guard store.hasReachedBlockPoint else {
+            store.resume()
+            XCTFail("Timed out waiting for speaker finalization planning")
+            return
+        }
+        do {
+            try FileManager.default.moveItem(at: originalTranscriptURL, to: renamedTranscriptURL)
+        } catch {
+            store.resume()
+            throw error
+        }
+        store.resume()
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+        }
+
+        XCTAssertEqual(harness.manager.displayStatus, .transcriptSaved)
+        XCTAssertEqual(harness.manager.lastSavedTranscriptURL, renamedTranscriptURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: originalTranscriptURL.path))
+        let savedTranscript = try String(contentsOf: renamedTranscriptURL, encoding: .utf8)
+        XCTAssertNotEqual(savedTranscript, originalTranscript)
+        XCTAssertTrue(savedTranscript.contains("Sarah Graham"), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains("[System/Speaker 1]"), savedTranscript)
+    }
+
+    @MainActor
+    func testHandleNamingCompleteReconcilesRenameBeforeMetadataPublication() async throws {
+        var blockingStore: BlockingSpeakerStore?
+        let harness = try makeHarness { speakerDB in
+            let store = BlockingSpeakerStore(base: speakerDB, blockPoint: .displayNameMutation)
+            blockingStore = store
+            return store
+        }
+        let store = try XCTUnwrap(blockingStore)
+        let transcriptId = UUID()
+        let savedTaskId = UUID()
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.3, count: 256),
+            existingId: nil
+        ).id
+        let originalTranscriptURL = harness.paths.transcripts.appendingPathComponent("Call_2026-04-10_15-01-24.md")
+        let renamedTranscriptURL = harness.paths.transcripts.appendingPathComponent("2026-04-10 Published Planning Sync.md")
+        let clipURL = harness.paths.speakerClips.appendingPathComponent("speaker-publication-rename.wav")
+        let micURL = harness.paths.audioCaptures.appendingPathComponent("mic-publication-rename.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("system-publication-rename.wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "System",
+                label: "Speaker 1",
+                text: "Thanks for joining."
+            )
+        ]
+
+        try sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: [
+                BreakdownEntry(name: "Speaker 1", utterances: 1, wordCount: 3, duration: "00:03")
+            ],
+            totalWords: 3
+        ).write(to: originalTranscriptURL, atomically: true, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: clipURL)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+
+        harness.manager.populateSavedMetadata(from: originalTranscriptURL, taskId: savedTaskId)
+        XCTAssertEqual(harness.manager.lastSavedTranscriptId, transcriptId)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: originalTranscriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Sarah Graham",
+                    previousName: nil,
+                    action: .named
+                )
+            ],
+            transcriptURL: originalTranscriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "Thanks for joining.",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: [Float](repeating: 0.3, count: 256)
+                )
+            ]
+        )
+
+        try await waitUntil {
+            store.hasReachedBlockPoint
+        }
+        guard store.hasReachedBlockPoint else {
+            store.resume()
+            XCTFail("Timed out waiting for post-finalization speaker mutation")
+            return
+        }
+        do {
+            try TranscriptSaver.serializeTranscriptFileUpdate {
+                let finalizedTranscript = try String(contentsOf: originalTranscriptURL, encoding: .utf8)
+                XCTAssertTrue(finalizedTranscript.contains("Sarah Graham"), finalizedTranscript)
+                try FileManager.default.moveItem(at: originalTranscriptURL, to: renamedTranscriptURL)
+            }
+        } catch {
+            store.resume()
+            throw error
+        }
+        store.resume()
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+        }
+
+        XCTAssertEqual(harness.manager.lastSavedTranscriptURL, renamedTranscriptURL)
+        XCTAssertEqual(harness.manager.lastSavedTranscriptId, transcriptId)
+        XCTAssertEqual(harness.manager.lastSavedTranscriptTaskId, savedTaskId)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: originalTranscriptURL.path))
+        let savedTranscript = try String(contentsOf: renamedTranscriptURL, encoding: .utf8)
+        XCTAssertTrue(savedTranscript.contains("Sarah Graham"), savedTranscript)
+    }
+
+    @MainActor
+    func testHandleNamingCompletePreservesRetryStateWhenMetadataPublicationCannotResolveTranscript() async throws {
+        let sourceFailedTranscriptionId = UUID()
+        let scenario = try await runMetadataPublicationFailureScenario(
+            sourceFailedTranscriptionId: sourceFailedTranscriptionId
+        )
+
+        XCTAssertEqual(
+            scenario.harness.manager.displayStatus,
+            .failed(message: "Final transcript could not be found. Retry audio was kept.")
+        )
+        let failedRetry = try XCTUnwrap(
+            scenario.harness.failedManager.failedTranscriptions.first { $0.id == sourceFailedTranscriptionId }
+        )
+        XCTAssertEqual(
+            failedRetry.errorMessage,
+            "Speaker names were saved, but the finalized transcript could not be found. Retry audio was preserved."
+        )
+        XCTAssertEqual(failedRetry.micAudioURL, scenario.micURL)
+        XCTAssertEqual(failedRetry.systemAudioURL, scenario.systemURL)
+        try assertMetadataPublicationFailurePreservedAssetsAndMutations(scenario)
+    }
+
+    @MainActor
+    func testHandleNamingCompleteQueuesFirstPassRetryWhenMetadataPublicationCannotResolveTranscript() async throws {
+        let scenario = try await runMetadataPublicationFailureScenario()
+
+        XCTAssertEqual(
+            scenario.harness.manager.displayStatus,
+            .failed(message: "Final transcript could not be found. Retry audio was kept.")
+        )
+        XCTAssertEqual(scenario.harness.failedManager.failedTranscriptions.count, 1)
+        let failedRetry = try XCTUnwrap(scenario.harness.failedManager.failedTranscriptions.first)
+        XCTAssertEqual(failedRetry.id, scenario.transcriptId)
+        XCTAssertEqual(
+            failedRetry.errorMessage,
+            "Speaker names were saved, but the finalized transcript could not be found. Retry audio was preserved."
+        )
+        XCTAssertEqual(failedRetry.micAudioURL, scenario.micURL)
+        XCTAssertEqual(failedRetry.systemAudioURL, scenario.systemURL)
+        XCTAssertTrue(failedRetry.isRetryable)
+        let reloadedManager = FailedTranscriptionManager(paths: scenario.harness.paths)
+        XCTAssertEqual(reloadedManager.failedTranscriptions.count, 1)
+        let reloadedRetry = try XCTUnwrap(reloadedManager.failedTranscriptions.first)
+        XCTAssertEqual(reloadedRetry.id, failedRetry.id)
+        XCTAssertEqual(reloadedRetry.micAudioURL, failedRetry.micAudioURL)
+        XCTAssertEqual(reloadedRetry.systemAudioURL, failedRetry.systemAudioURL)
+        XCTAssertEqual(reloadedRetry.errorMessage, failedRetry.errorMessage)
+        XCTAssertTrue(reloadedRetry.isRetryable)
+        try assertMetadataPublicationFailurePreservedAssetsAndMutations(scenario)
+    }
+
+    @MainActor
+    func testHandleNamingCompleteReportsQueueFailureWhenMetadataPublicationCannotResolveTranscript() async throws {
+        let scenario = try await runMetadataPublicationFailureScenario(blockQueuePersistence: true)
+
+        XCTAssertEqual(
+            scenario.harness.manager.displayStatus,
+            .failed(message: "Final transcript could not be found. Retry could not be saved; audio was left in place.")
+        )
+        XCTAssertTrue(scenario.harness.failedManager.failedTranscriptions.isEmpty)
+        try assertMetadataPublicationFailurePreservedAssetsAndMutations(scenario)
+    }
+
+    @MainActor
     func testHandleNamingCompleteCorrectionKeepsRejectedProfileAndUsesExistingTarget() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()
@@ -2667,7 +2977,176 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    private func makeHarness() throws -> TestHarness {
+    private func runMetadataPublicationFailureScenario(
+        sourceFailedTranscriptionId: UUID? = nil,
+        blockQueuePersistence: Bool = false
+    ) async throws -> MetadataPublicationFailureScenario {
+        var blockingStore: BlockingSpeakerStore?
+        let harness = try makeHarness { speakerDB in
+            let store = BlockingSpeakerStore(base: speakerDB, blockPoint: .displayNameMutation)
+            blockingStore = store
+            return store
+        }
+        let store = try XCTUnwrap(blockingStore)
+        let transcriptId = UUID()
+        let fileSuffix = String(transcriptId.uuidString.prefix(8))
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.3, count: 256),
+            existingId: nil
+        ).id
+        let transcriptURL = harness.paths.transcripts
+            .appendingPathComponent("Call_2026-04-10_15-01-25_\(fileSuffix).md")
+        let unresolvedTranscriptURL = tempDirectory
+            .appendingPathComponent("Unresolved finalized transcript \(fileSuffix).md")
+        let clipURL = harness.paths.speakerClips
+            .appendingPathComponent("speaker-publication-missing-\(fileSuffix).wav")
+        let micURL = harness.paths.audioCaptures
+            .appendingPathComponent("mic-publication-missing-\(fileSuffix).wav")
+        let systemURL = harness.paths.audioCaptures
+            .appendingPathComponent("system-publication-missing-\(fileSuffix).wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "System",
+                label: "Speaker 1",
+                text: "Thanks for joining."
+            )
+        ]
+
+        try sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: [
+                BreakdownEntry(name: "Speaker 1", utterances: 1, wordCount: 3, duration: "00:03")
+            ],
+            totalWords: 3
+        ).write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: clipURL)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+        if let sourceFailedTranscriptionId {
+            XCTAssertTrue(harness.failedManager.addFailedTranscription(
+                id: sourceFailedTranscriptionId,
+                micAudioURL: micURL,
+                systemAudioURL: systemURL,
+                errorMessage: "Earlier retry failure"
+            ))
+        }
+        if blockQueuePersistence {
+            try FileManager.default.createDirectory(
+                at: harness.paths.failedQueue,
+                withIntermediateDirectories: false
+            )
+        }
+
+        harness.manager.populateSavedMetadata(from: transcriptURL)
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Sarah Graham",
+                    previousName: nil,
+                    action: .named
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "Thanks for joining.",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: [Float](repeating: 0.3, count: 256)
+                )
+            ]
+        )
+
+        try await waitUntil {
+            store.hasReachedBlockPoint
+        }
+        guard store.hasReachedBlockPoint else {
+            store.resume()
+            throw MetadataPublicationFailureScenarioError.blockPointTimeout
+        }
+        do {
+            try TranscriptSaver.serializeTranscriptFileUpdate {
+                let finalizedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
+                XCTAssertTrue(finalizedTranscript.contains("Sarah Graham"), finalizedTranscript)
+                try FileManager.default.moveItem(at: transcriptURL, to: unresolvedTranscriptURL)
+            }
+        } catch {
+            store.resume()
+            throw error
+        }
+        store.resume()
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+        }
+
+        return MetadataPublicationFailureScenario(
+            harness: harness,
+            transcriptId: transcriptId,
+            persistentSpeakerId: persistentSpeakerId,
+            transcriptURL: transcriptURL,
+            unresolvedTranscriptURL: unresolvedTranscriptURL,
+            clipURL: clipURL,
+            micURL: micURL,
+            systemURL: systemURL
+        )
+    }
+
+    @MainActor
+    private func assertMetadataPublicationFailurePreservedAssetsAndMutations(
+        _ scenario: MetadataPublicationFailureScenario
+    ) throws {
+        XCTAssertEqual(scenario.harness.manager.lastSavedTranscriptId, scenario.transcriptId)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: scenario.micURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: scenario.systemURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: scenario.clipURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: scenario.transcriptURL.path))
+        let preservedTranscript = try String(contentsOf: scenario.unresolvedTranscriptURL, encoding: .utf8)
+        XCTAssertTrue(preservedTranscript.contains("Sarah Graham"), preservedTranscript)
+        XCTAssertEqual(
+            scenario.harness.speakerDB.getSpeaker(id: scenario.persistentSpeakerId)?.displayName,
+            "Sarah Graham"
+        )
+    }
+
+    @MainActor
+    private func makeHarness(
+        speakerStore: ((SpeakerDatabase) -> any SpeakerStore)? = nil
+    ) throws -> TestHarness {
         let paths = CoreStoragePaths(
             transcripts: tempDirectory.appendingPathComponent("transcripts"),
             speakerDB: tempDirectory.appendingPathComponent("speakers.sqlite"),
@@ -2684,17 +3163,28 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
         try FileManager.default.createDirectory(at: paths.logs, withIntermediateDirectories: true)
 
         let speakerDB = SpeakerDatabase(path: paths.speakerDB.path)
+        let resolvedSpeakerStore: any SpeakerStore
+        if let speakerStore {
+            resolvedSpeakerStore = speakerStore(speakerDB)
+        } else {
+            resolvedSpeakerStore = speakerDB
+        }
         let failedManager = FailedTranscriptionManager(paths: paths)
         let manager = TranscriptionTaskManager(
             failedTranscriptionManager: failedManager,
             speechToText: StubSpeechToTextEngine(),
             diarization: StubDiarizationEngine(),
-            speakerStore: speakerDB,
+            speakerStore: resolvedSpeakerStore,
             speakerClipsDirectory: paths.speakerClips,
             cleanupDirectories: [paths.audioCaptures, paths.speakerClips]
         )
 
-        return TestHarness(paths: paths, speakerDB: speakerDB, manager: manager)
+        return TestHarness(
+            paths: paths,
+            speakerDB: speakerDB,
+            failedManager: failedManager,
+            manager: manager
+        )
     }
 
     private func sampleTranscript(
@@ -2865,7 +3355,152 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
 private struct TestHarness {
     let paths: CoreStoragePaths
     let speakerDB: SpeakerDatabase
+    let failedManager: FailedTranscriptionManager
     let manager: TranscriptionTaskManager
+}
+
+@available(macOS 14.0, *)
+private struct MetadataPublicationFailureScenario {
+    let harness: TestHarness
+    let transcriptId: UUID
+    let persistentSpeakerId: UUID
+    let transcriptURL: URL
+    let unresolvedTranscriptURL: URL
+    let clipURL: URL
+    let micURL: URL
+    let systemURL: URL
+}
+
+private enum MetadataPublicationFailureScenarioError: Error {
+    case blockPointTimeout
+}
+
+@available(macOS 14.0, *)
+private final class BlockingSpeakerStore: SpeakerStore, @unchecked Sendable {
+    enum BlockPoint {
+        case planning
+        case displayNameMutation
+    }
+
+    private let base: any SpeakerStore
+    private let blockPoint: BlockPoint
+    private let mayContinue = DispatchSemaphore(value: 0)
+    private let stateLock = NSLock()
+    private var didReachBlockPoint = false
+
+    var hasReachedBlockPoint: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return didReachBlockPoint
+    }
+
+    init(base: any SpeakerStore, blockPoint: BlockPoint) {
+        self.base = base
+        self.blockPoint = blockPoint
+    }
+
+    func resume() {
+        mayContinue.signal()
+    }
+
+    func matchSpeaker(embedding: [Float], threshold: Double) -> SpeakerMatchResult? {
+        base.matchSpeaker(embedding: embedding, threshold: threshold)
+    }
+
+    func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?) -> SpeakerProfile {
+        base.addOrUpdateSpeaker(embedding: embedding, existingId: existingId)
+    }
+
+    func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?, blendAlpha: Float) -> SpeakerProfile {
+        base.addOrUpdateSpeaker(embedding: embedding, existingId: existingId, blendAlpha: blendAlpha)
+    }
+
+    func getSpeaker(id: UUID) -> SpeakerProfile? {
+        base.getSpeaker(id: id)
+    }
+
+    func allSpeakers() -> [SpeakerProfile] {
+        blockIfNeeded(at: .planning)
+        return base.allSpeakers()
+    }
+
+    func setDisplayName(id: UUID, name: String, source: String) {
+        base.setDisplayName(id: id, name: name, source: source)
+        blockIfNeeded(at: .displayNameMutation)
+    }
+
+    func restoreProfile(_ profile: SpeakerProfile) {
+        base.restoreProfile(profile)
+    }
+
+    func deleteSpeaker(id: UUID) {
+        base.deleteSpeaker(id: id)
+    }
+
+    func mergeProfiles(sourceId: UUID, into targetId: UUID) {
+        base.mergeProfiles(sourceId: sourceId, into: targetId)
+    }
+
+    func mergeProfilesByName() {
+        base.mergeProfilesByName()
+    }
+
+    func mergeDuplicates() {
+        base.mergeDuplicates()
+    }
+
+    func mergeDuplicates(protecting protectedIds: Set<UUID>) {
+        base.mergeDuplicates(protecting: protectedIds)
+    }
+
+    func pruneWeakProfiles() {
+        base.pruneWeakProfiles()
+    }
+
+    func incrementDisputeCount(id: UUID) {
+        base.incrementDisputeCount(id: id)
+    }
+
+    func resetDisputeCount(id: UUID) {
+        base.resetDisputeCount(id: id)
+    }
+
+    func findProfilesByName(_ name: String) -> [SpeakerProfile] {
+        return base.findProfilesByName(name)
+    }
+
+    func recordMatchOutcome(_ outcome: SpeakerMatchOutcome) {
+        base.recordMatchOutcome(outcome)
+    }
+
+    func recordMatchOutcomes(_ outcomes: [SpeakerMatchOutcome]) {
+        base.recordMatchOutcomes(outcomes)
+    }
+
+    func recentMatchOutcomes(profileId: UUID, limit: Int) -> [SpeakerMatchOutcome] {
+        base.recentMatchOutcomes(profileId: profileId, limit: limit)
+    }
+
+    func recordNegativeExemplar(profileId: UUID, embedding: [Float]) {
+        base.recordNegativeExemplar(profileId: profileId, embedding: embedding)
+    }
+
+    func negativeExemplarsByProfile() -> [UUID: [[Float]]] {
+        base.negativeExemplarsByProfile()
+    }
+
+    private func blockIfNeeded(at point: BlockPoint) {
+        guard blockPoint == point else { return }
+
+        stateLock.lock()
+        let shouldBlock = !didReachBlockPoint
+        didReachBlockPoint = true
+        stateLock.unlock()
+
+        if shouldBlock {
+            _ = mayContinue.wait(timeout: .now() + 5)
+        }
+    }
 }
 
 @available(macOS 14.0, *)


### PR DESCRIPTION
## What changed
- serialize speaker-name resolution with transcript mutation and re-resolve again before metadata publication
- prevent a rename during finalization from publishing stale speaker metadata
- turn metadata-publication failure into an explicit failed-transcription state
- durably queue first-pass retry audio by stable transcript ID, preserve existing retries, and avoid duplicate rows
- keep retained assets when queue persistence itself fails and report that failure honestly

## Proof
- three adversarial review rounds; final verdict clean
- focused speaker coverage: 140 of 140 plus final 28 of 28
- Swift package suite: 769 passed, 13 skipped
- fast suite: 13,189 of 13,189
- integration: 7 of 7
- dependency rebuild and signed app build and launch pass
- full QA bench: 18 of 18 completed, 17 pass plus 1 expected non-blocking local-artifact warning
- diff check passes

## Manual proof still required
- one real meeting that reaches speaker review while a rename is made during finalization
- one forced metadata-publication failure observed through the visible retry flow

No release surfaces were changed.