### PR TITLE
[bug-hunter] Stop cancelled wake recovery work

### DIFF
--- a/Sources/Reliability/WakeRecoveryCoordinator.swift
+++ b/Sources/Reliability/WakeRecoveryCoordinator.swift
@@ -74,6 +74,7 @@ final class WakeRecoveryCoordinator {
         let taskID = UUID()
         let task: Task<(Bool, String?), Never> = Task { @MainActor [weak self] in
             let hotkeyResult = await self?.recoverHotkeysAfterWake() ?? (false, "Wake recovery coordinator deallocated")
+            guard !Task.isCancelled else { return hotkeyResult }
             await self?.waitForRuntimeReadiness()
             return hotkeyResult
         }
@@ -84,7 +85,7 @@ final class WakeRecoveryCoordinator {
         guard wakeRecoveryTaskID == taskID else {
             return WakeRecoveryResult(
                 hotkeysRecovered: hotkeysRecovered,
-                performedRecovery: true,
+                performedRecovery: false,
                 hotkeyError: hotkeyError
             )
         }
@@ -113,6 +114,8 @@ final class WakeRecoveryCoordinator {
 
     private func recoverHotkeysAfterWake() async -> (Bool, String?) {
         for attempt in 1...hotkeyRetryAttempts {
+            guard !Task.isCancelled else { return (false, nil) }
+
             unregisterHotkeys()
             registerHotkeys()
 
@@ -125,6 +128,7 @@ final class WakeRecoveryCoordinator {
 
             guard attempt < hotkeyRetryAttempts else { break }
             await sleep(hotkeyRetryDelay)
+            guard !Task.isCancelled else { return (false, nil) }
         }
 
         return (false, currentHotkeyError())

--- a/Tests/WakeRecoveryCoordinatorTests.swift
+++ b/Tests/WakeRecoveryCoordinatorTests.swift
@@ -287,10 +287,51 @@ func testWakeRecoveryCoordinator() async {
         assertTrue(firstResult.hotkeysRecovered, "released cancelled recovery should still finish cleanly")
         assertTrue(secondResult.hotkeysRecovered, "replacement recovery should finish cleanly")
         assertTrue(thirdResult.hotkeysRecovered, "joined recovery should observe the replacement result")
-        assertTrue(firstResult.performedRecovery, "original task still owned its work before cancellation")
+        assertFalse(firstResult.performedRecovery, "cancelled recovery should not report a stale completion")
         assertTrue(secondResult.performedRecovery, "replacement task should perform the new recovery")
         assertFalse(thirdResult.performedRecovery, "follow-up wake should join the replacement task instead of starting a third recovery")
         let registerCalls = await MainActor.run { hotkeys.registerCalls }
         assertEqual(registerCalls, 2, "stale completion should not clear the active recovery task")
+    }
+
+    await runSuite("WakeRecoveryCoordinator.cancel — stops retries and runtime readiness") {
+        let hotkeys = await MainActor.run { HotkeyScript(scriptedErrors: ["busy", nil]) }
+        let readinessCalls = await MainActor.run { CountBox() }
+        let sleepStarted = AsyncSignal()
+        let sleepContinue = AsyncSignal()
+
+        let coordinator = await MainActor.run {
+            WakeRecoveryCoordinator(
+                hotkeyRetryAttempts: 3,
+                hotkeyRetryDelay: 1,
+                unregisterHotkeys: { hotkeys.unregister() },
+                registerHotkeys: { hotkeys.register() },
+                currentHotkeyError: { hotkeys.currentError },
+                waitForRuntimeReadiness: {
+                    await MainActor.run { readinessCalls.increment() }
+                },
+                sleep: { _ in
+                    await sleepStarted.open()
+                    await sleepContinue.wait()
+                }
+            )
+        }
+
+        let task = Task { await coordinator.handleSystemWake() }
+        await sleepStarted.wait()
+
+        await MainActor.run { coordinator.cancel() }
+        await sleepContinue.open()
+
+        let result = await task.value
+        let registerCalls = await MainActor.run { hotkeys.registerCalls }
+        let unregisterCalls = await MainActor.run { hotkeys.unregisterCalls }
+        let readinessCount = await MainActor.run { readinessCalls.count }
+
+        assertFalse(result.hotkeysRecovered, "cancelled recovery should not report hotkey success")
+        assertFalse(result.performedRecovery, "cancelled recovery should not report a stale completion")
+        assertEqual(registerCalls, 1, "cancelled recovery should not retry hotkey registration")
+        assertEqual(unregisterCalls, 1, "cancelled recovery should not retry hotkey cleanup")
+        assertEqual(readinessCount, 0, "cancelled recovery should not restart runtime readiness")
     }
 }


### PR DESCRIPTION
## Bug
During shutdown, a wake-recovery retry could outlive cancellation and re-register global hotkeys after shutdown had unregistered them. The stale task could also restart runtime-readiness work and emit completion telemetry.

## Fix
- stop hotkey retries when the recovery task is cancelled
- skip runtime readiness for cancelled recovery
- mark invalidated task completions as non-owning
- add a deterministic non-cooperative-sleep regression test

## Verification
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`: 12,956 passed
- `bash run-tests.sh --filter WakeRecoveryCoordinatorTests`: 38 passed
- `bash build-deps.sh --force`: passed
- `bash build.sh --no-open`: passed, including signing and launch smoke (1095 ms)
- `codex review --uncommitted`: clean, no actionable findings

## Review
Independent adversarial review confirmed the shutdown race. Final Codex review accepted the cancellation guards and result-ownership change; no findings were rejected.

## Manual proof
Real Mac sleep/wake followed by app shutdown was not performed and remains unknown.

lanes used: Codex=implementation and final review; Claude=async cancellation review; Local=skipped; Windows=skipped