### PR TITLE
Preserve stopped dictation audio on current main

### DIFF
--- a/Sources/Dictation/CLAUDE.md
+++ b/Sources/Dictation/CLAUDE.md
@@ -7,6 +7,7 @@
 ## Files
 
 - `DictationSessionTimeout.swift` — uptime-based timeout helper so sleep does not consume a session's remaining record window
+- `DictationStoppedAudioRecovery.swift` — writes a private recovery WAV plus restart-discovery metadata immediately after recording stops and retains both until transcript persistence succeeds or the user explicitly discards the session
 - `DictationStoragePaths.swift` — capture-library-backed storage root for dictation artifacts
 - `DictationTranscriptWriter.swift` — groups completed dictations into one markdown file per day; serializes day-file writes through `DictationTranscriptMutationLock`
 - `DictationTranscriptStore.swift` — shared seam for saving dictation markdown and reading the newest saved dictation back out
@@ -27,6 +28,13 @@
 - root: `<capture-library>/dictations/`
 - transcript folder: same as the dictation root
 - file shape: one `Dictations_YYYY-MM-DD.md` file per day, with multiple timestamped sections
+- stopped-audio recovery: `~/Library/Application Support/Transcripted/state/dictation-audio-recovery/`
+
+Stopped-audio recovery is intentionally bounded and local. Launch scans at most
+one pending metadata record for presentation, then `Show Audio` reveals the WAV
+in Finder. The operational recovery path is Home -> Import Audio -> select that
+WAV; this uses the normal local imported-audio transcription pipeline. Reveal or
+restart never deletes the checkpoint.
 
 Each section captures:
 
@@ -40,6 +48,7 @@ Each section captures:
 ## Test coverage
 
 - `Tests/DictationSessionTimeoutTests.swift`
+- `Tests/DictationStoppedAudioRecoveryTests.swift`
 - `Tests/DictationTranscriptStoreTests.swift`
 - `Tests/DictationTranscriptWriterTests.swift`
 

--- a/Sources/Dictation/DictationStoppedAudioRecovery.swift
+++ b/Sources/Dictation/DictationStoppedAudioRecovery.swift
@@ -9,6 +9,22 @@ struct DictationStoppedAudioRecovery: Equatable, Sendable {
     let createdAt: Date
 }
 
+struct DictationStoppedAudioRecoveryRetryRegistry {
+    private var recoveries: [UUID: DictationStoppedAudioRecovery] = [:]
+
+    mutating func retain(_ recovery: DictationStoppedAudioRecovery, for failedMeetingID: UUID) {
+        recoveries[failedMeetingID] = recovery
+    }
+
+    func recovery(for failedMeetingID: UUID) -> DictationStoppedAudioRecovery? {
+        recoveries[failedMeetingID]
+    }
+
+    mutating func remove(for failedMeetingID: UUID) -> DictationStoppedAudioRecovery? {
+        recoveries.removeValue(forKey: failedMeetingID)
+    }
+}
+
 enum DictationStoppedAudioRecoveryCommitPolicy {
     static func shouldPersist(
         taskCancelled: Bool,

--- a/Sources/Dictation/DictationStoppedAudioRecovery.swift
+++ b/Sources/Dictation/DictationStoppedAudioRecovery.swift
@@ -18,6 +18,13 @@ enum DictationStoppedAudioRecoveryCommitPolicy {
     ) -> Bool {
         !taskCancelled && isDictating && taskSessionID == currentSessionID
     }
+
+    static func shouldRetainPersistedRecovery(
+        taskSessionID: UUID,
+        preservationSessionID: UUID?
+    ) -> Bool {
+        taskSessionID == preservationSessionID
+    }
 }
 
 enum DictationStoppedAudioRecoveryStore {

--- a/Sources/Dictation/DictationStoppedAudioRecovery.swift
+++ b/Sources/Dictation/DictationStoppedAudioRecovery.swift
@@ -9,6 +9,17 @@ struct DictationStoppedAudioRecovery: Equatable, Sendable {
     let createdAt: Date
 }
 
+enum DictationStoppedAudioRecoveryCommitPolicy {
+    static func shouldPersist(
+        taskCancelled: Bool,
+        isDictating: Bool,
+        taskSessionID: UUID,
+        currentSessionID: UUID
+    ) -> Bool {
+        !taskCancelled && isDictating && taskSessionID == currentSessionID
+    }
+}
+
 enum DictationStoppedAudioRecoveryStore {
     static let sampleRate: UInt32 = 16_000
 
@@ -72,9 +83,20 @@ enum DictationStoppedAudioRecoveryStore {
                 sessionID: metadata.sessionID,
                 createdAt: metadata.createdAt
             ))
-            if recoveries.count >= limit { break }
         }
-        return recoveries.sorted { $0.createdAt > $1.createdAt }
+        return mostRecent(recoveries, limit: limit)
+    }
+
+    static func mostRecent(
+        _ recoveries: [DictationStoppedAudioRecovery],
+        limit: Int
+    ) -> [DictationStoppedAudioRecovery] {
+        guard limit > 0 else { return [] }
+        return Array(
+            recoveries
+                .sorted { $0.createdAt > $1.createdAt }
+                .prefix(limit)
+        )
     }
 
     @discardableResult

--- a/Sources/Dictation/DictationStoppedAudioRecovery.swift
+++ b/Sources/Dictation/DictationStoppedAudioRecovery.swift
@@ -1,0 +1,157 @@
+// DictationStoppedAudioRecovery.swift
+// Durable audio checkpoint for a stopped dictation awaiting transcription.
+
+import Foundation
+
+struct DictationStoppedAudioRecovery: Equatable, Sendable {
+    let url: URL
+    let sessionID: UUID
+    let createdAt: Date
+}
+
+enum DictationStoppedAudioRecoveryStore {
+    static let sampleRate: UInt32 = 16_000
+
+    private struct Metadata: Codable {
+        let version: Int
+        let sessionID: UUID
+        let createdAt: Date
+        let audioFilename: String
+    }
+
+    static var defaultDirectory: URL {
+        FileManager.default.transcriptedStateDir
+            .appendingPathComponent("dictation-audio-recovery", isDirectory: true)
+    }
+
+    static func persist(
+        samples16k: [Float],
+        sessionID: UUID,
+        createdAt: Date = Date(),
+        directory: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> DictationStoppedAudioRecovery? {
+        guard !samples16k.isEmpty else { return nil }
+
+        let folder = directory ?? defaultDirectory
+        try fileManager.createPrivateDirectory(at: folder)
+        let url = folder.appendingPathComponent("dictation_\(sessionID.uuidString.lowercased()).wav")
+        try wavData(samples16k: samples16k).write(to: url, options: .atomic)
+        fileManager.restrictFileToOwnerOnly(at: url)
+        let recovery = DictationStoppedAudioRecovery(url: url, sessionID: sessionID, createdAt: createdAt)
+        do {
+            try writeMetadata(for: recovery, fileManager: fileManager)
+        } catch {
+            try? fileManager.removeItem(at: url)
+            throw error
+        }
+        return recovery
+    }
+
+    static func pendingRecoveries(
+        limit: Int = 10,
+        directory: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> [DictationStoppedAudioRecovery] {
+        guard limit > 0 else { return [] }
+        let folder = directory ?? defaultDirectory
+        guard let enumerator = fileManager.enumerator(
+            at: folder,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ) else { return [] }
+
+        var recoveries: [DictationStoppedAudioRecovery] = []
+        for case let metadataURL as URL in enumerator where metadataURL.pathExtension == "json" {
+            guard let metadata = try? JSONDecoder().decode(Metadata.self, from: Data(contentsOf: metadataURL)),
+                  metadata.version == 1 else { continue }
+            let audioURL = folder.appendingPathComponent(metadata.audioFilename, isDirectory: false)
+            guard fileManager.fileExists(atPath: audioURL.path) else { continue }
+            recoveries.append(DictationStoppedAudioRecovery(
+                url: audioURL,
+                sessionID: metadata.sessionID,
+                createdAt: metadata.createdAt
+            ))
+            if recoveries.count >= limit { break }
+        }
+        return recoveries.sorted { $0.createdAt > $1.createdAt }
+    }
+
+    @discardableResult
+    static func cleanup(
+        _ recovery: DictationStoppedAudioRecovery?,
+        transcriptPersisted: Bool = false,
+        explicitDiscard: Bool = false,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard transcriptPersisted || explicitDiscard,
+              let recovery else { return false }
+
+        do {
+            if fileManager.fileExists(atPath: recovery.url.path) {
+                try fileManager.removeItem(at: recovery.url)
+            }
+            let metadataURL = metadataURL(for: recovery.url)
+            if fileManager.fileExists(atPath: metadataURL.path) {
+                try fileManager.removeItem(at: metadataURL)
+            }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private static func writeMetadata(
+        for recovery: DictationStoppedAudioRecovery,
+        fileManager: FileManager
+    ) throws {
+        let metadata = Metadata(
+            version: 1,
+            sessionID: recovery.sessionID,
+            createdAt: recovery.createdAt,
+            audioFilename: recovery.url.lastPathComponent
+        )
+        let url = metadataURL(for: recovery.url)
+        try JSONEncoder().encode(metadata).write(to: url, options: .atomic)
+        fileManager.restrictFileToOwnerOnly(at: url)
+    }
+
+    private static func metadataURL(for audioURL: URL) -> URL {
+        audioURL.deletingPathExtension().appendingPathExtension("json")
+    }
+
+    private static func wavData(samples16k: [Float]) -> Data {
+        let bytesPerSample: UInt16 = 2
+        let channelCount: UInt16 = 1
+        let dataByteCount = UInt32(samples16k.count) * UInt32(bytesPerSample)
+        var data = Data(capacity: 44 + Int(dataByteCount))
+
+        data.append(contentsOf: "RIFF".utf8)
+        append(UInt32(36) + dataByteCount, to: &data)
+        data.append(contentsOf: "WAVEfmt ".utf8)
+        append(UInt32(16), to: &data)
+        append(UInt16(1), to: &data)
+        append(channelCount, to: &data)
+        append(sampleRate, to: &data)
+        append(sampleRate * UInt32(channelCount) * UInt32(bytesPerSample), to: &data)
+        append(channelCount * bytesPerSample, to: &data)
+        append(UInt16(16), to: &data)
+        data.append(contentsOf: "data".utf8)
+        append(dataByteCount, to: &data)
+
+        for sample in samples16k {
+            let finiteSample = sample.isFinite ? sample : 0
+            let clamped = max(-1, min(1, finiteSample))
+            let pcm = Int16((clamped * Float(Int16.max)).rounded())
+            append(UInt16(bitPattern: pcm), to: &data)
+        }
+        return data
+    }
+
+    private static func append<T: FixedWidthInteger>(_ value: T, to data: inout Data) {
+        var littleEndian = value.littleEndian
+        withUnsafeBytes(of: &littleEndian) { bytes in
+            data.append(contentsOf: bytes)
+        }
+    }
+}

--- a/Sources/Meeting/FailedMeetingStore.swift
+++ b/Sources/Meeting/FailedMeetingStore.swift
@@ -33,6 +33,8 @@ final class FailedMeetingStore {
     private let canRetry: () -> Bool
     private let prepareModelsForRetry: () async -> Bool
     private let markRetryStarted: () -> Void
+    private let prepareStoppedAudioRecoveryForRetry: (UUID) -> Void
+    private let discardStoppedAudioRecoveryForRetry: (UUID) -> Void
     private let publishRefresh: () -> Void
     private let diagnosticsContext: ([String: String]) -> [String: String]
 
@@ -46,6 +48,8 @@ final class FailedMeetingStore {
         canRetry: @escaping () -> Bool,
         prepareModelsForRetry: @escaping () async -> Bool,
         markRetryStarted: @escaping () -> Void,
+        prepareStoppedAudioRecoveryForRetry: @escaping (UUID) -> Void,
+        discardStoppedAudioRecoveryForRetry: @escaping (UUID) -> Void,
         publishRefresh: @escaping () -> Void,
         diagnosticsContext: @escaping ([String: String]) -> [String: String]
     ) {
@@ -54,6 +58,8 @@ final class FailedMeetingStore {
         self.canRetry = canRetry
         self.prepareModelsForRetry = prepareModelsForRetry
         self.markRetryStarted = markRetryStarted
+        self.prepareStoppedAudioRecoveryForRetry = prepareStoppedAudioRecoveryForRetry
+        self.discardStoppedAudioRecoveryForRetry = discardStoppedAudioRecoveryForRetry
         self.publishRefresh = publishRefresh
         self.diagnosticsContext = diagnosticsContext
     }
@@ -79,6 +85,7 @@ final class FailedMeetingStore {
         failedAudioCompressionTask?.cancel()
         retryingFailedMeetingIDs.insert(id)
         markRetryStarted()
+        prepareStoppedAudioRecoveryForRetry(id)
         publishRefresh()
         let retryStartedAt = CFAbsoluteTimeGetCurrent()
         WorkflowRecoveryTelemetry.attempted(
@@ -144,6 +151,9 @@ final class FailedMeetingStore {
     func deleteFailedMeeting(id: UUID) -> Bool {
         retryingFailedMeetingIDs.remove(id)
         let didDelete = failedManager.deleteFailedTranscription(id: id)
+        if didDelete {
+            discardStoppedAudioRecoveryForRetry(id)
+        }
         publishRefresh()
         return didDelete || !failedManager.failedTranscriptions.contains(where: { $0.id == id })
     }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1578,9 +1578,9 @@ final class MeetingSessionController: ObservableObject {
         taskManager.cancelAll()
         if liveCodexSessionAwaitingFinalTranscript {
             finishLiveCodexSession(status: .failed, shouldAwaitFinalTranscript: false)
+        }
         activeQueuedTranscriptionJobID = nil
         activeStoppedAudioRecovery = nil
-        }
         state = .ready
         DiagnosticsTrail.record(
             level: .warning,

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -205,6 +205,7 @@ final class MeetingSessionController: ObservableObject {
     var liveCodexAwaitedTranscriptionJobID: UUID?
     var activeQueuedTranscriptionJobID: UUID?
     var activeStoppedAudioRecovery: DictationStoppedAudioRecovery?
+    private var stoppedAudioRecoveryRetryRegistry = DictationStoppedAudioRecoveryRetryRegistry()
 
     var shouldConfirmQuitForActiveCapture: Bool {
         isCaptureSessionActive || isFinishingRecording
@@ -1892,6 +1893,23 @@ final class MeetingSessionController: ObservableObject {
         failedMeetingStore.deleteFailedMeeting(id: id)
     }
 
+    private func prepareStoppedAudioRecoveryForRetry(failedMeetingID: UUID) {
+        activeStoppedAudioRecovery = stoppedAudioRecoveryRetryRegistry.recovery(
+            for: failedMeetingID
+        )
+    }
+
+    private func discardStoppedAudioRecoveryForRetry(failedMeetingID: UUID) {
+        let recovery = stoppedAudioRecoveryRetryRegistry.remove(for: failedMeetingID)
+        if activeQueuedTranscriptionJobID == failedMeetingID {
+            activeStoppedAudioRecovery = nil
+        }
+        guard recovery != nil else { return }
+        Task.detached(priority: .utility) {
+            DictationStoppedAudioRecoveryStore.cleanup(recovery, explicitDiscard: true)
+        }
+    }
+
     // MARK: - Subscriptions
 
     private func wireSubscriptions() {
@@ -2633,6 +2651,7 @@ final class MeetingSessionController: ObservableObject {
         switch status {
         case .transcriptSaved:
             lastTerminalTranscriptionOutcome = .transcriptSaved
+            let completedJobID = activeQueuedTranscriptionJobID
             if let stoppedAudioRecovery = activeStoppedAudioRecovery {
                 activeStoppedAudioRecovery = nil
                 Task.detached(priority: .utility) {
@@ -2641,6 +2660,9 @@ final class MeetingSessionController: ObservableObject {
                         transcriptPersisted: true
                     )
                 }
+            }
+            if let completedJobID {
+                stoppedAudioRecoveryRetryRegistry.remove(for: completedJobID)
             }
             let transcriptionTrigger = activeTranscriptionTrigger
             let promptTelemetryProperties = activeDetectedPromptTranscriptionTelemetryProperties
@@ -2672,6 +2694,13 @@ final class MeetingSessionController: ObservableObject {
         case .failed(let message):
             lastTerminalTranscriptionOutcome = .failed(message)
             // A failed import must retain its original stopped-audio checkpoint.
+            if let failedJobID = activeQueuedTranscriptionJobID,
+               let stoppedAudioRecovery = activeStoppedAudioRecovery {
+                stoppedAudioRecoveryRetryRegistry.retain(
+                    stoppedAudioRecovery,
+                    for: failedJobID
+                )
+            }
             activeStoppedAudioRecovery = nil
             let transcriptionTrigger = activeTranscriptionTrigger
             let diagnosticMessage = taskManager.lastFailureDiagnosticMessage ?? message
@@ -3197,6 +3226,12 @@ final class MeetingSessionController: ObservableObject {
             },
             markRetryStarted: { [weak self] in
                 self?.activeTranscriptionTrigger = .unknown
+            },
+            prepareStoppedAudioRecoveryForRetry: { [weak self] failedMeetingID in
+                self?.prepareStoppedAudioRecoveryForRetry(failedMeetingID: failedMeetingID)
+            },
+            discardStoppedAudioRecoveryForRetry: { [weak self] failedMeetingID in
+                self?.discardStoppedAudioRecoveryForRetry(failedMeetingID: failedMeetingID)
             },
             publishRefresh: { [weak self] in
                 self?.refreshFailedMeetings()

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -204,6 +204,7 @@ final class MeetingSessionController: ObservableObject {
     var liveCodexFinalTranscriptNeedsQueuedJobID = false
     var liveCodexAwaitedTranscriptionJobID: UUID?
     var activeQueuedTranscriptionJobID: UUID?
+    var activeStoppedAudioRecovery: DictationStoppedAudioRecovery?
 
     var shouldConfirmQuitForActiveCapture: Bool {
         isCaptureSessionActive || isFinishingRecording
@@ -1461,13 +1462,17 @@ final class MeetingSessionController: ObservableObject {
             return false
         }
 
+        let stoppedAudioRecovery = DictationStoppedAudioRecoveryStore
+            .pendingRecoveries(limit: Int.max)
+            .first { $0.url.standardizedFileURL == sourceURL.standardizedFileURL }
         let outcome: TranscriptionQueueCoordinator.QueueInsertionOutcome
         do {
             outcome = try transcriptionQueue.enqueueImportedAudioJob(
                 audioURL: preparedAudio.copiedAudioURL,
                 suggestedTitle: preparedAudio.suggestedTitle,
                 recordingDate: preparedAudio.recordingDate,
-                startTrigger: .fileImport
+                startTrigger: .fileImport,
+                stoppedAudioRecovery: stoppedAudioRecovery
             )
         } catch {
             let preservedForRelaunch = failedMeetingStore.preserveFailedMeetingForRetry(
@@ -1573,7 +1578,8 @@ final class MeetingSessionController: ObservableObject {
         taskManager.cancelAll()
         if liveCodexSessionAwaitingFinalTranscript {
             finishLiveCodexSession(status: .failed, shouldAwaitFinalTranscript: false)
-            activeQueuedTranscriptionJobID = nil
+        activeQueuedTranscriptionJobID = nil
+        activeStoppedAudioRecovery = nil
         }
         state = .ready
         DiagnosticsTrail.record(
@@ -2627,6 +2633,15 @@ final class MeetingSessionController: ObservableObject {
         switch status {
         case .transcriptSaved:
             lastTerminalTranscriptionOutcome = .transcriptSaved
+            if let stoppedAudioRecovery = activeStoppedAudioRecovery {
+                activeStoppedAudioRecovery = nil
+                Task.detached(priority: .utility) {
+                    DictationStoppedAudioRecoveryStore.cleanup(
+                        stoppedAudioRecovery,
+                        transcriptPersisted: true
+                    )
+                }
+            }
             let transcriptionTrigger = activeTranscriptionTrigger
             let promptTelemetryProperties = activeDetectedPromptTranscriptionTelemetryProperties
             let promptRecordingStartedAt = activeDetectedPromptTranscriptionRecordingStartedAt
@@ -2656,6 +2671,8 @@ final class MeetingSessionController: ObservableObject {
             activeTranscriptionCaptureDiagnostics = nil
         case .failed(let message):
             lastTerminalTranscriptionOutcome = .failed(message)
+            // A failed import must retain its original stopped-audio checkpoint.
+            activeStoppedAudioRecovery = nil
             let transcriptionTrigger = activeTranscriptionTrigger
             let diagnosticMessage = taskManager.lastFailureDiagnosticMessage ?? message
             let failureKind = MeetingFailureKind.classify(message: diagnosticMessage)

--- a/Sources/Meeting/TranscriptionQueueCoordinator.swift
+++ b/Sources/Meeting/TranscriptionQueueCoordinator.swift
@@ -40,6 +40,7 @@ final class TranscriptionQueueCoordinator {
         let kind: Kind
         let startTrigger: MeetingSessionController.StartTrigger
         let sttModel: TranscriptionModelChoice
+        let stoppedAudioRecovery: DictationStoppedAudioRecovery?
         let promptTelemetryProperties: [String: String]?
         let promptRecordingStartedAt: Date?
 
@@ -129,6 +130,7 @@ final class TranscriptionQueueCoordinator {
             ),
             startTrigger: startTrigger,
             sttModel: controller.sttRouter.selectedModel,
+            stoppedAudioRecovery: nil,
             promptTelemetryProperties: promptTelemetryProperties,
             promptRecordingStartedAt: promptRecordingStartedAt
         )
@@ -144,7 +146,8 @@ final class TranscriptionQueueCoordinator {
         audioURL: URL,
         suggestedTitle: String,
         recordingDate: Date,
-        startTrigger: MeetingSessionController.StartTrigger
+        startTrigger: MeetingSessionController.StartTrigger,
+        stoppedAudioRecovery: DictationStoppedAudioRecovery? = nil
     ) throws -> QueueInsertionOutcome {
         let job = QueuedTranscriptionJob(
             id: UUID(),
@@ -155,6 +158,7 @@ final class TranscriptionQueueCoordinator {
             ),
             startTrigger: startTrigger,
             sttModel: controller.sttRouter.selectedModel,
+            stoppedAudioRecovery: stoppedAudioRecovery,
             promptTelemetryProperties: nil,
             promptRecordingStartedAt: nil
         )
@@ -318,6 +322,7 @@ final class TranscriptionQueueCoordinator {
         controller.sttAdapter.selectPreparedModel(job.sttModel)
         queuedRuntimeDiagnosticsJobIDs.remove(job.id)
         controller.activeQueuedTranscriptionJobID = job.id
+        controller.activeStoppedAudioRecovery = job.stoppedAudioRecovery
 
         switch job.kind {
         case .recorded(let micURL, let systemURL, let healthInfo, _, let meetingTitle, let recordingDate):

--- a/Sources/Meeting/TranscriptionQueueCoordinator.swift
+++ b/Sources/Meeting/TranscriptionQueueCoordinator.swift
@@ -520,6 +520,7 @@ final class TranscriptionQueueCoordinator {
                     ),
                     startTrigger: .fileImport,
                     sttModel: model,
+                    stoppedAudioRecovery: nil,
                     promptTelemetryProperties: nil,
                     promptRecordingStartedAt: nil
                 )

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2224,6 +2224,24 @@ class ParakeetEngine: ObservableObject {
         return (nativeSampleCount, resampled)
     }
 
+    private func consumeRecordedSamples(
+        preparedRecording: RecordedSpeechSamples?
+    ) async -> (nativeSampleCount: Int, samples16k: [Float])? {
+        guard let preparedRecording else {
+            return await drainRecordedSamplesForInference()
+        }
+
+        // The persistence snapshot already resampled this exact stopped
+        // recording. Consume the native buffers without repeating that work.
+        drainPendingSamplesIntoSampleBuffer()
+        sampleBuffer.removeAll(keepingCapacity: true)
+        clearRecoveredRecordingTimeline(keepingCapacity: true)
+        return (
+            nativeSampleCount: preparedRecording.nativeSampleCount,
+            samples16k: preparedRecording.samples16k
+        )
+    }
+
     func snapshotRecordedSamplesForPersistence() async -> RecordedSpeechSamples? {
         drainPendingSamplesIntoSampleBuffer()
 
@@ -2251,7 +2269,10 @@ class ParakeetEngine: ObservableObject {
 
     // MARK: - Transcription
 
-    func drainRecordedSamplesForExternalTranscription(engineName: String) async -> RecordedSpeechSamples? {
+    func drainRecordedSamplesForExternalTranscription(
+        engineName: String,
+        preparedRecording: RecordedSpeechSamples? = nil
+    ) async -> RecordedSpeechSamples? {
         lastEmptyTranscriptionReason = nil
         guard !isTranscribing else {
             EventReporter.shared.capture(
@@ -2265,7 +2286,7 @@ class ParakeetEngine: ObservableObject {
 
         drainPendingSamplesIntoSampleBuffer()
 
-        guard !sampleBuffer.isEmpty || !recoveredRecordingTimeline.isEmpty else {
+        guard preparedRecording != nil || !sampleBuffer.isEmpty || !recoveredRecordingTimeline.isEmpty else {
             lastEmptyTranscriptionReason = .recordingTooShort
             EventReporter.shared.capture(
                 level: .warning,
@@ -2277,7 +2298,7 @@ class ParakeetEngine: ObservableObject {
         }
 
         isTranscribing = true
-        guard let recorded = await drainRecordedSamplesForInference() else {
+        guard let recorded = await consumeRecordedSamples(preparedRecording: preparedRecording) else {
             finishExternalTranscription()
             return nil
         }
@@ -2391,7 +2412,7 @@ class ParakeetEngine: ObservableObject {
         }
     }
 
-    func transcribe() async -> String? {
+    func transcribe(preparedRecording: RecordedSpeechSamples? = nil) async -> String? {
         lastEmptyTranscriptionReason = nil
         guard !isTranscribing else {
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "transcription_already_active",
@@ -2399,7 +2420,7 @@ class ParakeetEngine: ObservableObject {
             return nil
         }
         drainPendingSamplesIntoSampleBuffer()
-        guard !sampleBuffer.isEmpty || !recoveredRecordingTimeline.isEmpty else {
+        guard preparedRecording != nil || !sampleBuffer.isEmpty || !recoveredRecordingTimeline.isEmpty else {
             lastEmptyTranscriptionReason = .recordingTooShort
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "no_audio_samples",
                 message: "No audio samples in buffer when transcribe() called")
@@ -2415,7 +2436,7 @@ class ParakeetEngine: ObservableObject {
         isTranscribing = true
         let startTime = CFAbsoluteTimeGetCurrent()
 
-        guard let recorded = await drainRecordedSamplesForInference() else {
+        guard let recorded = await consumeRecordedSamples(preparedRecording: preparedRecording) else {
             finishTranscription()
             return nil
         }

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2224,6 +2224,31 @@ class ParakeetEngine: ObservableObject {
         return (nativeSampleCount, resampled)
     }
 
+    func snapshotRecordedSamplesForPersistence() async -> RecordedSpeechSamples? {
+        drainPendingSamplesIntoSampleBuffer()
+
+        var segments = recoveredRecordingTimeline.segments
+        if !sampleBuffer.isEmpty {
+            segments.append(RecordedAudioSegment(sampleRate: safeNativeSampleRate(), samples: sampleBuffer))
+        }
+        let nativeSampleCount = segments.reduce(0) { $0 + $1.samples.count }
+        guard nativeSampleCount > 0 else { return nil }
+
+        let samples16k = await Task.detached(priority: .userInitiated) {
+            var combined: [Float] = []
+            combined.reserveCapacity(nativeSampleCount)
+            for segment in segments {
+                combined.append(contentsOf: AudioResampler.resample(
+                    segment.samples,
+                    from: segment.sampleRate,
+                    to: TranscriptedConstants.parakeetSampleRate
+                ))
+            }
+            return combined
+        }.value
+        return RecordedSpeechSamples(nativeSampleCount: nativeSampleCount, samples16k: samples16k)
+    }
+
     // MARK: - Transcription
 
     func drainRecordedSamplesForExternalTranscription(engineName: String) async -> RecordedSpeechSamples? {

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -255,6 +255,7 @@ class STTRouter: ObservableObject {
     ) async -> String? {
         await initialize(model: model)
         guard isModelLoaded(for: model) else {
+            lastEmptyTranscriptionReason = .modelFailure
             EventReporter.shared.capture(
                 level: .error,
                 engine: model.engineName,
@@ -285,6 +286,7 @@ class STTRouter: ObservableObject {
             }
             return text
         } catch {
+            lastEmptyTranscriptionReason = .modelFailure
             EventReporter.shared.capture(
                 level: .error,
                 engine: model.engineName,

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -195,6 +195,10 @@ class STTRouter: ObservableObject {
         await parakeetEngine.stopRecording()
     }
 
+    func snapshotRecordedSamplesForPersistence() async -> RecordedSpeechSamples? {
+        await parakeetEngine.snapshotRecordedSamplesForPersistence()
+    }
+
     func resetAfterFailedRecordingStart() async {
         activeRecordingModel = nil
         await parakeetEngine.resetAfterFailedRecordingStart()

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -209,7 +209,7 @@ class STTRouter: ObservableObject {
         parakeetEngine.abandonBlockedRecordingStart(reason: reason)
     }
 
-    func transcribe() async -> String? {
+    func transcribe(preparedRecording: RecordedSpeechSamples? = nil) async -> String? {
         let model = activeRecordingModel ?? selectedModel
         lastEmptyTranscriptionReason = nil
         defer {
@@ -218,11 +218,14 @@ class STTRouter: ObservableObject {
 
         switch model {
         case .parakeetTDTv3:
-            let text = await parakeetEngine.transcribe()
+            let text = await parakeetEngine.transcribe(preparedRecording: preparedRecording)
             lastEmptyTranscriptionReason = text == nil ? parakeetEngine.lastEmptyTranscriptionReason : nil
             return text
         case .whisperLargeV3Turbo, .whisperLargeV3:
-            return await transcribeUsingExternalEngine(model: model) { [self] recording in
+            return await transcribeUsingExternalEngine(
+                model: model,
+                preparedRecording: preparedRecording
+            ) { [self] recording in
                 try await whisperEngine.transcribeSamples(
                     recording.samples16k,
                     source: .microphone,
@@ -230,7 +233,10 @@ class STTRouter: ObservableObject {
                 )
             }
         case .nemotronStreaming:
-            return await transcribeUsingExternalEngine(model: model) { [self] recording in
+            return await transcribeUsingExternalEngine(
+                model: model,
+                preparedRecording: preparedRecording
+            ) { [self] recording in
                 try await nemotronEngine.transcribeSamples(
                     recording.samples16k,
                     source: .microphone
@@ -244,6 +250,7 @@ class STTRouter: ObservableObject {
     /// Parakeet samples rather than owning the audio graph themselves.
     private func transcribeUsingExternalEngine(
         model: TranscriptionModelChoice,
+        preparedRecording: RecordedSpeechSamples?,
         transcribe: (RecordedSpeechSamples) async throws -> String
     ) async -> String? {
         await initialize(model: model)
@@ -259,7 +266,8 @@ class STTRouter: ObservableObject {
         }
 
         guard let recording = await parakeetEngine.drainRecordedSamplesForExternalTranscription(
-            engineName: model.engineName
+            engineName: model.engineName,
+            preparedRecording: preparedRecording
         ) else {
             lastEmptyTranscriptionReason = parakeetEngine.lastEmptyTranscriptionReason
             return nil

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -145,6 +145,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
         // Set up the floating overlay panel (pure AppKit — no NSHostingView)
         overlayController.setup(sttRouter: appState.sttRouter)
+        sessionController.presentPendingStoppedAudioRecoveryIfNeeded()
 
         // Meeting overlay + hotkey + speaker naming — Lane C wiring.
         if #available(macOS 14.0, *) {

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -71,6 +71,7 @@ class DictationSessionController: ObservableObject {
     private var currentDictationTrigger: DictationTrigger = .unknown
     private var currentDictationSessionID = UUID()
     private var stoppedAudioRecovery: DictationStoppedAudioRecovery?
+    private var stoppedAudioRecoveryPreservationSessionID: UUID?
     private var autoSendRequestDecision = DictationAutoSendRequestDecision.notEvaluated
 
     /// Max duration for a listening session before auto-cancel (5 minutes).
@@ -138,6 +139,7 @@ class DictationSessionController: ObservableObject {
         isDictating = true
         currentDictationSessionID = UUID()
         stoppedAudioRecovery = nil
+        stoppedAudioRecoveryPreservationSessionID = nil
         sessionSourceApp = sourceApp
         sessionPasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)
         sessionAnchorRect = anchorRect
@@ -959,12 +961,17 @@ class DictationSessionController: ObservableObject {
                         taskSessionID: taskSessionID,
                         currentSessionID: self.currentDictationSessionID
                     ) else {
-                        await Task.detached(priority: .utility) {
-                            DictationStoppedAudioRecoveryStore.cleanup(
-                                recovery,
-                                explicitDiscard: true
-                            )
-                        }.value
+                        if !DictationStoppedAudioRecoveryCommitPolicy.shouldRetainPersistedRecovery(
+                            taskSessionID: taskSessionID,
+                            preservationSessionID: self.stoppedAudioRecoveryPreservationSessionID
+                        ) {
+                            await Task.detached(priority: .utility) {
+                                DictationStoppedAudioRecoveryStore.cleanup(
+                                    recovery,
+                                    explicitDiscard: true
+                                )
+                            }.value
+                        }
                         return
                     }
                     self.stoppedAudioRecovery = recovery
@@ -1406,6 +1413,9 @@ class DictationSessionController: ObservableObject {
     /// Cancel dictation without pasting
     func cancelDictation(preserveStoppedAudio: Bool = false) {
         guard let (appState, overlayController) = readyState() else { return }
+        if preserveStoppedAudio {
+            stoppedAudioRecoveryPreservationSessionID = currentDictationSessionID
+        }
         cancelActiveTasks(cancelRecording: true)
         if !preserveStoppedAudio {
             discardStoppedAudioRecovery(explicitDiscard: true)

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -929,6 +929,7 @@ class DictationSessionController: ObservableObject {
         let taskSessionID = currentDictationSessionID
         streamingTask = Task {
             var stopTiming = DictationStopTiming(requestedAt: stopRequestedAt)
+            var stoppedRecordingSnapshot: RecordedSpeechSamples?
             appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "stop_requested")
             if appState.sttRouter.isRecording || appState.sttRouter.hasRecoverableRecording {
                 await appState.sttRouter.stopRecording()
@@ -946,12 +947,36 @@ class DictationSessionController: ObservableObject {
                         taskSessionID: taskSessionID,
                         currentSessionID: self.currentDictationSessionID
                     ) else { return }
-                    self.stoppedAudioRecovery = try DictationStoppedAudioRecoveryStore.persist(
-                        samples16k: recording.samples16k,
-                        sessionID: taskSessionID
-                    )
+                    let recovery = try await Task.detached(priority: .userInitiated) {
+                        try DictationStoppedAudioRecoveryStore.persist(
+                            samples16k: recording.samples16k,
+                            sessionID: taskSessionID
+                        )
+                    }.value
+                    guard DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
+                        taskCancelled: Task.isCancelled,
+                        isDictating: self.isDictating,
+                        taskSessionID: taskSessionID,
+                        currentSessionID: self.currentDictationSessionID
+                    ) else {
+                        await Task.detached(priority: .utility) {
+                            DictationStoppedAudioRecoveryStore.cleanup(
+                                recovery,
+                                explicitDiscard: true
+                            )
+                        }.value
+                        return
+                    }
+                    self.stoppedAudioRecovery = recovery
+                    stoppedRecordingSnapshot = recording
                 }
             } catch {
+                guard DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
+                    taskCancelled: Task.isCancelled,
+                    isDictating: self.isDictating,
+                    taskSessionID: taskSessionID,
+                    currentSessionID: self.currentDictationSessionID
+                ) else { return }
                 appState.logger.log("DICTATION | failed to preserve stopped audio: \(error.localizedDescription)")
                 EventReporter.shared.capture(
                     level: .error,
@@ -1026,7 +1051,9 @@ class DictationSessionController: ObservableObject {
             overlayController.resizePanelToCompact()
             appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "transcribing")
             stopTiming.transcriptionStartedAt = CFAbsoluteTimeGetCurrent()
-            let voiceText = await appState.sttRouter.transcribe()
+            let voiceText = await appState.sttRouter.transcribe(
+                preparedRecording: stoppedRecordingSnapshot
+            )
             stopTiming.transcribedAt = CFAbsoluteTimeGetCurrent()
             guard !Task.isCancelled,
                   self.isDictating,

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -940,6 +940,12 @@ class DictationSessionController: ObservableObject {
 
             do {
                 if let recording = await appState.sttRouter.snapshotRecordedSamplesForPersistence() {
+                    guard DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
+                        taskCancelled: Task.isCancelled,
+                        isDictating: self.isDictating,
+                        taskSessionID: taskSessionID,
+                        currentSessionID: self.currentDictationSessionID
+                    ) else { return }
                     self.stoppedAudioRecovery = try DictationStoppedAudioRecoveryStore.persist(
                         samples16k: recording.samples16k,
                         sessionID: taskSessionID

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -70,6 +70,7 @@ class DictationSessionController: ObservableObject {
     private var sessionStartTime: CFAbsoluteTime = 0
     private var currentDictationTrigger: DictationTrigger = .unknown
     private var currentDictationSessionID = UUID()
+    private var stoppedAudioRecovery: DictationStoppedAudioRecovery?
     private var autoSendRequestDecision = DictationAutoSendRequestDecision.notEvaluated
 
     /// Max duration for a listening session before auto-cancel (5 minutes).
@@ -102,6 +103,19 @@ class DictationSessionController: ObservableObject {
             }
     }
 
+    func presentPendingStoppedAudioRecoveryIfNeeded() {
+        guard !isDictating,
+              let overlayController,
+              let recovery = DictationStoppedAudioRecoveryStore.pendingRecoveries(limit: 1).first else { return }
+        overlayController.showError(
+            "A stopped dictation recording is available. Use Import Audio from Home to recover its transcript.",
+            actionTitle: "Show Audio",
+            action: {
+                NSWorkspace.shared.activateFileViewerSelecting([recovery.url])
+            }
+        )
+    }
+
     // MARK: - Dictation Mode (Option+Space)
 
     /// Start dictation — show overlay and begin voice recording (no screenshot/vision)
@@ -123,6 +137,7 @@ class DictationSessionController: ObservableObject {
         }
         isDictating = true
         currentDictationSessionID = UUID()
+        stoppedAudioRecovery = nil
         sessionSourceApp = sourceApp
         sessionPasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)
         sessionAnchorRect = anchorRect
@@ -923,6 +938,27 @@ class DictationSessionController: ObservableObject {
                   self.isDictating,
                   self.currentDictationSessionID == taskSessionID else { return }
 
+            do {
+                if let recording = await appState.sttRouter.snapshotRecordedSamplesForPersistence() {
+                    self.stoppedAudioRecovery = try DictationStoppedAudioRecoveryStore.persist(
+                        samples16k: recording.samples16k,
+                        sessionID: taskSessionID
+                    )
+                }
+            } catch {
+                appState.logger.log("DICTATION | failed to preserve stopped audio: \(error.localizedDescription)")
+                EventReporter.shared.capture(
+                    level: .error,
+                    engine: "dictation",
+                    event: "dictation_stopped_audio_persistence_failed",
+                    message: error.localizedDescription
+                )
+                overlayController.showError("The recording stopped, but its audio couldn't be saved safely. Free some disk space and try again.")
+                self.isDictating = false
+                appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "audio_persistence_failed")
+                return
+            }
+
             // Surface model warmup honestly instead of calling it "Transcribing"
             // before the local dictation model is actually ready.
             if !appState.sttRouter.isModelLoaded {
@@ -1040,6 +1076,9 @@ class DictationSessionController: ObservableObject {
                 overlayController.showNoSpeechAndDismiss(trigger: currentDictationTrigger.rawValue, reason: emptyReason)
                 isDictating = false
                 appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: emptyReason.runtimeOutcome)
+                if emptyReason != .modelFailure {
+                    self.discardStoppedAudioRecovery(explicitDiscard: true)
+                }
                 return
             }
 
@@ -1102,6 +1141,7 @@ class DictationSessionController: ObservableObject {
             )
             let autoSendOutcome = finalization.autoEnterOutcome
             let saveResult = finalization.saveResult
+            self.discardStoppedAudioRecovery(transcriptPersisted: saveResult.saved != nil)
             let saveFailureMessage = saveResult.failureMessage
             let wordCount = text.split(whereSeparator: \.isWhitespace).count
             stopTiming.completedAt = CFAbsoluteTimeGetCurrent()
@@ -1253,6 +1293,7 @@ class DictationSessionController: ObservableObject {
     ) {
         lastCompletedText = text
         let saveResult = persistDictationTranscript(text: text, delivery: .savedWithoutPaste)
+        discardStoppedAudioRecovery(transcriptPersisted: saveResult.saved != nil)
         let saveFailureMessage = saveResult.failureMessage
         let wordCount = text.split(whereSeparator: \.isWhitespace).count
         let durationSeconds = CFAbsoluteTimeGetCurrent() - sessionStartTime
@@ -1330,9 +1371,12 @@ class DictationSessionController: ObservableObject {
     }
 
     /// Cancel dictation without pasting
-    func cancelDictation() {
+    func cancelDictation(preserveStoppedAudio: Bool = false) {
         guard let (appState, overlayController) = readyState() else { return }
         cancelActiveTasks(cancelRecording: true)
+        if !preserveStoppedAudio {
+            discardStoppedAudioRecovery(explicitDiscard: true)
+        }
         AppSoundPlayer.shared.play(.dictationCancelled)
         overlayController.hideWithCancelAnimation()
         isDictating = false
@@ -1384,7 +1428,7 @@ class DictationSessionController: ObservableObject {
         }
 
         if isDictating {
-            cancelDictation()
+            cancelDictation(preserveStoppedAudio: true)
         }
     }
 
@@ -1958,6 +2002,18 @@ class DictationSessionController: ObservableObject {
         } catch {
             return .failure(recordDictationTranscriptSaveFailed(error))
         }
+    }
+
+    private func discardStoppedAudioRecovery(
+        transcriptPersisted: Bool = false,
+        explicitDiscard: Bool = false
+    ) {
+        guard DictationStoppedAudioRecoveryStore.cleanup(
+            stoppedAudioRecovery,
+            transcriptPersisted: transcriptPersisted,
+            explicitDiscard: explicitDiscard
+        ) else { return }
+        stoppedAudioRecovery = nil
     }
 
     private func startPersistingDictationTranscript(

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -5,6 +5,26 @@ import AppKit
 import AVFoundation
 import Combine
 
+private actor DictationStoppedAudioCheckpointSignal {
+    private var isComplete = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isComplete else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func complete() {
+        guard !isComplete else { return }
+        isComplete = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        pendingWaiters.forEach { $0.resume() }
+    }
+}
+
 @MainActor
 class DictationSessionController: ObservableObject {
     enum DictationTrigger: String {
@@ -72,6 +92,7 @@ class DictationSessionController: ObservableObject {
     private var currentDictationSessionID = UUID()
     private var stoppedAudioRecovery: DictationStoppedAudioRecovery?
     private var stoppedAudioRecoveryPreservationSessionID: UUID?
+    private var stoppedAudioCheckpointSignal: DictationStoppedAudioCheckpointSignal?
     private var autoSendRequestDecision = DictationAutoSendRequestDecision.notEvaluated
 
     /// Max duration for a listening session before auto-cancel (5 minutes).
@@ -140,6 +161,7 @@ class DictationSessionController: ObservableObject {
         currentDictationSessionID = UUID()
         stoppedAudioRecovery = nil
         stoppedAudioRecoveryPreservationSessionID = nil
+        stoppedAudioCheckpointSignal = nil
         sessionSourceApp = sourceApp
         sessionPasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)
         sessionAnchorRect = anchorRect
@@ -929,7 +951,12 @@ class DictationSessionController: ObservableObject {
 
         streamingTask?.cancel()
         let taskSessionID = currentDictationSessionID
+        let checkpointSignal = DictationStoppedAudioCheckpointSignal()
+        stoppedAudioCheckpointSignal = checkpointSignal
         streamingTask = Task {
+            defer {
+                Task { await checkpointSignal.complete() }
+            }
             var stopTiming = DictationStopTiming(requestedAt: stopRequestedAt)
             var stoppedRecordingSnapshot: RecordedSpeechSamples?
             appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "stop_requested")
@@ -996,6 +1023,8 @@ class DictationSessionController: ObservableObject {
                 appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "audio_persistence_failed")
                 return
             }
+
+            await checkpointSignal.complete()
 
             // Surface model warmup honestly instead of calling it "Transcribing"
             // before the local dictation model is actually ready.
@@ -1471,6 +1500,10 @@ class DictationSessionController: ObservableObject {
         }
 
         if isDictating {
+            stoppedAudioRecoveryPreservationSessionID = currentDictationSessionID
+            if let stoppedAudioCheckpointSignal {
+                await stoppedAudioCheckpointSignal.wait()
+            }
             cancelDictation(preserveStoppedAudio: true)
         }
     }

--- a/Tests/DictationStoppedAudioRecoveryTests.swift
+++ b/Tests/DictationStoppedAudioRecoveryTests.swift
@@ -209,6 +209,26 @@ func testDictationStoppedAudioRecovery() {
                 source.contains("stoppedAudioRecoveryPreservationSessionID = currentDictationSessionID"),
                 "termination cancellation must mark the active session before cancelling its stop task"
             )
+            let terminationSource = source.components(separatedBy: "func finishDictationForTermination() async").last ?? ""
+            guard let preservationRange = terminationSource.range(
+                of: "stoppedAudioRecoveryPreservationSessionID = currentDictationSessionID"
+            ),
+            let checkpointWaitRange = terminationSource.range(
+                of: "await stoppedAudioCheckpointSignal.wait()",
+                range: preservationRange.upperBound..<terminationSource.endIndex
+            ),
+            let preservingCancelRange = terminationSource.range(
+                of: "cancelDictation(preserveStoppedAudio: true)",
+                range: checkpointWaitRange.upperBound..<terminationSource.endIndex
+            ) else {
+                assertTrue(false, "termination must await checkpoint durability before cancelling the stop task")
+                return
+            }
+            assertTrue(
+                preservationRange.lowerBound < checkpointWaitRange.lowerBound
+                    && checkpointWaitRange.lowerBound < preservingCancelRange.lowerBound,
+                "termination must mark, await, then cancel the active stopped-audio session"
+            )
             let appSource = try String(contentsOf: repoFixtureURL("Sources/TranscriptedApp.swift"), encoding: .utf8)
             assertTrue(
                 appSource.contains("sessionController.presentPendingStoppedAudioRecoveryIfNeeded()"),

--- a/Tests/DictationStoppedAudioRecoveryTests.swift
+++ b/Tests/DictationStoppedAudioRecoveryTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+func testDictationStoppedAudioRecovery() {
+    runSuite("Dictation stopped audio recovery writes a valid private WAV") {
+        let directory = makeRecoveryTestDirectory("wav")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let sessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000123")!
+
+        do {
+            let recovery = try DictationStoppedAudioRecoveryStore.persist(
+                samples16k: [-1, -0.5, 0, 0.5, 1],
+                sessionID: sessionID,
+                directory: directory
+            )
+            assertNotNil(recovery, "non-empty stopped audio should be checkpointed")
+            guard let recovery else { return }
+            let data = try Data(contentsOf: recovery.url)
+            assertEqual(String(data: data[0..<4], encoding: .ascii), "RIFF", "recovery audio should use a WAV container")
+            assertEqual(String(data: data[8..<12], encoding: .ascii), "WAVE", "recovery audio should identify the WAV format")
+            assertEqual(readUInt32LE(data, offset: 24), 16_000, "recovery audio should be stored at the inference sample rate")
+            assertEqual(readUInt16LE(data, offset: 34), 16, "recovery audio should use 16-bit PCM")
+            assertEqual(readUInt32LE(data, offset: 40), 10, "WAV data length should match the sample count")
+            let attributes = try FileManager.default.attributesOfItem(atPath: recovery.url.path)
+            let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue
+            assertEqual(permissions, 0o600, "recovery audio should be owner-only")
+            let discovered = DictationStoppedAudioRecoveryStore.pendingRecoveries(limit: 1, directory: directory)
+            assertEqual(discovered, [recovery], "durable metadata should make recovery discoverable after store recreation")
+        } catch {
+            assertTrue(false, "recovery WAV should persist: \(error)")
+        }
+    }
+
+    runSuite("Dictation stopped audio recovery survives failed transcript persistence") {
+        let directory = makeRecoveryTestDirectory("retain")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        do {
+            let recovery = try DictationStoppedAudioRecoveryStore.persist(
+                samples16k: [0.25, -0.25],
+                sessionID: UUID(),
+                directory: directory
+            )
+            let cleaned = DictationStoppedAudioRecoveryStore.cleanup(
+                recovery,
+                transcriptPersisted: false,
+                explicitDiscard: false
+            )
+            assertFalse(cleaned, "failed transcript persistence must not clean recovery audio")
+            assertTrue(FileManager.default.fileExists(atPath: recovery!.url.path), "recovery audio must remain durable")
+        } catch {
+            assertTrue(false, "recovery audio should persist: \(error)")
+        }
+    }
+
+    runSuite("Dictation stopped audio recovery cleans up only after success or explicit discard") {
+        for transcriptPersisted in [true, false] {
+            let directory = makeRecoveryTestDirectory(transcriptPersisted ? "saved" : "discarded")
+            defer { try? FileManager.default.removeItem(at: directory) }
+            do {
+                let recovery = try DictationStoppedAudioRecoveryStore.persist(
+                    samples16k: [0.1],
+                    sessionID: UUID(),
+                    directory: directory
+                )
+                let cleaned = DictationStoppedAudioRecoveryStore.cleanup(
+                    recovery,
+                    transcriptPersisted: transcriptPersisted,
+                    explicitDiscard: !transcriptPersisted
+                )
+                assertTrue(cleaned, "successful save or explicit discard should clean recovery audio")
+                assertFalse(FileManager.default.fileExists(atPath: recovery!.url.path), "cleaned recovery audio should be deleted")
+                assertTrue(
+                    DictationStoppedAudioRecoveryStore.pendingRecoveries(directory: directory).isEmpty,
+                    "cleanup should remove restart-discovery metadata"
+                )
+            } catch {
+                assertTrue(false, "recovery cleanup should succeed: \(error)")
+            }
+        }
+    }
+
+    runSuite("Dictation controller checkpoints audio before waiting for the model") {
+        do {
+            let source = try String(
+                contentsOf: repoFixtureURL("Sources/UI/Overlay/DictationSessionController.swift"),
+                encoding: .utf8
+            )
+            guard let persistRange = source.range(of: "DictationStoppedAudioRecoveryStore.persist("),
+                  let modelWaitRange = source.range(of: "if !appState.sttRouter.isModelLoaded", range: persistRange.upperBound..<source.endIndex) else {
+                assertTrue(false, "controller should persist stopped audio before the model wait")
+                return
+            }
+            assertTrue(persistRange.lowerBound < modelWaitRange.lowerBound, "durable checkpoint must precede the model failure boundary")
+            assertTrue(source.contains("transcriptPersisted: saveResult.saved != nil"), "cleanup should be tied to successful transcript persistence")
+            assertTrue(source.contains("if emptyReason != .modelFailure"), "model failures should retain recovery audio")
+            assertTrue(
+                source.contains("cancelDictation(preserveStoppedAudio: true)"),
+                "termination timeout must not convert a durable checkpoint into an implicit discard"
+            )
+            let appSource = try String(contentsOf: repoFixtureURL("Sources/TranscriptedApp.swift"), encoding: .utf8)
+            assertTrue(
+                appSource.contains("sessionController.presentPendingStoppedAudioRecoveryIfNeeded()"),
+                "launch should scan for pending stopped audio"
+            )
+        } catch {
+            assertTrue(false, "controller source should be readable: \(error)")
+        }
+    }
+}
+
+private func makeRecoveryTestDirectory(_ suffix: String) -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent("DictationStoppedAudioRecoveryTests-\(suffix)-\(UUID().uuidString)", isDirectory: true)
+}
+
+private func readUInt16LE(_ data: Data, offset: Int) -> UInt16 {
+    UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+}
+
+private func readUInt32LE(_ data: Data, offset: Int) -> UInt32 {
+    UInt32(data[offset])
+        | (UInt32(data[offset + 1]) << 8)
+        | (UInt32(data[offset + 2]) << 16)
+        | (UInt32(data[offset + 3]) << 24)
+}

--- a/Tests/DictationStoppedAudioRecoveryTests.swift
+++ b/Tests/DictationStoppedAudioRecoveryTests.swift
@@ -78,6 +78,56 @@ func testDictationStoppedAudioRecovery() {
         }
     }
 
+    runSuite("Dictation stopped audio recovery limits after newest-first ordering") {
+        let oldSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let middleSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        let newSessionID = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+        let recoveries = [
+            DictationStoppedAudioRecovery(url: URL(fileURLWithPath: "/old.wav"), sessionID: oldSessionID, createdAt: Date(timeIntervalSince1970: 1)),
+            DictationStoppedAudioRecovery(url: URL(fileURLWithPath: "/new.wav"), sessionID: newSessionID, createdAt: Date(timeIntervalSince1970: 3)),
+            DictationStoppedAudioRecovery(url: URL(fileURLWithPath: "/middle.wav"), sessionID: middleSessionID, createdAt: Date(timeIntervalSince1970: 2))
+        ]
+
+        let limited = DictationStoppedAudioRecoveryStore.mostRecent(recoveries, limit: 2)
+
+        assertEqual(
+            limited.map(\.sessionID),
+            [newSessionID, middleSessionID],
+            "the limit must select the newest recoveries regardless of enumeration order"
+        )
+    }
+
+    runSuite("Stopped audio persistence rejects cancelled and superseded sessions") {
+        let activeSessionID = UUID()
+        assertTrue(
+            DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
+                taskCancelled: false,
+                isDictating: true,
+                taskSessionID: activeSessionID,
+                currentSessionID: activeSessionID
+            ),
+            "the current live stop task should persist its recovery checkpoint"
+        )
+        assertFalse(
+            DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
+                taskCancelled: true,
+                isDictating: true,
+                taskSessionID: activeSessionID,
+                currentSessionID: activeSessionID
+            ),
+            "a cancelled stop task must not persist after detached resampling returns"
+        )
+        assertFalse(
+            DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
+                taskCancelled: false,
+                isDictating: true,
+                taskSessionID: activeSessionID,
+                currentSessionID: UUID()
+            ),
+            "an old stop task must not mutate a successor session"
+        )
+    }
+
     runSuite("Dictation controller checkpoints audio before waiting for the model") {
         do {
             let source = try String(
@@ -90,6 +140,18 @@ func testDictationStoppedAudioRecovery() {
                 return
             }
             assertTrue(persistRange.lowerBound < modelWaitRange.lowerBound, "durable checkpoint must precede the model failure boundary")
+            guard let snapshotRange = source.range(of: "snapshotRecordedSamplesForPersistence()"),
+                  let commitGuardRange = source.range(
+                    of: "DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(",
+                    range: snapshotRange.upperBound..<persistRange.lowerBound
+                  ) else {
+                assertTrue(false, "controller should revalidate session ownership after snapshot resampling and before persistence")
+                return
+            }
+            assertTrue(
+                snapshotRange.lowerBound < commitGuardRange.lowerBound && commitGuardRange.lowerBound < persistRange.lowerBound,
+                "cancel/session guard must run after the detached snapshot and before recovery persistence"
+            )
             assertTrue(source.contains("transcriptPersisted: saveResult.saved != nil"), "cleanup should be tied to successful transcript persistence")
             assertTrue(source.contains("if emptyReason != .modelFailure"), "model failures should retain recovery audio")
             assertTrue(

--- a/Tests/DictationStoppedAudioRecoveryTests.swift
+++ b/Tests/DictationStoppedAudioRecoveryTests.swift
@@ -1,5 +1,38 @@
 import Foundation
 
+func testDictationStoppedAudioRecoveryRetryRegistry() {
+    runSuite("stopped dictation recovery survives a failed retry until success") {
+        let recovery = DictationStoppedAudioRecovery(
+            url: URL(fileURLWithPath: "/tmp/stopped-dictation.wav"),
+            sessionID: UUID(),
+            createdAt: Date()
+        )
+        let failedMeetingID = UUID()
+        var registry = DictationStoppedAudioRecoveryRetryRegistry()
+
+        registry.retain(recovery, for: failedMeetingID)
+        assertEqual(
+            registry.recovery(for: failedMeetingID),
+            recovery,
+            "a failed transcription keeps its stopped-audio recovery for retry"
+        )
+        assertEqual(
+            registry.recovery(for: failedMeetingID),
+            recovery,
+            "a retry failure does not consume the recovery"
+        )
+        assertEqual(
+            registry.remove(for: failedMeetingID),
+            recovery,
+            "a successful retry consumes the recovery for cleanup"
+        )
+        assertTrue(
+            registry.recovery(for: failedMeetingID) == nil,
+            "a successful retry does not leave registry state behind"
+        )
+    }
+}
+
 func testDictationStoppedAudioRecovery() {
     runSuite("Dictation stopped audio recovery writes a valid private WAV") {
         let directory = makeRecoveryTestDirectory("wav")

--- a/Tests/DictationStoppedAudioRecoveryTests.swift
+++ b/Tests/DictationStoppedAudioRecoveryTests.swift
@@ -168,6 +168,22 @@ func testDictationStoppedAudioRecovery() {
                 speechSource.contains("consumeRecordedSamples(preparedRecording: preparedRecording)"),
                 "speech inference should consume the prepared snapshot instead of resampling native buffers again"
             )
+            let routerSource = try String(
+                contentsOf: repoFixtureURL("Sources/Speech/STTRouter.swift"),
+                encoding: .utf8
+            )
+            assertTrue(
+                routerSource.contains("lastEmptyTranscriptionReason = .modelFailure"),
+                "external model failures must retain stopped-audio recovery instead of looking like no speech"
+            )
+            let meetingSource = try String(
+                contentsOf: repoFixtureURL("Sources/Meeting/MeetingSessionController.swift"),
+                encoding: .utf8
+            )
+            assertTrue(
+                meetingSource.contains("transcriptPersisted: true"),
+                "a successfully imported restart checkpoint should be retired after its transcript is saved"
+            )
             assertTrue(source.contains("transcriptPersisted: saveResult.saved != nil"), "cleanup should be tied to successful transcript persistence")
             assertTrue(source.contains("if emptyReason != .modelFailure"), "model failures should retain recovery audio")
             assertTrue(

--- a/Tests/DictationStoppedAudioRecoveryTests.swift
+++ b/Tests/DictationStoppedAudioRecoveryTests.swift
@@ -126,6 +126,21 @@ func testDictationStoppedAudioRecovery() {
             ),
             "an old stop task must not mutate a successor session"
         )
+
+        assertTrue(
+            DictationStoppedAudioRecoveryCommitPolicy.shouldRetainPersistedRecovery(
+                taskSessionID: activeSessionID,
+                preservationSessionID: activeSessionID
+            ),
+            "termination cancellation must retain a checkpoint already written for that session"
+        )
+        assertFalse(
+            DictationStoppedAudioRecoveryCommitPolicy.shouldRetainPersistedRecovery(
+                taskSessionID: activeSessionID,
+                preservationSessionID: UUID()
+            ),
+            "a successor session must not retain an old task's checkpoint"
+        )
     }
 
     runSuite("Dictation controller checkpoints audio before waiting for the model") {
@@ -189,6 +204,10 @@ func testDictationStoppedAudioRecovery() {
             assertTrue(
                 source.contains("cancelDictation(preserveStoppedAudio: true)"),
                 "termination timeout must not convert a durable checkpoint into an implicit discard"
+            )
+            assertTrue(
+                source.contains("stoppedAudioRecoveryPreservationSessionID = currentDictationSessionID"),
+                "termination cancellation must mark the active session before cancelling its stop task"
             )
             let appSource = try String(contentsOf: repoFixtureURL("Sources/TranscriptedApp.swift"), encoding: .utf8)
             assertTrue(

--- a/Tests/DictationStoppedAudioRecoveryTests.swift
+++ b/Tests/DictationStoppedAudioRecoveryTests.swift
@@ -152,6 +152,22 @@ func testDictationStoppedAudioRecovery() {
                 snapshotRange.lowerBound < commitGuardRange.lowerBound && commitGuardRange.lowerBound < persistRange.lowerBound,
                 "cancel/session guard must run after the detached snapshot and before recovery persistence"
             )
+            assertTrue(
+                source.contains("let recovery = try await Task.detached(priority: .userInitiated)"),
+                "WAV encoding and disk writes must stay off the main actor"
+            )
+            assertTrue(
+                source.contains("preparedRecording: stoppedRecordingSnapshot"),
+                "transcription should reuse the already-resampled stopped recording snapshot"
+            )
+            let speechSource = try String(
+                contentsOf: repoFixtureURL("Sources/Speech/ParakeetEngine.swift"),
+                encoding: .utf8
+            )
+            assertTrue(
+                speechSource.contains("consumeRecordedSamples(preparedRecording: preparedRecording)"),
+                "speech inference should consume the prepared snapshot instead of resampling native buffers again"
+            )
             assertTrue(source.contains("transcriptPersisted: saveResult.saved != nil"), "cleanup should be tied to successful transcript persistence")
             assertTrue(source.contains("if emptyReason != .modelFailure"), "model failures should retain recovery audio")
             assertTrue(

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -286,6 +286,7 @@ APP_SOURCES=(
     "Sources/Support/ClipboardRestoringTextPaster.swift"
     "Sources/Accessibility/AccessibilityBridge.swift"
     "Sources/Dictation/DictationSessionTimeout.swift"
+    "Sources/Dictation/DictationStoppedAudioRecovery.swift"
     "Sources/Dictation/DictationStoragePaths.swift"
     "Sources/Dictation/DictationStopFinalizationPolicy.swift"
     "Sources/Dictation/DictationTranscriptWriter.swift"


### PR DESCRIPTION
Current-main replacement for #1547 after the serialized room advanced through #1538, #1549, #1565, and #1564.

This preserves stopped dictation samples as an owner-only WAV checkpoint before model/transcription work, surfaces pending recovery after relaunch, carries ownership through imported-audio queue persistence and quit-time handoff, and removes the checkpoint only after successful persistence or explicit discard. The replay keeps current main's imported-audio queue failure preservation and does not restore the deleted Tests/FastTests.manifest.

Proof plan:
- build-deps.sh --force
- signed build and full tests
- integration smoke and package seam tests
- focused stopped-audio recovery tests
- exact-head review and merge simulation

Real capture, restart, Finder, and Home import behavior remain manual proof.
