### PR TITLE
Fix MCP attach timeout after updates

### DIFF
--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -35,11 +35,11 @@ When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 that mode the SQLite index also defaults to the shared root unless
 `TRANSCRIPTED_INDEX_DIR` is set.
 
-## Package Layout (37 Swift files)
+## Package Layout (38 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
 - `Sources/TranscriptedMCP/` — 23 source files for server startup, directory resolution, path validation, indexing, telemetry, semantic search, tool handlers (split by tool family), and the MCP Apps widget surface
-- `Tests/TranscriptedMCPTests/` — 14 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, tool handlers, markdown loading, logging, telemetry, name variants, semantic search, the recent-meetings widget, audio-directory naming, frontmatter corpus parity, and shared fixtures
+- `Tests/TranscriptedMCPTests/` — 15 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, tool handlers, markdown loading, logging, telemetry, name variants, semantic search, process startup, the recent-meetings widget, audio-directory naming, frontmatter corpus parity, and shared fixtures
 
 ## File Index
 
@@ -84,6 +84,7 @@ that mode the SQLite index also defaults to the shared root unless
 | `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error, read pagination windows and size guard |
 | `AgentCaptureQueryTelemetryTests.swift` | Terminal-result, bucketing, build-identity, and payload coverage for agent capture-query telemetry |
 | `SemanticSearchTests.swift` | Semantic + hybrid search via a deterministic stub provider, graceful fallback, model-change re-embed, vector-math, and RRF fusion |
+| `ProcessStartupTests.swift` | Launches the built executable and verifies a real MCP `initialize` round trip over stdio |
 | `RecentMeetingsWidgetTests.swift` | Widget-model and builder coverage for the `show_recent_meetings` MCP Apps surface |
 | `AudioDirectoryNamingTests.swift` | Retained-audio directory naming/resolution coverage |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
@@ -35,12 +35,6 @@ final class EmbeddingStore: @unchecked Sendable {
     /// very large libraries. Personal-scale libraries stay well under this.
     private let maxCandidateRows = 50_000
 
-    var isAvailable: Bool {
-        admissionCondition.lock()
-        defer { admissionCondition.unlock() }
-        return provider.isAvailable && !deferredStartupReconciliation && !reconciliationActive
-    }
-
     init(dbPath: URL, provider: EmbeddingProvider) throws {
         self.dbPath = dbPath
         self.provider = provider

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
@@ -167,7 +167,9 @@ final class EmbeddingStore: @unchecked Sendable {
             sqlite3_finalize(stmt)
         }
         sqlite3_exec(db, "COMMIT", nil, nil, nil)
-        if inserted > 0 { log("Embedded \(inserted) rows") }
+        if inserted > 0 {
+            log("Embedded semantic rows (count_bucket=\(MCPLogPrivacy.countBucket(inserted)))")
+        }
     }
 
     // MARK: - Semantic search
@@ -384,7 +386,7 @@ final class EmbeddingStore: @unchecked Sendable {
 
     private func execLocked(_ sql: String) {
         if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
-            log("Vector store SQL failed: \(dbErrorLocked()) for: \(sql)")
+            log("Vector store SQL operation failed")
         }
     }
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
@@ -16,6 +16,9 @@ import SQLite3
 final class EmbeddingStore: @unchecked Sendable {
     private var db: OpaquePointer?
     private let queue = DispatchQueue(label: "com.transcripted.mcp.vectors", qos: .utility)
+    private let availabilityLock = NSLock()
+    private var deferredStartupReconciliation = false
+    private var activeReconciliations = 0
     private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     private let provider: EmbeddingProvider
     private let dbPath: URL
@@ -31,7 +34,11 @@ final class EmbeddingStore: @unchecked Sendable {
     /// very large libraries. Personal-scale libraries stay well under this.
     private let maxCandidateRows = 50_000
 
-    var isAvailable: Bool { provider.isAvailable }
+    var isAvailable: Bool {
+        availabilityLock.withLock {
+            provider.isAvailable && !deferredStartupReconciliation && activeReconciliations == 0
+        }
+    }
 
     init(dbPath: URL, provider: EmbeddingProvider) throws {
         self.dbPath = dbPath
@@ -80,11 +87,31 @@ final class EmbeddingStore: @unchecked Sendable {
 
     // MARK: - Embedding reconciliation
 
+    func deferSemanticSearchUntilReconciled() {
+        availabilityLock.withLock {
+            deferredStartupReconciliation = true
+        }
+    }
+
+    func finishDeferredStartupReconciliation() {
+        availabilityLock.withLock {
+            deferredStartupReconciliation = false
+        }
+    }
+
     /// Embed any indexed rows that don't yet have a vector, drop orphaned
     /// vectors, and re-embed everything if the model identity changed. Safe to
     /// call after every lexical reconcile; it only does work for new/changed rows.
     func reconcileEmbeddings() {
         guard provider.isAvailable else { return }
+        availabilityLock.withLock {
+            activeReconciliations += 1
+        }
+        defer {
+            availabilityLock.withLock {
+                activeReconciliations -= 1
+            }
+        }
         queue.sync {
             invalidateOnModelChangeLocked()
             // Drop vectors whose backing rows are gone (reindex churns rowids).
@@ -152,21 +179,31 @@ final class EmbeddingStore: @unchecked Sendable {
         sqlite3_finalize(selectStmt)
         guard !pending.isEmpty else { return }
 
-        sqlite3_exec(db, "BEGIN", nil, nil, nil)
         var inserted = 0
-        for item in pending {
-            guard let vec = provider.embed(item.text) else { continue }
-            var stmt: OpaquePointer?
-            guard sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK else { continue }
-            sqlite3_bind_int64(stmt, 1, item.rowid)
-            let blob = VectorMath.blob(from: vec)
-            _ = blob.withUnsafeBytes { raw in
-                sqlite3_bind_blob(stmt, 2, raw.baseAddress, Int32(blob.count), SQLITE_TRANSIENT)
+        for batchStart in stride(from: 0, to: pending.count, by: 100) {
+            let batchEnd = min(batchStart + 100, pending.count)
+            let vectors = pending[batchStart..<batchEnd].compactMap { item -> (Int64, [Float])? in
+                provider.embed(item.text).map { (item.rowid, $0) }
             }
-            if sqlite3_step(stmt) == SQLITE_DONE { inserted += 1 }
-            sqlite3_finalize(stmt)
+            guard !vectors.isEmpty else { continue }
+
+            // Keep the database write lock short. Vector computation is the slow
+            // part and happens before the transaction so lexical watcher updates
+            // can continue while a large semantic backlog is processed.
+            sqlite3_exec(db, "BEGIN", nil, nil, nil)
+            for (rowid, vector) in vectors {
+                var stmt: OpaquePointer?
+                guard sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK else { continue }
+                sqlite3_bind_int64(stmt, 1, rowid)
+                let blob = VectorMath.blob(from: vector)
+                _ = blob.withUnsafeBytes { raw in
+                    sqlite3_bind_blob(stmt, 2, raw.baseAddress, Int32(blob.count), SQLITE_TRANSIENT)
+                }
+                if sqlite3_step(stmt) == SQLITE_DONE { inserted += 1 }
+                sqlite3_finalize(stmt)
+            }
+            sqlite3_exec(db, "COMMIT", nil, nil, nil)
         }
-        sqlite3_exec(db, "COMMIT", nil, nil, nil)
         if inserted > 0 {
             log("Embedded semantic rows (count_bucket=\(MCPLogPrivacy.countBucket(inserted)))")
         }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
@@ -16,9 +16,10 @@ import SQLite3
 final class EmbeddingStore: @unchecked Sendable {
     private var db: OpaquePointer?
     private let queue = DispatchQueue(label: "com.transcripted.mcp.vectors", qos: .utility)
-    private let availabilityLock = NSLock()
+    private let admissionCondition = NSCondition()
     private var deferredStartupReconciliation = false
-    private var activeReconciliations = 0
+    private var reconciliationActive = false
+    private var activeSemanticSearches = 0
     private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     private let provider: EmbeddingProvider
     private let dbPath: URL
@@ -35,9 +36,9 @@ final class EmbeddingStore: @unchecked Sendable {
     private let maxCandidateRows = 50_000
 
     var isAvailable: Bool {
-        availabilityLock.withLock {
-            provider.isAvailable && !deferredStartupReconciliation && activeReconciliations == 0
-        }
+        admissionCondition.lock()
+        defer { admissionCondition.unlock() }
+        return provider.isAvailable && !deferredStartupReconciliation && !reconciliationActive
     }
 
     init(dbPath: URL, provider: EmbeddingProvider) throws {
@@ -88,15 +89,15 @@ final class EmbeddingStore: @unchecked Sendable {
     // MARK: - Embedding reconciliation
 
     func deferSemanticSearchUntilReconciled() {
-        availabilityLock.withLock {
-            deferredStartupReconciliation = true
-        }
+        admissionCondition.lock()
+        deferredStartupReconciliation = true
+        admissionCondition.unlock()
     }
 
     func finishDeferredStartupReconciliation() {
-        availabilityLock.withLock {
-            deferredStartupReconciliation = false
-        }
+        admissionCondition.lock()
+        deferredStartupReconciliation = false
+        admissionCondition.unlock()
     }
 
     /// Embed any indexed rows that don't yet have a vector, drop orphaned
@@ -104,13 +105,22 @@ final class EmbeddingStore: @unchecked Sendable {
     /// call after every lexical reconcile; it only does work for new/changed rows.
     func reconcileEmbeddings() {
         guard provider.isAvailable else { return }
-        availabilityLock.withLock {
-            activeReconciliations += 1
+
+        admissionCondition.lock()
+        while reconciliationActive {
+            admissionCondition.wait()
         }
+        reconciliationActive = true
+        while activeSemanticSearches > 0 {
+            admissionCondition.wait()
+        }
+        admissionCondition.unlock()
+
         defer {
-            availabilityLock.withLock {
-                activeReconciliations -= 1
-            }
+            admissionCondition.lock()
+            reconciliationActive = false
+            admissionCondition.broadcast()
+            admissionCondition.unlock()
         }
         queue.sync {
             invalidateOnModelChangeLocked()
@@ -211,15 +221,57 @@ final class EmbeddingStore: @unchecked Sendable {
 
     // MARK: - Semantic search
 
-    /// Cosine-ranked meeting utterance search, grouped per meeting (same shape as
-    /// the lexical path). Returns empty when the query can't be embedded.
-    func semanticSearchUtterances(
+    private func withSemanticSearchAdmission<T>(_ body: () -> T) -> T? {
+        admissionCondition.lock()
+        guard provider.isAvailable,
+              !deferredStartupReconciliation,
+              !reconciliationActive else {
+            admissionCondition.unlock()
+            return nil
+        }
+        activeSemanticSearches += 1
+        admissionCondition.unlock()
+
+        defer {
+            admissionCondition.lock()
+            activeSemanticSearches -= 1
+            if activeSemanticSearches == 0 {
+                admissionCondition.broadcast()
+            }
+            admissionCondition.unlock()
+        }
+        return body()
+    }
+
+    func semanticSearchUtterancesIfAvailable(
         query: String,
         speaker: String?,
         dateFrom: String?,
         dateTo: String?,
         maxMeetings: Int = 10,
         snippetsPerMeeting: Int = 3
+    ) -> GroupedSearchResult? {
+        withSemanticSearchAdmission {
+            semanticSearchUtterances(
+                query: query,
+                speaker: speaker,
+                dateFrom: dateFrom,
+                dateTo: dateTo,
+                maxMeetings: maxMeetings,
+                snippetsPerMeeting: snippetsPerMeeting
+            )
+        }
+    }
+
+    /// Cosine-ranked meeting utterance search, grouped per meeting (same shape as
+    /// the lexical path). Returns empty when the query can't be embedded.
+    private func semanticSearchUtterances(
+        query: String,
+        speaker: String?,
+        dateFrom: String?,
+        dateTo: String?,
+        maxMeetings: Int,
+        snippetsPerMeeting: Int
     ) -> GroupedSearchResult {
         guard let qvec = provider.embed(query) else {
             return GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false)
@@ -336,13 +388,29 @@ final class EmbeddingStore: @unchecked Sendable {
         }
     }
 
-    /// Cosine-ranked dictation entry search, one snippet per entry (same shape as
-    /// the lexical path). Returns empty when the query can't be embedded.
-    func semanticSearchDictationEntries(
+    func semanticSearchDictationEntriesIfAvailable(
         query: String,
         dateFrom: String?,
         dateTo: String?,
         maxItems: Int = 10
+    ) -> [ContextSearchGroup]? {
+        withSemanticSearchAdmission {
+            semanticSearchDictationEntries(
+                query: query,
+                dateFrom: dateFrom,
+                dateTo: dateTo,
+                maxItems: maxItems
+            )
+        }
+    }
+
+    /// Cosine-ranked dictation entry search, one snippet per entry (same shape as
+    /// the lexical path). Returns empty when the query can't be embedded.
+    private func semanticSearchDictationEntries(
+        query: String,
+        dateFrom: String?,
+        dateTo: String?,
+        maxItems: Int
     ) -> [ContextSearchGroup] {
         guard let qvec = provider.embed(query) else { return [] }
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -6,6 +6,8 @@ struct TranscriptedMCP {
     static let serverVersion = "1.0.0"
 
     static func main() async throws {
+        let startupStartedAt = ProcessInfo.processInfo.systemUptime
+
         if CommandLine.arguments.contains("--help") || CommandLine.arguments.contains("-h") {
             print(Self.helpText)
             return
@@ -24,15 +26,16 @@ struct TranscriptedMCP {
         let directories = TranscriptedDataDirectories.resolve()
 
         log("Starting transcripted-mcp v\(serverVersion)")
-        log("Meetings directories: \(directories.meetingDirs.map(\.path).joined(separator: ", "))")
-        log("Dictations directories: \(directories.dictationDirs.map(\.path).joined(separator: ", "))")
-        log("Index directory: \(directories.indexDir.path)")
 
+        var createdDirectoryCount = 0
         for directory in directories.watchedDirectories + [directories.indexDir] {
             if !FileManager.default.fileExists(atPath: directory.path) {
-                log("Creating missing directory: \(directory.path)")
                 try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+                createdDirectoryCount += 1
             }
+        }
+        if createdDirectoryCount > 0 {
+            log("Created missing MCP data directories (count_bucket=\(MCPLogPrivacy.countBucket(createdDirectoryCount)))")
         }
 
         // Create and populate index
@@ -53,8 +56,12 @@ struct TranscriptedMCP {
                 meetingDirs: directories.meetingDirs,
                 dictationDirs: directories.dictationDirs
             )
+            log(MCPStartupDiagnostics.message(
+                phase: .lexicalIndexReady,
+                elapsedSeconds: ProcessInfo.processInfo.systemUptime - startupStartedAt
+            ))
         } catch {
-            log("Failed to initialize index: \(error.localizedDescription)")
+            log("MCP startup failed during lexical index preparation")
             throw error
         }
 
@@ -63,7 +70,7 @@ struct TranscriptedMCP {
                 do {
                     try index.reconcile(meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
                 } catch {
-                    log("Failed to reconcile watched directories: \(error.localizedDescription)")
+                    log("Failed to reconcile the watched capture index")
                 }
             }
         }
@@ -87,10 +94,21 @@ struct TranscriptedMCP {
         // Start stdio transport
         let transport = StdioTransport()
         try await server.start(transport: transport)
-        log("MCP server ready, waiting for connections")
+        log(MCPStartupDiagnostics.message(
+            phase: .transportReady,
+            elapsedSeconds: ProcessInfo.processInfo.systemUptime - startupStartedAt
+        ))
 
-        Task.detached(priority: .utility) {
-            MCPStartupIndexing.completeAfterAttach(index: index)
+        if index.embeddingStore != nil {
+            Task.detached(priority: .utility) {
+                let semanticStartedAt = ProcessInfo.processInfo.systemUptime
+                log(MCPStartupDiagnostics.message(phase: .semanticIndexStarted, elapsedSeconds: 0))
+                MCPStartupIndexing.completeAfterAttach(index: index)
+                log(MCPStartupDiagnostics.message(
+                    phase: .semanticIndexReady,
+                    elapsedSeconds: ProcessInfo.processInfo.systemUptime - semanticStartedAt
+                ))
+            }
         }
 
         await server.waitUntilCompleted()

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -48,7 +48,11 @@ struct TranscriptedMCP {
                 log("Semantic search unavailable on this host; using lexical search only")
             }
             index = try TranscriptIndex(indexDir: directories.indexDir, embeddingProvider: embeddingProvider)
-            try index.reconcile(meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
+            try MCPStartupIndexing.prepareForAttach(
+                index: index,
+                meetingDirs: directories.meetingDirs,
+                dictationDirs: directories.dictationDirs
+            )
         } catch {
             log("Failed to initialize index: \(error.localizedDescription)")
             throw error
@@ -80,11 +84,15 @@ struct TranscriptedMCP {
             server: server, index: index, directories: directories, serverVersion: serverVersion
         )
 
-        log("MCP server ready, waiting for connections")
-
         // Start stdio transport
         let transport = StdioTransport()
         try await server.start(transport: transport)
+        log("MCP server ready, waiting for connections")
+
+        Task.detached(priority: .utility) {
+            MCPStartupIndexing.completeAfterAttach(index: index)
+        }
+
         await server.waitUntilCompleted()
 
         watchers.forEach { $0.stop() }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -538,11 +538,12 @@ final class TranscriptIndex: @unchecked Sendable {
         // Semantic / hybrid routing. Falls through to lexical when no vector store
         // is available, so these modes degrade gracefully rather than returning
         // nothing. The lexical branch below is unchanged.
-        if mode != .lexical, let store = embeddingStore, store.isAvailable {
-            let semantic = store.semanticSearchUtterances(
+        if mode != .lexical,
+           let store = embeddingStore,
+           let semantic = store.semanticSearchUtterancesIfAvailable(
                 query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo,
                 maxMeetings: maxMeetings, snippetsPerMeeting: snippetsPerMeeting
-            )
+           ) {
             if mode == .semantic { return semantic }
             let lexical = try searchUtterances(
                 query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo,
@@ -899,10 +900,11 @@ final class TranscriptIndex: @unchecked Sendable {
     }
 
     func searchDictationEntries(query: String, dateFrom: String?, dateTo: String?, maxItems: Int = 10, mode: SearchMode = .lexical) throws -> [ContextSearchGroup] {
-        if mode != .lexical, let store = embeddingStore, store.isAvailable {
-            let semantic = store.semanticSearchDictationEntries(
+        if mode != .lexical,
+           let store = embeddingStore,
+           let semantic = store.semanticSearchDictationEntriesIfAvailable(
                 query: query, dateFrom: dateFrom, dateTo: dateTo, maxItems: maxItems
-            )
+           ) {
             if mode == .semantic { return semantic }
             let lexical = try searchDictationEntries(
                 query: query, dateFrom: dateFrom, dateTo: dateTo, maxItems: maxItems, mode: .lexical

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -105,11 +105,23 @@ final class TranscriptIndex: @unchecked Sendable {
 
     // MARK: - Reconciliation
 
-    func reconcile(meetingsDir: URL, dictationsDir: URL) throws {
-        try reconcile(meetingDirs: [meetingsDir], dictationDirs: [dictationsDir])
+    func reconcile(
+        meetingsDir: URL,
+        dictationsDir: URL,
+        updateEmbeddings: Bool = true
+    ) throws {
+        try reconcile(
+            meetingDirs: [meetingsDir],
+            dictationDirs: [dictationsDir],
+            updateEmbeddings: updateEmbeddings
+        )
     }
 
-    func reconcile(meetingDirs: [URL], dictationDirs: [URL]) throws {
+    func reconcile(
+        meetingDirs: [URL],
+        dictationDirs: [URL],
+        updateEmbeddings: Bool = true
+    ) throws {
         try queue.sync {
             var seenPaths: Set<String> = []
             var diskMap: [String: ContextArtifactFile] = [:]
@@ -148,6 +160,12 @@ final class TranscriptIndex: @unchecked Sendable {
 
         // Best-effort: embed any newly indexed rows. Never fails the reconcile —
         // lexical search must keep working even if embedding hits a snag.
+        if updateEmbeddings {
+            reconcileEmbeddings()
+        }
+    }
+
+    func reconcileEmbeddings() {
         embeddingStore?.reconcileEmbeddings()
     }
 
@@ -1695,5 +1713,26 @@ final class TranscriptIndex: @unchecked Sendable {
 
     private func dbError() -> String {
         sqlDBError(db)
+    }
+}
+
+/// Keeps the stdio attach path bounded by making the lexical index available
+/// first. Semantic vectors are additive and can finish after the client has
+/// connected without changing any read-only tool contract.
+enum MCPStartupIndexing {
+    static func prepareForAttach(
+        index: TranscriptIndex,
+        meetingDirs: [URL],
+        dictationDirs: [URL]
+    ) throws {
+        try index.reconcile(
+            meetingDirs: meetingDirs,
+            dictationDirs: dictationDirs,
+            updateEmbeddings: false
+        )
+    }
+
+    static func completeAfterAttach(index: TranscriptIndex) {
+        index.reconcileEmbeddings()
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -178,7 +178,7 @@ final class TranscriptIndex: @unchecked Sendable {
                 return resolvedURL.path == basePath
                     || resolvedURL.path.hasPrefix(basePath + "/")
             }) else {
-                log("Skipping index update outside watched roots: \(url.path)")
+                log("Skipping index update outside watched roots")
                 return
             }
 
@@ -194,7 +194,7 @@ final class TranscriptIndex: @unchecked Sendable {
                 case .missing:
                     continue
                 case .invalid:
-                    log("Skipping invalid or unsafe file change: \(root.appendingPathComponent(requestedName).path)")
+                    log("Skipping invalid or unsafe file change")
                     continue
                 }
             }
@@ -283,7 +283,7 @@ final class TranscriptIndex: @unchecked Sendable {
 
         try execOrThrow("COMMIT")
         committed = true
-        log("Indexed: \(filename) (\(transcript.utterances.count) utterances)")
+        log("Indexed meeting (utterance_count_bucket=\(MCPLogPrivacy.countBucket(transcript.utterances.count)))")
     }
 
     /// Parse the meeting's structured summary (inline transcript summary, then a
@@ -376,7 +376,7 @@ final class TranscriptIndex: @unchecked Sendable {
 
         try execOrThrow("COMMIT")
         committed = true
-        log("Indexed dictation day: \(filename) (\(day.entries.count) entries)")
+        log("Indexed dictation day (entry_count_bucket=\(MCPLogPrivacy.countBucket(day.entries.count)))")
     }
 
     private func reindex(file url: URL, filename: String, kind: ContextArtifactKind) throws {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -1725,6 +1725,7 @@ enum MCPStartupIndexing {
         meetingDirs: [URL],
         dictationDirs: [URL]
     ) throws {
+        index.embeddingStore?.deferSemanticSearchUntilReconciled()
         try index.reconcile(
             meetingDirs: meetingDirs,
             dictationDirs: dictationDirs,
@@ -1733,6 +1734,7 @@ enum MCPStartupIndexing {
     }
 
     static func completeAfterAttach(index: TranscriptIndex) {
+        defer { index.embeddingStore?.finishDeferredStartupReconciliation() }
         index.reconcileEmbeddings()
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -23,7 +23,7 @@ enum TranscriptLoader {
     static func loadMeeting(_ url: URL) -> AgentTranscript? {
         guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseMeeting(from: content) else {
-            log("Cannot read markdown meeting: \(url.lastPathComponent)")
+            log("Cannot read meeting markdown")
             return nil
         }
 
@@ -97,7 +97,7 @@ enum TranscriptLoader {
     static func loadDictationDay(_ url: URL) -> AgentDictationDay? {
         guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else {
-            log("Cannot read markdown dictation day: \(url.lastPathComponent)")
+            log("Cannot read dictation markdown")
             return nil
         }
 
@@ -191,4 +191,42 @@ func withLogsSuppressed<T>(_ body: () throws -> T) rethrows -> T {
     }
 
     return try body()
+}
+
+enum MCPLogPrivacy {
+    static func countBucket(_ count: Int) -> String {
+        switch max(0, count) {
+        case 0: return "0"
+        case 1: return "1"
+        case 2...10: return "2_to_10"
+        case 11...100: return "11_to_100"
+        case 101...1_000: return "101_to_1000"
+        default: return "over_1000"
+        }
+    }
+}
+
+enum MCPStartupDiagnostics {
+    enum Phase: String {
+        case lexicalIndexReady = "lexical_index_ready"
+        case transportReady = "transport_ready"
+        case semanticIndexStarted = "semantic_index_started"
+        case semanticIndexReady = "semantic_index_ready"
+    }
+
+    static func message(phase: Phase, elapsedSeconds: TimeInterval) -> String {
+        "Startup phase=\(phase.rawValue) elapsed_bucket=\(elapsedBucket(elapsedSeconds))"
+    }
+
+    static func elapsedBucket(_ seconds: TimeInterval) -> String {
+        switch max(0, seconds) {
+        case ..<0.25: return "under_250ms"
+        case ..<1: return "250ms_to_1s"
+        case ..<5: return "1s_to_5s"
+        case ..<15: return "5s_to_15s"
+        case ..<30: return "15s_to_30s"
+        case ..<60: return "30s_to_60s"
+        default: return "over_60s"
+        }
+    }
 }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/LoggingTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/LoggingTests.swift
@@ -29,6 +29,40 @@ final class LoggingTests: XCTestCase {
         XCTAssertEqual(output, "[transcripted-mcp] indexed fixture\n")
     }
 
+    func testStartupDiagnosticsUseOnlyAllowlistedPhasesAndBuckets() {
+        XCTAssertEqual(
+            MCPStartupDiagnostics.message(phase: .transportReady, elapsedSeconds: 23.44),
+            "Startup phase=transport_ready elapsed_bucket=15s_to_30s"
+        )
+        XCTAssertEqual(MCPStartupDiagnostics.elapsedBucket(0.24), "under_250ms")
+        XCTAssertEqual(MCPStartupDiagnostics.elapsedBucket(0.25), "250ms_to_1s")
+        XCTAssertEqual(MCPStartupDiagnostics.elapsedBucket(60), "over_60s")
+    }
+
+    func testCountDiagnosticsAreBucketed() {
+        XCTAssertEqual(MCPLogPrivacy.countBucket(0), "0")
+        XCTAssertEqual(MCPLogPrivacy.countBucket(1), "1")
+        XCTAssertEqual(MCPLogPrivacy.countBucket(9), "2_to_10")
+        XCTAssertEqual(MCPLogPrivacy.countBucket(50), "11_to_100")
+        XCTAssertEqual(MCPLogPrivacy.countBucket(500), "101_to_1000")
+        XCTAssertEqual(MCPLogPrivacy.countBucket(5_000), "over_1000")
+    }
+
+    func testUnreadableCaptureLogOmitsCustomerFilenameAndPath() {
+        let privateLookingName = "customer@example.com confidential meeting.md"
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("private-customer-folder", isDirectory: true)
+            .appendingPathComponent(privateLookingName, isDirectory: false)
+
+        let output = captureStandardError {
+            XCTAssertNil(TranscriptLoader.loadMeeting(url))
+        }
+
+        XCTAssertEqual(output, "[transcripted-mcp] Cannot read meeting markdown\n")
+        XCTAssertFalse(output.contains("customer@example.com"))
+        XCTAssertFalse(output.contains("private-customer-folder"))
+    }
+
     private func captureStandardError(_ body: () -> Void) -> String {
         let pipe = Pipe()
         let original = dup(STDERR_FILENO)

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ProcessStartupTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ProcessStartupTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import XCTest
+@testable import transcripted_mcp
+
+private final class ProcessResponseBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var response: [String: Any]?
+
+    func set(_ response: [String: Any]) {
+        lock.lock()
+        self.response = response
+        lock.unlock()
+    }
+
+    func get() -> [String: Any]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return response
+    }
+}
+
+final class ProcessStartupTests: XCTestCase {
+    func testExecutableAnswersInitializeOverStdio() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let executable = packageRoot.appendingPathComponent(".build/debug/transcripted-mcp")
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: executable.path))
+
+        let dataRoot = makeTempDir()
+        defer { removeTempDir(dataRoot) }
+
+        let process = Process()
+        let standardInput = Pipe()
+        let standardOutput = Pipe()
+        process.executableURL = executable
+        process.standardInput = standardInput
+        process.standardOutput = standardOutput
+        process.standardError = Pipe()
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["TRANSCRIPTED_DATA_DIR"] = dataRoot.path
+        environment["TRANSCRIPTED_INDEX_DIR"] = dataRoot.appendingPathComponent("index").path
+        environment["TRANSCRIPTED_DISABLE_FILE_LOGGER"] = "1"
+        process.environment = environment
+
+        let responseReceived = expectation(description: "initialize response")
+        let responseBox = ProcessResponseBox()
+        let outputLock = NSLock()
+        var outputBuffer = Data()
+        standardOutput.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty else { return }
+
+            outputLock.lock()
+            outputBuffer.append(data)
+            while let newline = outputBuffer.firstIndex(of: 0x0A) {
+                let line = outputBuffer[..<newline]
+                outputBuffer.removeSubrange(...newline)
+                guard let object = try? JSONSerialization.jsonObject(with: Data(line)),
+                      let response = object as? [String: Any],
+                      (response["id"] as? NSNumber)?.intValue == 1 else {
+                    continue
+                }
+                responseBox.set(response)
+                responseReceived.fulfill()
+                break
+            }
+            outputLock.unlock()
+        }
+
+        try process.run()
+        defer {
+            standardOutput.fileHandleForReading.readabilityHandler = nil
+            try? standardInput.fileHandleForWriting.close()
+            if process.isRunning {
+                process.terminate()
+                process.waitUntilExit()
+            }
+        }
+
+        let request = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"synthetic-test-client","version":"1.0"}}}"# + "\n"
+        try standardInput.fileHandleForWriting.write(contentsOf: Data(request.utf8))
+
+        XCTAssertEqual(XCTWaiter.wait(for: [responseReceived], timeout: 5), .completed)
+        let response = try XCTUnwrap(responseBox.get())
+        XCTAssertEqual(response["jsonrpc"] as? String, "2.0")
+
+        let result = try XCTUnwrap(response["result"] as? [String: Any])
+        XCTAssertEqual(result["protocolVersion"] as? String, "2025-06-18")
+        let serverInfo = try XCTUnwrap(result["serverInfo"] as? [String: Any])
+        XCTAssertEqual(serverInfo["name"] as? String, "transcripted")
+        XCTAssertEqual(serverInfo["version"] as? String, TranscriptedMCP.serverVersion)
+    }
+}

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
@@ -86,6 +86,47 @@ private final class BlockingEmbeddingProvider: EmbeddingProvider, @unchecked Sen
     }
 }
 
+private final class AdmissionRaceEmbeddingProvider: EmbeddingProvider, @unchecked Sendable {
+    let modelID = "admission-race.v1"
+    let dimension = 3
+    let isAvailable = true
+    let queryStarted = DispatchSemaphore(value: 0)
+    let resumeQuery = DispatchSemaphore(value: 0)
+    let reconciliationStarted = DispatchSemaphore(value: 0)
+    let resumeReconciliation = DispatchSemaphore(value: 0)
+
+    func embed(_ text: String) -> [Float]? {
+        switch text {
+        case "querygate":
+            queryStarted.signal()
+            _ = resumeQuery.wait(timeout: .now() + 5)
+        case "backfill gate":
+            reconciliationStarted.signal()
+            _ = resumeReconciliation.wait(timeout: .now() + 5)
+        default:
+            break
+        }
+        return text.isEmpty ? nil : [1, 0, 0]
+    }
+}
+
+private final class LockedValue<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value?
+
+    var value: Value? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func set(_ value: Value) {
+        lock.lock()
+        storage = value
+        lock.unlock()
+    }
+}
+
 final class SemanticSearchTests: XCTestCase {
     var tempDir: URL!
 
@@ -304,6 +345,103 @@ final class SemanticSearchTests: XCTestCase {
 
         provider.resume.signal()
         wait(for: [completed], timeout: 5)
+    }
+
+    func testSemanticAdmissionAndReconciliationAreAtomic() throws {
+        let provider = AdmissionRaceEmbeddingProvider()
+        let index = try makeIndex(provider)
+
+        try MCPStartupIndexing.prepareForAttach(
+            index: index,
+            meetingDirs: [tempDir],
+            dictationDirs: [tempDir]
+        )
+        MCPStartupIndexing.completeAfterAttach(index: index)
+
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "querygate existing capture"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let queryResultCount = LockedValue<Int>()
+        let queryCompleted = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            let count = try? index.searchUtterances(
+                query: "querygate",
+                speaker: nil,
+                dateFrom: nil,
+                dateTo: nil,
+                mode: .hybrid
+            ).results.count
+            queryResultCount.set(count ?? -1)
+            queryCompleted.signal()
+        }
+        XCTAssertEqual(provider.queryStarted.wait(timeout: .now() + 2), .success)
+
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "backfill gate"),
+        ]), filename: "Call_2026-03-30_10-00-00", to: tempDir)
+        try index.reconcile(
+            meetingDirs: [tempDir],
+            dictationDirs: [tempDir],
+            updateEmbeddings: false
+        )
+
+        let reconciliationCompleted = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async {
+            index.reconcileEmbeddings()
+            reconciliationCompleted.signal()
+        }
+
+        let reconciliationEnteredBeforeQueryFinished =
+            provider.reconciliationStarted.wait(timeout: .now() + 0.5) == .success
+        provider.resumeQuery.signal()
+        let queryFinishedWithoutReleasingReconciliation =
+            queryCompleted.wait(timeout: .now() + 1) == .success
+
+        if !reconciliationEnteredBeforeQueryFinished {
+            XCTAssertEqual(provider.reconciliationStarted.wait(timeout: .now() + 2), .success)
+        }
+
+        let fallbackResultCount = LockedValue<Int>()
+        let fallbackCompleted = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            let count = try? index.searchUtterances(
+                query: "capture",
+                speaker: nil,
+                dateFrom: nil,
+                dateTo: nil,
+                mode: .hybrid
+            ).results.count
+            fallbackResultCount.set(count ?? -1)
+            fallbackCompleted.signal()
+        }
+        let fallbackFinishedWithoutReleasingReconciliation =
+            fallbackCompleted.wait(timeout: .now() + 1) == .success
+
+        provider.resumeReconciliation.signal()
+        if !queryFinishedWithoutReleasingReconciliation {
+            _ = queryCompleted.wait(timeout: .now() + 2)
+        }
+        if !fallbackFinishedWithoutReleasingReconciliation {
+            _ = fallbackCompleted.wait(timeout: .now() + 2)
+        }
+        XCTAssertEqual(reconciliationCompleted.wait(timeout: .now() + 2), .success)
+
+        XCTAssertFalse(
+            reconciliationEnteredBeforeQueryFinished,
+            "reconciliation must wait for an atomically admitted semantic query"
+        )
+        XCTAssertTrue(
+            queryFinishedWithoutReleasingReconciliation,
+            "an admitted hybrid query must not queue behind later reconciliation"
+        )
+        XCTAssertEqual(queryResultCount.value, 1)
+        XCTAssertTrue(
+            fallbackFinishedWithoutReleasingReconciliation,
+            "hybrid search must fall back immediately while reconciliation owns the store"
+        )
+        XCTAssertEqual(fallbackResultCount.value, 1)
     }
 
     // MARK: - Re-embedding on model change

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
@@ -50,6 +50,28 @@ private struct UnavailableEmbeddingProvider: EmbeddingProvider {
     func embed(_ text: String) -> [Float]? { nil }
 }
 
+private final class CountingEmbeddingProvider: EmbeddingProvider, @unchecked Sendable {
+    let modelID = "counting.v1"
+    let dimension = 3
+    let isAvailable = true
+
+    private let lock = NSLock()
+    private var requestCount = 0
+
+    var requests: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestCount
+    }
+
+    func embed(_ text: String) -> [Float]? {
+        lock.lock()
+        requestCount += 1
+        lock.unlock()
+        return text.isEmpty ? nil : [1, 0, 0]
+    }
+}
+
 final class SemanticSearchTests: XCTestCase {
     var tempDir: URL!
 
@@ -183,6 +205,36 @@ final class SemanticSearchTests: XCTestCase {
 
         let hybrid = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
         XCTAssertEqual(hybrid.results.count, 1)
+    }
+
+    func testStartupMakesLexicalIndexAvailableBeforeEmbeddingWork() throws {
+        let provider = CountingEmbeddingProvider()
+        let index = try makeIndex(provider)
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The product roadmap is ready"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+
+        try MCPStartupIndexing.prepareForAttach(
+            index: index,
+            meetingDirs: [tempDir],
+            dictationDirs: [tempDir]
+        )
+
+        XCTAssertEqual(provider.requests, 0, "attach preparation must not wait for semantic vectors")
+        XCTAssertEqual(
+            try index.searchUtterances(
+                query: "roadmap",
+                speaker: nil,
+                dateFrom: nil,
+                dateTo: nil,
+                mode: .lexical
+            ).results.count,
+            1,
+            "lexical tools should be usable as soon as the client attaches"
+        )
+
+        MCPStartupIndexing.completeAfterAttach(index: index)
+        XCTAssertGreaterThan(provider.requests, 0, "semantic vectors should still be populated after attach")
     }
 
     // MARK: - Re-embedding on model change

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
@@ -72,6 +72,20 @@ private final class CountingEmbeddingProvider: EmbeddingProvider, @unchecked Sen
     }
 }
 
+private final class BlockingEmbeddingProvider: EmbeddingProvider, @unchecked Sendable {
+    let modelID = "blocking.v1"
+    let dimension = 3
+    let isAvailable = true
+    let started = DispatchSemaphore(value: 0)
+    let resume = DispatchSemaphore(value: 0)
+
+    func embed(_ text: String) -> [Float]? {
+        started.signal()
+        _ = resume.wait(timeout: .now() + 5)
+        return text.isEmpty ? nil : [1, 0, 0]
+    }
+}
+
 final class SemanticSearchTests: XCTestCase {
     var tempDir: URL!
 
@@ -232,9 +246,64 @@ final class SemanticSearchTests: XCTestCase {
             1,
             "lexical tools should be usable as soon as the client attaches"
         )
+        XCTAssertEqual(
+            try index.searchUtterances(
+                query: "roadmap",
+                speaker: nil,
+                dateFrom: nil,
+                dateTo: nil,
+                mode: .hybrid
+            ).results.count,
+            1,
+            "default hybrid search should fall back to lexical while startup embeddings are pending"
+        )
+        XCTAssertEqual(provider.requests, 0, "hybrid search must not queue behind startup embeddings")
 
         MCPStartupIndexing.completeAfterAttach(index: index)
         XCTAssertGreaterThan(provider.requests, 0, "semantic vectors should still be populated after attach")
+        XCTAssertTrue(index.embeddingStore?.isAvailable == true)
+    }
+
+    func testStartupEmbeddingComputationDoesNotHoldLexicalWriteLock() throws {
+        let provider = BlockingEmbeddingProvider()
+        let index = try makeIndex(provider)
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The product roadmap is ready"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try MCPStartupIndexing.prepareForAttach(
+            index: index,
+            meetingDirs: [tempDir],
+            dictationDirs: [tempDir]
+        )
+
+        let completed = expectation(description: "semantic reconciliation completed")
+        DispatchQueue.global(qos: .utility).async {
+            MCPStartupIndexing.completeAfterAttach(index: index)
+            completed.fulfill()
+        }
+        XCTAssertEqual(provider.started.wait(timeout: .now() + 2), .success)
+
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "A new capture arrived"),
+        ]), filename: "Call_2026-03-30_10-00-00", to: tempDir)
+        XCTAssertNoThrow(try index.reconcile(
+            meetingDirs: [tempDir],
+            dictationDirs: [tempDir],
+            updateEmbeddings: false
+        ))
+        XCTAssertEqual(
+            try index.searchUtterances(
+                query: "capture",
+                speaker: nil,
+                dateFrom: nil,
+                dateTo: nil,
+                mode: .lexical
+            ).results.count,
+            1
+        )
+
+        provider.resume.signal()
+        wait(for: [completed], timeout: 5)
     }
 
     // MARK: - Re-embedding on model change

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
@@ -302,7 +302,6 @@ final class SemanticSearchTests: XCTestCase {
 
         MCPStartupIndexing.completeAfterAttach(index: index)
         XCTAssertGreaterThan(provider.requests, 0, "semantic vectors should still be populated after attach")
-        XCTAssertTrue(index.embeddingStore?.isAvailable == true)
     }
 
     func testStartupEmbeddingComputationDoesNotHoldLexicalWriteLock() throws {


### PR DESCRIPTION
## Summary

- start the Transcripted MCP stdio transport immediately after lexical indexing
- defer semantic embedding reconciliation until after the client can attach
- add privacy-safe startup phase/count buckets without paths, filenames, payloads, or transcript data

## Cause and fix

The released MCP helper synchronously reconciles semantic embeddings before starting its stdio transport. Existing installs with larger meeting libraries can therefore exceed the Claude Desktop/Cowork attach timeout even though registration, server naming, configuration, code signing, and the helper self-test are valid.

The fix preserves lexical search at startup, starts the MCP transport, then reconciles embeddings in the background. Existing semantic data and existing configurations remain compatible.

## Deterministic reproduction

Using a synthetic-only fixture with 100 meetings and 5,000 utterances:

- released v1.1.50 helper: 23.44 seconds before ready; an MCP `initialize` request timed out at 10 seconds
- patched helper: MCP `initialize` response in 0.37 seconds

No customer data or identifying information was used or recorded.

## Verification

- `swift test --package-path Tools/TranscriptedMCP` — 188 tests passed
- `bash run-e2e-smoke.sh` — passed
- `python3 scripts/ops/privacy-leak-sweep.py --write-report build/mcp-privacy-leak-sweep.json` — passed, 0 findings
- `bash scripts/ops/transcripted-qa-bench.sh --mode full` — PASS, 18 checks with one non-blocking local-artifact warning
- `git diff --check origin/main...HEAD` — passed
- `codex review --base origin/main` — clean after repairing two concurrency findings; no actionable regressions remain

## Proof boundary

Automated and synthetic proof is clean. A real Claude Desktop/Cowork install-update-restart attach against a customer-scale existing library remains manual/unknown. This PR does not merge or publish a release.
