### PR TITLE
Fix recovery deadline under scheduler delay

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -47,6 +47,8 @@ public class TranscriptionTaskManager: ObservableObject {
     private let cleanupDirectories: [URL]
     private var orphanedRecordingRecoveryTask: Task<Int, Never>?
     private var orphanedRecordingRecoveryRequestGeneration: UInt64 = 0
+    /// Deterministic task-start delay point for recovery scheduler tests.
+    var orphanedRecordingRecoveryTaskCreatedObserver: (() -> Void)?
     /// Deterministic pause point for recovery interleaving tests.
     var orphanedRecordingRecoveryPassObserver: (() -> Void)?
 
@@ -1038,11 +1040,14 @@ public class TranscriptionTaskManager: ObservableObject {
         // One monotonic deadline belongs to the single-flight owner. Joined
         // requests can ask it to rescan, but cannot extend its lifetime.
         let maximumWaitInterval = max(0.02, (livenessWindow * 2) + 0.02)
-        let waitDeadline = ContinuousClock.now.advanced(
-            by: .seconds(maximumWaitInterval)
-        )
         let recoveryTask = Task { [weak self] in
             guard let self else { return 0 }
+            // Start the budget when the stored owner actually begins running.
+            // A busy MainActor must not consume the entire recovery window
+            // before the first directory scan has even started.
+            let waitDeadline = ContinuousClock.now.advanced(
+                by: .seconds(maximumWaitInterval)
+            )
             var totalRecovered = 0
             while ContinuousClock.now < waitDeadline {
                 let ownerRequestGeneration = self.orphanedRecordingRecoveryRequestGeneration
@@ -1060,6 +1065,7 @@ public class TranscriptionTaskManager: ObservableObject {
             return totalRecovered
         }
         orphanedRecordingRecoveryTask = recoveryTask
+        orphanedRecordingRecoveryTaskCreatedObserver?()
         return await recoveryTask.value
     }
 

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRecoveryTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRecoveryTests.swift
@@ -413,7 +413,10 @@ final class TranscriptionTaskManagerRecoveryTests: XCTestCase {
         let micURL = paths.audioCaptures.appendingPathComponent("meeting_repeated_write_mic.wav")
         try writeMonoWAV(to: micURL, sampleRate: 48_000, samples: Array(repeating: 0.4, count: 4_800))
         try FileManager.default.setAttributes(
-            [.modificationDate: Date().addingTimeInterval(livenessWindow)],
+            // Keep the first snapshot fresh even if the owner task is heavily
+            // delayed. The pass hook below supplies the repeated write at the
+            // exact recovery boundary under test.
+            [.modificationDate: Date().addingTimeInterval(60)],
             ofItemAtPath: micURL.path
         )
         let journalURL = try writeJournal(

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRecoveryTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRecoveryTests.swift
@@ -409,8 +409,13 @@ final class TranscriptionTaskManagerRecoveryTests: XCTestCase {
 
     func testRecoveryWaitsThroughRepeatedFreshWrites() async throws {
         let (manager, paths) = makeManager()
+        let livenessWindow: TimeInterval = 0.08
         let micURL = paths.audioCaptures.appendingPathComponent("meeting_repeated_write_mic.wav")
         try writeMonoWAV(to: micURL, sampleRate: 48_000, samples: Array(repeating: 0.4, count: 4_800))
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(livenessWindow)],
+            ofItemAtPath: micURL.path
+        )
         let journalURL = try writeJournal(
             in: paths.audioCaptures,
             primaryMicFilename: micURL.lastPathComponent,
@@ -419,20 +424,57 @@ final class TranscriptionTaskManagerRecoveryTests: XCTestCase {
             state: .stopping
         )
 
-        let recoveryTask = Task {
-            await manager.recoverOrphanedRecordings(
-                in: paths.audioCaptures,
-                livenessWindow: 0.08,
-                waitForRecentJournals: true
-            )
+        var passCount = 0
+        manager.orphanedRecordingRecoveryPassObserver = {
+            passCount += 1
+            guard passCount == 1 else { return }
+            do {
+                try FileManager.default.setAttributes(
+                    [.modificationDate: Date()],
+                    ofItemAtPath: micURL.path
+                )
+            } catch {
+                XCTFail("Could not refresh recovery fixture: \(type(of: error))")
+            }
         }
-        try await Task.sleep(for: .seconds(0.05))
-        try FileManager.default.setAttributes(
-            [.modificationDate: Date()],
-            ofItemAtPath: micURL.path
-        )
 
-        let recovered = await recoveryTask.value
+        let recovered = await manager.recoverOrphanedRecordings(
+            in: paths.audioCaptures,
+            livenessWindow: livenessWindow,
+            waitForRecentJournals: true
+        )
+        manager.orphanedRecordingRecoveryPassObserver = nil
+
+        XCTAssertGreaterThanOrEqual(passCount, 2)
+        XCTAssertEqual(recovered, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+        XCTAssertEqual(manager.failedTranscriptionManager.failedTranscriptions.count, 1)
+    }
+
+    func testRecoveryDeadlineStartsWhenOwnerTaskRuns() async throws {
+        let (manager, paths) = makeManager()
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting_delayed_owner_mic.wav")
+        try writeMonoWAV(to: micURL, sampleRate: 48_000, samples: Array(repeating: 0.4, count: 4_800))
+        try backdate(micURL)
+        let journalURL = try writeJournal(
+            in: paths.audioCaptures,
+            primaryMicFilename: micURL.lastPathComponent,
+            segments: [.init(filename: micURL.lastPathComponent, gapBefore: 0)],
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            state: .stopping
+        )
+        manager.orphanedRecordingRecoveryTaskCreatedObserver = {
+            // This runs synchronously on the MainActor before the stored owner
+            // can start. It deterministically exceeds the old 20 ms budget.
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        let recovered = await manager.recoverOrphanedRecordings(
+            in: paths.audioCaptures,
+            livenessWindow: 0,
+            waitForRecentJournals: false
+        )
+        manager.orphanedRecordingRecoveryTaskCreatedObserver = nil
 
         XCTAssertEqual(recovered, 1)
         XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))


### PR DESCRIPTION
## Summary
- start orphaned-recording recovery budget when the single-flight owner task actually begins
- replace the repeated-write wall-clock race with deterministic recovery-phase coordination
- prove delayed owner startup and repeated fresh writes without weakening recovery assertions

## Exact-head proof
Head: 794152d1168a9f2ade5169afac7e7af76763984a
Base: 0465d5d105e5e0a92d2b6085c2f4613c14b82f64

- build-deps.sh --force: PASS
- build.sh --no-open: PASS (signature, launch smoke, performance budget)
- run-tests.sh: PASS (13,393/13,393)
- run-integration-smoke.sh: PASS
- swift test --jobs 1: PASS (860 executed, 13 skipped, 0 failures)
- TranscriptionTaskManagerRecoveryTests: PASS (23/23)
- repeated-write stress: PASS (30/30)
- full QA bench deterministic software steps: PASS; overall INCOMPLETE only because duplicate app build was skipped after the separate exact-head build and current local artifact validation was warnings-only
- codex review --base origin/main: PASS, no actionable findings
- correctness: PASS
- security/privacy: PASS
- thermonuclear maintainability: PASS
- hosted Swift CI software checks: PASS

The earlier correctness finding that the first test snapshot was still scheduler-sensitive was accepted and repaired in 794152d1. Hardware/UI/audio proof remains UNKNOWN.