### PR TITLE
Restore missing Claude Desktop MCP helper

### DIFF
--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -202,9 +202,21 @@ enum ClaudeDesktopIntegrationInstaller {
             throw ClaudeDesktopIntegrationError.bundledBinaryMissing(bundledBinaryURL)
         }
 
-        try installBundledBinary(
+        let stagedBinaryURL = try stageBundledBinary(
             from: bundledBinaryURL,
-            to: installedBinaryURL,
+            in: installedBinaryURL.deletingLastPathComponent(),
+            fileManager: fileManager
+        )
+        defer {
+            if fileManager.fileExists(atPath: stagedBinaryURL.path) {
+                try? fileManager.removeItem(at: stagedBinaryURL)
+            }
+        }
+
+        let selfTest = try runSelfTest(binaryURL: stagedBinaryURL, fileManager: fileManager)
+        try replaceInstalledBinary(
+            withStagedBinaryAt: stagedBinaryURL,
+            at: installedBinaryURL,
             fileManager: fileManager
         )
         try writeMCPObservabilityConfigIfAvailable(fileManager: fileManager)
@@ -215,7 +227,6 @@ enum ClaudeDesktopIntegrationInstaller {
             fileManager: fileManager
         )
 
-        let selfTest = try runSelfTest(binaryURL: installedBinaryURL, fileManager: fileManager)
         return ClaudeDesktopIntegrationInstallResult(
             configURL: configURL,
             installedBinaryURL: installedBinaryURL,
@@ -268,9 +279,24 @@ enum ClaudeDesktopIntegrationInstaller {
             return false
         }
 
-        try installBundledBinary(
+        let stagedBinaryURL = try stageBundledBinary(
             from: bundledBinaryURL,
-            to: installedBinaryURL,
+            in: installedBinaryURL.deletingLastPathComponent(),
+            fileManager: fileManager
+        )
+        defer {
+            if fileManager.fileExists(atPath: stagedBinaryURL.path) {
+                try? fileManager.removeItem(at: stagedBinaryURL)
+            }
+        }
+
+        // Validate the exact bytes we plan to install before replacing an
+        // existing helper, so failed refreshes cannot strand Claude on a bad
+        // update.
+        _ = try runSelfTest(binaryURL: stagedBinaryURL, fileManager: fileManager)
+        try replaceInstalledBinary(
+            withStagedBinaryAt: stagedBinaryURL,
+            at: installedBinaryURL,
             fileManager: fileManager
         )
         try writeMCPObservabilityConfigIfAvailable(
@@ -306,22 +332,45 @@ enum ClaudeDesktopIntegrationInstaller {
         to installedBinaryURL: URL,
         fileManager: FileManager = .default
     ) throws {
-        let installDirectory = installedBinaryURL.deletingLastPathComponent()
-        try fileManager.createDirectory(at: installDirectory, withIntermediateDirectories: true)
-        let stagedBinaryURL = installDirectory
-            .appendingPathComponent(".\(helperBinaryName).install-\(UUID().uuidString)", isDirectory: false)
+        let stagedBinaryURL = try stageBundledBinary(
+            from: bundledBinaryURL,
+            in: installedBinaryURL.deletingLastPathComponent(),
+            fileManager: fileManager
+        )
         defer {
             if fileManager.fileExists(atPath: stagedBinaryURL.path) {
                 try? fileManager.removeItem(at: stagedBinaryURL)
             }
         }
 
+        try replaceInstalledBinary(
+            withStagedBinaryAt: stagedBinaryURL,
+            at: installedBinaryURL,
+            fileManager: fileManager
+        )
+    }
+
+    static func stageBundledBinary(
+        from bundledBinaryURL: URL,
+        in installDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try fileManager.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        let stagedBinaryURL = installDirectory
+            .appendingPathComponent(".\(helperBinaryName).install-\(UUID().uuidString)", isDirectory: false)
         try fileManager.copyItem(at: bundledBinaryURL, to: stagedBinaryURL)
         try fileManager.setAttributes(
             [.posixPermissions: NSNumber(value: 0o755)],
             ofItemAtPath: stagedBinaryURL.path
         )
+        return stagedBinaryURL
+    }
 
+    static func replaceInstalledBinary(
+        withStagedBinaryAt stagedBinaryURL: URL,
+        at installedBinaryURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
         if fileManager.fileExists(atPath: installedBinaryURL.path) {
             _ = try fileManager.replaceItemAt(
                 installedBinaryURL,

--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -224,26 +224,42 @@ enum ClaudeDesktopIntegrationInstaller {
         )
     }
 
-    /// Silently re-copies the bundled helper over a previously installed one
-    /// when their contents differ, e.g. after an app update. Helper analytics
-    /// config is refreshed only when an installed helper already exists. Never
-    /// installs fresh: a missing installed helper means the user has not
-    /// opted into agent setup yet.
+    /// Silently restores or refreshes the bundled helper after app updates.
+    /// An existing helper or an exact Claude Desktop config entry proves the
+    /// user already opted into agent setup. Without either signal this never
+    /// installs fresh.
     @discardableResult
     static func refreshInstalledHelperIfNeeded(
         bundledBinaryURL: URL? = bundledMCPBinaryURL(),
         installedBinaryURL: URL = installedMCPBinaryURL,
+        configURL: URL = claudeDesktopConfigURL,
         observabilityConfigURL: URL = mcpObservabilityConfigURL,
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
         fileManager: FileManager = .default
     ) throws -> Bool {
-        guard fileManager.fileExists(atPath: installedBinaryURL.path) else {
+        let installedBinaryExists = fileManager.fileExists(atPath: installedBinaryURL.path)
+        let configuredCommandPath = readClaudeDesktopConfig(at: configURL, fileManager: fileManager)
+            .config
+            .flatMap(transcriptedCommandPath(in:))
+        let hasCanonicalClaudeConfig = configuredCommandPath == installedBinaryURL.path
+        guard installedBinaryExists || hasCanonicalClaudeConfig else {
             return false
         }
+
         guard let bundledBinaryURL,
               fileManager.isExecutableFile(atPath: bundledBinaryURL.path),
-              bundledBinaryURL.standardizedFileURL.path != installedBinaryURL.standardizedFileURL.path,
-              !fileManager.contentsEqual(atPath: installedBinaryURL.path, andPath: bundledBinaryURL.path) else {
+              bundledBinaryURL.standardizedFileURL.path != installedBinaryURL.standardizedFileURL.path else {
+            try writeMCPObservabilityConfigIfAvailable(
+                configURL: observabilityConfigURL,
+                infoDictionary: infoDictionary,
+                fileManager: fileManager
+            )
+            return false
+        }
+
+        let installedBinaryIsCurrent = fileManager.isExecutableFile(atPath: installedBinaryURL.path)
+            && fileManager.contentsEqual(atPath: installedBinaryURL.path, andPath: bundledBinaryURL.path)
+        guard !installedBinaryIsCurrent else {
             try writeMCPObservabilityConfigIfAvailable(
                 configURL: observabilityConfigURL,
                 infoDictionary: infoDictionary,
@@ -292,12 +308,30 @@ enum ClaudeDesktopIntegrationInstaller {
     ) throws {
         let installDirectory = installedBinaryURL.deletingLastPathComponent()
         try fileManager.createDirectory(at: installDirectory, withIntermediateDirectories: true)
-
-        if fileManager.fileExists(atPath: installedBinaryURL.path) {
-            try fileManager.removeItem(at: installedBinaryURL)
+        let stagedBinaryURL = installDirectory
+            .appendingPathComponent(".\(helperBinaryName).install-\(UUID().uuidString)", isDirectory: false)
+        defer {
+            if fileManager.fileExists(atPath: stagedBinaryURL.path) {
+                try? fileManager.removeItem(at: stagedBinaryURL)
+            }
         }
 
-        try fileManager.copyItem(at: bundledBinaryURL, to: installedBinaryURL)
+        try fileManager.copyItem(at: bundledBinaryURL, to: stagedBinaryURL)
+        try fileManager.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: stagedBinaryURL.path
+        )
+
+        if fileManager.fileExists(atPath: installedBinaryURL.path) {
+            _ = try fileManager.replaceItemAt(
+                installedBinaryURL,
+                withItemAt: stagedBinaryURL,
+                backupItemName: nil,
+                options: [.usingNewMetadataOnly]
+            )
+        } else {
+            try fileManager.moveItem(at: stagedBinaryURL, to: installedBinaryURL)
+        }
         try fileManager.setAttributes(
             [.posixPermissions: NSNumber(value: 0o755)],
             ofItemAtPath: installedBinaryURL.path

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -667,9 +667,10 @@ func testClaudeDesktopIntegrationInstaller() {
         try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? "#!/bin/sh\nexit 0\n".write(to: installedBinaryURL, atomically: true, encoding: .utf8)
-        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
+        try? writeSelfTestHelper(to: bundledBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":1,"dictation_file_count":0}
+        """)
         try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: installedBinaryURL.path)
-        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
         _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(commandPath: installedBinaryURL.path, configURL: configURL)
 
         let status = ClaudeDesktopIntegrationInstaller.currentStatus(
@@ -702,41 +703,45 @@ func testClaudeDesktopIntegrationInstaller() {
         try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? "#!/bin/sh\nexit 0\n".write(to: installedBinaryURL, atomically: true, encoding: .utf8)
-        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
+        try? writeSelfTestHelper(to: bundledBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":1,"dictation_file_count":0}
+        """)
         try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: installedBinaryURL.path)
-        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
 
-        let refreshed = try? ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
-            bundledBinaryURL: bundledBinaryURL,
-            installedBinaryURL: installedBinaryURL,
-            observabilityConfigURL: helperConfigURL,
-            infoDictionary: [
-                AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_current",
-                AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
-                ClaudeDesktopIntegrationInstaller.appVersionInfoKey: "1.2.3",
-                AnalyticsRuntimeConfiguration.buildChannelInfoKey: "release",
-                AnalyticsRuntimeConfiguration.buildRevisionInfoKey: "abc123def456",
-            ]
-        )
+        do {
+            let refreshed = try ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
+                bundledBinaryURL: bundledBinaryURL,
+                installedBinaryURL: installedBinaryURL,
+                observabilityConfigURL: helperConfigURL,
+                infoDictionary: [
+                    AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_current",
+                    AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+                    ClaudeDesktopIntegrationInstaller.appVersionInfoKey: "1.2.3",
+                    AnalyticsRuntimeConfiguration.buildChannelInfoKey: "release",
+                    AnalyticsRuntimeConfiguration.buildRevisionInfoKey: "abc123def456",
+                ]
+            )
 
-        assertEqual(refreshed, true, "stale installed helper should be refreshed at launch")
-        assertEqual(
-            (try? String(contentsOf: installedBinaryURL, encoding: .utf8)) ?? "",
-            "#!/bin/sh\necho current\n",
-            "refresh should copy the bundled helper bytes over the stale install"
-        )
-        assertTrue(
-            FileManager.default.isExecutableFile(atPath: installedBinaryURL.path),
-            "refreshed helper should stay executable"
-        )
-        assertTrue(
-            FileManager.default.fileExists(atPath: helperConfigURL.path),
-            "refresh should keep installed-helper analytics config in sync"
-        )
-        let helperConfig = helperObservabilityConfig(at: helperConfigURL)
-        assertEqual(helperConfig?[ClaudeDesktopIntegrationInstaller.appVersionInfoKey], "1.2.3", "refresh should write the current app version")
-        assertEqual(helperConfig?[AnalyticsRuntimeConfiguration.buildChannelInfoKey], "release", "refresh should write the current build channel")
-        assertEqual(helperConfig?[AnalyticsRuntimeConfiguration.buildRevisionInfoKey], "abc123def456", "refresh should write the current build revision")
+            assertEqual(refreshed, true, "stale installed helper should be refreshed at launch")
+            assertTrue(
+                FileManager.default.contentsEqual(atPath: bundledBinaryURL.path, andPath: installedBinaryURL.path),
+                "refresh should copy the bundled helper bytes over the stale install"
+            )
+            assertTrue(
+                FileManager.default.isExecutableFile(atPath: installedBinaryURL.path),
+                "refreshed helper should stay executable"
+            )
+            assertTrue(
+                FileManager.default.fileExists(atPath: helperConfigURL.path),
+                "refresh should keep installed-helper analytics config in sync"
+            )
+            let helperConfig = helperObservabilityConfig(at: helperConfigURL)
+            assertEqual(helperConfig?[ClaudeDesktopIntegrationInstaller.appVersionInfoKey], "1.2.3", "refresh should write the current app version")
+            assertEqual(helperConfig?[AnalyticsRuntimeConfiguration.buildChannelInfoKey], "release", "refresh should write the current build channel")
+            assertEqual(helperConfig?[AnalyticsRuntimeConfiguration.buildRevisionInfoKey], "abc123def456", "refresh should write the current build revision")
+        } catch {
+            assertTrue(false, "stale installed helper refresh should succeed: \(error)")
+        }
     }
 
     runSuite("ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded — leaves a current helper untouched") {
@@ -797,8 +802,9 @@ func testClaudeDesktopIntegrationInstaller() {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
         try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
-        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
+        try? writeSelfTestHelper(to: bundledBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":1,"dictation_file_count":0}
+        """)
         _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
             commandPath: installedBinaryURL.path,
             configURL: configURL
@@ -840,10 +846,13 @@ func testClaudeDesktopIntegrationInstaller() {
 
         try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try? "#!/bin/sh\necho current\n".write(to: installedBinaryURL, atomically: true, encoding: .utf8)
-        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
+        try? writeSelfTestHelper(to: installedBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":2,"dictation_file_count":0}
+        """)
+        try? writeSelfTestHelper(to: bundledBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":2,"dictation_file_count":0}
+        """)
         try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o644)], ofItemAtPath: installedBinaryURL.path)
-        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
         _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
             commandPath: installedBinaryURL.path,
             configURL: configURL
@@ -862,6 +871,56 @@ func testClaudeDesktopIntegrationInstaller() {
             FileManager.default.isExecutableFile(atPath: installedBinaryURL.path),
             "permission repair should restore an executable helper"
         )
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded — preserves a working helper when the bundled refresh fails self-test") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeHelperRefreshFailureTests-\(UUID().uuidString)", isDirectory: true)
+        let installedBinaryURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let bundledBinaryURL = tempRoot
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let helperConfigURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? writeSelfTestHelper(to: installedBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":3,"dictation_file_count":1}
+        """)
+        let installedBeforeFailure = (try? String(contentsOf: installedBinaryURL, encoding: .utf8)) ?? ""
+        try? writeSelfTestHelper(to: bundledBinaryURL, stdout: "helper failed", exitCode: 9)
+
+        do {
+            _ = try ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
+                bundledBinaryURL: bundledBinaryURL,
+                installedBinaryURL: installedBinaryURL,
+                observabilityConfigURL: helperConfigURL,
+                infoDictionary: [
+                    AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_current",
+                    AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+                ]
+            )
+            assertTrue(false, "refresh should surface a bundled helper that fails self-test")
+        } catch let error as ClaudeDesktopIntegrationError {
+            assertEqual(
+                error,
+                .selfTestFailed(status: 9, output: "helper failed\n"),
+                "refresh should preserve the bundled helper diagnostics when self-test fails"
+            )
+            assertEqual(
+                (try? String(contentsOf: installedBinaryURL, encoding: .utf8)) ?? "",
+                installedBeforeFailure,
+                "a failed refresh must keep the previously working helper installed"
+            )
+            assertFalse(
+                FileManager.default.fileExists(atPath: helperConfigURL.path),
+                "failed refresh should not rewrite helper observability config"
+            )
+        } catch {
+            assertTrue(false, "failed refresh should throw ClaudeDesktopIntegrationError: \(error)")
+        }
     }
 
     runSuite("ClaudeDesktopIntegrationInstaller.installBundledBinary — preserves installed helper when staging fails") {
@@ -1017,8 +1076,9 @@ func testClaudeDesktopIntegrationInstaller() {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
         try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
-        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
+        try? writeSelfTestHelper(to: bundledBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":0,"dictation_file_count":0}
+        """)
 
         let refreshed = try? ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
             bundledBinaryURL: bundledBinaryURL,
@@ -1484,10 +1544,68 @@ func testClaudeDesktopIntegrationInstaller() {
                 .selfTestFailed(status: 7, output: "helper failed\n"),
                 "self-test failure should include exit status and helper output"
             )
-            assertTrue(FileManager.default.isExecutableFile(atPath: installedBinaryURL.path), "failed self-test should still leave the copied helper for inspection")
-            assertEqual(transcriptedCommandPath(inConfigAt: configURL), installedBinaryURL.path, "config should show which helper failed self-test")
+            assertFalse(
+                FileManager.default.fileExists(atPath: installedBinaryURL.path),
+                "failed self-test should not replace a helper on disk"
+            )
+            assertFalse(
+                FileManager.default.fileExists(atPath: configURL.path),
+                "failed self-test should not rewrite Claude config"
+            )
         } catch {
             assertTrue(false, "self-test failure should throw ClaudeDesktopIntegrationError: \(error)")
+        }
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.installForClaudeDesktop — preserves an existing helper when replacement self-test fails") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeInstallReplaceFailureTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        let bundledBinaryURL = tempRoot
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let installedBinaryURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? writeSelfTestHelper(to: installedBinaryURL, stdout: """
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":4,"dictation_file_count":1}
+        """)
+        let installedBeforeFailure = (try? String(contentsOf: installedBinaryURL, encoding: .utf8)) ?? ""
+        _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
+            commandPath: installedBinaryURL.path,
+            configURL: configURL
+        )
+        try? writeSelfTestHelper(to: bundledBinaryURL, stdout: "helper failed", exitCode: 7)
+
+        do {
+            _ = try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop(
+                bundledBinaryURL: bundledBinaryURL,
+                installedBinaryURL: installedBinaryURL,
+                configURL: configURL
+            )
+            assertTrue(false, "install should surface helper self-test failures before replacing a working helper")
+        } catch let error as ClaudeDesktopIntegrationError {
+            assertEqual(
+                error,
+                .selfTestFailed(status: 7, output: "helper failed\n"),
+                "replacement failure should keep helper self-test diagnostics"
+            )
+            assertEqual(
+                (try? String(contentsOf: installedBinaryURL, encoding: .utf8)) ?? "",
+                installedBeforeFailure,
+                "replacement failure must leave the previous helper installed"
+            )
+            assertEqual(
+                transcriptedCommandPath(inConfigAt: configURL),
+                installedBinaryURL.path,
+                "replacement failure must leave Claude config pointing at the last known-good helper"
+            )
+        } catch {
+            assertTrue(false, "replacement self-test failure should throw ClaudeDesktopIntegrationError: \(error)")
         }
     }
 
@@ -1525,8 +1643,14 @@ func testClaudeDesktopIntegrationInstaller() {
                 "Transcripted direct tools ran, but the health check output could not be read.",
                 "install should keep unreadable self-test output generic for users"
             )
-            assertTrue(FileManager.default.isExecutableFile(atPath: installedBinaryURL.path), "failed self-test decode should leave the copied helper for inspection")
-            assertEqual(transcriptedCommandPath(inConfigAt: configURL), installedBinaryURL.path, "config should show which helper produced unreadable self-test output")
+            assertFalse(
+                FileManager.default.fileExists(atPath: installedBinaryURL.path),
+                "failed self-test decode should not replace a helper on disk"
+            )
+            assertFalse(
+                FileManager.default.fileExists(atPath: configURL.path),
+                "failed self-test decode should not rewrite Claude config"
+            )
         } catch {
             assertTrue(false, "unreadable self-test output should throw ClaudeDesktopIntegrationError: \(error)")
         }
@@ -1691,8 +1815,14 @@ func testClaudeDesktopIntegrationInstaller() {
                 .selfTestReportedUnhealthy(output: "\(output)\n"),
                 "install should report unhealthy self-test output from the copied helper"
             )
-            assertTrue(FileManager.default.isExecutableFile(atPath: installedBinaryURL.path), "unhealthy self-test should leave the copied helper for inspection")
-            assertEqual(transcriptedCommandPath(inConfigAt: configURL), installedBinaryURL.path, "config should show which helper reported an unhealthy self-test")
+            assertFalse(
+                FileManager.default.fileExists(atPath: installedBinaryURL.path),
+                "unhealthy self-test should not replace a helper on disk"
+            )
+            assertFalse(
+                FileManager.default.fileExists(atPath: configURL.path),
+                "unhealthy self-test should not rewrite Claude config"
+            )
         } catch {
             assertTrue(false, "unhealthy install self-test output should throw ClaudeDesktopIntegrationError: \(error)")
         }

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -781,6 +781,123 @@ func testClaudeDesktopIntegrationInstaller() {
         assertEqual(helperConfig?[AnalyticsRuntimeConfiguration.buildRevisionInfoKey], "def456abc123", "matching helper refresh should update build identity")
     }
 
+    runSuite("ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded — restores a configured missing helper") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeHelperMissingRefreshTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        let installedBinaryURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let bundledBinaryURL = tempRoot
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let helperConfigURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
+        _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
+            commandPath: installedBinaryURL.path,
+            configURL: configURL
+        )
+
+        let refreshed = try? ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
+            bundledBinaryURL: bundledBinaryURL,
+            installedBinaryURL: installedBinaryURL,
+            configURL: configURL,
+            observabilityConfigURL: helperConfigURL,
+            infoDictionary: [:]
+        )
+
+        assertEqual(refreshed, true, "a surviving canonical Claude config should prove prior consent and restore its missing helper")
+        assertTrue(
+            FileManager.default.isExecutableFile(atPath: installedBinaryURL.path),
+            "restored configured helper should be executable"
+        )
+        assertTrue(
+            FileManager.default.contentsEqual(atPath: bundledBinaryURL.path, andPath: installedBinaryURL.path),
+            "restored configured helper should match the bundled helper"
+        )
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded — repairs execute permission") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeHelperPermissionRefreshTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        let installedBinaryURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let bundledBinaryURL = tempRoot
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let helperConfigURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "#!/bin/sh\necho current\n".write(to: installedBinaryURL, atomically: true, encoding: .utf8)
+        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o644)], ofItemAtPath: installedBinaryURL.path)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
+        _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
+            commandPath: installedBinaryURL.path,
+            configURL: configURL
+        )
+
+        let refreshed = try? ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
+            bundledBinaryURL: bundledBinaryURL,
+            installedBinaryURL: installedBinaryURL,
+            configURL: configURL,
+            observabilityConfigURL: helperConfigURL,
+            infoDictionary: [:]
+        )
+
+        assertEqual(refreshed, true, "a configured helper without execute permission should be repaired")
+        assertTrue(
+            FileManager.default.isExecutableFile(atPath: installedBinaryURL.path),
+            "permission repair should restore an executable helper"
+        )
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.installBundledBinary — preserves installed helper when staging fails") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeHelperAtomicInstallTests-\(UUID().uuidString)", isDirectory: true)
+        let installedBinaryURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let missingBundledBinaryURL = tempRoot
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("missing-transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "#!/bin/sh\necho installed\n".write(to: installedBinaryURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: installedBinaryURL.path)
+
+        do {
+            try ClaudeDesktopIntegrationInstaller.installBundledBinary(
+                from: missingBundledBinaryURL,
+                to: installedBinaryURL
+            )
+            assertTrue(false, "install should fail when the bundled helper cannot be staged")
+        } catch {
+            assertEqual(
+                (try? String(contentsOf: installedBinaryURL, encoding: .utf8)) ?? "",
+                "#!/bin/sh\necho installed\n",
+                "a failed update must leave the previously installed helper available"
+            )
+            assertTrue(
+                FileManager.default.isExecutableFile(atPath: installedBinaryURL.path),
+                "a failed update must preserve the executable installed helper"
+            )
+        }
+    }
+
     runSuite("ClaudeDesktopIntegrationInstaller.writeMCPObservabilityConfigIfAvailable — writes validated app identity") {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptedClaudeHelperIdentityTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 import SQLite3
 import TranscriptedCaptureKit
 
@@ -16,7 +17,12 @@ final class TranscriptIndex: @unchecked Sendable {
 
     init(indexDir: URL, embeddingProvider: EmbeddingProvider? = nil) throws {
         self.indexPath = indexDir.appendingPathComponent("mcp_index.sqlite")
-        try queue.sync { try self.openAndSetup() }
+        let setupLockPath = indexDir.appendingPathComponent("mcp_index.setup.lock", isDirectory: false)
+        try queue.sync {
+            try Self.withExclusiveSetupLock(at: setupLockPath) {
+                try self.openAndSetup()
+            }
+        }
         if let provider = embeddingProvider, provider.isAvailable {
             self.embeddingStore = try EmbeddingStore(dbPath: indexPath, provider: provider)
         }
@@ -29,6 +35,31 @@ final class TranscriptIndex: @unchecked Sendable {
     }
 
     // MARK: - Setup
+
+    /// Schema gates can delete and recreate the derived index. Serialize only
+    /// that setup window across MCP client processes so two cold starts cannot
+    /// remove the database underneath each other.
+    private static func withExclusiveSetupLock(
+        at lockPath: URL,
+        operation: () throws -> Void
+    ) throws {
+        let descriptor = open(lockPath.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw MCPIndexError.databaseOpenFailed("Could not open the index setup lock")
+        }
+        defer {
+            _ = flock(descriptor, LOCK_UN)
+            close(descriptor)
+        }
+
+        while flock(descriptor, LOCK_EX) != 0 {
+            guard errno == EINTR else {
+                throw MCPIndexError.databaseOpenFailed("Could not acquire the index setup lock")
+            }
+        }
+        _ = chmod(lockPath.path, 0o600)
+        try operation()
+    }
 
     private func openAndSetup() throws {
         if sqlite3_open(indexPath.path, &db) != SQLITE_OK {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ProcessStartupTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ProcessStartupTests.swift
@@ -19,13 +19,46 @@ private final class ProcessResponseBox: @unchecked Sendable {
     }
 }
 
+private final class ProcessInitializeReader: @unchecked Sendable {
+    private let lock = NSLock()
+    private var buffer = Data()
+    private var completed = false
+    private let responseBox: ProcessResponseBox
+    private let responseReceived: XCTestExpectation
+
+    init(responseBox: ProcessResponseBox, responseReceived: XCTestExpectation) {
+        self.responseBox = responseBox
+        self.responseReceived = responseReceived
+    }
+
+    func consume(_ data: Data) {
+        guard !data.isEmpty else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+        guard !completed else { return }
+
+        buffer.append(data)
+        while let newline = buffer.firstIndex(of: 0x0A) {
+            let line = buffer[..<newline]
+            buffer.removeSubrange(...newline)
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line)),
+                  let response = object as? [String: Any],
+                  (response["id"] as? NSNumber)?.intValue == 1 else {
+                continue
+            }
+
+            completed = true
+            responseBox.set(response)
+            responseReceived.fulfill()
+            return
+        }
+    }
+}
+
 final class ProcessStartupTests: XCTestCase {
     func testExecutableAnswersInitializeOverStdio() throws {
-        let packageRoot = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-        let executable = packageRoot.appendingPathComponent(".build/debug/transcripted-mcp")
+        let executable = builtExecutable()
         XCTAssertTrue(FileManager.default.isExecutableFile(atPath: executable.path))
 
         let dataRoot = makeTempDir()
@@ -92,5 +125,88 @@ final class ProcessStartupTests: XCTestCase {
         let serverInfo = try XCTUnwrap(result["serverInfo"] as? [String: Any])
         XCTAssertEqual(serverInfo["name"] as? String, "transcripted")
         XCTAssertEqual(serverInfo["version"] as? String, TranscriptedMCP.serverVersion)
+    }
+
+    func testConcurrentExecutablesAnswerInitializeAgainstSharedColdIndex() throws {
+        let executable = builtExecutable()
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: executable.path))
+
+        let dataRoot = makeTempDir()
+        defer { removeTempDir(dataRoot) }
+        let sharedIndexRoot = dataRoot.appendingPathComponent("shared-index", isDirectory: true)
+
+        var processes: [Process] = []
+        var standardInputs: [Pipe] = []
+        var standardOutputs: [Pipe] = []
+        var responseBoxes: [ProcessResponseBox] = []
+        let responseExpectations = (1...2).map {
+            expectation(description: "concurrent initialize response \($0)")
+        }
+
+        defer {
+            for output in standardOutputs {
+                output.fileHandleForReading.readabilityHandler = nil
+            }
+            for input in standardInputs {
+                try? input.fileHandleForWriting.close()
+            }
+            for process in processes where process.isRunning {
+                process.terminate()
+                process.waitUntilExit()
+            }
+        }
+
+        for responseExpectation in responseExpectations {
+            let process = Process()
+            let standardInput = Pipe()
+            let standardOutput = Pipe()
+            let responseBox = ProcessResponseBox()
+            let responseReader = ProcessInitializeReader(
+                responseBox: responseBox,
+                responseReceived: responseExpectation
+            )
+
+            process.executableURL = executable
+            process.standardInput = standardInput
+            process.standardOutput = standardOutput
+            process.standardError = Pipe()
+
+            var environment = ProcessInfo.processInfo.environment
+            environment["TRANSCRIPTED_DATA_DIR"] = dataRoot.path
+            environment["TRANSCRIPTED_INDEX_DIR"] = sharedIndexRoot.path
+            environment["TRANSCRIPTED_DISABLE_FILE_LOGGER"] = "1"
+            process.environment = environment
+            standardOutput.fileHandleForReading.readabilityHandler = { handle in
+                responseReader.consume(handle.availableData)
+            }
+
+            try process.run()
+            processes.append(process)
+            standardInputs.append(standardInput)
+            standardOutputs.append(standardOutput)
+            responseBoxes.append(responseBox)
+        }
+
+        let request = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"synthetic-concurrent-client","version":"1.0"}}}"# + "\n"
+        for input in standardInputs {
+            try input.fileHandleForWriting.write(contentsOf: Data(request.utf8))
+        }
+
+        XCTAssertEqual(XCTWaiter.wait(for: responseExpectations, timeout: 10), .completed)
+        for responseBox in responseBoxes {
+            let response = try XCTUnwrap(responseBox.get())
+            XCTAssertEqual(response["jsonrpc"] as? String, "2.0")
+            let result = try XCTUnwrap(response["result"] as? [String: Any])
+            let serverInfo = try XCTUnwrap(result["serverInfo"] as? [String: Any])
+            XCTAssertEqual(serverInfo["name"] as? String, "transcripted")
+        }
+    }
+
+    private func builtExecutable() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(".build/debug/transcripted-mcp")
     }
 }


### PR DESCRIPTION
## What changed

- Restore the installed `transcripted-mcp` helper when Claude Desktop still has the canonical Transcripted config entry but the helper is missing or no longer executable.
- Stage and chmod helper updates before atomically replacing the installed binary, so an interrupted refresh preserves the previous working helper.
- Serialize the derived SQLite index setup window across MCP processes so concurrent cold starts cannot remove the database underneath each other.
- Add regression coverage for missing-helper recovery, execute-permission repair, failed-update preservation, and two real MCP executables initializing against one shared cold index.

## Root cause and user impact

Claude Desktop's JSON config could continue pointing at Transcripted while the installed helper was absent or non-executable after an interrupted update. The launch refresh only repaired helpers that already existed, so that state never self-healed. Claude then could not spawn the configured stdio server, leaving Transcripted absent from the local Connections/Connectors list even though its config entry remained.

A second startup defect allowed two MCP clients sharing a cold derived index to race through the schema rebuild. One process could remove the SQLite file while the other was preparing it, causing a pre-handshake crash and the same config-present/server-absent symptom.

Server key casing, helper name, canonical install path, app identity routing, and the shipped stdio protocol response were checked and were not the regression.

## Synthetic proof

Only synthetic local data was used.

- Before the index lock, two real MCP processes sharing a fresh index and 1,000 synthetic capture files reproduced a pre-`initialize` SQLite failure in 2 of 3 runs (`disk I/O error` / missing-table startup failure).
- After the lock, both processes returned valid `initialize` responses in all 3 equivalent runs.
- The automated process regression launches two built `transcripted-mcp` executables against one shared cold index and requires both server responses.
- Focused helper installer regression suite: 179/179 passed.
- Full MCP package suite: 191/191 passed.
- Full app fast suite: 13,400/13,400 passed.
- Deterministic E2E smoke, signed `bash build.sh --no-open`, agent preflight, `git diff --check`, and privacy leak sweep passed.
- Independent `codex review --uncommitted` completed with no accepted or actionable findings.

## Manual proof still required

This branch has not been merged or released, and no private user config or diagnostics were accessed. Final proof remains a current Claude Desktop run with an installed patched Transcripted build and a populated real library: use Transcripted's Connect/Repair action, fully quit and reopen Claude Desktop, then confirm Transcripted appears and connects in Claude Desktop's local Connections/Connectors list and Developer MCP status.