### PR TITLE
Fix stalled first-run model downloads

### DIFF
--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -122,6 +122,11 @@ struct SentryEventPolicy: Equatable {
             event: "model_init_failed",
             summary: "Speech model initialization failed."
         ),
+        "parakeet.model_download_stalled": .init(
+            engine: "parakeet",
+            event: "model_download_stalled",
+            summary: "Speech model download stopped making progress."
+        ),
         "parakeet.prewarm_failed": .init(
             engine: "parakeet",
             event: "prewarm_failed",

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -88,8 +88,11 @@ class ParakeetEngine: ObservableObject {
     // FluidAudio ASR
     var asrManager: AsrManager?
     var modelInitializationTask: Task<Void, Never>?
+    var modelInitializationGeneration: UInt64 = 0
     var modelFilePrefetchTask: Task<URL, Error>?
     var prefetchedModelPath: URL?
+    var modelDownloadWatchdogTask: Task<Void, Never>?
+    var modelDownloadAttemptGeneration: UInt64 = 0
     private var audioWatchdogTask: Task<Void, Never>?
     private var zombieRecoveryTask: Task<Void, Never>?
     private var zombieRecoveryState = ParakeetZombieRecoveryState()

--- a/Sources/Speech/ParakeetModelInitDiagnostics.swift
+++ b/Sources/Speech/ParakeetModelInitDiagnostics.swift
@@ -1,6 +1,106 @@
 import AVFoundation
 import Foundation
 
+final class ParakeetModelDownloadProgressTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private let stageCount: Int
+    private var stageIndex = 0
+    private var stageProgress = 0.0
+    private var maximumPublishedProgress = 0.0
+    private var lastCallbackProgress = -1.0
+    private var lastActivityUptime: TimeInterval
+
+    init(
+        stageCount: Int = 4,
+        initialActivityUptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) {
+        self.stageCount = max(1, stageCount)
+        self.lastActivityUptime = initialActivityUptime
+    }
+
+    /// FluidAudio reports each Parakeet model component as a separate 0...1
+    /// operation. Fold those updates into one monotonic 0...1 value so the UI
+    /// never jumps backward between component downloads.
+    func overallProgress(rawProgress: Double, beginsNewStage: Bool) -> Double {
+        lock.withLock {
+            updateLocked(rawProgress: rawProgress, beginsNewStage: beginsNewStage)
+        }
+    }
+
+    /// Keep byte-level callbacks useful without scheduling tens of thousands
+    /// of main-actor UI updates during a large download.
+    func progressToPublish(
+        rawProgress: Double,
+        beginsNewStage: Bool,
+        activityUptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> Double? {
+        lock.withLock {
+            lastActivityUptime = max(lastActivityUptime, activityUptime)
+            let overall = updateLocked(
+                rawProgress: rawProgress,
+                beginsNewStage: beginsNewStage
+            )
+            guard beginsNewStage
+                || overall >= 1
+                || overall - lastCallbackProgress >= 0.002
+            else {
+                return nil
+            }
+            lastCallbackProgress = overall
+            return overall
+        }
+    }
+
+    func remainingNoProgressInterval(
+        timeout: TimeInterval,
+        nowUptime: TimeInterval = ProcessInfo.processInfo.systemUptime
+    ) -> TimeInterval {
+        lock.withLock {
+            max(0, timeout - max(0, nowUptime - lastActivityUptime))
+        }
+    }
+
+    private func updateLocked(rawProgress: Double, beginsNewStage: Bool) -> Double {
+        let clamped = max(0, min(1, rawProgress))
+        // FluidAudio emits `.listing` only for the first component. Each later
+        // component restarts its own 0...1 progress range, commonly at 0.5.
+        let restartedCompletedStage = stageProgress >= 0.99
+            && clamped < stageProgress - 0.25
+        if stageProgress >= 0.99, beginsNewStage || restartedCompletedStage {
+            stageIndex = min(stageIndex + 1, stageCount - 1)
+            stageProgress = 0
+        }
+
+        stageProgress = max(stageProgress, clamped)
+        let overall = min(
+            1,
+            (Double(stageIndex) + stageProgress) / Double(stageCount)
+        )
+        maximumPublishedProgress = max(maximumPublishedProgress, overall)
+        return maximumPublishedProgress
+    }
+}
+
+enum ParakeetModelDownloadAttemptPolicy {
+    static func isCurrent(expectedGeneration: UInt64, currentGeneration: UInt64) -> Bool {
+        expectedGeneration == currentGeneration
+    }
+
+    static func shouldTimeOut(
+        expectedGeneration: UInt64,
+        currentGeneration: UInt64,
+        hasActiveTask: Bool,
+        taskCancelled: Bool
+    ) -> Bool {
+        isCurrent(
+            expectedGeneration: expectedGeneration,
+            currentGeneration: currentGeneration
+        )
+            && hasActiveTask
+            && !taskCancelled
+    }
+}
+
 enum ParakeetModelInitStage: String, Equatable {
     case authorizationRequest = "authorization_request"
     case bundleLoad = "bundle_load"

--- a/Sources/Speech/ParakeetModelLifecycle.swift
+++ b/Sources/Speech/ParakeetModelLifecycle.swift
@@ -11,8 +11,132 @@ import FluidAudio
 import Foundation
 import TranscriptedCore
 
+private final class ParakeetModelDownloadProgressTarget: @unchecked Sendable {
+    weak var engine: ParakeetEngine?
+
+    @MainActor
+    init(engine: ParakeetEngine) {
+        self.engine = engine
+    }
+}
+
 extension ParakeetEngine {
     // MARK: - Model Initialization
+
+    private static let stalledDownloadMessage =
+        "The model download stopped making progress. Check your connection and retry the download."
+    /// Slow downloads remain valid while bytes are moving. A silent task
+    /// fails into the existing Retry Download path instead of waiting forever.
+    private static let modelDownloadNoProgressTimeout: TimeInterval = 300
+
+    private func startModelDownloadTask() -> Task<URL, Error> {
+        let progressTracker = ParakeetModelDownloadProgressTracker()
+        let generation = beginModelDownloadAttempt(progressTracker: progressTracker)
+        let progressTarget = ParakeetModelDownloadProgressTarget(engine: self)
+        let task = Task.detached(priority: .utility) {
+            try await AsrModels.download(version: .v3) { progress in
+                let beginsNewStage: Bool
+                switch progress.phase {
+                case .listing:
+                    beginsNewStage = true
+                case .downloading, .compiling:
+                    beginsNewStage = false
+                }
+                guard let overallProgress = progressTracker.progressToPublish(
+                    rawProgress: progress.fractionCompleted,
+                    beginsNewStage: beginsNewStage
+                ) else { return }
+                Task { @MainActor in
+                    progressTarget.engine?.recordModelDownloadProgress(
+                        overallProgress,
+                        generation: generation
+                    )
+                }
+            }
+        }
+        modelFilePrefetchTask = task
+        return task
+    }
+
+    private func beginModelDownloadAttempt(
+        progressTracker: ParakeetModelDownloadProgressTracker
+    ) -> UInt64 {
+        modelDownloadAttemptGeneration &+= 1
+        modelDownloadState = .downloading(progress: 0)
+        scheduleModelDownloadWatchdog(
+            generation: modelDownloadAttemptGeneration,
+            progressTracker: progressTracker
+        )
+        return modelDownloadAttemptGeneration
+    }
+
+    private func recordModelDownloadProgress(_ progress: Double, generation: UInt64) {
+        guard ParakeetModelDownloadAttemptPolicy.isCurrent(
+            expectedGeneration: generation,
+            currentGeneration: modelDownloadAttemptGeneration
+        ), modelFilePrefetchTask != nil else { return }
+        modelDownloadState = .downloading(progress: max(0, min(1, progress)))
+    }
+
+    private func scheduleModelDownloadWatchdog(
+        generation: UInt64,
+        progressTracker: ParakeetModelDownloadProgressTracker
+    ) {
+        modelDownloadWatchdogTask?.cancel()
+        modelDownloadWatchdogTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                let remaining = progressTracker.remainingNoProgressInterval(
+                    timeout: Self.modelDownloadNoProgressTimeout
+                )
+                guard remaining > 0 else { break }
+                do {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(remaining * 1_000_000_000)
+                    )
+                } catch {
+                    return
+                }
+            }
+            guard let self else { return }
+            guard ParakeetModelDownloadAttemptPolicy.shouldTimeOut(
+                expectedGeneration: generation,
+                currentGeneration: self.modelDownloadAttemptGeneration,
+                hasActiveTask: self.modelFilePrefetchTask != nil,
+                taskCancelled: Task.isCancelled
+            ) else {
+                return
+            }
+
+            self.modelDownloadAttemptGeneration &+= 1
+            self.modelFilePrefetchTask?.cancel()
+            self.modelFilePrefetchTask = nil
+            self.modelInitializationGeneration &+= 1
+            self.modelInitializationTask?.cancel()
+            self.modelInitializationTask = nil
+            self.modelDownloadState = .failed(Self.stalledDownloadMessage)
+            EventReporter.shared.capture(
+                level: .error,
+                engine: "parakeet",
+                event: "model_download_stalled",
+                message: "Local speech model download stopped making progress",
+                context: [
+                    "failure_kind": "no_progress_timeout",
+                    "stall_stage": "model_download",
+                ]
+            )
+        }
+    }
+
+    @discardableResult
+    private func finishModelDownloadAttempt(generation: UInt64) -> Bool {
+        guard ParakeetModelDownloadAttemptPolicy.isCurrent(
+            expectedGeneration: generation,
+            currentGeneration: modelDownloadAttemptGeneration
+        ) else { return false }
+        modelDownloadWatchdogTask?.cancel()
+        modelDownloadWatchdogTask = nil
+        return true
+    }
 
     /// Load Parakeet models from the app bundle (preferred) or download from HuggingFace (fallback).
     /// Bundle path: Contents/Resources/parakeet-models/parakeet-tdt-0.6b-v3-coreml/
@@ -24,9 +148,11 @@ extension ParakeetEngine {
             return
         }
 
+        modelInitializationGeneration &+= 1
+        let generation = modelInitializationGeneration
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.performInitialize()
+            await self.performInitialize(generation: generation)
         }
         modelInitializationTask = task
         await task.value
@@ -41,8 +167,12 @@ extension ParakeetEngine {
         return true
     }
 
-    private func performInitialize() async {
-        defer { modelInitializationTask = nil }
+    private func performInitialize(generation: UInt64) async {
+        defer {
+            if generation == modelInitializationGeneration {
+                modelInitializationTask = nil
+            }
+        }
         guard !isShuttingDown, !Task.isCancelled else { return }
         scheduleInputDeviceNameRefresh()
         markCachedRuntimeModelIfAvailable()
@@ -112,8 +242,9 @@ extension ParakeetEngine {
                 let downloadedPath: URL
                 if let modelFilePrefetchTask {
                     AppLogger.transcription.info("PARAKEET | waiting for background Parakeet model cache...")
-                    modelDownloadState = .downloading(progress: 0.0)
+                    let generation = modelDownloadAttemptGeneration
                     downloadedPath = try await modelFilePrefetchTask.value
+                    guard finishModelDownloadAttempt(generation: generation) else { return }
                     prefetchedModelPath = downloadedPath
                     self.modelFilePrefetchTask = nil
                 } else if let prefetchedModelPath {
@@ -123,8 +254,11 @@ extension ParakeetEngine {
                     downloadedPath = cachedModelPath
                 } else {
                     AppLogger.transcription.info("PARAKEET | models not bundled, downloading (~600MB)...")
-                    modelDownloadState = .downloading(progress: 0.0)
-                    downloadedPath = try await AsrModels.download(version: .v3)
+                    let task = startModelDownloadTask()
+                    let generation = modelDownloadAttemptGeneration
+                    downloadedPath = try await task.value
+                    guard finishModelDownloadAttempt(generation: generation) else { return }
+                    modelFilePrefetchTask = nil
                     prefetchedModelPath = downloadedPath
                 }
                 guard !Task.isCancelled, !isShuttingDown else { return }
@@ -153,6 +287,7 @@ extension ParakeetEngine {
 
         } catch {
             guard !Task.isCancelled, !isShuttingDown else { return }
+            finishModelDownloadAttempt(generation: modelDownloadAttemptGeneration)
             modelFilePrefetchTask = nil
             prefetchedModelPath = nil
             let friendlyMessage = ModelDownloadService.classifyError(error).detail
@@ -195,15 +330,13 @@ extension ParakeetEngine {
         if let modelFilePrefetchTask {
             task = modelFilePrefetchTask
         } else {
-            modelDownloadState = .downloading(progress: 0.0)
-            task = Task.detached(priority: .utility) {
-                try await AsrModels.download(version: .v3)
-            }
-            modelFilePrefetchTask = task
+            task = startModelDownloadTask()
         }
+        let generation = modelDownloadAttemptGeneration
 
         do {
             let downloadedPath = try await task.value
+            guard finishModelDownloadAttempt(generation: generation) else { return }
             guard !Task.isCancelled, !isShuttingDown else { return }
             guard modelInitializationTask == nil, asrManager == nil, !asrManagerReady else {
                 if modelFilePrefetchTask != nil {
@@ -225,8 +358,13 @@ extension ParakeetEngine {
             )
         } catch {
             guard !Task.isCancelled, !isShuttingDown else { return }
+            guard finishModelDownloadAttempt(generation: generation) else { return }
             if modelFilePrefetchTask != nil {
                 modelFilePrefetchTask = nil
+            }
+            if case .failed(let message) = modelDownloadState,
+               message == Self.stalledDownloadMessage {
+                return
             }
             let friendlyMessage = ModelDownloadService.classifyError(error).detail
             modelDownloadState = .failed(friendlyMessage)
@@ -292,6 +430,10 @@ extension ParakeetEngine {
 
     /// Cancel in-flight model init/prefetch work. Called from `cleanup()`.
     func cancelModelWork() {
+        modelDownloadAttemptGeneration &+= 1
+        modelDownloadWatchdogTask?.cancel()
+        modelDownloadWatchdogTask = nil
+        modelInitializationGeneration &+= 1
         modelInitializationTask?.cancel()
         modelInitializationTask = nil
         modelFilePrefetchTask?.cancel()

--- a/Tests/ParakeetModelInitDiagnosticsTests.swift
+++ b/Tests/ParakeetModelInitDiagnosticsTests.swift
@@ -15,4 +15,148 @@ func testParakeetModelInitDiagnostics() {
         assertEqual(context["model_bundle_present"], "false", "bundle presence should be explicit for packaging/debugging issues")
         assertEqual(context["mic_status"], "denied", "microphone status should be preserved in a sanitized form")
     }
+
+    runSuite("ParakeetModelDownloadProgressTracker maps component downloads monotonically") {
+        let tracker = ParakeetModelDownloadProgressTracker(
+            stageCount: 4,
+            initialActivityUptime: 0
+        )
+
+        assertEqual(
+            tracker.overallProgress(rawProgress: 0, beginsNewStage: true),
+            0,
+            "the first listing callback should start at zero"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 0.6, beginsNewStage: false),
+            0.6 / 4.0,
+            "the first component should occupy one fourth of overall progress"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 1, beginsNewStage: false),
+            1.0 / 4.0,
+            "completing the first component should publish one-fourth progress"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 0.5, beginsNewStage: false),
+            0.375,
+            "a reset after completion should begin the next FluidAudio component"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 1, beginsNewStage: false),
+            0.5,
+            "completing the second component should publish half progress"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 0.5, beginsNewStage: false),
+            0.625,
+            "the third component should advance without another listing callback"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 1, beginsNewStage: false),
+            0.75,
+            "completing the third component should publish three-fourths progress"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 0.5, beginsNewStage: false),
+            0.875,
+            "the fourth component should advance without another listing callback"
+        )
+        assertEqual(
+            tracker.overallProgress(rawProgress: 1, beginsNewStage: false),
+            1,
+            "completing all four components should publish full progress"
+        )
+    }
+
+    runSuite("ParakeetModelDownloadAttemptPolicy only times out the current active download") {
+        assertTrue(
+            ParakeetModelDownloadAttemptPolicy.shouldTimeOut(
+                expectedGeneration: 4,
+                currentGeneration: 4,
+                hasActiveTask: true,
+                taskCancelled: false
+            ),
+            "a current download with an active watchdog should fail after no progress"
+        )
+        assertFalse(
+            ParakeetModelDownloadAttemptPolicy.shouldTimeOut(
+                expectedGeneration: 3,
+                currentGeneration: 4,
+                hasActiveTask: true,
+                taskCancelled: false
+            ),
+            "a stale watchdog must not fail a newer download"
+        )
+        assertFalse(
+            ParakeetModelDownloadAttemptPolicy.shouldTimeOut(
+                expectedGeneration: 4,
+                currentGeneration: 4,
+                hasActiveTask: false,
+                taskCancelled: false
+            ),
+            "a download without an active task must not be failed"
+        )
+    }
+
+    runSuite("ParakeetModelDownloadAttemptPolicy rejects late completion from a timed-out attempt") {
+        assertFalse(
+            ParakeetModelDownloadAttemptPolicy.isCurrent(
+                expectedGeneration: 4,
+                currentGeneration: 5
+            ),
+            "a timed-out attempt must not clear or overwrite a newer retry"
+        )
+        assertTrue(
+            ParakeetModelDownloadAttemptPolicy.isCurrent(
+                expectedGeneration: 5,
+                currentGeneration: 5
+            ),
+            "the active retry should own completion-side state changes"
+        )
+    }
+
+    runSuite("ParakeetModelDownloadProgressTracker bounds UI callback volume") {
+        let tracker = ParakeetModelDownloadProgressTracker(
+            stageCount: 1,
+            initialActivityUptime: 0
+        )
+
+        assertEqual(
+            tracker.progressToPublish(
+                rawProgress: 0,
+                beginsNewStage: true,
+                activityUptime: 0
+            ),
+            0,
+            "the initial download state should publish"
+        )
+        assertNil(
+            tracker.progressToPublish(
+                rawProgress: 0.001,
+                beginsNewStage: false,
+                activityUptime: 240
+            ),
+            "tiny byte-level updates should stay off the main actor"
+        )
+        assertEqual(
+            tracker.remainingNoProgressInterval(timeout: 300, nowUptime: 300),
+            240,
+            "a throttled UI callback should still refresh download liveness"
+        )
+        assertEqual(
+            tracker.progressToPublish(
+                rawProgress: 0.003,
+                beginsNewStage: false,
+                activityUptime: 480
+            ),
+            0.003,
+            "meaningful progress should refresh the UI and stall watchdog"
+        )
+        assertEqual(
+            tracker.remainingNoProgressInterval(timeout: 300, nowUptime: 780),
+            0,
+            "the watchdog should expire only after the full quiet interval"
+        )
+    }
 }

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -74,6 +74,10 @@ func testSentryEventPolicy() {
             forEngine: "parakeet",
             event: "model_init_failed"
         )
+        let modelDownloadStalled = SentryEventPolicy.policy(
+            forEngine: "parakeet",
+            event: "model_download_stalled"
+        )
         let onboardingStartFailure = SentryEventPolicy.policy(
             forEngine: "onboarding",
             event: "first_dictation_start_failed"
@@ -109,6 +113,7 @@ func testSentryEventPolicy() {
         assertNil(meetingTranscriptSkipped, "expected empty/no-speech meeting outcomes should stay out of Sentry")
         assertEqual(speakerFinalizationFailed?.summary, "Meeting speaker naming finalization failed.", "speaker finalization failures should not masquerade as full transcript failures")
         assertEqual(modelInitFailure?.summary, "Speech model initialization failed.", "model-init failures should stay allowlisted with a privacy-safe summary")
+        assertEqual(modelDownloadStalled?.summary, "Speech model download stopped making progress.", "stalled downloads should be visible without user content")
         assertEqual(onboardingStartFailure?.summary, "Onboarding could not start first dictation.", "onboarding start wiring failures should be visible without clickstream data")
         assertEqual(onboardingStopFailure?.summary, "Onboarding could not stop first dictation.", "onboarding stop wiring failures should be visible without clickstream data")
         assertNil(unknown, "unknown events should stay local-only by default")


### PR DESCRIPTION
## Summary
- replace the fake 8% floor with FluidAudio's real byte-level model progress
- fail downloads after five minutes with no upstream activity and expose the existing Retry Download path
- make timeout/retry ownership generation-safe so abandoned work cannot overwrite a newer attempt
- report a bounded privacy-safe `parakeet.model_download_stalled` Sentry event

## User impact
A first-run model download can no longer sit on an unchanging progress indicator indefinitely. Active slow downloads remain alive while callbacks arrive; truly stalled downloads become an actionable failure with retry copy.

## Verification
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 13,413 passed
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open` — signed app, signature valid, launch smoke passed (953.2ms)
- [x] `git diff --check`
- [x] independent thermonuclear review of the full diff
- [x] final independent review after fixing callback-cycle/liveness handling — PASS

## Review findings fixed
- Retry now detaches the canceled initialization instead of rejoining it.
- Late completion from an abandoned prefetch cannot clear or overwrite a newer retry.
- FluidAudio's one-listing/four-component callback sequence maps monotonically to 0–100%.
- Every callback refreshes liveness even when UI updates are throttled.
- The Sentry event uses error level so the explicit allowlist can forward it.

## Proof boundary
Deterministic tests and signed local build are green. A real throttled or interrupted first-run network download on a separate Mac remains manual/unknown until tested. No release, appcast, Homebrew, notarization, or publishing change is included.