### PR TITLE
Relax onboarding sharing policy while keeping Settings protected

### DIFF
--- a/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
@@ -35,7 +35,8 @@ final class TranscriptedOnboardingWindowController: NSWindowController {
         window.isReleasedWhenClosed = false
         window.minSize = PermissionsOnboardingView.preferredSize
         window.contentViewController = hostingController
-        window.sharingType = .none
+        // First-run setup should be capturable for support and QA walkthroughs.
+        window.sharingType = .readOnly
         window.center()
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true
 

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -37,6 +37,8 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
         window.contentViewController = hostingController
         window.contentMinSize = NSSize(width: 880, height: 640)
         window.isReleasedWhenClosed = false
+        // The reusable Settings shell can surface recent captures, speaker
+        // review, and storage diagnostics, so keep the whole window protected.
         window.sharingType = .none
         window.center()
 

--- a/Tests/OverlayScreenSharePrivacyTests.swift
+++ b/Tests/OverlayScreenSharePrivacyTests.swift
@@ -1,14 +1,14 @@
 // OverlayScreenSharePrivacyTests.swift
-// Guards that every Transcripted AppKit window/panel surface is excluded from
-// screen capture / screen sharing.
+// Guards that privacy-sensitive Transcripted AppKit surfaces stay excluded from
+// screen capture / screen sharing, while explicitly support-safe onboarding
+// stays capturable.
 //
-// AppKit panels default to `NSWindow.SharingType.readOnly`, which
-// ScreenCaptureKit happily captures. For a tool whose whole premise is
-// privately recording a call, that default is a trust failure: a user sharing
-// their screen during a recorded meeting could unintentionally broadcast live
-// transcript text. The fix sets `sharingType = .none` in every Transcripted
-// NSWindow/NSPanel init; this test makes that property a regression-guarded
-// invariant.
+// AppKit windows and panels default to `NSWindow.SharingType.readOnly`, which
+// ScreenCaptureKit and Screenshot window capture can use. That is the right
+// choice for first-run onboarding, which shows demo/support setup content. The
+// reusable Settings shell and live overlays must opt out with
+// `sharingType = .none` so screen sharing and screenshots do not silently leak
+// transcript, speaker-review, or storage-diagnostic content.
 
 import AppKit
 import Foundation
@@ -77,13 +77,12 @@ func testOverlayScreenSharePrivacy() async {
 
     // Source contract: most app surfaces live in files the fast runner cannot
     // compile in isolation, so guard their init bodies at the source level.
-    runSuite("every Transcripted NSWindow/NSPanel init sets sharingType = .none") {
+    runSuite("protected Transcripted NSWindow/NSPanel inits set sharingType = .none") {
         let floating = overlayPrivacySource("Sources/UI/Overlay/FloatingOverlayPanel.swift")
         let capturePill = overlayPrivacySource("Sources/UI/Overlay/CapturePillController.swift")
         let controller = overlayPrivacySource("Sources/UI/Overlay/MeetingOverlayController.swift")
         let pasteFeedback = overlayPrivacySource("Sources/UI/MenuBar/PasteLastDictationFeedback.swift")
         let settingsWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedSettingsWindowController.swift")
-        let onboardingWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedOnboardingWindowController.swift")
         let speakerNaming = overlayPrivacySource("Sources/UI/Settings/SpeakerNamingSheet.swift")
 
         let inits: [(name: String, body: String)] = [
@@ -128,25 +127,17 @@ func testOverlayScreenSharePrivacy() async {
                 )
             ),
             (
-                "TranscriptedSettingsWindowController",
-                overlayPrivacySlice(
-                    settingsWindow,
-                    from: "let window = NSWindow(",
-                    to: "super.init(window: window)"
-                )
-            ),
-            (
-                "TranscriptedOnboardingWindowController",
-                overlayPrivacySlice(
-                    onboardingWindow,
-                    from: "let window = NSWindow(",
-                    to: "super.init(window: window)"
-                )
-            ),
-            (
                 "NamingWindowController",
                 overlayPrivacySlice(
                     speakerNaming,
+                    from: "let window = NSWindow(",
+                    to: "super.init(window: window)"
+                )
+            ),
+            (
+                "TranscriptedSettingsWindowController",
+                overlayPrivacySlice(
+                    settingsWindow,
                     from: "let window = NSWindow(",
                     to: "super.init(window: window)"
                 )
@@ -161,7 +152,26 @@ func testOverlayScreenSharePrivacy() async {
         }
     }
 
-    runSuite("new NSWindow/NSPanel surfaces must be added to the screen-share contract") {
+    runSuite("first-run onboarding stays capturable") {
+        let onboardingWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedOnboardingWindowController.swift")
+
+        let onboardingInit = overlayPrivacySlice(
+            onboardingWindow,
+            from: "let window = NSWindow(",
+            to: "super.init(window: window)"
+        )
+
+        assertTrue(
+            onboardingInit.contains("sharingType = .readOnly"),
+            "first-run onboarding should stay capturable for support and QA walkthroughs"
+        )
+        assertFalse(
+            onboardingInit.contains("sharingType = .none"),
+            "first-run onboarding must not opt itself out of screenshots"
+        )
+    }
+
+    runSuite("new NSWindow/NSPanel surfaces must be reviewed by the capture policy contract") {
         let expectedMarkers: [String] = [
             "Sources/UI/MenuBar/PasteLastDictationFeedback.swift|private final class PasteLastDictationFeedbackPanel: NSPanel {",
             "Sources/UI/Overlay/CapturePillController.swift|final class CapturePillPanel: NSPanel {",
@@ -176,7 +186,7 @@ func testOverlayScreenSharePrivacy() async {
         assertEqual(
             markers,
             expectedMarkers,
-            "any new Transcripted NSWindow/NSPanel must be reviewed here and set sharingType = .none"
+            "any new Transcripted NSWindow/NSPanel must be reviewed here and classified as protected or capturable"
         )
     }
 


### PR DESCRIPTION
## Summary

- keep the reusable Settings window protected from capture because it can expose recent captures, speaker review, and storage diagnostics
- relax only the first-run onboarding window from `sharingType = .none` to `.readOnly`
- narrow the privacy regression test so onboarding is the only capturable Settings-side window and protected surfaces stay explicit

## Live proof

- Host permission state: `transcripted-qa permission-state --mode computer-use --app-bundle build/Transcripted.app --format json`
  - PASS for Accessibility, Event Posting, Input Monitoring, Screen Recording, Automation, Microphone, bundle id, and cached system-audio probe
- Standalone window lab:
  - compiled `/private/tmp/window_capture_lab.swift` and tested baseline windows, exact onboarding-style windows, and a popover-like panel
  - every `sharingType = .readOnly` variant, including the exact onboarding-style `NSWindow`, succeeded under direct `screencapture -l`
- Protected Settings shell on the built app:
  - runtime window `Transcripted Settings` reported `sharing=0`
  - direct window capture failed with `could not create image from window`
  - region capture produced the underlying desktop content instead of the Settings UI
- Menu bar popover on the built app:
  - runtime popover window reported `sharing=1`
  - direct window capture succeeded
- Meeting overlay on the built app:
  - runtime overlay window reported `sharing=0`
  - direct window capture failed with `could not create image from window`
- First-run onboarding on the built app:
  - runtime window `Welcome to Transcripted` reported `sharing=1`
  - direct window capture succeeded
  - region and full-screen captures also showed the onboarding UI normally

## Root cause

- The earlier “onboarding still fails direct window capture” conclusion was a local repro bug, not a remaining app behavior problem.
- The shell proof was accidentally feeding `screencapture -l` the process id parsed from strings like `id=10224 pid=31699 ...`, not the real `CGWindowID`.
- After correcting that parser, the behavior matched the window sharing policy exactly:
  - protected surfaces on `sharingType = .none` still fail direct window capture
  - onboarding on `sharingType = .readOnly` succeeds
- The standalone matrix also showed no additional window style, class, or lifecycle blocker in the onboarding configuration beyond the explicit sharing policy.

## Review

- Accepted finding: do not make the whole Settings shell capturable because the same window can surface recent capture previews, speaker review, and storage diagnostics. Addressed by keeping `TranscriptedSettingsWindowController` on `sharingType = .none`.
- Rejected finding: onboarding should stay protected too. Rejected because the first-run surface is demo/setup content, not live transcript/audio review.
- Follow-up `~/.codex/skills/codex-review/scripts/codex-review --mode branch` inspected the final 3-file diff but did not produce a clean terminal verdict because the helper's parallel fast-test subprocess hit a local `build/FastTestRunner.*.swift` race. Standalone mapped checks below passed on the same diff.

## Checks

- `bash build.sh --no-open`
- `bash run-tests.sh --filter testOverlayScreenSharePrivacy`
- `bash run-tests.sh`
- `swift run --package-path Tools/TranscriptedQA transcripted-qa ui-smoke --app build/Transcripted.app --report /private/tmp/transcripted-window-capture-ui-smoke-final.json --keep-running`
- `swift run --package-path Tools/TranscriptedQA transcripted-qa ui-smoke --app build/Transcripted.app --report /private/tmp/transcripted-window-capture-ui-smoke-final-2.json --keep-running`
- `swift run --package-path Tools/TranscriptedQA transcripted-qa permission-state --mode computer-use --app-bundle build/Transcripted.app --format json`
- `python3 scripts/ops/privacy-leak-sweep.py --write-report build/privacy-leak-sweep-report.json`
