### PR TITLE
Add first-run reliability harness

### DIFF
--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -77,7 +77,9 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     private static let pendingInstalledUpdateVersionKey = "Transcripted.PendingInstalledUpdateVersion"
     private static let pendingInstalledUpdatePreviousVersionKey = "Transcripted.PendingInstalledUpdatePreviousVersion"
     private static var isLaunchUISmoke: Bool {
-        ProcessInfo.processInfo.environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT"] != nil
+        let environment = ProcessInfo.processInfo.environment
+        return environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT"] != nil
+            || environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_REPORT"] != nil
     }
 
     override init() {

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -19,6 +19,11 @@ enum TranscriptedPermissionAccess {
     private static let systemAudioRecordingGrantedKey = "systemAudioRecordingPermissionGranted"
     private static let systemAudioRecordingKnownKey = "systemAudioRecordingPermissionKnown"
     @MainActor private static var activeSystemAudioRevalidator: Task<Bool, Never>?
+    private static var isLaunchSmokeMode: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT"] != nil
+            || environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_REPORT"] != nil
+    }
 
     static func isGranted(_ kind: TranscriptedPermissionKind) -> Bool {
         switch kind {
@@ -192,6 +197,9 @@ enum TranscriptedPermissionAccess {
 
     @MainActor
     static func revalidateSystemAudioRecordingStatus() async -> Bool {
+        if isLaunchSmokeMode {
+            return systemAudioRecordingGranted()
+        }
         if let activeSystemAudioRevalidator {
             return await activeSystemAudioRevalidator.value
         }
@@ -210,8 +218,12 @@ enum TranscriptedPermissionAccess {
 
     @MainActor
     static func revalidateSystemAudioRecordingStatus(
-        requester: @escaping @MainActor () async -> Bool
+        requester: @escaping @MainActor () async -> Bool,
+        skipSmokeRevalidation: Bool = isLaunchSmokeMode
     ) async -> Bool {
+        if skipSmokeRevalidation {
+            return systemAudioRecordingGranted()
+        }
         let granted = await requester()
         setSystemAudioRecordingGranted(granted)
         notifyPermissionsDidChange(kind: .systemAudioRecording)

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -107,6 +107,25 @@ private struct FirstRunReliabilitySyntheticCard: Codable {
     let tone: String
 }
 
+private func firstRunReliabilityBool(
+    userDefaults: UserDefaults,
+    key: String
+) -> Bool {
+    guard let value = userDefaults.object(forKey: key) else { return false }
+    switch value {
+    case let value as Bool:
+        return value
+    case let value as NSNumber:
+        return value.boolValue
+    case let value as NSString:
+        return value.boolValue
+    case let value as String:
+        return (value as NSString).boolValue
+    default:
+        return userDefaults.bool(forKey: key)
+    }
+}
+
 private enum FirstRunReliabilitySmokeAction: String {
     case installHelper = "install-helper"
     case refreshHelper = "refresh-helper"
@@ -1041,8 +1060,14 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 temporaryPath: temporaryURL.path,
                 mcpManifestPath: manifestURL.path,
                 mcpManifestExists: fileManager.fileExists(atPath: manifestURL.path),
-                systemAudioPermissionKnown: UserDefaults.standard.bool(forKey: "systemAudioRecordingPermissionKnown"),
-                systemAudioPermissionGranted: UserDefaults.standard.object(forKey: "systemAudioRecordingPermissionGranted") as? Bool == true,
+                systemAudioPermissionKnown: firstRunReliabilityBool(
+                    userDefaults: UserDefaults.standard,
+                    key: "systemAudioRecordingPermissionKnown"
+                ),
+                systemAudioPermissionGranted: firstRunReliabilityBool(
+                    userDefaults: UserDefaults.standard,
+                    key: "systemAudioRecordingPermissionGranted"
+                ),
                 appSupportWritable: firstRunReliabilityCanWrite(to: appSupportURL),
                 captureLibraryWritable: firstRunReliabilityCanWrite(to: captureLibraryURL),
                 cacheWritable: firstRunReliabilityCanWrite(to: cacheURL)

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -28,6 +28,91 @@ struct TranscriptedApp: App {
     }
 }
 
+private struct FirstRunReliabilitySmokeReport: Codable {
+    let appLaunched: Bool
+    let statusItemExists: Bool
+    let popoverConfigured: Bool
+    let permissionsOnboardingCompleted: Bool
+    let selectedModel: String
+    let actualModelState: String
+    let cachedModelDirectory: String?
+    let launchToInteractiveMs: Double?
+    let menuContent: MenuBarContentSmokeSnapshot
+    let runtime: FirstRunReliabilityRuntimeState
+    let helper: FirstRunReliabilityHelperReport
+    let syntheticModel: FirstRunReliabilitySyntheticModelReport?
+}
+
+private struct FirstRunReliabilityRuntimeState: Codable {
+    let homePath: String
+    let containerPath: String?
+    let appSupportPath: String
+    let captureLibraryPath: String
+    let meetingsPath: String
+    let dictationsPath: String
+    let cachePath: String
+    let logsPath: String
+    let temporaryPath: String
+    let mcpManifestPath: String
+    let mcpManifestExists: Bool
+    let systemAudioPermissionKnown: Bool
+    let systemAudioPermissionGranted: Bool
+    let appSupportWritable: Bool
+    let captureLibraryWritable: Bool
+    let cacheWritable: Bool
+}
+
+private struct FirstRunReliabilityHelperReport: Codable {
+    let action: String
+    let backupPath: String?
+    let bundledBinaryExists: Bool
+    let bundledBinaryPath: String?
+    let configuredCommandPathAfter: String?
+    let configuredCommandPathBefore: String?
+    let configIsReadableAfter: Bool
+    let configIsReadableBefore: Bool
+    let configPath: String
+    let error: String?
+    let installedBinaryExistsAfter: Bool
+    let installedBinaryExistsBefore: Bool
+    let installedBinaryMatchesBundledAfter: Bool
+    let installedBinaryMatchesBundledBefore: Bool
+    let installedBinaryPath: String
+    let refreshed: Bool?
+    let selfTestDictationFileCount: Int?
+    let selfTestMeetingFileCount: Int?
+    let selfTestOK: Bool?
+    let stateAfter: String
+    let stateBefore: String
+}
+
+private struct FirstRunReliabilitySyntheticModelReport: Codable {
+    let requestedState: String
+    let action: FirstRunReliabilitySyntheticAction
+    let card: FirstRunReliabilitySyntheticCard
+}
+
+private struct FirstRunReliabilitySyntheticAction: Codable {
+    let isEnabled: Bool
+    let subtitle: String
+    let symbolName: String
+    let title: String
+}
+
+private struct FirstRunReliabilitySyntheticCard: Codable {
+    let detail: String
+    let progress: Double?
+    let status: String
+    let title: String
+    let tone: String
+}
+
+private enum FirstRunReliabilitySmokeAction: String {
+    case installHelper = "install-helper"
+    case refreshHelper = "refresh-helper"
+    case reportOnly = "report-only"
+}
+
 // MARK: - App Delegate
 
 @MainActor
@@ -460,6 +545,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         Task { @MainActor in
             await appState.initialize()
             appState.contextCapture.registerHotkey()
+            await writeFirstRunReliabilityReportIfRequested()
         }
     }
 
@@ -893,6 +979,92 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
     }
 
+    private func writeFirstRunReliabilityReportIfRequested() async {
+        let environment = ProcessInfo.processInfo.environment
+        guard let reportPath = environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_REPORT"],
+              !reportPath.isEmpty else {
+            return
+        }
+        defer {
+            scheduleFirstRunReliabilityTerminationIfRequested(environment: environment)
+        }
+
+        if environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_ACTIVATE_CACHED_MODEL"] == "1",
+           ModelCacheInventory.activeParakeetModelDirectory() != nil {
+            await appState.sttRouter.prefetchSelectedModelFilesForExistingInstall()
+        }
+
+        let fileManager = FileManager.default
+        let homePath = environment["CFFIXED_USER_HOME"]
+            ?? environment["HOME"]
+            ?? fileManager.homeDirectoryForCurrentUser.path
+        let appSupportURL = fileManager.transcriptedAppSupportDir
+        let captureLibraryURL = fileManager.transcriptedCaptureLibraryDir
+        let meetingsURL = fileManager.meetingSupportDir
+        let dictationsURL = fileManager.dictationSupportDir
+        let cacheURL = fileManager.transcriptedCacheDir
+        let logsURL = fileManager.transcriptedLogsDir
+        let temporaryURL = fileManager.transcriptedTemporaryDir
+        let manifestURL = fileManager.transcriptedMCPDirectoriesManifestURL
+        let helperReport = await runFirstRunReliabilityHelperAction(environment: environment)
+        let syntheticModel = syntheticModelReport(
+            rawState: environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_SYNTHETIC_MODEL_STATE"]
+        )
+
+        let smokeMenuVisibility = Dictionary(uniqueKeysWithValues: MenuBarOptionalItem.allCases.map { ($0, true) })
+        let menuReport = menuPanelController.launchUISmokeReport(
+            statusItemExists: statusItem != nil,
+            popoverConfigured: popover != nil,
+            onboardingCompleted: PermissionsOnboardingPreferences.hasCompleted(),
+            launchToInteractiveMs: Self.processStartToNowMilliseconds(),
+            menuVisibilityOverride: smokeMenuVisibility
+        )
+        let report = FirstRunReliabilitySmokeReport(
+            appLaunched: true,
+            statusItemExists: statusItem != nil,
+            popoverConfigured: popover != nil,
+            permissionsOnboardingCompleted: PermissionsOnboardingPreferences.hasCompleted(),
+            selectedModel: appState.sttRouter.selectedModel.rawValue,
+            actualModelState: appState.sttRouter.modelDownloadState.diagnosticName,
+            cachedModelDirectory: ModelCacheInventory.activeParakeetModelDirectory()?.path,
+            launchToInteractiveMs: Self.processStartToNowMilliseconds(),
+            menuContent: menuReport.content,
+            runtime: FirstRunReliabilityRuntimeState(
+                homePath: homePath,
+                containerPath: environment["TRANSCRIPTED_CONTAINER_DIR"],
+                appSupportPath: appSupportURL.path,
+                captureLibraryPath: captureLibraryURL.path,
+                meetingsPath: meetingsURL.path,
+                dictationsPath: dictationsURL.path,
+                cachePath: cacheURL.path,
+                logsPath: logsURL.path,
+                temporaryPath: temporaryURL.path,
+                mcpManifestPath: manifestURL.path,
+                mcpManifestExists: fileManager.fileExists(atPath: manifestURL.path),
+                systemAudioPermissionKnown: UserDefaults.standard.bool(forKey: "systemAudioRecordingPermissionKnown"),
+                systemAudioPermissionGranted: UserDefaults.standard.object(forKey: "systemAudioRecordingPermissionGranted") as? Bool == true,
+                appSupportWritable: firstRunReliabilityCanWrite(to: appSupportURL),
+                captureLibraryWritable: firstRunReliabilityCanWrite(to: captureLibraryURL),
+                cacheWritable: firstRunReliabilityCanWrite(to: cacheURL)
+            ),
+            helper: helperReport,
+            syntheticModel: syntheticModel
+        )
+        let reportURL = URL(fileURLWithPath: reportPath, isDirectory: false)
+
+        do {
+            try fileManager.createDirectory(
+                at: reportURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(report).write(to: reportURL, options: .atomic)
+        } catch {
+            NSLog("Failed to write first-run reliability report: \(error.localizedDescription)")
+        }
+    }
+
     /// Wall-clock milliseconds from the kernel's process-start time to now.
     /// Measured from `kinfo_proc.p_starttime` so it captures the true
     /// launch-to-interactive latency including pre-`main` dyld/runtime setup,
@@ -927,6 +1099,168 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
             Darwin.exit(0)
         }
+    }
+
+    private func scheduleFirstRunReliabilityTerminationIfRequested(environment: [String: String]) {
+        guard environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_TERMINATE_AFTER_REPORT"] == "1" else { return }
+
+        let delay = environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_TERMINATE_DELAY_SECONDS"]
+            .flatMap(Double.init)
+            .map { max(0, $0) } ?? 0.1
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            Darwin.exit(0)
+        }
+    }
+
+    private func firstRunReliabilityCanWrite(to directoryURL: URL) -> Bool {
+        let probeURL = directoryURL.appendingPathComponent(".first-run-smoke-\(UUID().uuidString)", isDirectory: false)
+        do {
+            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            try Data().write(to: probeURL, options: [.atomic])
+            try FileManager.default.removeItem(at: probeURL)
+            return true
+        } catch {
+            try? FileManager.default.removeItem(at: probeURL)
+            return false
+        }
+    }
+
+    private func runFirstRunReliabilityHelperAction(
+        environment: [String: String]
+    ) async -> FirstRunReliabilityHelperReport {
+        let action = FirstRunReliabilitySmokeAction(
+            rawValue: environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_ACTION"] ?? FirstRunReliabilitySmokeAction.reportOnly.rawValue
+        ) ?? .reportOnly
+
+        return await Task.detached(priority: .utility) {
+            let before = ClaudeDesktopIntegrationInstaller.currentStatus()
+            let bundledPath = before.bundledBinaryURL?.path
+            let stateName: (ClaudeDesktopIntegrationStatus.State) -> String = { state in
+                switch state {
+                case .notInstalled:
+                    return "notInstalled"
+                case .installed:
+                    return "installed"
+                case .needsRepair:
+                    return "needsRepair"
+                }
+            }
+            var backupPath: String?
+            var refreshed: Bool?
+            var selfTest: TranscriptedMCPSelfTest?
+            var errorMessage: String?
+
+            do {
+                switch action {
+                case .reportOnly:
+                    break
+                case .installHelper:
+                    let result = try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop()
+                    backupPath = result.backupURL?.path
+                    selfTest = result.selfTest
+                case .refreshHelper:
+                    refreshed = try ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded()
+                }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+
+            let after = ClaudeDesktopIntegrationInstaller.currentStatus()
+            return FirstRunReliabilityHelperReport(
+                action: action.rawValue,
+                backupPath: backupPath,
+                bundledBinaryExists: after.bundledBinaryExists,
+                bundledBinaryPath: bundledPath,
+                configuredCommandPathAfter: after.configuredCommandPath,
+                configuredCommandPathBefore: before.configuredCommandPath,
+                configIsReadableAfter: after.configIsReadable,
+                configIsReadableBefore: before.configIsReadable,
+                configPath: after.configURL.path,
+                error: errorMessage,
+                installedBinaryExistsAfter: after.installedBinaryExists,
+                installedBinaryExistsBefore: before.installedBinaryExists,
+                installedBinaryMatchesBundledAfter: after.installedBinaryMatchesBundled,
+                installedBinaryMatchesBundledBefore: before.installedBinaryMatchesBundled,
+                installedBinaryPath: after.installedBinaryURL.path,
+                refreshed: refreshed,
+                selfTestDictationFileCount: selfTest?.dictationFileCount,
+                selfTestMeetingFileCount: selfTest?.meetingFileCount,
+                selfTestOK: selfTest?.ok,
+                stateAfter: stateName(after.state),
+                stateBefore: stateName(before.state)
+            )
+        }.value
+    }
+
+    private func syntheticModelReport(
+        rawState: String?
+    ) -> FirstRunReliabilitySyntheticModelReport? {
+        guard let rawState,
+              let state = parseSyntheticModelState(rawState) else {
+            return nil
+        }
+
+        let action = FirstRunExperience.dictationAction(for: state)
+        let card = FirstRunExperience.modelCard(for: state)
+        let tone: String
+        switch card.tone {
+        case .ready:
+            tone = "ready"
+        case .working:
+            tone = "working"
+        case .failed:
+            tone = "failed"
+        }
+        return FirstRunReliabilitySyntheticModelReport(
+            requestedState: rawState,
+            action: FirstRunReliabilitySyntheticAction(
+                isEnabled: action.isEnabled,
+                subtitle: action.subtitle,
+                symbolName: action.symbolName,
+                title: action.title
+            ),
+            card: FirstRunReliabilitySyntheticCard(
+                detail: card.detail,
+                progress: card.progress,
+                status: card.status,
+                title: card.title,
+                tone: tone
+            )
+        )
+    }
+
+    private func parseSyntheticModelState(_ rawValue: String) -> FirstRunLocalModelState? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed == "not-loaded" {
+            return .notLoaded
+        }
+        if trimmed == "cached" {
+            return .cached
+        }
+        if trimmed == "loading" {
+            return .loading
+        }
+        if trimmed == "ready" {
+            return .ready
+        }
+        if trimmed.hasPrefix("downloading:") {
+            let progressValue = String(trimmed.dropFirst("downloading:".count))
+            guard let progress = Double(progressValue) else { return nil }
+            return .downloading(progress: progress)
+        }
+        if trimmed.hasPrefix("failed") {
+            let message: String
+            if let separator = trimmed.firstIndex(of: ":") {
+                message = String(trimmed[trimmed.index(after: separator)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                message = "Synthetic failure"
+            }
+            return .failed(message)
+        }
+        return nil
     }
 
     private func bindStatusItemUpdateBadge() {

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -64,22 +64,24 @@ class TranscriptedAppState: ObservableObject {
         guard !isInitialized else { return }
         isInitialized = true
 
-        do {
-            try LaunchAtLoginController.applySavedOptOutAtStartup()
-        } catch {
-            EventReporter.shared.capture(level: .warning, engine: "app", event: "login_item_opt_out_sync_failed",
-                message: error.localizedDescription)
-        }
+        if !Self.isLaunchSmokeMode {
+            do {
+                try LaunchAtLoginController.applySavedOptOutAtStartup()
+            } catch {
+                EventReporter.shared.capture(level: .warning, engine: "app", event: "login_item_opt_out_sync_failed",
+                    message: error.localizedDescription)
+            }
 
-        // Covers existing installs that finished onboarding before the default
-        // existed; fresh installs get it from the onboarding-completion hook.
-        do {
-            try LaunchAtLoginController.applyDefaultEnableIfNeeded(
-                onboardingCompleted: PermissionsOnboardingPreferences.hasCompleted()
-            )
-        } catch {
-            EventReporter.shared.capture(level: .warning, engine: "app", event: "login_item_default_enable_failed",
-                message: error.localizedDescription)
+            // Covers existing installs that finished onboarding before the default
+            // existed; fresh installs get it from the onboarding-completion hook.
+            do {
+                try LaunchAtLoginController.applyDefaultEnableIfNeeded(
+                    onboardingCompleted: PermissionsOnboardingPreferences.hasCompleted()
+                )
+            } catch {
+                EventReporter.shared.capture(level: .warning, engine: "app", event: "login_item_default_enable_failed",
+                    message: error.localizedDescription)
+            }
         }
 
         if !Self.isLaunchSmokeMode {

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -8,6 +8,11 @@ import TranscriptedCore
 class TranscriptedAppState: ObservableObject {
     private static let wakeHotkeyRetryAttempts = 3
     private static let wakeHotkeyRetryDelay: UInt64 = 500_000_000
+    private static var isLaunchSmokeMode: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        return environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT"] != nil
+            || environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_REPORT"] != nil
+    }
     let logger = AppLogSink()
     let sparkleUpdater = SparkleUpdaterController()
     let contextCapture = ContextCaptureEngine()
@@ -77,7 +82,7 @@ class TranscriptedAppState: ObservableObject {
                 message: error.localizedDescription)
         }
 
-        if ProcessInfo.processInfo.environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT"] == nil {
+        if !Self.isLaunchSmokeMode {
             sparkleUpdater.performStartupUpdateCheckIfNeeded()
         }
         AppSoundPlayer.shared.setWarningReporter { cue in
@@ -99,7 +104,7 @@ class TranscriptedAppState: ObservableObject {
             startExistingInstallModelPrefetchIfNeeded()
         }
         startAudioStorageMaintenanceIfNeeded()
-        if ProcessInfo.processInfo.environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT"] == nil {
+        if !Self.isLaunchSmokeMode {
             startAgentHelperRefreshIfNeeded()
         }
         if #available(macOS 14.0, *) {

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -364,6 +364,38 @@ func testTranscriptedPermissionAccess() async {
         )
     }
 
+    await runSuite("TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus — smoke mode preserves cached granted state without a live probe") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+        }
+
+        UserDefaults.standard.set(true, forKey: knownKey)
+        UserDefaults.standard.set(true, forKey: grantedKey)
+
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus(
+            requester: {
+                requestBox.callCount += 1
+                return false
+            },
+            skipSmokeRevalidation: true
+        )
+
+        assertTrue(granted, "smoke-mode revalidation should keep the cached granted state")
+        assertEqual(requestBox.callCount, 0, "smoke mode should not perform a live system-audio probe")
+        assertTrue(
+            UserDefaults.standard.bool(forKey: knownKey),
+            "smoke mode should keep the cached system-audio state marked as known"
+        )
+        assertTrue(
+            UserDefaults.standard.bool(forKey: grantedKey),
+            "smoke mode should preserve the cached granted state"
+        )
+    }
+
     await runSuite("TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded — skips requester when microphone is already authorized") {
         let requestBox = PermissionRequestBox()
         let granted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded(

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
@@ -847,8 +847,7 @@ final class FirstRunReliabilitySmokeRunner {
         let onboardingWorkspace = makeWorkspace(id: "zero-state", evidenceRoot: evidenceRoot)
         scenarios.append(runZeroStateAndRestartScenario(executableURL: executableURL, workspace: onboardingWorkspace))
 
-        let permissionsWorkspace = makeWorkspace(id: "permissions-matrix", evidenceRoot: evidenceRoot)
-        scenarios.append(runPermissionsMatrixScenario(executableURL: executableURL, workspace: permissionsWorkspace))
+        scenarios.append(runPermissionsMatrixScenario(executableURL: executableURL, evidenceRoot: evidenceRoot))
 
         let staleCacheWorkspace = makeWorkspace(id: "stale-model-cache", evidenceRoot: evidenceRoot)
         scenarios.append(runStaleModelCacheScenario(executableURL: executableURL, workspace: staleCacheWorkspace))
@@ -949,16 +948,18 @@ final class FirstRunReliabilitySmokeRunner {
 
     private func runPermissionsMatrixScenario(
         executableURL: URL,
-        workspace: FirstRunScenarioWorkspace
+        evidenceRoot: URL
     ) -> FirstRunReliabilityScenario {
+        let deniedWorkspace = makeWorkspace(id: "permissions-matrix-denied", evidenceRoot: evidenceRoot)
+        let grantedWorkspace = makeWorkspace(id: "permissions-matrix-granted", evidenceRoot: evidenceRoot)
         let denied = launch(
             executableURL: executableURL,
-            workspace: workspace,
+            workspace: deniedWorkspace,
             tag: "permissions-denied",
             options: FirstRunLaunchOptions(
                 onboardingCompleted: false,
                 forceOnboarding: true,
-                preferenceOverrides: [
+                launchDefaultsOverrides: [
                     "systemAudioRecordingPermissionKnown": true,
                     "systemAudioRecordingPermissionGranted": false,
                 ]
@@ -966,12 +967,12 @@ final class FirstRunReliabilitySmokeRunner {
         )
         let granted = launch(
             executableURL: executableURL,
-            workspace: workspace,
+            workspace: grantedWorkspace,
             tag: "permissions-granted",
             options: FirstRunLaunchOptions(
                 onboardingCompleted: true,
                 forceOnboarding: false,
-                preferenceOverrides: [
+                launchDefaultsOverrides: [
                     "systemAudioRecordingPermissionKnown": true,
                     "systemAudioRecordingPermissionGranted": true,
                 ]
@@ -980,15 +981,15 @@ final class FirstRunReliabilitySmokeRunner {
         return buildScenario(
             id: "permissions-state-matrix",
             launches: [denied, granted],
-            successDetail: "The packaged app preserved incomplete and completed onboarding prefs while exercising cached denied and granted system-audio permission flags from isolated preferences."
+            successDetail: "The packaged app preserved incomplete and completed onboarding prefs while exercising cached denied and granted system-audio permission flags from separate isolated launch defaults."
         ) { reports in
             guard reports.count == 2 else {
                 return ["expected denied and granted permission launch reports"]
             }
             let denied = reports[0]
             let granted = reports[1]
-            var failures = isolationFailures(in: denied, workspace: workspace)
-            failures.append(contentsOf: isolationFailures(in: granted, workspace: workspace))
+            var failures = isolationFailures(in: denied, workspace: deniedWorkspace)
+            failures.append(contentsOf: isolationFailures(in: granted, workspace: grantedWorkspace))
             failures.append(contentsOf: expectedBooleanFailures(
                 denied.runtime.systemAudioPermissionKnown && !denied.runtime.systemAudioPermissionGranted,
                 message: "denied launch should report the cached known=true granted=false system-audio flags"
@@ -996,6 +997,11 @@ final class FirstRunReliabilitySmokeRunner {
             failures.append(contentsOf: expectedBooleanFailures(
                 granted.runtime.systemAudioPermissionKnown && granted.runtime.systemAudioPermissionGranted,
                 message: "granted launch should report the cached known=true granted=true system-audio flags"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                denied.runtime.homePath != granted.runtime.homePath
+                    && denied.runtime.containerPath != granted.runtime.containerPath,
+                message: "cached permission-state coverage should launch denied and granted cases from separate isolated homes and containers"
             ))
             failures.append(contentsOf: expectedBooleanFailures(
                 denied.permissionsOnboardingCompleted == false && granted.permissionsOnboardingCompleted,
@@ -1384,6 +1390,10 @@ final class FirstRunReliabilitySmokeRunner {
             "-observability-anonymous-analytics-enabled", "NO",
             "-observability-crash-reporting-enabled", "NO",
         ]
+        for key in options.launchDefaultsOverrides.keys.sorted() {
+            guard let value = userDefaultsArgumentValue(options.launchDefaultsOverrides[key]) else { continue }
+            process.arguments?.append(contentsOf: ["-\(key)", value])
+        }
 
         var environment = ProcessInfo.processInfo.environment
         environment["HOME"] = workspace.homeURL.path
@@ -1691,6 +1701,21 @@ final class FirstRunReliabilitySmokeRunner {
             waitForProcessExit(process)
         }
     }
+
+    private func userDefaultsArgumentValue(_ value: Any?) -> String? {
+        switch value {
+        case let value as Bool:
+            return value ? "YES" : "NO"
+        case let value as Int:
+            return String(value)
+        case let value as Double:
+            return String(value)
+        case let value as String:
+            return value
+        default:
+            return nil
+        }
+    }
 }
 
 private struct FirstRunScenarioWorkspace {
@@ -1705,6 +1730,7 @@ private struct FirstRunLaunchOptions {
     let onboardingCompleted: Bool
     let forceOnboarding: Bool
     var preferenceOverrides: [String: Any] = [:]
+    var launchDefaultsOverrides: [String: Any] = [:]
     var environmentOverrides: [String: String] = [:]
     var containerURL: URL? = nil
 }

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
@@ -912,7 +912,7 @@ final class FirstRunReliabilitySmokeRunner {
         return buildScenario(
             id: "zero-state-and-restart",
             launches: [first, second],
-            successDetail: "Two launches from the same empty isolated profile kept onboarding incomplete, model state idle, and the observed host-owned system-audio state stable across restart."
+            successDetail: "Two launches from the same empty isolated profile kept onboarding incomplete, model state idle, and the same cached system-audio permission flags across restart."
         ) { reports in
             guard reports.count == 2 else {
                 return ["expected two successful launch reports"]
@@ -937,7 +937,7 @@ final class FirstRunReliabilitySmokeRunner {
             failures.append(contentsOf: expectedBooleanFailures(
                 reports[0].runtime.systemAudioPermissionKnown == reports[1].runtime.systemAudioPermissionKnown
                     && reports[0].runtime.systemAudioPermissionGranted == reports[1].runtime.systemAudioPermissionGranted,
-                message: "zero-state restart should preserve the same observed host-owned system-audio permission state"
+                message: "zero-state restart should preserve the same cached system-audio permission flags"
             ))
             failures.append(contentsOf: expectedBooleanFailures(
                 reports[0].runtime.captureLibraryPath == reports[1].runtime.captureLibraryPath,
@@ -980,7 +980,7 @@ final class FirstRunReliabilitySmokeRunner {
         return buildScenario(
             id: "permissions-state-matrix",
             launches: [denied, granted],
-            successDetail: "The packaged app preserved incomplete and completed onboarding prefs while observing the same host-owned system-audio state across isolated launches, without claiming live TCC mutation."
+            successDetail: "The packaged app preserved incomplete and completed onboarding prefs while exercising cached denied and granted system-audio permission flags from isolated preferences."
         ) { reports in
             guard reports.count == 2 else {
                 return ["expected denied and granted permission launch reports"]
@@ -990,13 +990,16 @@ final class FirstRunReliabilitySmokeRunner {
             var failures = isolationFailures(in: denied, workspace: workspace)
             failures.append(contentsOf: isolationFailures(in: granted, workspace: workspace))
             failures.append(contentsOf: expectedBooleanFailures(
-                denied.runtime.systemAudioPermissionKnown == granted.runtime.systemAudioPermissionKnown
-                    && denied.runtime.systemAudioPermissionGranted == granted.runtime.systemAudioPermissionGranted,
-                message: "isolated launches should observe the same host-owned system-audio permission state without pretending HOME isolation can mutate TCC"
+                denied.runtime.systemAudioPermissionKnown && !denied.runtime.systemAudioPermissionGranted,
+                message: "denied launch should report the cached known=true granted=false system-audio flags"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                granted.runtime.systemAudioPermissionKnown && granted.runtime.systemAudioPermissionGranted,
+                message: "granted launch should report the cached known=true granted=true system-audio flags"
             ))
             failures.append(contentsOf: expectedBooleanFailures(
                 denied.permissionsOnboardingCompleted == false && granted.permissionsOnboardingCompleted,
-                message: "permission matrix should preserve incomplete and completed onboarding states"
+                message: "permission matrix should preserve incomplete and completed onboarding states while covering cached permission-state restoration"
             ))
             return failures
         }

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Darwin
 import Foundation
 
 struct PackagedAppSmoke: ParsableCommand {
@@ -31,8 +32,14 @@ struct PackagedAppSmoke: ParsableCommand {
     @Option(name: .long, help: "Write UI smoke JSON evidence to this path when --run-ui-smoke is set.")
     var uiReport: String?
 
+    @Option(name: .long, help: "Write first-run reliability JSON evidence to this path when --run-first-run-reliability is set.")
+    var firstRunReport: String?
+
     @Option(name: .long, help: "Seconds to wait for each UI smoke surface.")
     var uiTimeout: Double = 12
+
+    @Option(name: .long, help: "Seconds to wait for each first-run reliability launch.")
+    var firstRunTimeout: Double = 20
 
     @Flag(name: .long, help: "Warn instead of fail when the dSYM is missing or unverifiable.")
     var allowMissingDSYM = false
@@ -42,6 +49,9 @@ struct PackagedAppSmoke: ParsableCommand {
 
     @Flag(name: .long, help: "Launch the built app and validate the menu bar through Accessibility.")
     var runUISmoke = false
+
+    @Flag(name: .long, help: "Launch the packaged app inside isolated homes and containers to validate first-run reliability scenarios.")
+    var runFirstRunReliability = false
 
     @Flag(name: .long, help: "Allow a pre-existing Transcripted process during --run-ui-smoke.")
     var allowExistingInstance = false
@@ -62,10 +72,13 @@ struct PackagedAppSmoke: ParsableCommand {
             logPaths: logPath,
             reportPath: report,
             uiReportPath: uiReport,
+            firstRunReportPath: firstRunReport,
             uiTimeout: uiTimeout,
+            firstRunTimeout: firstRunTimeout,
             requireDSYM: !allowMissingDSYM,
             requireDMG: !allowMissingDMG,
             runUISmoke: runUISmoke,
+            runFirstRunReliability: runFirstRunReliability,
             allowExistingInstance: allowExistingInstance,
             promptForAccessibility: promptForAccessibility,
             verifyCodeSignature: !skipCodeSignatureCheck
@@ -89,10 +102,13 @@ final class PackagedAppSmokeRunner {
     private let initialLogPaths: [String]
     private let reportPath: String?
     private let uiReportPath: String?
+    private let firstRunReportPath: String?
     private let uiTimeout: Double
+    private let firstRunTimeout: Double
     private let requireDSYM: Bool
     private let requireDMG: Bool
     private let runUISmoke: Bool
+    private let runFirstRunReliability: Bool
     private let allowExistingInstance: Bool
     private let promptForAccessibility: Bool
     private let verifyCodeSignature: Bool
@@ -109,10 +125,13 @@ final class PackagedAppSmokeRunner {
         logPaths: [String],
         reportPath: String?,
         uiReportPath: String?,
+        firstRunReportPath: String?,
         uiTimeout: Double,
+        firstRunTimeout: Double,
         requireDSYM: Bool,
         requireDMG: Bool,
         runUISmoke: Bool,
+        runFirstRunReliability: Bool,
         allowExistingInstance: Bool,
         promptForAccessibility: Bool,
         verifyCodeSignature: Bool,
@@ -127,10 +146,13 @@ final class PackagedAppSmokeRunner {
         self.initialLogPaths = logPaths
         self.reportPath = reportPath
         self.uiReportPath = uiReportPath
+        self.firstRunReportPath = firstRunReportPath
         self.uiTimeout = uiTimeout
+        self.firstRunTimeout = firstRunTimeout
         self.requireDSYM = requireDSYM
         self.requireDMG = requireDMG
         self.runUISmoke = runUISmoke
+        self.runFirstRunReliability = runFirstRunReliability
         self.allowExistingInstance = allowExistingInstance
         self.promptForAccessibility = promptForAccessibility
         self.verifyCodeSignature = verifyCodeSignature
@@ -142,10 +164,18 @@ final class PackagedAppSmokeRunner {
         var checks: [PackagedAppSmokeCheck] = []
         var scannedLogPaths = initialLogPaths
         var uiEvidencePath: String?
+        var firstRunEvidencePath: String?
 
         guard fileManager.fileExists(atPath: appBundleURL.path) else {
             checks.append(.fail("app-bundle", target: appBundleURL.path, detail: "Run SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name> first, or pass --app."))
-            return buildReport(checks: checks, dmgPath: nil, logPaths: scannedLogPaths, uiEvidencePath: uiEvidencePath, generatedAt: generatedAt)
+            return buildReport(
+                checks: checks,
+                dmgPath: nil,
+                logPaths: scannedLogPaths,
+                uiEvidencePath: uiEvidencePath,
+                firstRunEvidencePath: firstRunEvidencePath,
+                generatedAt: generatedAt
+            )
         }
         checks.append(.pass("app-bundle", target: appBundleURL.path, detail: "Built app bundle exists."))
 
@@ -168,12 +198,38 @@ final class PackagedAppSmokeRunner {
             let version = stringValue(builtInfo["CFBundleShortVersionString"]) ?? "unknown"
             let dmgURL = resolvedDMGURL(version: version)
             checks.append(validateDMG(at: dmgURL))
-            return buildReport(checks: checksAfterTail(checks, scannedLogPaths: &scannedLogPaths, uiEvidencePath: &uiEvidencePath, executableURL: executableURL), dmgPath: dmgURL.path, logPaths: scannedLogPaths, uiEvidencePath: uiEvidencePath, generatedAt: generatedAt)
+            return buildReport(
+                checks: checksAfterTail(
+                    checks,
+                    scannedLogPaths: &scannedLogPaths,
+                    uiEvidencePath: &uiEvidencePath,
+                    firstRunEvidencePath: &firstRunEvidencePath,
+                    executableURL: executableURL
+                ),
+                dmgPath: dmgURL.path,
+                logPaths: scannedLogPaths,
+                uiEvidencePath: uiEvidencePath,
+                firstRunEvidencePath: firstRunEvidencePath,
+                generatedAt: generatedAt
+            )
         } else {
             checks.append(.fail("version-config", target: builtInfoURL.path, detail: "Cannot validate version/Sparkle config until both source and built Info.plist files are readable."))
             let dmgURL = resolvedDMGURL(version: "unknown")
             checks.append(validateDMG(at: dmgURL))
-            return buildReport(checks: checksAfterTail(checks, scannedLogPaths: &scannedLogPaths, uiEvidencePath: &uiEvidencePath, executableURL: executableURL), dmgPath: dmgURL.path, logPaths: scannedLogPaths, uiEvidencePath: uiEvidencePath, generatedAt: generatedAt)
+            return buildReport(
+                checks: checksAfterTail(
+                    checks,
+                    scannedLogPaths: &scannedLogPaths,
+                    uiEvidencePath: &uiEvidencePath,
+                    firstRunEvidencePath: &firstRunEvidencePath,
+                    executableURL: executableURL
+                ),
+                dmgPath: dmgURL.path,
+                logPaths: scannedLogPaths,
+                uiEvidencePath: uiEvidencePath,
+                firstRunEvidencePath: firstRunEvidencePath,
+                generatedAt: generatedAt
+            )
         }
     }
 
@@ -181,6 +237,7 @@ final class PackagedAppSmokeRunner {
         _ initialChecks: [PackagedAppSmokeCheck],
         scannedLogPaths: inout [String],
         uiEvidencePath: inout String?,
+        firstRunEvidencePath: inout String?,
         executableURL: URL
     ) -> [PackagedAppSmokeCheck] {
         var checks = initialChecks
@@ -216,7 +273,36 @@ final class PackagedAppSmokeRunner {
             checks.append(.warn("ui-smoke", target: appBundleURL.path, detail: "Menu bar launch proof was not run. Rerun with --run-ui-smoke on a host with Accessibility permission."))
         }
 
-        checks.append(contentsOf: validateLogPrivacy(paths: scannedLogPaths))
+        if runFirstRunReliability {
+            let defaultFirstRunReport = reportPath.map { path in
+                URL(fileURLWithPath: path)
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("packaged-app-first-run-reliability.json", isDirectory: false)
+                    .path
+            }
+            let firstRunReportTarget = firstRunReportPath ?? defaultFirstRunReport
+            let firstRunRunner = FirstRunReliabilitySmokeRunner(
+                appBundlePath: appBundleURL.path,
+                reportPath: firstRunReportTarget,
+                timeout: firstRunTimeout
+            )
+            let firstRunReport = firstRunRunner.run()
+            try? firstRunReport.writeIfRequested()
+            firstRunEvidencePath = firstRunReport.reportPath
+            scannedLogPaths.append(contentsOf: firstRunReport.privacySweepPaths)
+            checks.append(contentsOf: validateFirstRunReliability(firstRunReport))
+        } else {
+            checks.append(.warn(
+                "first-run-reliability",
+                target: appBundleURL.path,
+                detail: "Packaged first-run reliability proof was not run. Rerun with --run-first-run-reliability for isolated clean-install coverage."
+            ))
+        }
+
+        checks.append(contentsOf: validateLogPrivacy(
+            paths: scannedLogPaths,
+            allowedPathPrefixes: privacyAllowedPathPrefixes(firstRunReportPath: firstRunEvidencePath)
+        ))
         checks.append(validateAppcastFile())
 
         return checks
@@ -227,6 +313,7 @@ final class PackagedAppSmokeRunner {
         dmgPath: String?,
         logPaths: [String],
         uiEvidencePath: String?,
+        firstRunEvidencePath: String?,
         generatedAt: Date
     ) -> PackagedAppSmokeReport {
         PackagedAppSmokeReport(
@@ -239,6 +326,7 @@ final class PackagedAppSmokeRunner {
             appcastPath: appcastURL.path,
             logPaths: logPaths,
             uiReportPath: uiEvidencePath,
+            firstRunReportPath: firstRunEvidencePath,
             reportPath: reportPath,
             checks: checks
         )
@@ -488,7 +576,10 @@ final class PackagedAppSmokeRunner {
         }
     }
 
-    private func validateLogPrivacy(paths: [String]) -> [PackagedAppSmokeCheck] {
+    private func validateLogPrivacy(
+        paths: [String],
+        allowedPathPrefixes: [String] = []
+    ) -> [PackagedAppSmokeCheck] {
         let uniquePaths = Array(Set(paths.filter { !$0.isEmpty })).sorted()
         guard !uniquePaths.isEmpty else {
             return [.warn("logs/privacy-scan", target: "local logs", detail: "No log path was provided and UI smoke did not produce an app log to scan.")]
@@ -501,7 +592,10 @@ final class PackagedAppSmokeRunner {
             }
             do {
                 let content = try String(contentsOf: url, encoding: .utf8)
-                let findings = PrivacyLogScanner.findings(in: content)
+                let findings = PrivacyLogScanner.findings(
+                    in: content,
+                    allowedPathPrefixes: allowedPathPrefixes
+                )
                 if findings.isEmpty {
                     return .pass("logs/privacy-scan", target: url.path, detail: "No obvious raw transcript/audio/title/path/email/token leak patterns found.")
                 }
@@ -541,6 +635,50 @@ final class PackagedAppSmokeRunner {
             "\(check.id): \(check.detail ?? check.target)"
         }
     }
+
+    private func privacyAllowedPathPrefixes(firstRunReportPath: String?) -> [String] {
+        var prefixes = [
+            appBundleURL.path,
+            dSYMURL.path,
+        ]
+
+        guard let firstRunReportPath, !firstRunReportPath.isEmpty else {
+            return Array(Set(prefixes)).sorted()
+        }
+        let reportURL = URL(fileURLWithPath: firstRunReportPath).standardizedFileURL
+        guard let data = try? Data(contentsOf: reportURL),
+              let report = try? JSONDecoder().decode(FirstRunReliabilitySmokeReport.self, from: data) else {
+            return Array(Set(prefixes)).sorted()
+        }
+
+        prefixes.append(report.evidenceRootPath)
+        prefixes.append(report.appBundlePath)
+        prefixes.append(contentsOf: report.scenarios.flatMap { $0.isolatedHomePaths + $0.containerPaths })
+        return Array(Set(prefixes.filter { !$0.isEmpty })).sorted()
+    }
+
+    private func validateFirstRunReliability(_ report: FirstRunReliabilitySmokeReport) -> [PackagedAppSmokeCheck] {
+        let summaryDetail = report.status == .pass
+            ? "Isolated first-run reliability matrix passed \(report.summary.passed)/\(report.scenarios.count) scenarios."
+            : "Isolated first-run reliability matrix flagged \(report.summary.failed) failures and \(report.summary.warnings) warnings."
+        var checks = [
+            PackagedAppSmokeCheck(
+                id: "first-run-reliability",
+                status: report.status,
+                target: appBundleURL.path,
+                detail: summaryDetail
+            )
+        ]
+        checks.append(contentsOf: report.scenarios.map { scenario in
+            PackagedAppSmokeCheck(
+                id: "first-run-\(scenario.id)",
+                status: scenario.status,
+                target: scenario.primaryEvidencePath ?? appBundleURL.path,
+                detail: scenario.detail
+            )
+        })
+        return checks
+    }
 }
 
 struct PackagedAppSmokeCheck: Codable, Equatable {
@@ -578,6 +716,7 @@ struct PackagedAppSmokeReport: Codable, Equatable {
     let appcastPath: String
     let logPaths: [String]
     let uiReportPath: String?
+    let firstRunReportPath: String?
     let reportPath: String?
     let checks: [PackagedAppSmokeCheck]
 
@@ -621,6 +760,9 @@ struct PackagedAppSmokeReport: Codable, Equatable {
         if let uiReportPath {
             print("UI report: \(uiReportPath)")
         }
+        if let firstRunReportPath {
+            print("First-run report: \(firstRunReportPath)")
+        }
         if let reportPath {
             print("Report: \(reportPath)")
         }
@@ -634,6 +776,1138 @@ struct PackagedAppSmokeReport: Codable, Equatable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         try encoder.encode(self).write(to: url, options: .atomic)
     }
+}
+
+final class FirstRunReliabilitySmokeRunner {
+    private let appBundleURL: URL
+    private let reportPath: String?
+    private let timeout: TimeInterval
+    private let fileManager: FileManager
+    private let runID = UUID().uuidString
+
+    init(
+        appBundlePath: String,
+        reportPath: String?,
+        timeout: Double,
+        fileManager: FileManager = .default
+    ) {
+        self.appBundleURL = URL(fileURLWithPath: appBundlePath).standardizedFileURL
+        self.reportPath = reportPath
+        self.timeout = max(5, timeout)
+        self.fileManager = fileManager
+    }
+
+    func run(generatedAt: Date = Date()) -> FirstRunReliabilitySmokeReport {
+        let evidenceRoot = resolvedEvidenceRoot()
+        var scenarios: [FirstRunReliabilityScenario] = []
+        let executableURL = appBundleURL.appendingPathComponent("Contents/MacOS/Transcripted", isDirectory: false)
+
+        guard fileManager.isExecutableFile(atPath: executableURL.path) else {
+            scenarios.append(
+                FirstRunReliabilityScenario(
+                    id: "harness-bootstrap",
+                    status: .fail,
+                    detail: "Packaged app executable is missing: \(executableURL.path)",
+                    reportPaths: [],
+                    logPaths: [],
+                    isolatedHomePaths: [],
+                    containerPaths: [],
+                    launches: []
+                )
+            )
+            return buildReport(
+                scenarios: scenarios,
+                evidenceRoot: evidenceRoot,
+                generatedAt: generatedAt
+            )
+        }
+
+        do {
+            try fileManager.createDirectory(at: evidenceRoot, withIntermediateDirectories: true)
+        } catch {
+            scenarios.append(
+                FirstRunReliabilityScenario(
+                    id: "harness-bootstrap",
+                    status: .fail,
+                    detail: "Failed to prepare first-run evidence root: \(error.localizedDescription)",
+                    reportPaths: [],
+                    logPaths: [],
+                    isolatedHomePaths: [],
+                    containerPaths: [],
+                    launches: []
+                )
+            )
+            return buildReport(
+                scenarios: scenarios,
+                evidenceRoot: evidenceRoot,
+                generatedAt: generatedAt
+            )
+        }
+
+        let onboardingWorkspace = makeWorkspace(id: "zero-state", evidenceRoot: evidenceRoot)
+        scenarios.append(runZeroStateAndRestartScenario(executableURL: executableURL, workspace: onboardingWorkspace))
+
+        let permissionsWorkspace = makeWorkspace(id: "permissions-matrix", evidenceRoot: evidenceRoot)
+        scenarios.append(runPermissionsMatrixScenario(executableURL: executableURL, workspace: permissionsWorkspace))
+
+        let staleCacheWorkspace = makeWorkspace(id: "stale-model-cache", evidenceRoot: evidenceRoot)
+        scenarios.append(runStaleModelCacheScenario(executableURL: executableURL, workspace: staleCacheWorkspace))
+
+        let cachedModelWorkspace = makeWorkspace(id: "cached-model", evidenceRoot: evidenceRoot)
+        scenarios.append(runCachedModelScenario(executableURL: executableURL, workspace: cachedModelWorkspace))
+
+        let blockedDestinationWorkspace = makeWorkspace(id: "destination-unwritable", evidenceRoot: evidenceRoot)
+        scenarios.append(runUnwritableDestinationScenario(executableURL: executableURL, workspace: blockedDestinationWorkspace))
+
+        let helperWorkspace = makeWorkspace(id: "helper-install", evidenceRoot: evidenceRoot)
+        scenarios.append(runHelperInstallScenario(executableURL: executableURL, workspace: helperWorkspace))
+
+        let repairWorkspace = makeWorkspace(id: "helper-repair", evidenceRoot: evidenceRoot)
+        scenarios.append(runHelperRepairScenario(executableURL: executableURL, workspace: repairWorkspace))
+
+        scenarios.append(runHelperRefreshScenario(executableURL: executableURL, workspace: helperWorkspace))
+        scenarios.append(runHelperReadySecondLaunchScenario(executableURL: executableURL, workspace: helperWorkspace))
+
+        let syntheticWorkspace = makeWorkspace(id: "synthetic-models", evidenceRoot: evidenceRoot)
+        scenarios.append(runSyntheticModelMatrixScenario(executableURL: executableURL, workspace: syntheticWorkspace))
+
+        return buildReport(
+            scenarios: scenarios,
+            evidenceRoot: evidenceRoot,
+            generatedAt: generatedAt
+        )
+    }
+
+    private func buildReport(
+        scenarios: [FirstRunReliabilityScenario],
+        evidenceRoot: URL,
+        generatedAt: Date
+    ) -> FirstRunReliabilitySmokeReport {
+        FirstRunReliabilitySmokeReport(
+            runID: runID,
+            generatedAt: ISO8601DateFormatter().string(from: generatedAt),
+            appBundlePath: appBundleURL.path,
+            evidenceRootPath: evidenceRoot.path,
+            reportPath: reportPath,
+            scenarios: scenarios
+        )
+    }
+
+    private func runZeroStateAndRestartScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        let first = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "zero-state-first",
+            options: FirstRunLaunchOptions(onboardingCompleted: false, forceOnboarding: true)
+        )
+        let second = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "zero-state-restart",
+            options: FirstRunLaunchOptions(onboardingCompleted: false, forceOnboarding: true)
+        )
+        return buildScenario(
+            id: "zero-state-and-restart",
+            launches: [first, second],
+            successDetail: "Two launches from the same empty isolated profile kept onboarding incomplete, model state idle, and the observed host-owned system-audio state stable across restart."
+        ) { reports in
+            guard reports.count == 2 else {
+                return ["expected two successful launch reports"]
+            }
+            var failures = isolationFailures(in: reports[0], workspace: workspace)
+            failures.append(contentsOf: isolationFailures(in: reports[1], workspace: workspace))
+            failures.append(contentsOf: expectedBooleanFailures(
+                reports[0].permissionsOnboardingCompleted == false
+                    && reports[1].permissionsOnboardingCompleted == false,
+                message: "onboarding should stay incomplete across restart"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                reports[0].actualModelState == "not_loaded"
+                    && reports[1].actualModelState == "not_loaded",
+                message: "zero-state launches should keep actual model state at not_loaded"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                reports[0].helper.stateAfter == "notInstalled"
+                    && reports[1].helper.stateAfter == "notInstalled",
+                message: "helper should stay notInstalled in the empty profile"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                reports[0].runtime.systemAudioPermissionKnown == reports[1].runtime.systemAudioPermissionKnown
+                    && reports[0].runtime.systemAudioPermissionGranted == reports[1].runtime.systemAudioPermissionGranted,
+                message: "zero-state restart should preserve the same observed host-owned system-audio permission state"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                reports[0].runtime.captureLibraryPath == reports[1].runtime.captureLibraryPath,
+                message: "restart should keep the same isolated capture-library path"
+            ))
+            return failures
+        }
+    }
+
+    private func runPermissionsMatrixScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        let denied = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "permissions-denied",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: false,
+                forceOnboarding: true,
+                preferenceOverrides: [
+                    "systemAudioRecordingPermissionKnown": true,
+                    "systemAudioRecordingPermissionGranted": false,
+                ]
+            )
+        )
+        let granted = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "permissions-granted",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                preferenceOverrides: [
+                    "systemAudioRecordingPermissionKnown": true,
+                    "systemAudioRecordingPermissionGranted": true,
+                ]
+            )
+        )
+        return buildScenario(
+            id: "permissions-state-matrix",
+            launches: [denied, granted],
+            successDetail: "The packaged app preserved incomplete and completed onboarding prefs while observing the same host-owned system-audio state across isolated launches, without claiming live TCC mutation."
+        ) { reports in
+            guard reports.count == 2 else {
+                return ["expected denied and granted permission launch reports"]
+            }
+            let denied = reports[0]
+            let granted = reports[1]
+            var failures = isolationFailures(in: denied, workspace: workspace)
+            failures.append(contentsOf: isolationFailures(in: granted, workspace: workspace))
+            failures.append(contentsOf: expectedBooleanFailures(
+                denied.runtime.systemAudioPermissionKnown == granted.runtime.systemAudioPermissionKnown
+                    && denied.runtime.systemAudioPermissionGranted == granted.runtime.systemAudioPermissionGranted,
+                message: "isolated launches should observe the same host-owned system-audio permission state without pretending HOME isolation can mutate TCC"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                denied.permissionsOnboardingCompleted == false && granted.permissionsOnboardingCompleted,
+                message: "permission matrix should preserve incomplete and completed onboarding states"
+            ))
+            return failures
+        }
+    }
+
+    private func runStaleModelCacheScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        seedStaleModelCache(in: workspace.homeURL)
+        let outcome = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "stale-model-cache",
+            options: FirstRunLaunchOptions(onboardingCompleted: true, forceOnboarding: false)
+        )
+        return buildScenario(
+            id: "stale-model-cache",
+            launches: [outcome],
+            successDetail: "Stale local-model cache folders stayed isolated and did not trick first run into reporting a reusable active model."
+        ) { reports in
+            guard let report = reports.first else {
+                return ["expected stale-cache launch report"]
+            }
+            var failures = isolationFailures(in: report, workspace: workspace)
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.cachedModelDirectory == nil,
+                message: "stale cache should not report an active cached model directory"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.actualModelState == "not_loaded",
+                message: "stale cache should keep actual model state at not_loaded"
+            ))
+            return failures
+        }
+    }
+
+    private func runCachedModelScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        seedActiveModelCache(in: workspace.homeURL)
+        let outcome = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "cached-model",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_ACTIVATE_CACHED_MODEL": "1",
+                ]
+            )
+        )
+        return buildScenario(
+            id: "cached-model-detected",
+            launches: [outcome],
+            successDetail: "A complete synthetic Parakeet cache was detected as cached files on second launch without starting a real download."
+        ) { reports in
+            guard let report = reports.first else {
+                return ["expected cached-model launch report"]
+            }
+            var failures = isolationFailures(in: report, workspace: workspace)
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.actualModelState == "cached",
+                message: "active model cache should surface actual model state cached"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.cachedModelDirectory?.hasSuffix("parakeet-tdt-0.6b-v3") == true,
+                message: "active model cache should report the synthetic Parakeet directory"
+            ))
+            return failures
+        }
+    }
+
+    private func runUnwritableDestinationScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        let blockedParent = workspace.rootURL.appendingPathComponent("blocked-parent", isDirectory: true)
+        try? fileManager.createDirectory(at: blockedParent, withIntermediateDirectories: true)
+        try? fileManager.setAttributes([.posixPermissions: 0o555], ofItemAtPath: blockedParent.path)
+        let blockedContainer = blockedParent.appendingPathComponent("Transcripted", isDirectory: true)
+        let outcome = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "destination-unwritable",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                containerURL: blockedContainer
+            )
+        )
+        return buildScenario(
+            id: "destination-unwritable",
+            launches: [outcome],
+            successDetail: "The harness caught the safe stand-in for full or read-only destinations: app-owned paths stayed isolated and write probes failed loudly."
+        ) { reports in
+            guard let report = reports.first else {
+                return ["expected destination failure launch report"]
+            }
+            var failures = isolationFailures(in: report, workspace: workspace, expectedContainerURL: blockedContainer)
+            failures.append(contentsOf: expectedBooleanFailures(
+                !report.runtime.appSupportWritable && !report.runtime.captureLibraryWritable && !report.runtime.cacheWritable,
+                message: "blocked destination should report every app-owned store as unwritable"
+            ))
+            return failures
+        }
+    }
+
+    private func runHelperInstallScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        let outcome = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "helper-install",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_ACTION": "install-helper",
+                ]
+            )
+        )
+        return buildScenario(
+            id: "helper-install",
+            launches: [outcome],
+            successDetail: "The packaged app installed the bundled MCP helper into the isolated container, wrote an isolated Claude config, and passed the helper self-test."
+        ) { reports in
+            guard let report = reports.first else {
+                return ["expected helper install launch report"]
+            }
+            var failures = isolationFailures(in: report, workspace: workspace)
+            failures.append(contentsOf: helperInstalledFailures(report))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.stateBefore == "notInstalled",
+                message: "helper install should start from notInstalled"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.selfTestOK == true,
+                message: "helper install should report a passing self-test"
+            ))
+            return failures
+        }
+    }
+
+    private func runHelperRepairScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        seedMalformedClaudeConfig(in: workspace.homeURL)
+        seedInstalledHelperStub(at: workspace.containerURL.appendingPathComponent("mcp/transcripted-mcp", isDirectory: false))
+        let outcome = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "helper-repair",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_ACTION": "install-helper",
+                ]
+            )
+        )
+        return buildScenario(
+            id: "helper-repair",
+            launches: [outcome],
+            successDetail: "Malformed helper config was backed up, repaired, and replaced with the bundled helper inside the isolated harness."
+        ) { reports in
+            guard let report = reports.first else {
+                return ["expected helper repair launch report"]
+            }
+            var failures = isolationFailures(in: report, workspace: workspace)
+            failures.append(contentsOf: helperInstalledFailures(report))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.stateBefore == "needsRepair",
+                message: "repair scenario should start from needsRepair"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.backupPath != nil,
+                message: "repair scenario should back up the unreadable Claude config"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.configIsReadableBefore == false && report.helper.configIsReadableAfter == true,
+                message: "repair scenario should rewrite the unreadable Claude config"
+            ))
+            return failures
+        }
+    }
+
+    private func runHelperRefreshScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        seedInstalledHelperStub(at: workspace.containerURL.appendingPathComponent("mcp/transcripted-mcp", isDirectory: false))
+        let outcome = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "helper-refresh",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_ACTION": "refresh-helper",
+                ]
+            )
+        )
+        return buildScenario(
+            id: "helper-refresh-after-update",
+            launches: [outcome],
+            successDetail: "A stale installed MCP helper was refreshed in place to match the bundled helper, which approximates an app-update replacement path."
+        ) { reports in
+            guard let report = reports.first else {
+                return ["expected helper refresh launch report"]
+            }
+            var failures = isolationFailures(in: report, workspace: workspace)
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.stateBefore == "needsRepair",
+                message: "refresh scenario should detect a stale helper as needsRepair before refresh"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.refreshed == true,
+                message: "refresh scenario should report refreshed=true"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.installedBinaryMatchesBundledAfter,
+                message: "refresh scenario should leave the installed helper matching the bundled helper"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.stateAfter == "installed",
+                message: "refresh scenario should end in installed state"
+            ))
+            return failures
+        }
+    }
+
+    private func runHelperReadySecondLaunchScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        let outcome = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "helper-ready-second-launch",
+            options: FirstRunLaunchOptions(onboardingCompleted: true, forceOnboarding: false)
+        )
+        return buildScenario(
+            id: "ready-second-launch",
+            launches: [outcome],
+            successDetail: "A second launch after helper install and refresh stayed ready: the isolated helper remained installed, configured, and matched to the packaged build."
+        ) { reports in
+            guard let report = reports.first else {
+                return ["expected second-launch readiness report"]
+            }
+            var failures = isolationFailures(in: report, workspace: workspace)
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.stateBefore == "installed" && report.helper.stateAfter == "installed",
+                message: "second launch should keep helper state installed before and after reporting"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                report.helper.installedBinaryMatchesBundledAfter,
+                message: "second launch should keep the installed helper aligned with the bundled helper"
+            ))
+            return failures
+        }
+    }
+
+    private func runSyntheticModelMatrixScenario(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace
+    ) -> FirstRunReliabilityScenario {
+        let failed = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "synthetic-failed",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_SYNTHETIC_MODEL_STATE": "failed:Synthetic setup failed",
+                ]
+            )
+        )
+        let resumed = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "synthetic-resumed",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_SYNTHETIC_MODEL_STATE": "downloading:0.73",
+                ]
+            )
+        )
+        let ready = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "synthetic-ready",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_SYNTHETIC_MODEL_STATE": "ready",
+                ]
+            )
+        )
+        return buildScenario(
+            id: "synthetic-model-matrix",
+            launches: [failed, resumed, ready],
+            successDetail: "Synthetic model states covered failure, retry copy, resumed download progress, and ready-state copy without triggering a real model download."
+        ) { reports in
+            guard reports.count == 3 else {
+                return ["expected three synthetic model launch reports"]
+            }
+            let failed = reports[0]
+            let resumed = reports[1]
+            let ready = reports[2]
+            var failures = isolationFailures(in: failed, workspace: workspace)
+            failures.append(contentsOf: isolationFailures(in: resumed, workspace: workspace))
+            failures.append(contentsOf: isolationFailures(in: ready, workspace: workspace))
+            failures.append(contentsOf: expectedBooleanFailures(
+                failed.syntheticModel?.card.tone == "failed"
+                    && failed.syntheticModel?.card.status == "Retry needed"
+                    && failed.syntheticModel?.action.subtitle.contains("Try again") == true,
+                message: "failed synthetic state should keep retry-focused first-run copy"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                resumed.syntheticModel?.card.tone == "working"
+                    && resumed.syntheticModel?.card.status.contains("73%") == true
+                    && resumed.syntheticModel?.card.progress.map { $0 > 0.5 } == true,
+                message: "resumed synthetic state should show in-progress download copy and progress"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                ready.syntheticModel?.card.tone == "ready"
+                    && ready.syntheticModel?.card.status == "Ready"
+                    && ready.syntheticModel?.action.subtitle.isEmpty == true,
+                message: "ready synthetic state should expose ready copy with no setup subtitle"
+            ))
+            return failures
+        }
+    }
+
+    private func launch(
+        executableURL: URL,
+        workspace: FirstRunScenarioWorkspace,
+        tag: String,
+        options: FirstRunLaunchOptions
+    ) -> FirstRunReliabilityLaunchOutcome {
+        do {
+            try fileManager.createDirectory(at: workspace.rootURL, withIntermediateDirectories: true)
+            try writePreferences(
+                home: workspace.homeURL,
+                values: defaultPreferences(
+                    onboardingCompleted: options.onboardingCompleted,
+                    forceOnboarding: options.forceOnboarding,
+                    overrides: options.preferenceOverrides
+                )
+            )
+            try fileManager.createDirectory(at: workspace.reportsDirectoryURL, withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: workspace.logsDirectoryURL, withIntermediateDirectories: true)
+        } catch {
+            return .failure(
+                reportURL: workspace.reportsDirectoryURL.appendingPathComponent("\(tag).json", isDirectory: false),
+                logURL: workspace.logsDirectoryURL.appendingPathComponent("\(tag).log", isDirectory: false),
+                detail: "Failed to prepare isolated launch state: \(error.localizedDescription)",
+                homeURL: workspace.homeURL,
+                containerURL: options.containerURL ?? workspace.containerURL
+            )
+        }
+
+        let reportURL = workspace.reportsDirectoryURL.appendingPathComponent("\(tag).json", isDirectory: false)
+        let logURL = workspace.logsDirectoryURL.appendingPathComponent("\(tag).log", isDirectory: false)
+
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = [
+            "-permissionsOnboardingCompleted", options.onboardingCompleted ? "YES" : "NO",
+            "-forcePermissionsOnboarding", options.forceOnboarding ? "YES" : "NO",
+            "-observability-anonymous-analytics-enabled", "NO",
+            "-observability-crash-reporting-enabled", "NO",
+        ]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = workspace.homeURL.path
+        environment["CFFIXED_USER_HOME"] = workspace.homeURL.path
+        environment["TRANSCRIPTED_CONTAINER_DIR"] = (options.containerURL ?? workspace.containerURL).path
+        environment["TRANSCRIPTED_DISABLE_FILE_LOGGER"] = "1"
+        environment["TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS"] = "1"
+        environment["TRANSCRIPTED_DISABLE_SINGLE_INSTANCE_GUARD"] = "1"
+        environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_REPORT"] = reportURL.path
+        environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_TERMINATE_AFTER_REPORT"] = "1"
+        environment["TRANSCRIPTED_FIRST_RUN_RELIABILITY_TERMINATE_DELAY_SECONDS"] = "0.1"
+        environment.removeValue(forKey: "__CFBundleIdentifier")
+        for (key, value) in options.environmentOverrides {
+            environment[key] = value
+        }
+        process.environment = environment
+
+        fileManager.createFile(atPath: logURL.path, contents: nil)
+        if let handle = try? FileHandle(forWritingTo: logURL) {
+            process.standardOutput = handle
+            process.standardError = handle
+        }
+
+        do {
+            try process.run()
+        } catch {
+            return .failure(
+                reportURL: reportURL,
+                logURL: logURL,
+                detail: "Failed to launch packaged app: \(error.localizedDescription)",
+                homeURL: workspace.homeURL,
+                containerURL: options.containerURL ?? workspace.containerURL
+            )
+        }
+
+        defer {
+            terminate(process: process)
+        }
+
+        guard waitForFile(at: reportURL, process: process) else {
+            let detail = process.isRunning
+                ? "Timed out waiting for the first-run reliability report."
+                : "App exited before writing the first-run reliability report."
+            return .failure(
+                reportURL: reportURL,
+                logURL: logURL,
+                detail: detail,
+                homeURL: workspace.homeURL,
+                containerURL: options.containerURL ?? workspace.containerURL
+            )
+        }
+
+        guard let data = try? Data(contentsOf: reportURL) else {
+            return .failure(
+                reportURL: reportURL,
+                logURL: logURL,
+                detail: "First-run reliability report was written but not readable.",
+                homeURL: workspace.homeURL,
+                containerURL: options.containerURL ?? workspace.containerURL
+            )
+        }
+
+        do {
+            let report = try JSONDecoder().decode(FirstRunReliabilityAppReport.self, from: data)
+            waitForProcessExit(process)
+            return .success(
+                report: report,
+                reportURL: reportURL,
+                logURL: logURL,
+                homeURL: workspace.homeURL,
+                containerURL: options.containerURL ?? workspace.containerURL
+            )
+        } catch {
+            return .failure(
+                reportURL: reportURL,
+                logURL: logURL,
+                detail: "First-run reliability report could not be decoded: \(error.localizedDescription)",
+                homeURL: workspace.homeURL,
+                containerURL: options.containerURL ?? workspace.containerURL
+            )
+        }
+    }
+
+    private func buildScenario(
+        id: String,
+        launches: [FirstRunReliabilityLaunchOutcome],
+        successDetail: String,
+        evaluate: ([FirstRunReliabilityAppReport]) -> [String]
+    ) -> FirstRunReliabilityScenario {
+        let reports = launches.compactMap(\.report)
+        let launchFailures = launches.compactMap(\.failureDetail)
+        let evaluationFailures = launchFailures.isEmpty ? evaluate(reports) : []
+        let failures = launchFailures + evaluationFailures
+        let detail = failures.isEmpty ? successDetail : failures.joined(separator: "; ")
+
+        return FirstRunReliabilityScenario(
+            id: id,
+            status: failures.isEmpty ? .pass : .fail,
+            detail: detail,
+            reportPaths: launches.map(\.reportURL.path),
+            logPaths: launches.map(\.logURL.path),
+            isolatedHomePaths: Array(Set(launches.map(\.homeURL.path))).sorted(),
+            containerPaths: Array(Set(launches.map(\.containerURL.path))).sorted(),
+            launches: reports
+        )
+    }
+
+    private func isolationFailures(
+        in report: FirstRunReliabilityAppReport,
+        workspace: FirstRunScenarioWorkspace,
+        expectedContainerURL: URL? = nil
+    ) -> [String] {
+        let expectedContainer = (expectedContainerURL ?? workspace.containerURL).standardizedFileURL
+        var failures: [String] = []
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.appLaunched && report.statusItemExists && report.popoverConfigured,
+            message: "packaged app should launch far enough to configure the status item and popover"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.runtime.homePath == workspace.homeURL.path,
+            message: "report home path should stay inside the isolated HOME"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.runtime.containerPath == expectedContainer.path,
+            message: "report container path should match the isolated Transcripted container"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.runtime.appSupportPath == expectedContainer.path,
+            message: "app support root should resolve to the isolated Transcripted container"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.runtime.captureLibraryPath.hasPrefix(expectedContainer.path + "/")
+                && report.runtime.cachePath.hasPrefix(expectedContainer.path + "/")
+                && report.runtime.logsPath.hasPrefix(expectedContainer.path + "/")
+                && report.runtime.temporaryPath.hasPrefix(expectedContainer.path + "/")
+                && report.runtime.mcpManifestPath.hasPrefix(expectedContainer.path + "/"),
+            message: "capture, cache, logs, tmp, and MCP manifest paths should stay inside the isolated container"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.configPath.hasPrefix(workspace.homeURL.path + "/"),
+            message: "Claude helper config path should stay inside the isolated HOME"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.installedBinaryPath.hasPrefix(expectedContainer.path + "/"),
+            message: "installed helper path should stay inside the isolated Transcripted container"
+        ))
+        return failures
+    }
+
+    private func helperInstalledFailures(_ report: FirstRunReliabilityAppReport) -> [String] {
+        var failures: [String] = []
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.error == nil,
+            message: "helper action should finish without an error"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.bundledBinaryExists,
+            message: "packaged app should include the bundled MCP helper"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.installedBinaryExistsAfter,
+            message: "helper action should leave an installed helper binary"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.installedBinaryMatchesBundledAfter,
+            message: "installed helper should match the bundled helper after the action"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.stateAfter == "installed",
+            message: "helper action should leave the helper in installed state"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.configuredCommandPathAfter == report.helper.installedBinaryPath,
+            message: "Claude config should point at the installed helper path"
+        ))
+        failures.append(contentsOf: expectedBooleanFailures(
+            report.helper.configIsReadableAfter,
+            message: "Claude config should be readable after the helper action"
+        ))
+        return failures
+    }
+
+    private func expectedBooleanFailures(_ condition: Bool, message: String) -> [String] {
+        condition ? [] : [message]
+    }
+
+    private func resolvedEvidenceRoot() -> URL {
+        if let reportPath, !reportPath.isEmpty {
+            return URL(fileURLWithPath: reportPath)
+                .deletingLastPathComponent()
+                .appendingPathComponent("packaged-app-first-run-reliability-\(runID)", isDirectory: true)
+        }
+        return fileManager.temporaryDirectory
+            .appendingPathComponent("transcripted-first-run-reliability-\(runID)", isDirectory: true)
+    }
+
+    private func makeWorkspace(id: String, evidenceRoot: URL) -> FirstRunScenarioWorkspace {
+        let rootURL = evidenceRoot.appendingPathComponent(id, isDirectory: true)
+        return FirstRunScenarioWorkspace(
+            rootURL: rootURL,
+            homeURL: rootURL.appendingPathComponent("home", isDirectory: true),
+            containerURL: rootURL.appendingPathComponent("container", isDirectory: true),
+            reportsDirectoryURL: rootURL.appendingPathComponent("reports", isDirectory: true),
+            logsDirectoryURL: rootURL.appendingPathComponent("logs", isDirectory: true)
+        )
+    }
+
+    private func defaultPreferences(
+        onboardingCompleted: Bool,
+        forceOnboarding: Bool,
+        overrides: [String: Any]
+    ) -> [String: Any] {
+        var values: [String: Any] = [
+            "permissionsOnboardingCompleted": onboardingCompleted,
+            "forcePermissionsOnboarding": forceOnboarding,
+            "observability-anonymous-analytics-enabled": false,
+            "observability-crash-reporting-enabled": false,
+        ]
+        for (key, value) in overrides {
+            values[key] = value
+        }
+        return values
+    }
+
+    private func writePreferences(home: URL, values: [String: Any]) throws {
+        let preferencesDirectory = home.appendingPathComponent("Library/Preferences", isDirectory: true)
+        try fileManager.createDirectory(at: preferencesDirectory, withIntermediateDirectories: true)
+        let preferencesURL = preferencesDirectory.appendingPathComponent("com.justinbetker.draft.plist", isDirectory: false)
+        let data = try PropertyListSerialization.data(fromPropertyList: values, format: .xml, options: 0)
+        try data.write(to: preferencesURL, options: .atomic)
+    }
+
+    private func seedStaleModelCache(in home: URL) {
+        let stale = home
+            .appendingPathComponent("Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml/Encoder.mlmodelc", isDirectory: true)
+            .appendingPathComponent("coremldata.bin", isDirectory: false)
+        try? writeFixtureFile(at: stale, contents: "stale")
+    }
+
+    private func seedActiveModelCache(in home: URL) {
+        let activeRoot = home
+            .appendingPathComponent("Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3", isDirectory: true)
+        for directory in ["Encoder.mlmodelc", "JointDecision.mlmodelc", "Decoder.mlmodelc", "Preprocessor.mlmodelc"] {
+            let url = activeRoot.appendingPathComponent(directory, isDirectory: true)
+                .appendingPathComponent("coremldata.bin", isDirectory: false)
+            try? writeFixtureFile(at: url, contents: directory)
+        }
+        for filename in ["config.json", "parakeet_v3_vocab.json", "parakeet_vocab.json"] {
+            try? writeFixtureFile(
+                at: activeRoot.appendingPathComponent(filename, isDirectory: false),
+                contents: filename
+            )
+        }
+    }
+
+    private func seedMalformedClaudeConfig(in home: URL) {
+        let configURL = home
+            .appendingPathComponent("Library/Application Support/Claude/claude_desktop_config.json", isDirectory: false)
+        try? writeFixtureFile(at: configURL, contents: "{ this is not valid json")
+    }
+
+    private func seedInstalledHelperStub(at url: URL) {
+        try? writeFixtureFile(at: url, contents: "#!/bin/sh\necho stale helper\n", makeExecutable: true)
+    }
+
+    private func writeFixtureFile(
+        at url: URL,
+        contents: String,
+        makeExecutable: Bool = false
+    ) throws {
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+        if makeExecutable {
+            try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        }
+    }
+
+    private func waitForFile(at url: URL, process: Process) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if fileManager.fileExists(atPath: url.path) {
+                return true
+            }
+            if !process.isRunning {
+                return fileManager.fileExists(atPath: url.path)
+            }
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        return fileManager.fileExists(atPath: url.path)
+    }
+
+    private func waitForProcessExit(_ process: Process) {
+        let deadline = Date().addingTimeInterval(2)
+        while process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+    }
+
+    private func terminate(process: Process) {
+        guard process.isRunning else { return }
+        process.terminate()
+        waitForProcessExit(process)
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+            waitForProcessExit(process)
+        }
+    }
+}
+
+private struct FirstRunScenarioWorkspace {
+    let rootURL: URL
+    let homeURL: URL
+    let containerURL: URL
+    let reportsDirectoryURL: URL
+    let logsDirectoryURL: URL
+}
+
+private struct FirstRunLaunchOptions {
+    let onboardingCompleted: Bool
+    let forceOnboarding: Bool
+    var preferenceOverrides: [String: Any] = [:]
+    var environmentOverrides: [String: String] = [:]
+    var containerURL: URL? = nil
+}
+
+private struct FirstRunReliabilityLaunchOutcome {
+    let report: FirstRunReliabilityAppReport?
+    let reportURL: URL
+    let logURL: URL
+    let failureDetail: String?
+    let homeURL: URL
+    let containerURL: URL
+
+    static func success(
+        report: FirstRunReliabilityAppReport,
+        reportURL: URL,
+        logURL: URL,
+        homeURL: URL,
+        containerURL: URL
+    ) -> Self {
+        Self(
+            report: report,
+            reportURL: reportURL,
+            logURL: logURL,
+            failureDetail: nil,
+            homeURL: homeURL,
+            containerURL: containerURL
+        )
+    }
+
+    static func failure(
+        reportURL: URL,
+        logURL: URL,
+        detail: String,
+        homeURL: URL,
+        containerURL: URL
+    ) -> Self {
+        Self(
+            report: nil,
+            reportURL: reportURL,
+            logURL: logURL,
+            failureDetail: detail,
+            homeURL: homeURL,
+            containerURL: containerURL
+        )
+    }
+}
+
+struct FirstRunReliabilitySmokeReport: Codable, Equatable {
+    struct Summary: Codable, Equatable {
+        let passed: Int
+        let failed: Int
+        let warnings: Int
+    }
+
+    let runID: String
+    let generatedAt: String
+    let appBundlePath: String
+    let evidenceRootPath: String
+    let reportPath: String?
+    let scenarios: [FirstRunReliabilityScenario]
+
+    var summary: Summary {
+        Summary(
+            passed: scenarios.filter { $0.status == .pass }.count,
+            failed: scenarios.filter { $0.status == .fail }.count,
+            warnings: scenarios.filter { $0.status == .warn }.count
+        )
+    }
+
+    var status: ValidationStatus {
+        if summary.failed > 0 { return .fail }
+        if summary.warnings > 0 { return .warn }
+        return .pass
+    }
+
+    var privacySweepPaths: [String] {
+        scenarios
+            .flatMap { $0.reportPaths + $0.logPaths }
+            .sorted()
+    }
+
+    func writeIfRequested() throws {
+        guard let reportPath, !reportPath.isEmpty else { return }
+        let url = URL(fileURLWithPath: reportPath)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(self).write(to: url, options: .atomic)
+    }
+}
+
+struct FirstRunReliabilityScenario: Codable, Equatable {
+    let id: String
+    let status: ValidationStatus
+    let detail: String
+    let reportPaths: [String]
+    let logPaths: [String]
+    let isolatedHomePaths: [String]
+    let containerPaths: [String]
+    let launches: [FirstRunReliabilityAppReport]
+
+    var primaryEvidencePath: String? {
+        reportPaths.first ?? logPaths.first
+    }
+}
+
+struct FirstRunReliabilityAppReport: Codable, Equatable {
+    let appLaunched: Bool
+    let statusItemExists: Bool
+    let popoverConfigured: Bool
+    let permissionsOnboardingCompleted: Bool
+    let selectedModel: String
+    let actualModelState: String
+    let cachedModelDirectory: String?
+    let launchToInteractiveMs: Double?
+    let menuContent: FirstRunReliabilityMenuContentSnapshot
+    let runtime: FirstRunReliabilityRuntimeState
+    let helper: FirstRunReliabilityHelperState
+    let syntheticModel: FirstRunReliabilitySyntheticModelState?
+}
+
+struct FirstRunReliabilityMenuContentSnapshot: Codable, Equatable {
+    let header: FirstRunReliabilityMenuHeaderSnapshot
+    let updateCallout: FirstRunReliabilityActionRowSnapshot
+    let primaryActions: [String: FirstRunReliabilityActionRowSnapshot]
+    let utilityActions: [String: FirstRunReliabilityActionRowSnapshot]
+}
+
+struct FirstRunReliabilityMenuHeaderSnapshot: Codable, Equatable {
+    let statusText: String
+    let detailText: String
+    let warningText: String
+    let isReady: Bool
+}
+
+struct FirstRunReliabilityActionRowSnapshot: Codable, Equatable {
+    let title: String
+    let detail: String
+    let trailingText: String
+    let automationIdentifier: String
+    let isVisible: Bool
+    let isEnabled: Bool
+}
+
+struct FirstRunReliabilityRuntimeState: Codable, Equatable {
+    let homePath: String
+    let containerPath: String?
+    let appSupportPath: String
+    let captureLibraryPath: String
+    let meetingsPath: String
+    let dictationsPath: String
+    let cachePath: String
+    let logsPath: String
+    let temporaryPath: String
+    let mcpManifestPath: String
+    let mcpManifestExists: Bool
+    let systemAudioPermissionKnown: Bool
+    let systemAudioPermissionGranted: Bool
+    let appSupportWritable: Bool
+    let captureLibraryWritable: Bool
+    let cacheWritable: Bool
+}
+
+struct FirstRunReliabilityHelperState: Codable, Equatable {
+    let action: String
+    let backupPath: String?
+    let bundledBinaryExists: Bool
+    let bundledBinaryPath: String?
+    let configuredCommandPathAfter: String?
+    let configuredCommandPathBefore: String?
+    let configIsReadableAfter: Bool
+    let configIsReadableBefore: Bool
+    let configPath: String
+    let error: String?
+    let installedBinaryExistsAfter: Bool
+    let installedBinaryExistsBefore: Bool
+    let installedBinaryMatchesBundledAfter: Bool
+    let installedBinaryMatchesBundledBefore: Bool
+    let installedBinaryPath: String
+    let refreshed: Bool?
+    let selfTestDictationFileCount: Int?
+    let selfTestMeetingFileCount: Int?
+    let selfTestOK: Bool?
+    let stateAfter: String
+    let stateBefore: String
+}
+
+struct FirstRunReliabilitySyntheticModelState: Codable, Equatable {
+    let requestedState: String
+    let action: FirstRunReliabilitySyntheticActionState
+    let card: FirstRunReliabilitySyntheticCardState
+}
+
+struct FirstRunReliabilitySyntheticActionState: Codable, Equatable {
+    let isEnabled: Bool
+    let subtitle: String
+    let symbolName: String
+    let title: String
+}
+
+struct FirstRunReliabilitySyntheticCardState: Codable, Equatable {
+    let detail: String
+    let progress: Double?
+    let status: String
+    let title: String
+    let tone: String
 }
 
 protocol PackagedAppSmokeCommandRunning {
@@ -695,12 +1969,17 @@ enum PrivacyLogScanner {
         "source_app",
     ])
 
-    static func findings(in content: String) -> [String] {
+    static func findings(in content: String, allowedPathPrefixes: [String] = []) -> [String] {
         var findings: [String] = []
+        let normalizedAllowedPathPrefixes = normalizeAllowedPathPrefixes(allowedPathPrefixes)
         let lines = content.split(separator: "\n", omittingEmptySubsequences: true)
         for (index, lineSlice) in lines.enumerated() {
             let line = String(lineSlice)
-            if let jsonFinding = jsonFinding(in: line, lineNumber: index + 1) {
+            if let jsonFinding = jsonFinding(
+                in: line,
+                lineNumber: index + 1,
+                allowedPathPrefixes: normalizedAllowedPathPrefixes
+            ) {
                 findings.append(jsonFinding)
                 continue
             }
@@ -710,14 +1989,18 @@ enum PrivacyLogScanner {
             if containsTokenAssignment(line) {
                 findings.append("line \(index + 1) contains a token/secret-looking assignment")
             }
-            if line.contains("/Users/") || line.contains("file://") {
+            if containsDisallowedLocalPath(line, allowedPathPrefixes: normalizedAllowedPathPrefixes) {
                 findings.append("line \(index + 1) contains an absolute local path")
             }
         }
         return findings
     }
 
-    private static func jsonFinding(in line: String, lineNumber: Int) -> String? {
+    private static func jsonFinding(
+        in line: String,
+        lineNumber: Int,
+        allowedPathPrefixes: [String]
+    ) -> String? {
         guard let data = line.data(using: .utf8),
               let object = try? JSONSerialization.jsonObject(with: data) else {
             return nil
@@ -725,7 +2008,7 @@ enum PrivacyLogScanner {
         if let key = firstSensitiveKey(in: object) {
             return "line \(lineNumber) contains sensitive key \(key)"
         }
-        if containsSensitiveValue(in: object) {
+        if containsSensitiveValue(in: object, allowedPathPrefixes: allowedPathPrefixes) {
             return "line \(lineNumber) contains an email, URL, or absolute local path"
         }
         return nil
@@ -752,17 +2035,70 @@ enum PrivacyLogScanner {
         return nil
     }
 
-    private static func containsSensitiveValue(in object: Any) -> Bool {
+    private static func containsSensitiveValue(
+        in object: Any,
+        allowedPathPrefixes: [String]
+    ) -> Bool {
         if let string = object as? String {
-            return containsEmail(string) || string.contains("/Users/") || string.contains("file://")
+            return containsEmail(string) || containsDisallowedLocalPath(string, allowedPathPrefixes: allowedPathPrefixes)
         }
         if let dictionary = object as? [String: Any] {
-            return dictionary.values.contains(where: containsSensitiveValue)
+            return dictionary.values.contains { containsSensitiveValue(in: $0, allowedPathPrefixes: allowedPathPrefixes) }
         }
         if let array = object as? [Any] {
-            return array.contains(where: containsSensitiveValue)
+            return array.contains { containsSensitiveValue(in: $0, allowedPathPrefixes: allowedPathPrefixes) }
         }
         return false
+    }
+
+    private static func normalizeAllowedPathPrefixes(_ prefixes: [String]) -> [String] {
+        Array(
+            Set(
+                prefixes
+                    .filter { !$0.isEmpty }
+                    .map { URL(fileURLWithPath: $0).standardizedFileURL.path }
+            )
+        ).sorted()
+    }
+
+    private static func containsDisallowedLocalPath(
+        _ value: String,
+        allowedPathPrefixes: [String]
+    ) -> Bool {
+        let pattern = #"(file://[^\s`"']+|/(?:Users|Volumes|private|tmp)/[^\s`"']+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return value.contains("/Users/") || value.contains("file://")
+        }
+
+        let fullRange = NSRange(value.startIndex..<value.endIndex, in: value)
+        for match in regex.matches(in: value, range: fullRange) {
+            guard let range = Range(match.range, in: value) else { continue }
+            let normalized = normalizedLocalPath(String(value[range]))
+            if isAllowedLocalPath(normalized, allowedPathPrefixes: allowedPathPrefixes) {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
+    private static func normalizedLocalPath(_ candidate: String) -> String {
+        let trimmed = candidate.trimmingCharacters(in: CharacterSet(charactersIn: ",;:.)]"))
+        if trimmed.hasPrefix("file://"),
+           let url = URL(string: trimmed),
+           url.isFileURL {
+            return url.standardizedFileURL.path
+        }
+        return URL(fileURLWithPath: trimmed).standardizedFileURL.path
+    }
+
+    private static func isAllowedLocalPath(
+        _ path: String,
+        allowedPathPrefixes: [String]
+    ) -> Bool {
+        allowedPathPrefixes.contains { prefix in
+            path == prefix || path.hasPrefix(prefix + "/")
+        }
     }
 
     private static func normalized(_ value: String) -> String {

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/PackagedAppSmokeTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/PackagedAppSmokeTests.swift
@@ -30,6 +30,16 @@ final class PackagedAppSmokeTests: XCTestCase {
         XCTAssertEqual(report.exitCode, 3)
     }
 
+    func testPackagedAppSmokeWarnsWhenFirstRunReliabilityHarnessIsSkipped() throws {
+        let fixture = try makeFixture()
+
+        let report = makeRunner(fixture: fixture).run()
+
+        XCTAssertTrue(report.checks.contains {
+            $0.id == "first-run-reliability" && $0.status == .warn
+        })
+    }
+
     func testMissingDSYMFailsByDefault() throws {
         let fixture = try makeFixture()
         try FileManager.default.removeItem(at: fixture.dSYM)
@@ -99,6 +109,18 @@ final class PackagedAppSmokeTests: XCTestCase {
         XCTAssertTrue(findings.contains { $0.contains("token/secret") })
     }
 
+    func testPrivacyLogScannerAllowsHarnessOwnedAbsolutePathsWhenAllowlisted() {
+        let findings = PrivacyLogScanner.findings(
+            in: """
+            {"path":"/Users/redbars/harness/run/report.json"}
+            failed to create folder at /Users/redbars/harness/run/container/cache
+            """,
+            allowedPathPrefixes: ["/Users/redbars/harness"]
+        )
+
+        XCTAssertTrue(findings.isEmpty)
+    }
+
     func testMissingExecutableFails() throws {
         let fixture = try makeFixture()
         try FileManager.default.removeItem(at: fixture.app.appendingPathComponent("Contents/MacOS/Transcripted"))
@@ -125,10 +147,13 @@ final class PackagedAppSmokeTests: XCTestCase {
             logPaths: [fixture.log.path],
             reportPath: nil,
             uiReportPath: nil,
+            firstRunReportPath: nil,
             uiTimeout: 1,
+            firstRunTimeout: 1,
             requireDSYM: requireDSYM,
             requireDMG: requireDMG,
             runUISmoke: false,
+            runFirstRunReliability: false,
             allowExistingInstance: false,
             promptForAccessibility: false,
             verifyCodeSignature: true,

--- a/scripts/ops/transcripted-qa-bench.sh
+++ b/scripts/ops/transcripted-qa-bench.sh
@@ -854,7 +854,7 @@ run_packaged_tail() {
   fi
 
   run_step "70-packaged-app-smoke" "Packaged app smoke" "yes" \
-    "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke --report $(shell_quote "${RAW_DIR}/packaged-app-smoke.json") --ui-report $(shell_quote "${RAW_DIR}/packaged-app-ui-smoke.json")"
+    "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke --run-first-run-reliability --report $(shell_quote "${RAW_DIR}/packaged-app-smoke.json") --ui-report $(shell_quote "${RAW_DIR}/packaged-app-ui-smoke.json") --first-run-report $(shell_quote "${RAW_DIR}/packaged-app-first-run-reliability.json")"
 }
 
 run_corpus_tail() {


### PR DESCRIPTION
## Summary
- add a packaged-app first-run reliability harness that runs Transcripted inside isolated HOME/container state and exercises zero-state launch, restart, cached/stale model paths, destination failures, helper install/repair/refresh, update-style replacement, and second-launch readiness
- emit deterministic first-run reliability reports from the app and suppress startup Sparkle/helper side effects during harness launches
- wire the harness into packaged-app-smoke, QA bench quick mode, and regression tests, including privacy scanning of the isolated evidence set

## Proof
- `swift build --package-path Tools/TranscriptedQA`
- `swift test --package-path Tools/TranscriptedQA`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh '' redbars`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke --run-first-run-reliability --report build/packaged-app-smoke.json --ui-report build/packaged-app-ui-smoke.json --first-run-report build/packaged-app-first-run-reliability.json`
- `bash -n scripts/ops/transcripted-qa-bench.sh`
- `bash -n scripts/ops/run-local-summary-fixture.sh`
- `bash scripts/ops/run-local-summary-fixture.sh`
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick`
- `python3 -m py_compile scripts/ops/validate-meeting-corpus.py scripts/ops/compare-meeting-corpus.py scripts/ops/privacy-leak-sweep.py`
- `python3 scripts/ops/privacy-leak-sweep.py --write-report build/privacy-leak-sweep-report.json`

## Review
- `codex-review` helper was inconclusive tooling noise on Monday, July 27, 2026. It repeatedly logged local model-cache metadata errors like `missing field supports_reasoning_summaries` and never produced a final accept/reject summary before the merge-room steer.
- I still used the helper run as a spot-check: it re-ran `swift test --package-path Tools/TranscriptedQA`, `bash build.sh --no-open`, and a reduced `packaged-app-smoke --run-first-run-reliability` flow while inspecting the new harness paths.
- No actionable review finding was emitted from that helper session before we stopped treating it as a blocker.

## Remaining Gap
- Deterministic proof is green for the isolated first-run harness.
- Manual host proof is still separate: the packaged UI smoke on this Mac is only `WARN` because another Transcripted instance was already running, so real clean-Mac / Accessibility / hardware-first-launch behavior remains manual and unclaimed.