### PR TITLE
Share bundled Parakeet model detection

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -146,14 +146,7 @@ class ParakeetEngine: ObservableObject {
     }
 
     private lazy var hasBundledParakeetModel: Bool =
-        bundledModelPath(
-            subdirectory: "parakeet-tdt-0.6b-v3",
-            checkFile: "JointDecisionv3.mlmodelc"
-        ) != nil ||
-        bundledModelPath(
-            subdirectory: "parakeet-tdt-0.6b-v3-coreml",
-            checkFile: "Encoder.mlmodelc"
-        ) != nil
+        bundledParakeetModelPath() != nil
 
     init() {
         markCachedRuntimeModelIfAvailable()

--- a/Sources/Speech/ParakeetModelInitDiagnostics.swift
+++ b/Sources/Speech/ParakeetModelInitDiagnostics.swift
@@ -114,6 +114,42 @@ enum ParakeetModelLoadSource: String, Equatable {
     case download
 }
 
+struct ParakeetBundledModelLayout: Equatable {
+    let subdirectory: String
+    let checkFile: String
+}
+
+enum ParakeetBundledModelLayoutPolicy {
+    static let runtime = ParakeetBundledModelLayout(
+        subdirectory: "parakeet-tdt-0.6b-v3",
+        checkFile: "JointDecisionv3.mlmodelc"
+    )
+    static let legacy = ParakeetBundledModelLayout(
+        subdirectory: "parakeet-tdt-0.6b-v3-coreml",
+        checkFile: "Encoder.mlmodelc"
+    )
+    static let candidates = [runtime, legacy]
+
+    static func resolveBundledModelPath(
+        resourcePath: String?,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> URL? {
+        guard let resourcePath else { return nil }
+
+        let root = URL(fileURLWithPath: resourcePath)
+            .appendingPathComponent("parakeet-models")
+        for candidate in candidates {
+            let path = root.appendingPathComponent(candidate.subdirectory)
+            guard fileExists(path.appendingPathComponent(candidate.checkFile).path) else {
+                continue
+            }
+            return path
+        }
+
+        return nil
+    }
+}
+
 enum ParakeetModelInitDiagnostics {
     static func failureContext(
         stage: ParakeetModelInitStage,

--- a/Sources/Speech/ParakeetModelInitDiagnostics.swift
+++ b/Sources/Speech/ParakeetModelInitDiagnostics.swift
@@ -124,12 +124,9 @@ enum ParakeetBundledModelLayoutPolicy {
         subdirectory: "parakeet-tdt-0.6b-v3",
         checkFile: "JointDecisionv3.mlmodelc"
     )
-    static let legacy = ParakeetBundledModelLayout(
-        subdirectory: "parakeet-tdt-0.6b-v3-coreml",
-        checkFile: "Encoder.mlmodelc"
-    )
-    static let candidates = [runtime, legacy]
 
+    // FluidAudio reloads v3 from its canonical folder name, so a legacy-only
+    // bundled directory is not actually loadable and must fail closed here.
     static func resolveBundledModelPath(
         resourcePath: String?,
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
@@ -138,15 +135,11 @@ enum ParakeetBundledModelLayoutPolicy {
 
         let root = URL(fileURLWithPath: resourcePath)
             .appendingPathComponent("parakeet-models")
-        for candidate in candidates {
-            let path = root.appendingPathComponent(candidate.subdirectory)
-            guard fileExists(path.appendingPathComponent(candidate.checkFile).path) else {
-                continue
-            }
-            return path
+        let path = root.appendingPathComponent(runtime.subdirectory)
+        guard fileExists(path.appendingPathComponent(runtime.checkFile).path) else {
+            return nil
         }
-
-        return nil
+        return path
     }
 }
 

--- a/Sources/Speech/ParakeetModelLifecycle.swift
+++ b/Sources/Speech/ParakeetModelLifecycle.swift
@@ -139,7 +139,7 @@ extension ParakeetEngine {
     }
 
     /// Load Parakeet models from the app bundle (preferred) or download from HuggingFace (fallback).
-    /// Bundle path: Contents/Resources/parakeet-models/parakeet-tdt-0.6b-v3-coreml/
+    /// Bundle path: Contents/Resources/parakeet-models/parakeet-tdt-0.6b-v3/
     func initialize() async {
         guard !isShuttingDown, !Task.isCancelled else { return }
 
@@ -206,7 +206,7 @@ extension ParakeetEngine {
         // FluidAudio 0.15.x resolves bundled models as <parent>/<repo folderName>, and the
         // folder name lost its -coreml suffix. Gate on JointDecisionv3.mlmodelc (new required
         // file) so an incomplete bundle can't trigger a download into the signed app bundle.
-        let bundledModelPath = bundledModelPath(subdirectory: "parakeet-tdt-0.6b-v3", checkFile: "JointDecisionv3.mlmodelc")
+        let bundledModelPath = bundledParakeetModelPath()
         let bundledModelPresent = bundledModelPath != nil
 
         do {
@@ -308,10 +308,7 @@ extension ParakeetEngine {
         guard !isShuttingDown, !Task.isCancelled else { return }
         guard asrManager == nil else { return }
 
-        guard bundledModelPath(
-            subdirectory: "parakeet-tdt-0.6b-v3-coreml",
-            checkFile: "Encoder.mlmodelc"
-        ) == nil else {
+        guard bundledParakeetModelPath() == nil else {
             return
         }
 
@@ -424,6 +421,12 @@ extension ParakeetEngine {
             .appendingPathComponent(subdirectory)
         guard FileManager.default.fileExists(atPath: path.appendingPathComponent(checkFile).path) else { return nil }
         return path
+    }
+
+    func bundledParakeetModelPath() -> URL? {
+        ParakeetBundledModelLayoutPolicy.resolveBundledModelPath(
+            resourcePath: Bundle.main.resourcePath
+        )
     }
 
     // MARK: - Model teardown

--- a/Tests/ParakeetModelInitDiagnosticsTests.swift
+++ b/Tests/ParakeetModelInitDiagnosticsTests.swift
@@ -160,7 +160,7 @@ func testParakeetModelInitDiagnostics() {
         )
     }
 
-    runSuite("ParakeetBundledModelLayoutPolicy prefers the current runtime bundle layout") {
+    runSuite("ParakeetBundledModelLayoutPolicy resolves the current runtime bundle layout") {
         let root = makeBundledModelFixtureRoot()
         defer { try? FileManager.default.removeItem(at: root) }
 
@@ -168,11 +168,6 @@ func testParakeetModelInitDiagnostics() {
             root: root,
             subdirectory: ParakeetBundledModelLayoutPolicy.runtime.subdirectory,
             checkFile: ParakeetBundledModelLayoutPolicy.runtime.checkFile
-        )
-        writeBundledModelFixture(
-            root: root,
-            subdirectory: ParakeetBundledModelLayoutPolicy.legacy.subdirectory,
-            checkFile: ParakeetBundledModelLayoutPolicy.legacy.checkFile
         )
 
         let resolved = ParakeetBundledModelLayoutPolicy.resolveBundledModelPath(
@@ -182,28 +177,27 @@ func testParakeetModelInitDiagnostics() {
         assertEqual(
             resolved?.lastPathComponent,
             ParakeetBundledModelLayoutPolicy.runtime.subdirectory,
-            "the runtime bundle directory should win when both layouts exist"
+            "the packaged runtime bundle directory should resolve as bundled"
         )
     }
 
-    runSuite("ParakeetBundledModelLayoutPolicy falls back to the legacy bundle layout") {
+    runSuite("ParakeetBundledModelLayoutPolicy ignores legacy-only bundled layouts") {
         let root = makeBundledModelFixtureRoot()
         defer { try? FileManager.default.removeItem(at: root) }
 
         writeBundledModelFixture(
             root: root,
-            subdirectory: ParakeetBundledModelLayoutPolicy.legacy.subdirectory,
-            checkFile: ParakeetBundledModelLayoutPolicy.legacy.checkFile
+            subdirectory: "parakeet-tdt-0.6b-v3-coreml",
+            checkFile: "Encoder.mlmodelc"
         )
 
         let resolved = ParakeetBundledModelLayoutPolicy.resolveBundledModelPath(
             resourcePath: root.path
         )
 
-        assertEqual(
-            resolved?.lastPathComponent,
-            ParakeetBundledModelLayoutPolicy.legacy.subdirectory,
-            "older bundled builds should still resolve their legacy Parakeet directory"
+        assertNil(
+            resolved,
+            "legacy-only bundle directories are not loadable through the current FluidAudio runtime layout"
         )
     }
 

--- a/Tests/ParakeetModelInitDiagnosticsTests.swift
+++ b/Tests/ParakeetModelInitDiagnosticsTests.swift
@@ -159,4 +159,87 @@ func testParakeetModelInitDiagnostics() {
             "the watchdog should expire only after the full quiet interval"
         )
     }
+
+    runSuite("ParakeetBundledModelLayoutPolicy prefers the current runtime bundle layout") {
+        let root = makeBundledModelFixtureRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        writeBundledModelFixture(
+            root: root,
+            subdirectory: ParakeetBundledModelLayoutPolicy.runtime.subdirectory,
+            checkFile: ParakeetBundledModelLayoutPolicy.runtime.checkFile
+        )
+        writeBundledModelFixture(
+            root: root,
+            subdirectory: ParakeetBundledModelLayoutPolicy.legacy.subdirectory,
+            checkFile: ParakeetBundledModelLayoutPolicy.legacy.checkFile
+        )
+
+        let resolved = ParakeetBundledModelLayoutPolicy.resolveBundledModelPath(
+            resourcePath: root.path
+        )
+
+        assertEqual(
+            resolved?.lastPathComponent,
+            ParakeetBundledModelLayoutPolicy.runtime.subdirectory,
+            "the runtime bundle directory should win when both layouts exist"
+        )
+    }
+
+    runSuite("ParakeetBundledModelLayoutPolicy falls back to the legacy bundle layout") {
+        let root = makeBundledModelFixtureRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        writeBundledModelFixture(
+            root: root,
+            subdirectory: ParakeetBundledModelLayoutPolicy.legacy.subdirectory,
+            checkFile: ParakeetBundledModelLayoutPolicy.legacy.checkFile
+        )
+
+        let resolved = ParakeetBundledModelLayoutPolicy.resolveBundledModelPath(
+            resourcePath: root.path
+        )
+
+        assertEqual(
+            resolved?.lastPathComponent,
+            ParakeetBundledModelLayoutPolicy.legacy.subdirectory,
+            "older bundled builds should still resolve their legacy Parakeet directory"
+        )
+    }
+
+    runSuite("ParakeetBundledModelLayoutPolicy ignores incomplete runtime bundles") {
+        let root = makeBundledModelFixtureRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        writeBundledModelFixture(
+            root: root,
+            subdirectory: ParakeetBundledModelLayoutPolicy.runtime.subdirectory,
+            checkFile: "Encoder.mlmodelc"
+        )
+
+        let resolved = ParakeetBundledModelLayoutPolicy.resolveBundledModelPath(
+            resourcePath: root.path
+        )
+
+        assertNil(
+            resolved,
+            "the runtime bundle should not count as present unless JointDecisionv3.mlmodelc exists"
+        )
+    }
+}
+
+private func makeBundledModelFixtureRoot() -> URL {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ParakeetBundledModelLayoutPolicy-\(UUID().uuidString)", isDirectory: true)
+    let resources = root.appendingPathComponent("parakeet-models", isDirectory: true)
+    try! FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+    return root
+}
+
+private func writeBundledModelFixture(root: URL, subdirectory: String, checkFile: String) {
+    let directory = root
+        .appendingPathComponent("parakeet-models", isDirectory: true)
+        .appendingPathComponent(subdirectory, isDirectory: true)
+        .appendingPathComponent(checkFile, isDirectory: true)
+    try! FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 }


### PR DESCRIPTION
## Summary
- share bundled Parakeet detection between runtime init and existing-install background prefetch
- restrict bundled detection to the current packaged runtime layout `parakeet-tdt-0.6b-v3`
- add regression coverage for current runtime, incomplete bundle, and legacy-only fail-closed behavior

## Context
- separate narrow fix from merged #1579
- fixes the false-download path without claiming legacy bundled layouts are loadable through the current FluidAudio runtime

## Proof
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter testParakeetModelInitDiagnostics
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open

## Independent Review
- exact-head diff review against `origin/main` on `ab75f9cc6e6e937f17e0634f3b2a873aca860c45` via `~/.codex/bin/maestro-delegate claude --label bundled-model-review ...`
- result: clean, no correctness regressions found
- proof: `MAESTRO_PROOF=/Users/redbars/.codex/maestro/runs/20260727T213312Z-bundled-model-review-claude`
