### PR TITLE
Prevent meeting starts from hanging during system audio handoff

### DIFF
--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -78,7 +78,9 @@ enum TranscriptedConstants {
     /// Timeout for MeetingCaptureBridge.startRecording — resolves the start
     /// continuation with the current `isRecording` state after this window if
     /// neither the success nor error publisher has fired.
-    static let meetingStartTimeout: UInt64 = 5_000_000_000  // 5 seconds
+    // ScreenCaptureKit allows its start callback up to 8 seconds. Keep the
+    // host deadline above that backend contract and aligned with the live smoke.
+    static let meetingStartTimeout: UInt64 = 12_000_000_000  // 12 seconds
 
     /// Bounds the ScreenCaptureKit probe used to verify System Audio Recording
     /// access before meeting capture. A stalled TCC/ScreenCaptureKit callback

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1046,7 +1046,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         return capture
     }
 
-    private func replaceSystemAudioMonitoringAttempt(
+    func replaceSystemAudioMonitoringAttempt(
         with attempt: SystemAudioCaptureStartAttempt?
     ) -> SystemAudioCaptureStartAttempt? {
         systemAudioMonitoringAttemptLock.lock()
@@ -1947,7 +1947,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // Start system audio capture for level metering only (no file writing)
         if let capture = systemAudioCapture {
             let monitoringAttempt = SystemAudioCaptureStartAttempt(capture: capture)
-            replaceSystemAudioMonitoringAttempt(with: monitoringAttempt)?.cancel()
+            if let displacedAttempt = replaceSystemAudioMonitoringAttempt(with: monitoringAttempt) {
+                systemAudioSetupQueue.async {
+                    displacedAttempt.cancel()
+                }
+            }
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 do {
                     try monitoringAttempt.prepare()
@@ -1991,7 +1995,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
             realtimeAGC = nil
         }
 
-        monitoringAttempt?.cancel()
+        if let monitoringAttempt {
+            // ScreenCaptureKit start/stop can each wait for a bounded callback.
+            // Keep that serialization on the attempt, but never make the UI
+            // thread wait while monitoring hands off to full recording.
+            systemAudioSetupQueue.async {
+                monitoringAttempt.cancel()
+            }
+        }
 
         DispatchQueue.main.async {
             self.isMonitoring = false

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -654,10 +654,17 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     // System audio capture
     var systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?
+    private let systemAudioCaptureFactory:
+        () -> (any SystemAudioCaptureEngine & Sendable)?
 
     // Audio file recording
-    var systemAudioFileOwnership = SystemAudioWriterOwnership<AVAudioFile>()
-    let systemAudioSetupQueue = DispatchQueue(label: "SystemAudioSetup", qos: .userInitiated)
+    var systemAudioCaptureAttemptOwnership =
+        SystemAudioCaptureAttemptOwnership<any SystemAudioCaptureEngine & Sendable, AVAudioFile>()
+    let systemAudioSetupQueue = DispatchQueue(
+        label: "SystemAudioSetup",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
     var micAudioFileOwnership = MicWriterOwnership<AVAudioFile>()
     let systemAudioFileQueue = DispatchQueue(label: "SystemAudioFileWrite", qos: .utility)
     let micAudioFileQueue = DispatchQueue(label: "MicAudioFileWrite", qos: .utility)
@@ -982,6 +989,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         self.paths = paths
         self.sleepWakeNotifications = sleepWakeNotifications
         self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
+        self.systemAudioCaptureFactory = { SCKAudioCapture() }
     }
 
     init(
@@ -993,6 +1001,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         self.sleepWakeNotifications = sleepWakeNotifications
         self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
         self.systemAudioCapture = systemAudioCapture
+        self.systemAudioCaptureFactory = { systemAudioCapture }
         if let systemAudioCapture {
             wireSystemAudioStatusPublisher(from: systemAudioCapture)
         }
@@ -1005,10 +1014,18 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // ScreenCaptureKit path. This keeps meeting audio on the narrower
         // "System Audio Recording" permission tier and avoids restart-required
         // Screen Recording flows.
-        let capture = SCKAudioCapture()
+        guard let capture = systemAudioCaptureFactory() else { return }
         systemAudioCapture = capture
         wireSystemAudioStatusPublisher(from: capture)
         installWorkspaceSleepWakeObservers()
+    }
+
+    func makeSystemAudioCaptureForRecordingAttempt()
+        -> (any SystemAudioCaptureEngine & Sendable)? {
+        guard let capture = systemAudioCaptureFactory() else { return nil }
+        systemAudioCapture = capture
+        wireSystemAudioStatusPublisher(from: capture)
+        return capture
     }
 
     private func wireSystemAudioStatusPublisher(from capture: any SystemAudioCaptureEngine) {
@@ -1663,6 +1680,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // Bump generation synchronously on the calling thread so any
         // concurrent recovery work that checks the generation immediately
         // sees the new session boundary.
+        let captureGeneration = recordingSessionGeneration
+        let fallbackSystemCaptureRef = systemAudioCapture
         pendingStartIntentId = nil
         recordingSessionGeneration &+= 1
         let stopGeneration = recordingSessionGeneration
@@ -1672,13 +1691,16 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // while UI updates happen in parallel.
         let engineRef = self.engine
         let inputNodeRef = self.inputNode
-        let systemCaptureRef = self.systemAudioCapture
         let micAudioFileRef = micAudioFileQueue.sync {
             self.micAudioFileOwnership.takeWriterAndInvalidate(for: stopGeneration)
         }
-        let systemAudioFileRef = systemAudioFileQueue.sync {
-            self.systemAudioFileOwnership.takeWriterAndInvalidate(for: stopGeneration)
+        let systemAudioAttempt = systemAudioFileQueue.sync {
+            self.systemAudioCaptureAttemptOwnership.takeAttemptOwned(
+                by: captureGeneration
+            )
         }
+        let systemCaptureRef = systemAudioAttempt?.capture ?? fallbackSystemCaptureRef
+        let systemAudioFileRef = systemAudioAttempt?.writer
         // Use the original mic URL (set at recording start), not the potentially-overwritten
         // recovery URL. Device recovery creates a new WAV segment but the original file
         // contains the bulk of the recording.
@@ -1729,7 +1751,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
-            var didTeardownCurrentSession = false
             self.withAudioGraphLock {
                 guard self.recordingSessionGeneration == stopGeneration else {
                     AppLogger.audio.info("Skipping stale audio graph teardown because a newer session exists", [
@@ -1738,7 +1759,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
                     ])
                     return
                 }
-                didTeardownCurrentSession = true
 
                 if let engineRef, let inputNodeRef {
                     AppLogger.audio.info("Stopping audio capture")
@@ -1756,12 +1776,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 self.realtimeAGC = nil
             }
 
-            // This closure already runs off-main, so use the synchronous system
-            // capture stop. It keeps onRecordingComplete behind backend teardown
-            // and avoids stale ScreenCaptureKit cleanup racing the next start.
-            if didTeardownCurrentSession {
-                systemCaptureRef?.stopSync()
-            }
+            // The capture reference belongs to this exact attempt. Stop it even
+            // when mic-graph teardown is stale; a newer attempt owns a different
+            // capture engine and cannot be affected.
+            systemCaptureRef?.stopSync()
 
             // Coordinate file close. With the engine fully stopped above,
             // no new buffers will arrive on these queues — closing here is

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -656,7 +656,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
     var systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?
 
     // Audio file recording
-    var systemAudioFile: AVAudioFile?
+    var systemAudioFileOwnership = SystemAudioWriterOwnership<AVAudioFile>()
+    let systemAudioSetupQueue = DispatchQueue(label: "SystemAudioSetup", qos: .userInitiated)
     var micAudioFileOwnership = MicWriterOwnership<AVAudioFile>()
     let systemAudioFileQueue = DispatchQueue(label: "SystemAudioFileWrite", qos: .utility)
     let micAudioFileQueue = DispatchQueue(label: "MicAudioFileWrite", qos: .utility)
@@ -1675,7 +1676,9 @@ public class Audio: ObservableObject, @unchecked Sendable {
         let micAudioFileRef = micAudioFileQueue.sync {
             self.micAudioFileOwnership.takeWriterAndInvalidate(for: stopGeneration)
         }
-        let systemAudioFileRef = systemAudioFileQueue.sync { self.systemAudioFile }
+        let systemAudioFileRef = systemAudioFileQueue.sync {
+            self.systemAudioFileOwnership.takeWriterAndInvalidate(for: stopGeneration)
+        }
         // Use the original mic URL (set at recording start), not the potentially-overwritten
         // recovery URL. Device recovery creates a new WAV segment but the original file
         // contains the bulk of the recording.
@@ -1781,11 +1784,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
             }
 
             cleanupGroup.enter()
-            self.systemAudioFileQueue.async { [weak self] in
-                if let self, let systemAudioFileRef {
-                    if let currentSystemFile = self.systemAudioFile, currentSystemFile === systemAudioFileRef {
-                        self.systemAudioFile = nil
-                    }
+            self.systemAudioFileQueue.async {
+                if let systemAudioFileRef {
                     systemAudioFileRef.close()
                     AppLogger.audioSystem.info("Audio file closed", ["file": finalSystemURL?.lastPathComponent ?? "unknown"])
                 }

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -653,13 +653,28 @@ public class Audio: ObservableObject, @unchecked Sendable {
     @Published var systemAudioFailed: Bool = false
 
     // System audio capture
-    var systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?
+    private let systemAudioCaptureStateLock = NSLock()
+    private var _systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?
+    var systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)? {
+        get {
+            systemAudioCaptureStateLock.lock()
+            defer { systemAudioCaptureStateLock.unlock() }
+            return _systemAudioCapture
+        }
+        set {
+            systemAudioCaptureStateLock.lock()
+            _systemAudioCapture = newValue
+            systemAudioCaptureStateLock.unlock()
+        }
+    }
     private let systemAudioCaptureFactory:
         () -> (any SystemAudioCaptureEngine & Sendable)?
+    private let systemAudioMonitoringAttemptLock = NSLock()
+    private var systemAudioMonitoringAttempt: SystemAudioCaptureStartAttempt?
 
     // Audio file recording
     var systemAudioCaptureAttemptOwnership =
-        SystemAudioCaptureAttemptOwnership<any SystemAudioCaptureEngine & Sendable, AVAudioFile>()
+        SystemAudioCaptureAttemptOwnership<SystemAudioCaptureStartAttempt, AVAudioFile>()
     let systemAudioSetupQueue = DispatchQueue(
         label: "SystemAudioSetup",
         qos: .userInitiated,
@@ -995,13 +1010,16 @@ public class Audio: ObservableObject, @unchecked Sendable {
     init(
         paths: CoreStoragePaths = .default,
         systemAudioCaptureForTesting systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?,
+        systemAudioCaptureFactoryForTesting systemAudioCaptureFactory:
+            (() -> (any SystemAudioCaptureEngine & Sendable)?)? = nil,
         sleepWakeNotifications: AudioSleepWakeNotifications = .macOSWorkspace
     ) {
         self.paths = paths
         self.sleepWakeNotifications = sleepWakeNotifications
         self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
-        self.systemAudioCapture = systemAudioCapture
-        self.systemAudioCaptureFactory = { systemAudioCapture }
+        self._systemAudioCapture = systemAudioCapture
+        self.systemAudioCaptureFactory =
+            systemAudioCaptureFactory ?? { systemAudioCapture }
         if let systemAudioCapture {
             wireSystemAudioStatusPublisher(from: systemAudioCapture)
         }
@@ -1026,6 +1044,24 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioCapture = capture
         wireSystemAudioStatusPublisher(from: capture)
         return capture
+    }
+
+    private func replaceSystemAudioMonitoringAttempt(
+        with attempt: SystemAudioCaptureStartAttempt?
+    ) -> SystemAudioCaptureStartAttempt? {
+        systemAudioMonitoringAttemptLock.lock()
+        let previous = systemAudioMonitoringAttempt
+        systemAudioMonitoringAttempt = attempt
+        systemAudioMonitoringAttemptLock.unlock()
+        return previous
+    }
+
+    private func currentSystemAudioMonitoringAttemptIs(
+        _ attempt: SystemAudioCaptureStartAttempt
+    ) -> Bool {
+        systemAudioMonitoringAttemptLock.lock()
+        defer { systemAudioMonitoringAttemptLock.unlock() }
+        return systemAudioMonitoringAttempt === attempt
     }
 
     private func wireSystemAudioStatusPublisher(from capture: any SystemAudioCaptureEngine) {
@@ -1681,7 +1717,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // concurrent recovery work that checks the generation immediately
         // sees the new session boundary.
         let captureGeneration = recordingSessionGeneration
-        let fallbackSystemCaptureRef = systemAudioCapture
         pendingStartIntentId = nil
         recordingSessionGeneration &+= 1
         let stopGeneration = recordingSessionGeneration
@@ -1699,7 +1734,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 by: captureGeneration
             )
         }
-        let systemCaptureRef = systemAudioAttempt?.capture ?? fallbackSystemCaptureRef
+        let systemCaptureAttempt = systemAudioAttempt?.capture
         let systemAudioFileRef = systemAudioAttempt?.writer
         // Use the original mic URL (set at recording start), not the potentially-overwritten
         // recovery URL. Device recovery creates a new WAV segment but the original file
@@ -1779,7 +1814,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             // The capture reference belongs to this exact attempt. Stop it even
             // when mic-graph teardown is stale; a newer attempt owns a different
             // capture engine and cannot be affected.
-            systemCaptureRef?.stopSync()
+            systemCaptureAttempt?.cancel()
 
             // Coordinate file close. With the engine fully stopped above,
             // no new buffers will arrive on these queues — closing here is
@@ -1911,13 +1946,18 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         // Start system audio capture for level metering only (no file writing)
         if let capture = systemAudioCapture {
+            let monitoringAttempt = SystemAudioCaptureStartAttempt(capture: capture)
+            replaceSystemAudioMonitoringAttempt(with: monitoringAttempt)?.cancel()
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 do {
-                    try capture.prepare()
-                    try capture.start { [weak self] systemBuffer in
+                    try monitoringAttempt.prepare()
+                    let started = try monitoringAttempt.startIfNotCancelled { [weak self] systemBuffer in
                         self?.calculateSystemLevel(buffer: systemBuffer)
                     }
-                    AppLogger.audioSystem.info("System audio monitoring started")
+                    if started,
+                       self?.currentSystemAudioMonitoringAttemptIs(monitoringAttempt) == true {
+                        AppLogger.audioSystem.info("System audio monitoring started")
+                    }
                 } catch {
                     AppLogger.audioSystem.warning("System audio monitoring unavailable", ["error": error.localizedDescription])
                     // Mic monitoring still works — system audio is optional
@@ -1925,14 +1965,13 @@ public class Audio: ObservableObject, @unchecked Sendable {
             }
         }
 
-        DispatchQueue.main.async {
-            self.isMonitoring = true
-        }
+        isMonitoring = true
     }
 
     /// Stop level metering. Called automatically before `start()` begins full recording.
     public func stopMonitoring() {
-        guard isMonitoring else { return }
+        let monitoringAttempt = replaceSystemAudioMonitoringAttempt(with: nil)
+        guard isMonitoring || monitoringAttempt != nil else { return }
 
         AppLogger.audio.info("Stopping audio level monitoring")
 
@@ -1952,7 +1991,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             realtimeAGC = nil
         }
 
-        systemAudioCapture?.stopSync()  // Synchronous — avoids race where delayed cleanup destroys the next recording's tap
+        monitoringAttempt?.cancel()
 
         DispatchQueue.main.async {
             self.isMonitoring = false
@@ -1973,6 +2012,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         timer?.invalidate()
         watchdogTimer?.invalidate()
         systemAudioCancellable?.cancel()
+        replaceSystemAudioMonitoringAttempt(with: nil)?.cancel()
         systemAudioCapture?.stopSync()
 
         withAudioGraphLock {

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -2,6 +2,41 @@ import Foundation
 @preconcurrency import AVFoundation
 import QuartzCore
 
+/// Serializes start and stop for one system-audio capture attempt. A stop that
+/// arrives during `prepare()` marks the attempt cancelled; a stop that races
+/// `start()` waits and then tears it down.
+final class SystemAudioCaptureStartAttempt: @unchecked Sendable {
+    let capture: any SystemAudioCaptureEngine & Sendable
+    private let lifecycleLock = NSLock()
+    private var cancelled = false
+
+    init(capture: any SystemAudioCaptureEngine & Sendable) {
+        self.capture = capture
+    }
+
+    func prepare() throws {
+        try capture.prepare()
+    }
+
+    @discardableResult
+    func startIfNotCancelled(
+        bufferCallback: @escaping (AVAudioPCMBuffer) -> Void
+    ) throws -> Bool {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+        guard !cancelled else { return false }
+        try capture.start(bufferCallback: bufferCallback)
+        return true
+    }
+
+    func cancel() {
+        lifecycleLock.lock()
+        cancelled = true
+        capture.stopSync()
+        lifecycleLock.unlock()
+    }
+}
+
 /// Queue-confined ownership for one system-audio capture attempt. Capture
 /// lifecycle and writer lifecycle move together so stale setup, cleanup, and
 /// stop work cannot act on a newer recording.
@@ -124,6 +159,7 @@ extension Audio {
         // CRITICAL: Create audio file BEFORE starting I/O proc to avoid CPU overload
         // Creating files in the audio callback causes HALC_ProxyIOContext::IOWorkLoop overload
         if let capture = makeSystemAudioCaptureForRecordingAttempt() {
+            let captureAttempt = SystemAudioCaptureStartAttempt(capture: capture)
             AppLogger.audioSystem.info("System audio capture object exists, setting up")
             let captureDir = self.paths.audioCaptures
             try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
@@ -133,17 +169,17 @@ extension Audio {
 
             var displacedAttempt:
                 SystemAudioCaptureAttemptOwnership<
-                    any SystemAudioCaptureEngine & Sendable,
+                    SystemAudioCaptureStartAttempt,
                     AVAudioFile
                 >.Attempt?
             let claimedSetup = systemAudioFileQueue.sync {
                 displacedAttempt = systemAudioCaptureAttemptOwnership.begin(
                     generation: sessionGeneration,
-                    capture: capture
+                    capture: captureAttempt
                 )
                 return systemAudioCaptureAttemptOwnership.owns(
                     generation: sessionGeneration,
-                    capture: capture
+                    capture: captureAttempt
                 )
             }
             guard claimedSetup else {
@@ -152,7 +188,7 @@ extension Audio {
             if let displacedAttempt {
                 displacedAttempt.writer?.close()
                 systemAudioSetupQueue.async {
-                    displacedAttempt.capture.stopSync()
+                    displacedAttempt.capture.cancel()
                 }
             }
 
@@ -168,7 +204,7 @@ extension Audio {
                     let abandonedWriter = strongSelf.systemAudioFileQueue.sync {
                         strongSelf.systemAudioCaptureAttemptOwnership.takeWriterOwned(
                             by: sessionGeneration,
-                            capture: capture
+                            capture: captureAttempt
                         )
                     }
                     abandonedWriter?.close()
@@ -178,10 +214,10 @@ extension Audio {
                             return false
                         }
                         return current.generation != sessionGeneration
-                            && current.captureID == ObjectIdentifier(capture as AnyObject)
+                            && current.captureID == ObjectIdentifier(captureAttempt)
                     }
                     if !captureIsOwnedByAnotherAttempt {
-                        capture.stopSync()
+                        captureAttempt.cancel()
                     }
                     try? FileManager.default.removeItem(at: fileURL)
                 }
@@ -200,7 +236,7 @@ extension Audio {
 
                     // Step 1: Prepare the tap (creates aggregate device, gets format)
                     // This does NOT start the I/O proc yet
-                    try capture.prepare()
+                    try captureAttempt.prepare()
 
                     guard sessionIsCurrent() else {
                         cleanupAbandonedSetup()
@@ -240,7 +276,7 @@ extension Audio {
                         strongSelf.systemAudioCaptureAttemptOwnership.install(
                             file,
                             generation: sessionGeneration,
-                            capture: capture
+                            capture: captureAttempt
                         )
                     }
                     guard installed else {
@@ -257,7 +293,7 @@ extension Audio {
 
                     // Step 4: Now start the I/O proc with a lightweight callback
                     // The file already exists, so callback only needs to copy+write
-                    try capture.start { [weak self] systemBuffer in
+                    let started = try captureAttempt.startIfNotCancelled { [weak self] systemBuffer in
                         guard let self = self else { return }
                         guard sessionGeneration == self.recordingSessionGeneration else { return }
 
@@ -305,7 +341,7 @@ extension Audio {
                                   let audioFile =
                                     self.systemAudioCaptureAttemptOwnership.writerOwned(
                                         by: sessionGeneration,
-                                        capture: capture
+                                        capture: captureAttempt
                                   ) else { return }
                             do {
                                 try audioFile.write(from: bufferForAsyncUse)
@@ -314,6 +350,10 @@ extension Audio {
                                 self.recordSystemWriteFailure(error, bufferNumber: currentBufferCount)
                             }
                         }
+                    }
+                    guard started else {
+                        cleanupAbandonedSetup()
+                        return
                     }
 
                     guard sessionIsCurrent() else {
@@ -336,7 +376,7 @@ extension Audio {
                     let failedWriter = strongSelf.systemAudioFileQueue.sync {
                         strongSelf.systemAudioCaptureAttemptOwnership.takeWriterOwned(
                             by: sessionGeneration,
-                            capture: capture
+                            capture: captureAttempt
                         )
                     }
                     failedWriter?.close()

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -2,52 +2,77 @@ import Foundation
 @preconcurrency import AVFoundation
 import QuartzCore
 
-/// Queue-confined ownership for the system-audio writer. A newer recording
-/// claims the slot before its asynchronous setup begins, so late setup,
-/// cleanup, or failure work from an older generation cannot mutate its writer.
-struct SystemAudioWriterOwnership<Writer: AnyObject> {
-    private(set) var writer: Writer?
-    private(set) var generation: UInt64?
-
-    @discardableResult
-    mutating func begin(generation: UInt64) -> Writer? {
-        if let currentGeneration = self.generation,
-           currentGeneration > generation {
-            return nil
-        }
-        let displacedWriter = writer
-        writer = nil
-        self.generation = generation
-        return displacedWriter
+/// Queue-confined ownership for one system-audio capture attempt. Capture
+/// lifecycle and writer lifecycle move together so stale setup, cleanup, and
+/// stop work cannot act on a newer recording.
+struct SystemAudioCaptureAttemptOwnership<Capture, Writer: AnyObject> {
+    struct Attempt {
+        let generation: UInt64
+        let capture: Capture
+        let captureID: ObjectIdentifier
+        var writer: Writer?
     }
 
-    mutating func install(_ writer: Writer, generation: UInt64) -> Bool {
-        guard self.generation == generation, self.writer == nil else { return false }
-        self.writer = writer
+    private(set) var current: Attempt?
+
+    @discardableResult
+    mutating func begin(generation: UInt64, capture: Capture) -> Attempt? {
+        if let current, current.generation > generation {
+            return nil
+        }
+        let displacedAttempt = current
+        current = Attempt(
+            generation: generation,
+            capture: capture,
+            captureID: ObjectIdentifier(capture as AnyObject),
+            writer: nil
+        )
+        return displacedAttempt
+    }
+
+    mutating func install(
+        _ writer: Writer,
+        generation: UInt64,
+        capture: Capture
+    ) -> Bool {
+        guard var current,
+              current.generation == generation,
+              current.captureID == ObjectIdentifier(capture as AnyObject),
+              current.writer == nil else {
+            return false
+        }
+        current.writer = writer
+        self.current = current
         return true
     }
 
-    func owns(generation: UInt64) -> Bool {
-        self.generation == generation
+    func owns(generation: UInt64, capture: Capture) -> Bool {
+        current?.generation == generation
+            && current?.captureID == ObjectIdentifier(capture as AnyObject)
     }
 
-    func writerOwned(by generation: UInt64) -> Writer? {
-        guard self.generation == generation else { return nil }
-        return writer
+    func captureOwned(by generation: UInt64) -> Capture? {
+        guard current?.generation == generation else { return nil }
+        return current?.capture
     }
 
-    mutating func takeWriterOwned(by generation: UInt64) -> Writer? {
-        guard self.generation == generation else { return nil }
-        let ownedWriter = writer
-        writer = nil
+    func writerOwned(by generation: UInt64, capture: Capture) -> Writer? {
+        guard owns(generation: generation, capture: capture) else { return nil }
+        return current?.writer
+    }
+
+    mutating func takeWriterOwned(by generation: UInt64, capture: Capture) -> Writer? {
+        guard owns(generation: generation, capture: capture) else { return nil }
+        let ownedWriter = current?.writer
+        current?.writer = nil
         return ownedWriter
     }
 
-    mutating func takeWriterAndInvalidate(for generation: UInt64) -> Writer? {
-        let ownedWriter = writer
-        writer = nil
-        self.generation = generation
-        return ownedWriter
+    mutating func takeAttemptOwned(by generation: UInt64) -> Attempt? {
+        guard current?.generation == generation else { return nil }
+        let ownedAttempt = current
+        current = nil
+        return ownedAttempt
     }
 }
 
@@ -98,7 +123,7 @@ extension Audio {
         // Start system audio capture
         // CRITICAL: Create audio file BEFORE starting I/O proc to avoid CPU overload
         // Creating files in the audio callback causes HALC_ProxyIOContext::IOWorkLoop overload
-        if let capture = systemAudioCapture {
+        if let capture = makeSystemAudioCaptureForRecordingAttempt() {
             AppLogger.audioSystem.info("System audio capture object exists, setting up")
             let captureDir = self.paths.audioCaptures
             try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
@@ -106,17 +131,33 @@ extension Audio {
             let fileURL = captureDir.appendingPathComponent("meeting_\(timestamp)_system.wav")
             AppLogger.audioSystem.info("System audio file URL", ["file": fileURL.lastPathComponent])
 
+            var displacedAttempt:
+                SystemAudioCaptureAttemptOwnership<
+                    any SystemAudioCaptureEngine & Sendable,
+                    AVAudioFile
+                >.Attempt?
             let claimedSetup = systemAudioFileQueue.sync {
-                systemAudioFileOwnership.begin(generation: sessionGeneration)?.close()
-                return systemAudioFileOwnership.owns(generation: sessionGeneration)
+                displacedAttempt = systemAudioCaptureAttemptOwnership.begin(
+                    generation: sessionGeneration,
+                    capture: capture
+                )
+                return systemAudioCaptureAttemptOwnership.owns(
+                    generation: sessionGeneration,
+                    capture: capture
+                )
             }
             guard claimedSetup else {
                 throw AudioCaptureStaleSessionError()
             }
+            if let displacedAttempt {
+                displacedAttempt.writer?.close()
+                systemAudioSetupQueue.async {
+                    displacedAttempt.capture.stopSync()
+                }
+            }
 
-            // Setup and teardown share one serial lane. A stale attempt therefore
-            // finishes stopping its capture before a newer attempt can prepare or
-            // start the shared ScreenCaptureKit object.
+            // Each attempt owns a fresh capture engine, so a blocked prepare from
+            // an older generation cannot hold up or stop this setup.
             systemAudioSetupQueue.async { [weak self] in
                 guard let strongSelf = self else {
                     AppLogger.audioSystem.error("System audio setup: self is nil")
@@ -125,12 +166,23 @@ extension Audio {
 
                 func cleanupAbandonedSetup() {
                     let abandonedWriter = strongSelf.systemAudioFileQueue.sync {
-                        strongSelf.systemAudioFileOwnership.takeWriterOwned(
-                            by: sessionGeneration
+                        strongSelf.systemAudioCaptureAttemptOwnership.takeWriterOwned(
+                            by: sessionGeneration,
+                            capture: capture
                         )
                     }
                     abandonedWriter?.close()
-                    capture.stopSync()
+                    let captureIsOwnedByAnotherAttempt = strongSelf.systemAudioFileQueue.sync {
+                        guard let current =
+                            strongSelf.systemAudioCaptureAttemptOwnership.current else {
+                            return false
+                        }
+                        return current.generation != sessionGeneration
+                            && current.captureID == ObjectIdentifier(capture as AnyObject)
+                    }
+                    if !captureIsOwnedByAnotherAttempt {
+                        capture.stopSync()
+                    }
                     try? FileManager.default.removeItem(at: fileURL)
                 }
 
@@ -185,9 +237,10 @@ extension Audio {
                     )
                     FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
                     let installed = strongSelf.systemAudioFileQueue.sync {
-                        strongSelf.systemAudioFileOwnership.install(
+                        strongSelf.systemAudioCaptureAttemptOwnership.install(
                             file,
-                            generation: sessionGeneration
+                            generation: sessionGeneration,
+                            capture: capture
                         )
                     }
                     guard installed else {
@@ -249,8 +302,10 @@ extension Audio {
                         self.systemAudioFileQueue.async { [weak self] in
                             guard let self = self,
                                   self.consecutiveSystemWriteErrors < self.maxConsecutiveWriteErrors,
-                                  let audioFile = self.systemAudioFileOwnership.writerOwned(
-                                    by: sessionGeneration
+                                  let audioFile =
+                                    self.systemAudioCaptureAttemptOwnership.writerOwned(
+                                        by: sessionGeneration,
+                                        capture: capture
                                   ) else { return }
                             do {
                                 try audioFile.write(from: bufferForAsyncUse)
@@ -279,8 +334,9 @@ extension Audio {
                     }
                     AppLogger.audioSystem.warning("System audio failed", ["error": error.localizedDescription])
                     let failedWriter = strongSelf.systemAudioFileQueue.sync {
-                        strongSelf.systemAudioFileOwnership.takeWriterOwned(
-                            by: sessionGeneration
+                        strongSelf.systemAudioCaptureAttemptOwnership.takeWriterOwned(
+                            by: sessionGeneration,
+                            capture: capture
                         )
                     }
                     failedWriter?.close()

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -2,6 +2,55 @@ import Foundation
 @preconcurrency import AVFoundation
 import QuartzCore
 
+/// Queue-confined ownership for the system-audio writer. A newer recording
+/// claims the slot before its asynchronous setup begins, so late setup,
+/// cleanup, or failure work from an older generation cannot mutate its writer.
+struct SystemAudioWriterOwnership<Writer: AnyObject> {
+    private(set) var writer: Writer?
+    private(set) var generation: UInt64?
+
+    @discardableResult
+    mutating func begin(generation: UInt64) -> Writer? {
+        if let currentGeneration = self.generation,
+           currentGeneration > generation {
+            return nil
+        }
+        let displacedWriter = writer
+        writer = nil
+        self.generation = generation
+        return displacedWriter
+    }
+
+    mutating func install(_ writer: Writer, generation: UInt64) -> Bool {
+        guard self.generation == generation, self.writer == nil else { return false }
+        self.writer = writer
+        return true
+    }
+
+    func owns(generation: UInt64) -> Bool {
+        self.generation == generation
+    }
+
+    func writerOwned(by generation: UInt64) -> Writer? {
+        guard self.generation == generation else { return nil }
+        return writer
+    }
+
+    mutating func takeWriterOwned(by generation: UInt64) -> Writer? {
+        guard self.generation == generation else { return nil }
+        let ownedWriter = writer
+        writer = nil
+        return ownedWriter
+    }
+
+    mutating func takeWriterAndInvalidate(for generation: UInt64) -> Writer? {
+        let ownedWriter = writer
+        writer = nil
+        self.generation = generation
+        return ownedWriter
+    }
+}
+
 // MARK: - Audio File Creation & Buffer Management
 
 /// Extension handling audio file creation, WAV writing, buffer copying, and format conversion.
@@ -57,16 +106,30 @@ extension Audio {
             let fileURL = captureDir.appendingPathComponent("meeting_\(timestamp)_system.wav")
             AppLogger.audioSystem.info("System audio file URL", ["file": fileURL.lastPathComponent])
 
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let claimedSetup = systemAudioFileQueue.sync {
+                systemAudioFileOwnership.begin(generation: sessionGeneration)?.close()
+                return systemAudioFileOwnership.owns(generation: sessionGeneration)
+            }
+            guard claimedSetup else {
+                throw AudioCaptureStaleSessionError()
+            }
+
+            // Setup and teardown share one serial lane. A stale attempt therefore
+            // finishes stopping its capture before a newer attempt can prepare or
+            // start the shared ScreenCaptureKit object.
+            systemAudioSetupQueue.async { [weak self] in
                 guard let strongSelf = self else {
                     AppLogger.audioSystem.error("System audio setup: self is nil")
                     return
                 }
 
                 func cleanupAbandonedSetup() {
-                    strongSelf.systemAudioFileQueue.sync {
-                        strongSelf.systemAudioFile = nil
+                    let abandonedWriter = strongSelf.systemAudioFileQueue.sync {
+                        strongSelf.systemAudioFileOwnership.takeWriterOwned(
+                            by: sessionGeneration
+                        )
                     }
+                    abandonedWriter?.close()
                     capture.stopSync()
                     try? FileManager.default.removeItem(at: fileURL)
                 }
@@ -121,7 +184,17 @@ extension Audio {
                         interleaved: tapFormat.isInterleaved
                     )
                     FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
-                    strongSelf.systemAudioFileQueue.sync { strongSelf.systemAudioFile = file }
+                    let installed = strongSelf.systemAudioFileQueue.sync {
+                        strongSelf.systemAudioFileOwnership.install(
+                            file,
+                            generation: sessionGeneration
+                        )
+                    }
+                    guard installed else {
+                        file.close()
+                        cleanupAbandonedSetup()
+                        return
+                    }
                     AppLogger.audioSystem.info("System audio file created before I/O proc", ["sampleRate": AudioRecordingFormatPolicy.displaySampleRate(sampleRate), "channels": "\(tapFormat.channelCount)"])
 
                     guard sessionIsCurrent() else {
@@ -176,7 +249,9 @@ extension Audio {
                         self.systemAudioFileQueue.async { [weak self] in
                             guard let self = self,
                                   self.consecutiveSystemWriteErrors < self.maxConsecutiveWriteErrors,
-                                  let audioFile = self.systemAudioFile else { return }
+                                  let audioFile = self.systemAudioFileOwnership.writerOwned(
+                                    by: sessionGeneration
+                                  ) else { return }
                             do {
                                 try audioFile.write(from: bufferForAsyncUse)
                                 self.consecutiveSystemWriteErrors = 0
@@ -203,11 +278,17 @@ extension Audio {
                         return
                     }
                     AppLogger.audioSystem.warning("System audio failed", ["error": error.localizedDescription])
-                    strongSelf.systemAudioFileQueue.sync {
-                        strongSelf.systemAudioFile = nil
+                    let failedWriter = strongSelf.systemAudioFileQueue.sync {
+                        strongSelf.systemAudioFileOwnership.takeWriterOwned(
+                            by: sessionGeneration
+                        )
                     }
+                    failedWriter?.close()
                     try? FileManager.default.removeItem(at: fileURL)
                     DispatchQueue.main.async {
+                        guard strongSelf.recordingSessionGeneration == sessionGeneration else {
+                            return
+                        }
                         strongSelf.error = "System audio unavailable \u{2014} can only record your microphone. To capture Zoom/Teams audio, go to System Settings \u{2192} Privacy & Security \u{2192} System Audio Recording and enable Transcripted."
                         strongSelf.systemAudioFileURL = nil
                         strongSelf.systemAudioFailed = true

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -55,6 +55,19 @@ func testTranscriptedConstants() async {
         )
     }
 
+    runSuite("TranscriptedConstants lets ScreenCaptureKit finish before the meeting start deadline") {
+        let screenCaptureKitStartTimeout: UInt64 = 8_000_000_000
+        assertEqual(
+            TranscriptedConstants.meetingStartTimeout,
+            12_000_000_000,
+            "meeting start should use the same 12-second budget as the live capture smoke"
+        )
+        assertTrue(
+            TranscriptedConstants.meetingStartTimeout > screenCaptureKitStartTimeout,
+            "the outer meeting deadline must outlast ScreenCaptureKit's 8-second callback timeout"
+        )
+    }
+
     runSuite("TranscriptedConstants scales meeting stop timeout for long recordings") {
         assertEqual(
             TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 10 * 60),

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
@@ -4,6 +4,7 @@ import XCTest
 
 @available(macOS 14.0, *)
 final class AudioFileManagerTests: XCTestCase {
+    private final class StubSystemWriter {}
 
     // MARK: - Test scaffolding
 
@@ -23,6 +24,36 @@ final class AudioFileManagerTests: XCTestCase {
     private func makeRoot(name: String = "AudioFileManagerTests") -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    func testSystemAudioWriterOwnershipRejectsStaleCleanup() {
+        var ownership = SystemAudioWriterOwnership<StubSystemWriter>()
+        let oldWriter = StubSystemWriter()
+        let newWriter = StubSystemWriter()
+
+        XCTAssertNil(ownership.begin(generation: 1))
+        XCTAssertTrue(ownership.install(oldWriter, generation: 1))
+
+        XCTAssertTrue(ownership.begin(generation: 2) === oldWriter)
+        XCTAssertTrue(ownership.install(newWriter, generation: 2))
+
+        XCTAssertNil(ownership.takeWriterOwned(by: 1))
+        XCTAssertTrue(ownership.writerOwned(by: 2) === newWriter)
+    }
+
+    func testSystemAudioWriterOwnershipRejectsLateFailureInstall() {
+        var ownership = SystemAudioWriterOwnership<StubSystemWriter>()
+        let lateWriter = StubSystemWriter()
+        let currentWriter = StubSystemWriter()
+
+        XCTAssertNil(ownership.begin(generation: 10))
+        XCTAssertNil(ownership.begin(generation: 11))
+        XCTAssertNil(ownership.begin(generation: 10))
+
+        XCTAssertFalse(ownership.install(lateWriter, generation: 10))
+        XCTAssertFalse(ownership.owns(generation: 10))
+        XCTAssertTrue(ownership.install(currentWriter, generation: 11))
+        XCTAssertTrue(ownership.writerOwned(by: 11) === currentWriter)
     }
 
     private func makeNonInterleavedBuffer(

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
@@ -4,6 +4,7 @@ import XCTest
 
 @available(macOS 14.0, *)
 final class AudioFileManagerTests: XCTestCase {
+    private final class StubSystemCapture {}
     private final class StubSystemWriter {}
 
     // MARK: - Test scaffolding
@@ -26,34 +27,88 @@ final class AudioFileManagerTests: XCTestCase {
             .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
     }
 
-    func testSystemAudioWriterOwnershipRejectsStaleCleanup() {
-        var ownership = SystemAudioWriterOwnership<StubSystemWriter>()
+    func testSystemAudioCaptureAttemptOwnershipRejectsStaleWriterMutation() {
+        var ownership =
+            SystemAudioCaptureAttemptOwnership<StubSystemCapture, StubSystemWriter>()
+        let oldCapture = StubSystemCapture()
+        let newCapture = StubSystemCapture()
         let oldWriter = StubSystemWriter()
         let newWriter = StubSystemWriter()
 
-        XCTAssertNil(ownership.begin(generation: 1))
-        XCTAssertTrue(ownership.install(oldWriter, generation: 1))
+        XCTAssertNil(ownership.begin(generation: 1, capture: oldCapture))
+        XCTAssertTrue(
+            ownership.install(oldWriter, generation: 1, capture: oldCapture)
+        )
 
-        XCTAssertTrue(ownership.begin(generation: 2) === oldWriter)
-        XCTAssertTrue(ownership.install(newWriter, generation: 2))
+        let displaced = ownership.begin(generation: 2, capture: newCapture)
+        XCTAssertTrue(displaced?.capture === oldCapture)
+        XCTAssertTrue(displaced?.writer === oldWriter)
+        XCTAssertTrue(
+            ownership.install(newWriter, generation: 2, capture: newCapture)
+        )
 
-        XCTAssertNil(ownership.takeWriterOwned(by: 1))
-        XCTAssertTrue(ownership.writerOwned(by: 2) === newWriter)
+        XCTAssertNil(ownership.takeWriterOwned(by: 1, capture: oldCapture))
+        XCTAssertTrue(
+            ownership.writerOwned(by: 2, capture: newCapture) === newWriter
+        )
     }
 
-    func testSystemAudioWriterOwnershipRejectsLateFailureInstall() {
-        var ownership = SystemAudioWriterOwnership<StubSystemWriter>()
+    func testSystemAudioCaptureAttemptOwnershipKeepsOldStopAwayFromNewCapture() {
+        var ownership =
+            SystemAudioCaptureAttemptOwnership<StubSystemCapture, StubSystemWriter>()
+        let oldCapture = StubSystemCapture()
+        let newCapture = StubSystemCapture()
+
+        XCTAssertNil(ownership.begin(generation: 10, capture: oldCapture))
+        XCTAssertNil(ownership.begin(generation: 11, capture: newCapture)?.writer)
+
+        XCTAssertNil(ownership.takeAttemptOwned(by: 10))
+        XCTAssertTrue(ownership.captureOwned(by: 11) === newCapture)
+    }
+
+    func testSystemAudioCaptureAttemptOwnershipRejectsLateCallbackInstall() {
+        var ownership =
+            SystemAudioCaptureAttemptOwnership<StubSystemCapture, StubSystemWriter>()
+        let lateCapture = StubSystemCapture()
+        let currentCapture = StubSystemCapture()
         let lateWriter = StubSystemWriter()
         let currentWriter = StubSystemWriter()
 
-        XCTAssertNil(ownership.begin(generation: 10))
-        XCTAssertNil(ownership.begin(generation: 11))
-        XCTAssertNil(ownership.begin(generation: 10))
+        XCTAssertNil(ownership.begin(generation: 10, capture: lateCapture))
+        XCTAssertNil(ownership.begin(generation: 11, capture: currentCapture)?.writer)
+        XCTAssertNil(ownership.begin(generation: 10, capture: lateCapture))
 
-        XCTAssertFalse(ownership.install(lateWriter, generation: 10))
-        XCTAssertFalse(ownership.owns(generation: 10))
-        XCTAssertTrue(ownership.install(currentWriter, generation: 11))
-        XCTAssertTrue(ownership.writerOwned(by: 11) === currentWriter)
+        XCTAssertFalse(
+            ownership.install(lateWriter, generation: 10, capture: lateCapture)
+        )
+        XCTAssertFalse(ownership.owns(generation: 10, capture: lateCapture))
+        XCTAssertTrue(
+            ownership.install(currentWriter, generation: 11, capture: currentCapture)
+        )
+        XCTAssertTrue(
+            ownership.writerOwned(by: 11, capture: currentCapture) === currentWriter
+        )
+    }
+
+    func testStalledSystemAudioSetupDoesNotBlockNextAttempt() {
+        let root = makeRoot(name: "ConcurrentSystemAudioSetup")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let audio = makeAudio(root: root)
+        let releaseFirst = DispatchSemaphore(value: 0)
+        let firstStarted = expectation(description: "first setup started")
+        let secondStarted = expectation(description: "second setup started")
+
+        audio.systemAudioSetupQueue.async {
+            firstStarted.fulfill()
+            _ = releaseFirst.wait(timeout: .now() + 2)
+        }
+        wait(for: [firstStarted], timeout: 1)
+
+        audio.systemAudioSetupQueue.async {
+            secondStarted.fulfill()
+        }
+        wait(for: [secondStarted], timeout: 0.5)
+        releaseFirst.signal()
     }
 
     private func makeNonInterleavedBuffer(

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -404,7 +404,17 @@ final class AudioInitializationTests: XCTestCase {
                 generation: audio.recordingSessionGeneration
             )
         }
-        audio.systemAudioFileQueue.sync { audio.systemAudioFile = oldSystemFile }
+        audio.systemAudioFileQueue.sync {
+            _ = audio.systemAudioFileOwnership.begin(
+                generation: audio.recordingSessionGeneration
+            )
+            XCTAssertTrue(
+                audio.systemAudioFileOwnership.install(
+                    oldSystemFile,
+                    generation: audio.recordingSessionGeneration
+                )
+            )
+        }
 
         let lockHeld = expectation(description: "audio graph lock held")
         let releaseLock = DispatchSemaphore(value: 0)
@@ -438,7 +448,17 @@ final class AudioInitializationTests: XCTestCase {
                 generation: audio.recordingSessionGeneration
             )
         }
-        audio.systemAudioFileQueue.sync { audio.systemAudioFile = newSystemFile }
+        audio.systemAudioFileQueue.sync {
+            _ = audio.systemAudioFileOwnership.begin(
+                generation: audio.recordingSessionGeneration
+            )
+            XCTAssertTrue(
+                audio.systemAudioFileOwnership.install(
+                    newSystemFile,
+                    generation: audio.recordingSessionGeneration
+                )
+            )
+        }
 
         releaseLock.signal()
         wait(for: [stopFinished], timeout: 1.0)
@@ -453,7 +473,9 @@ final class AudioInitializationTests: XCTestCase {
         let activeMicFile = audio.micAudioFileQueue.sync {
             audio.micAudioFileOwnership.writer
         }
-        let activeSystemFile = audio.systemAudioFileQueue.sync { audio.systemAudioFile }
+        let activeSystemFile = audio.systemAudioFileQueue.sync {
+            audio.systemAudioFileOwnership.writerOwned(by: newGeneration)
+        }
         XCTAssertNotNil(activeMicFile)
         XCTAssertNotNil(activeSystemFile)
         XCTAssertTrue(activeMicFile === newMicFile)

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -237,10 +237,14 @@ final class AudioInitializationTests: XCTestCase {
         let newAttempt = SystemAudioCaptureStartAttempt(capture: newCapture)
         let oldStartEntered = expectation(description: "old monitoring start entered")
         let oldAttemptFinished = expectation(description: "old monitoring attempt stopped")
+        let oldStopFinished = expectation(description: "old monitoring backend stopped")
         let releaseOldStart = DispatchSemaphore(value: 0)
         oldCapture.onStart = {
             oldStartEntered.fulfill()
             _ = releaseOldStart.wait(timeout: .now() + 2)
+        }
+        oldCapture.onStopSync = {
+            oldStopFinished.fulfill()
         }
 
         let audio = Audio(
@@ -268,7 +272,8 @@ final class AudioInitializationTests: XCTestCase {
         )
 
         releaseOldStart.signal()
-        wait(for: [oldAttemptFinished], timeout: 1)
+        wait(for: [oldAttemptFinished, oldStopFinished], timeout: 1)
+        oldCapture.onStopSync = nil
         XCTAssertEqual(oldCapture.stopSyncCallCount, 1)
         XCTAssertEqual(newCapture.startCallCount, 1)
         XCTAssertEqual(newCapture.stopSyncCallCount, 0)

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -377,7 +377,12 @@ final class AudioInitializationTests: XCTestCase {
         )
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
 
-        let audio = Audio(paths: paths)
+        let oldSystemCapture = StubSystemAudioCapture()
+        let newSystemCapture = StubSystemAudioCapture()
+        let audio = Audio(
+            paths: paths,
+            systemAudioCaptureForTesting: oldSystemCapture
+        )
         let format = try XCTUnwrap(AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: 48_000,
@@ -405,13 +410,15 @@ final class AudioInitializationTests: XCTestCase {
             )
         }
         audio.systemAudioFileQueue.sync {
-            _ = audio.systemAudioFileOwnership.begin(
-                generation: audio.recordingSessionGeneration
+            _ = audio.systemAudioCaptureAttemptOwnership.begin(
+                generation: audio.recordingSessionGeneration,
+                capture: oldSystemCapture
             )
             XCTAssertTrue(
-                audio.systemAudioFileOwnership.install(
+                audio.systemAudioCaptureAttemptOwnership.install(
                     oldSystemFile,
-                    generation: audio.recordingSessionGeneration
+                    generation: audio.recordingSessionGeneration,
+                    capture: oldSystemCapture
                 )
             )
         }
@@ -442,6 +449,7 @@ final class AudioInitializationTests: XCTestCase {
         audio.micSegments = [MicRecordingSegment(url: newMicURL)]
         audio.micAudioFileURL = newMicURL
         audio.systemAudioFileURL = newSystemURL
+        audio.systemAudioCapture = newSystemCapture
         _ = audio.micAudioFileQueue.sync {
             audio.micAudioFileOwnership.installSessionWriter(
                 newMicFile,
@@ -449,13 +457,15 @@ final class AudioInitializationTests: XCTestCase {
             )
         }
         audio.systemAudioFileQueue.sync {
-            _ = audio.systemAudioFileOwnership.begin(
-                generation: audio.recordingSessionGeneration
+            _ = audio.systemAudioCaptureAttemptOwnership.begin(
+                generation: audio.recordingSessionGeneration,
+                capture: newSystemCapture
             )
             XCTAssertTrue(
-                audio.systemAudioFileOwnership.install(
+                audio.systemAudioCaptureAttemptOwnership.install(
                     newSystemFile,
-                    generation: audio.recordingSessionGeneration
+                    generation: audio.recordingSessionGeneration,
+                    capture: newSystemCapture
                 )
             )
         }
@@ -474,12 +484,17 @@ final class AudioInitializationTests: XCTestCase {
             audio.micAudioFileOwnership.writer
         }
         let activeSystemFile = audio.systemAudioFileQueue.sync {
-            audio.systemAudioFileOwnership.writerOwned(by: newGeneration)
+            audio.systemAudioCaptureAttemptOwnership.writerOwned(
+                by: newGeneration,
+                capture: newSystemCapture
+            )
         }
         XCTAssertNotNil(activeMicFile)
         XCTAssertNotNil(activeSystemFile)
         XCTAssertTrue(activeMicFile === newMicFile)
         XCTAssertTrue(activeSystemFile === newSystemFile)
+        XCTAssertEqual(oldSystemCapture.stopSyncCallCount, 1)
+        XCTAssertEqual(newSystemCapture.stopSyncCallCount, 0)
     }
 
     func testPrepareForNewRecordingStartClearsStaleCaptureArtifacts() {

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -226,6 +226,54 @@ final class AudioInitializationTests: XCTestCase {
         XCTAssertEqual(capture.stopSyncCallCount, 1)
     }
 
+    func testStoppingMonitoringDoesNotWaitForBlockedSystemAudioStart() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MonitoringHandoffTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let oldCapture = StubSystemAudioCapture()
+        let newCapture = StubSystemAudioCapture()
+        let oldAttempt = SystemAudioCaptureStartAttempt(capture: oldCapture)
+        let newAttempt = SystemAudioCaptureStartAttempt(capture: newCapture)
+        let oldStartEntered = expectation(description: "old monitoring start entered")
+        let oldAttemptFinished = expectation(description: "old monitoring attempt stopped")
+        let releaseOldStart = DispatchSemaphore(value: 0)
+        oldCapture.onStart = {
+            oldStartEntered.fulfill()
+            _ = releaseOldStart.wait(timeout: .now() + 2)
+        }
+
+        let audio = Audio(
+            paths: makeCoreStoragePaths(root: root),
+            systemAudioCaptureForTesting: oldCapture
+        )
+        XCTAssertNil(audio.replaceSystemAudioMonitoringAttempt(with: oldAttempt))
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = try? oldAttempt.startIfNotCancelled { _ in }
+            oldAttemptFinished.fulfill()
+        }
+        wait(for: [oldStartEntered], timeout: 1)
+
+        let stopStartedAt = Date()
+        audio.stopMonitoring()
+        XCTAssertLessThan(
+            Date().timeIntervalSince(stopStartedAt),
+            0.25,
+            "clicking Record must not wait for a blocked monitoring start/stop"
+        )
+        XCTAssertTrue(
+            try newAttempt.startIfNotCancelled { _ in },
+            "a fresh recording attempt must be able to start while old monitoring tears down"
+        )
+
+        releaseOldStart.signal()
+        wait(for: [oldAttemptFinished], timeout: 1)
+        XCTAssertEqual(oldCapture.stopSyncCallCount, 1)
+        XCTAssertEqual(newCapture.startCallCount, 1)
+        XCTAssertEqual(newCapture.stopSyncCallCount, 0)
+    }
+
     func testDisplacedDelayedAttemptCannotStartOrStopReplacementAttempt() throws {
         let oldCapture = StubSystemAudioCapture()
         let newCapture = StubSystemAudioCapture()
@@ -869,6 +917,7 @@ private final class StubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked
     }
     var onStopSync: (() -> Void)?
     var onPrepare: (() -> Void)?
+    var onStart: (() -> Void)?
 
     var stopCallCount: Int {
         lock.lock()
@@ -896,6 +945,7 @@ private final class StubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked
         lock.lock()
         _startCallCount += 1
         lock.unlock()
+        onStart?()
     }
 
     func stop() {

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -184,6 +184,12 @@ final class AudioInitializationTests: XCTestCase {
             paths: makeCoreStoragePaths(root: root),
             systemAudioCaptureForTesting: capture
         )
+        audio.systemAudioFileQueue.sync {
+            _ = audio.systemAudioCaptureAttemptOwnership.begin(
+                generation: audio.recordingSessionGeneration,
+                capture: SystemAudioCaptureStartAttempt(capture: capture)
+            )
+        }
 
         audio.stop()
 
@@ -191,6 +197,95 @@ final class AudioInitializationTests: XCTestCase {
         capture.onStopSync = nil
         XCTAssertEqual(capture.stopSyncCallCount, 1)
         XCTAssertEqual(capture.stopCallCount, 0, "recording teardown should use synchronous backend stop to avoid delayed cleanup racing the next start")
+    }
+
+    func testCancelledMonitoringAttemptCannotStartAfterDelayedPrepare() {
+        let capture = StubSystemAudioCapture()
+        let prepareStarted = expectation(description: "monitoring prepare started")
+        let attemptFinished = expectation(description: "monitoring attempt finished")
+        let releasePrepare = DispatchSemaphore(value: 0)
+        capture.onPrepare = {
+            prepareStarted.fulfill()
+            _ = releasePrepare.wait(timeout: .now() + 2)
+        }
+
+        let attempt = SystemAudioCaptureStartAttempt(capture: capture)
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? attempt.prepare()
+            let didStart = (try? attempt.startIfNotCancelled { _ in }) ?? false
+            XCTAssertFalse(didStart)
+            attemptFinished.fulfill()
+        }
+
+        wait(for: [prepareStarted], timeout: 1)
+        attempt.cancel()
+        releasePrepare.signal()
+        wait(for: [attemptFinished], timeout: 1)
+
+        XCTAssertEqual(capture.startCallCount, 0)
+        XCTAssertEqual(capture.stopSyncCallCount, 1)
+    }
+
+    func testDisplacedDelayedAttemptCannotStartOrStopReplacementAttempt() throws {
+        let oldCapture = StubSystemAudioCapture()
+        let newCapture = StubSystemAudioCapture()
+        let oldAttempt = SystemAudioCaptureStartAttempt(capture: oldCapture)
+        let newAttempt = SystemAudioCaptureStartAttempt(capture: newCapture)
+        let prepareStarted = expectation(description: "old prepare started")
+        let oldAttemptFinished = expectation(description: "old attempt finished")
+        let releasePrepare = DispatchSemaphore(value: 0)
+        oldCapture.onPrepare = {
+            prepareStarted.fulfill()
+            _ = releasePrepare.wait(timeout: .now() + 2)
+        }
+
+        var ownership =
+            SystemAudioCaptureAttemptOwnership<SystemAudioCaptureStartAttempt, NSObject>()
+        XCTAssertNil(ownership.begin(generation: 1, capture: oldAttempt))
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? oldAttempt.prepare()
+            _ = try? oldAttempt.startIfNotCancelled { _ in }
+            oldAttemptFinished.fulfill()
+        }
+        wait(for: [prepareStarted], timeout: 1)
+
+        let displaced = try XCTUnwrap(
+            ownership.begin(generation: 2, capture: newAttempt)
+        )
+        displaced.capture.cancel()
+        XCTAssertTrue(try newAttempt.startIfNotCancelled { _ in })
+
+        releasePrepare.signal()
+        wait(for: [oldAttemptFinished], timeout: 1)
+
+        XCTAssertEqual(oldCapture.startCallCount, 0)
+        XCTAssertEqual(oldCapture.stopSyncCallCount, 1)
+        XCTAssertEqual(newCapture.startCallCount, 1)
+        XCTAssertEqual(newCapture.stopSyncCallCount, 0)
+        XCTAssertTrue(ownership.owns(generation: 2, capture: newAttempt))
+    }
+
+    func testRecordingCaptureFactoryCreatesDistinctRetryAttempts() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SystemCaptureFactoryTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let firstCapture = StubSystemAudioCapture()
+        let secondCapture = StubSystemAudioCapture()
+        let captures = CaptureFactorySequence([firstCapture, secondCapture])
+        let audio = Audio(
+            paths: makeCoreStoragePaths(root: root),
+            systemAudioCaptureForTesting: nil,
+            systemAudioCaptureFactoryForTesting: { captures.next() }
+        )
+
+        let first = audio.makeSystemAudioCaptureForRecordingAttempt()
+        let second = audio.makeSystemAudioCaptureForRecordingAttempt()
+
+        XCTAssertTrue((first as AnyObject) === firstCapture)
+        XCTAssertTrue((second as AnyObject) === secondCapture)
+        XCTAssertFalse((first as AnyObject) === (second as AnyObject))
     }
 
     func testAudioRecordingFormatPolicyRejectsInvalidSampleRatesBeforeCreatingFormats() throws {
@@ -398,6 +493,8 @@ final class AudioInitializationTests: XCTestCase {
         let oldSystemFile = try AVAudioFile(forWriting: oldSystemURL, settings: format.settings)
         let newMicFile = try AVAudioFile(forWriting: newMicURL, settings: format.settings)
         let newSystemFile = try AVAudioFile(forWriting: newSystemURL, settings: format.settings)
+        let oldSystemAttempt = SystemAudioCaptureStartAttempt(capture: oldSystemCapture)
+        let newSystemAttempt = SystemAudioCaptureStartAttempt(capture: newSystemCapture)
 
         audio.originalMicAudioFileURL = oldMicURL
         audio.micSegments = [MicRecordingSegment(url: oldMicURL)]
@@ -412,13 +509,13 @@ final class AudioInitializationTests: XCTestCase {
         audio.systemAudioFileQueue.sync {
             _ = audio.systemAudioCaptureAttemptOwnership.begin(
                 generation: audio.recordingSessionGeneration,
-                capture: oldSystemCapture
+                capture: oldSystemAttempt
             )
             XCTAssertTrue(
                 audio.systemAudioCaptureAttemptOwnership.install(
                     oldSystemFile,
                     generation: audio.recordingSessionGeneration,
-                    capture: oldSystemCapture
+                    capture: oldSystemAttempt
                 )
             )
         }
@@ -459,13 +556,13 @@ final class AudioInitializationTests: XCTestCase {
         audio.systemAudioFileQueue.sync {
             _ = audio.systemAudioCaptureAttemptOwnership.begin(
                 generation: audio.recordingSessionGeneration,
-                capture: newSystemCapture
+                capture: newSystemAttempt
             )
             XCTAssertTrue(
                 audio.systemAudioCaptureAttemptOwnership.install(
                     newSystemFile,
                     generation: audio.recordingSessionGeneration,
-                    capture: newSystemCapture
+                    capture: newSystemAttempt
                 )
             )
         }
@@ -486,7 +583,7 @@ final class AudioInitializationTests: XCTestCase {
         let activeSystemFile = audio.systemAudioFileQueue.sync {
             audio.systemAudioCaptureAttemptOwnership.writerOwned(
                 by: newGeneration,
-                capture: newSystemCapture
+                capture: newSystemAttempt
             )
         }
         XCTAssertNotNil(activeMicFile)
@@ -761,6 +858,7 @@ private final class StubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked
     private let lock = NSLock()
     private var _stopCallCount = 0
     private var _stopSyncCallCount = 0
+    private var _startCallCount = 0
 
     var diagnosticBackendName: String { "stub_system_audio" }
     var audioFormat: AVAudioFormat?
@@ -770,6 +868,7 @@ private final class StubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked
         subject.eraseToAnyPublisher()
     }
     var onStopSync: (() -> Void)?
+    var onPrepare: (() -> Void)?
 
     var stopCallCount: Int {
         lock.lock()
@@ -783,9 +882,21 @@ private final class StubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked
         return _stopSyncCallCount
     }
 
-    func prepare() throws {}
+    var startCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _startCallCount
+    }
 
-    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {}
+    func prepare() throws {
+        onPrepare?()
+    }
+
+    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {
+        lock.lock()
+        _startCallCount += 1
+        lock.unlock()
+    }
 
     func stop() {
         lock.lock()
@@ -802,5 +913,22 @@ private final class StubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked
 
     func emit(errorMessage: String?) {
         subject.send(errorMessage)
+    }
+}
+
+@available(macOS 14.0, *)
+private final class CaptureFactorySequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var captures: [any SystemAudioCaptureEngine & Sendable]
+
+    init(_ captures: [any SystemAudioCaptureEngine & Sendable]) {
+        self.captures = captures
+    }
+
+    func next() -> (any SystemAudioCaptureEngine & Sendable)? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !captures.isEmpty else { return nil }
+        return captures.removeFirst()
     }
 }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -848,6 +848,8 @@ func testUIAutomationSurfaceContract() {
             "onboardingAppLogPath",
             "appInspector",
             "systemUIServerStatusItem",
+            "selectRow(identifier:",
+            "kAXSelectedAttribute",
             "performPress(identifier:",
             "performPressOrClick(identifier:",
             "CGEvent(mouseEventSource:",

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
@@ -391,7 +391,8 @@ final class UIAutomationSmokeRunner {
         ]
 
         for check in primaryPageChecks {
-            guard appInspector.performPressOrClick(identifier: check.triggerID) else {
+            guard appInspector.selectRow(identifier: check.triggerID)
+                    || appInspector.performPressOrClick(identifier: check.triggerID) else {
                 builder.add(.fail(
                     check.id,
                     check.title,
@@ -1069,6 +1070,39 @@ private struct AXInspector {
         return false
     }
 
+    func selectRow(identifier: String, maxDepth: Int = 12, maxNodes: Int = 2_000) -> Bool {
+        var queue: [(element: AXUIElement, depth: Int, ancestors: [AXUIElement])] = [(root, 0, [])]
+        var visited = Set<CFHashCode>()
+        var visitedCount = 0
+
+        while !queue.isEmpty, visitedCount < maxNodes {
+            let (element, depth, ancestors) = queue.removeFirst()
+            let key = CFHash(element)
+            if visited.contains(key) { continue }
+            visited.insert(key)
+            visitedCount += 1
+
+            if observedElement(for: element).identifier == identifier {
+                for candidate in [element] + ancestors.reversed() {
+                    guard string(candidate, kAXRoleAttribute as String) == kAXRowRole as String else {
+                        continue
+                    }
+                    if Self.select(candidate) {
+                        return true
+                    }
+                }
+                return false
+            }
+
+            guard depth < maxDepth else { continue }
+            for child in children(of: element) {
+                queue.append((child, depth + 1, ancestors + [element]))
+            }
+        }
+
+        return false
+    }
+
     func performPressOrClick(identifier: String, maxDepth: Int = 12, maxNodes: Int = 2_000) -> Bool {
         if performPress(identifier: identifier, maxDepth: maxDepth, maxNodes: maxNodes) {
             return true
@@ -1113,6 +1147,22 @@ private struct AXInspector {
             return false
         }
         return AXUIElementPerformAction(element, kAXPressAction as CFString) == .success
+    }
+
+    static func select(_ element: AXUIElement) -> Bool {
+        var isSettable = DarwinBoolean(false)
+        guard AXUIElementIsAttributeSettable(
+            element,
+            kAXSelectedAttribute as CFString,
+            &isSettable
+        ) == .success, isSettable.boolValue else {
+            return false
+        }
+        return AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedAttribute as CFString,
+            kCFBooleanTrue
+        ) == .success
     }
 
     static func performClick(frame: AXFrame) -> Bool {


### PR DESCRIPTION
## Summary

- give ScreenCaptureKit enough time to complete a legitimate meeting start
- serialize system-audio start/cancel ownership per recording attempt
- prevent stale monitoring teardown from stopping a fresh recording capture
- move monitoring teardown off the UI thread so clicking Record stays responsive
- make the QA CLI select SwiftUI sidebar rows through the accessibility selection API

## User impact

The meeting prompt can hand off from background audio monitoring to recording without leaving the app stuck on “checking permissions and audio,” blocking the UI, or letting an older capture attempt tear down the new one.

## Acceptance checklist

- [x] stale system-audio setup cannot claim or stop a newer recording attempt
- [x] monitoring teardown does not block the main thread
- [x] a fresh recording can begin while the old monitoring backend finishes stopping
- [x] UI automation reaches Home, Dictations, People, Agent, and Settings deterministically
- [x] packaged build and built-in mic/system-audio smoke pass
- [x] independent complete-diff review passes at exact head `666ae557`

## Verification

- `bash build-deps.sh --force` — PASS
- `bash build.sh --no-open` — PASS; Developer ID signature valid
- `bash run-tests.sh` — 13,438/13,438 PASS
- `swift test --jobs 1` — 868 PASS, 13 intentional skips, 0 failures
- monitoring handoff regression — 100/100 repeated runs PASS
- TranscriptedQA package tests — 55/55 PASS
- `transcripted-qa ui-smoke` — 32/32 PASS
- full QA bench at `26e92d1c` — 18 checks complete, PASS, one non-blocking local-artifact warning
- non-publishing packaged QA — 3/3 PASS
- live built-in microphone + system-audio capture smoke — PASS
- independent review at exact head `666ae557` — PASS, no actionable findings

## Proof boundary

Real AirPods/Bluetooth and a real Zoom/WebRTC meeting remain manual hardware/client proof. No release, tag, notarization, appcast, Homebrew, or publishing action is included in this PR.
