### PR TITLE
Remove duplicate QA health check

### DIFF
--- a/scripts/ops/transcripted-qa-bench.sh
+++ b/scripts/ops/transcripted-qa-bench.sh
@@ -700,13 +700,9 @@ run_pasteback_synthetic() {
 run_artifact_validation() {
   local blocking="$1"
   if [[ "${blocking}" == "yes" ]]; then
-    run_step "20-qa-health" "TranscriptedQA health check" "yes" \
-      "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa check-health --format json"
     run_step "21-qa-validate-all" "TranscriptedQA validate current artifacts" "yes" \
       "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa validate-all --format json"
   else
-    run_step "20-qa-health" "TranscriptedQA health check" "yes" \
-      "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa check-health --format json"
     run_warnings_only_step "21-qa-validate-all" "TranscriptedQA validate current artifacts (warnings-only local state)" \
       "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa validate-all --format json"
   fi


### PR DESCRIPTION
## Summary

- stop running `check-health` immediately before `validate-all`
- keep one health evaluation because `ValidateAll.run()` already invokes `HealthChecker`
- preserve blocking versus warnings-only handling for the complete validation result

This is a four-line deletion stacked on #1586.

## Verification

- [x] `bash -n scripts/ops/transcripted-qa-bench.sh`
- [x] signed `bash build.sh --no-open`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash scripts/ops/transcripted-qa-bench.sh --mode quick` (6/6 passed)
- [x] independent exact-base diff review

## Independent review
PASS against the real #1586 base with no actionable findings.

## Proof boundaries

The QA command path and all automated quick lanes are green. This changes no product runtime behavior and makes no claim about real hardware.