### PR TITLE
Simplify dictation input settling

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1295,20 +1295,8 @@ class ParakeetEngine: ObservableObject {
             return snapshot
         }
 
-        let immediateReadiness = audioFormatReadiness(
-            outputFormat: snapshot.outputFormat,
-            hwFormat: snapshot.hwFormat,
-            selection: snapshot.selection
-        )
-        let overrideSettleDelay = ParakeetInputOverrideSettlePolicy.delayNanoseconds(
-            afterImmediateReadiness: immediateReadiness
-        )
-        if overrideSettleDelay == 0 {
-            return snapshot
-        }
-
         let settleSleepStartedAt = CFAbsoluteTimeGetCurrent()
-        try? await Task.sleep(nanoseconds: overrideSettleDelay)
+        try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
         stageTimings["audio_input_override_settle_sleep_ms"] = Self.elapsedMilliseconds(since: settleSleepStartedAt)
         guard ownsAudioEngineQueue(operationOwner) else { throw CancellationError() }
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -232,15 +232,6 @@ enum ParakeetAudioFormatReadinessPolicy {
     }
 }
 
-enum ParakeetInputOverrideSettlePolicy {
-    static func delayNanoseconds(afterImmediateReadiness readiness: ParakeetAudioFormatReadiness) -> UInt64 {
-        switch readiness {
-        case .ready, .invalid, .routeNotSettled:
-            return TranscriptedConstants.audioRecoveryDelay
-        }
-    }
-}
-
 enum ParakeetTapSampleRatePolicy {
     static func effectiveSampleRate(
         bufferSampleRate: Double,

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -463,27 +463,6 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness, .ready, "native 24k external capture should stay usable when input and output agree")
     }
 
-    runSuite("ParakeetInputOverrideSettlePolicy waits after a ready input override") {
-        assertEqual(
-            ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .ready),
-            TranscriptedConstants.audioRecoveryDelay,
-            "ready formats still get a short settle after forcing AirPods input away from the headset mic"
-        )
-    }
-
-    runSuite("ParakeetInputOverrideSettlePolicy keeps delay while route is settling") {
-        assertEqual(
-            ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .routeNotSettled),
-            TranscriptedConstants.audioRecoveryDelay,
-            "stale route formats should still get the full CoreAudio settle delay"
-        )
-        assertEqual(
-            ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .invalid),
-            TranscriptedConstants.audioRecoveryDelay,
-            "invalid formats should still get the full CoreAudio settle delay"
-        )
-    }
-
     runSuite("ParakeetTapSampleRatePolicy trusts the tap buffer rate over AirPods hardware rate") {
         let effectiveSampleRate = ParakeetTapSampleRatePolicy.effectiveSampleRate(
             bufferSampleRate: 48_000,


### PR DESCRIPTION
## Summary

- delete `ParakeetInputOverrideSettlePolicy`, which returned the same delay for every readiness state
- keep the exact existing 300 ms CoreAudio settle after a successful input override
- remove policy tests that only asserted the constant against itself

This is intentionally stacked on #1587. The input selection, settle duration, post-sleep ownership checks, recovery-generation checks, and settled format re-read are unchanged.

## Scope proof

- 43 net lines removed
- no call sites remain for the deleted policy
- the only changed runtime expression is `Task.sleep(policyResult)` to `Task.sleep(existingConstant)`, and the policy always returned that constant

## Verification

- [x] `bash scripts/dev/agent-preflight.sh`
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` (13,434 passed)
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-e2e-smoke.sh`
- [x] independent exact-base diff review

## Independent review
PASS on exact `cca41428..fabc40e7`: no actionable findings. The reviewer also reran the app build, focused policy tests (166/166), and full fast suite (13,434/13,434).

## Proof boundaries

Automated build and deterministic tests are green. Real microphone start, Bluetooth route recovery, and AirPods behavior are unchanged but remain manual hardware unknowns.