### PR TITLE
[settings] Keep storage presentation state local

### DIFF
--- a/Sources/UI/Settings/CLAUDE.md
+++ b/Sources/UI/Settings/CLAUDE.md
@@ -10,8 +10,9 @@ settings-side agent connection flow.
 
 - `TranscriptedSettingsView.swift` - settings shell, navigation, shared state,
   page routing, and page-level actions. General, Storage, and Beta presentation
-  now live in focused page files while their bindings and runtime work stay in
-  this shell.
+  live in focused page files. Pages own local disclosure and confirmation
+  state; persisted state and runtime work stay behind injected bindings and
+  actions.
 - `TranscriptedSettingsSidebar.swift` - sidebar sections and rows: a primary
   content section (Home/Dictations/Speakers/Agent); the settings pages are
   reached via the sidebar gear and an in-content tab strip.

--- a/Sources/UI/Settings/HomeRootAlertPolicy.swift
+++ b/Sources/UI/Settings/HomeRootAlertPolicy.swift
@@ -1,20 +1,18 @@
 import Foundation
 
-/// One of the Home surface's three independent alert states.
+/// One of the Home surface's independent alert states.
 ///
 /// They are presented through a single `.alert(item:)` because several legacy
 /// `.alert(item:)` stacked on one SwiftUI view shadow all but the last.
 enum HomeRootAlertSlot: String, Equatable {
     case deleteConfirmation
     case deleteFailure
-    case audioRetention
 }
 
-/// Which of the three Home alert states are currently set.
+/// Which Home alert states are currently set.
 struct HomeRootAlertStates: Equatable {
     var hasDeleteConfirmation: Bool
     var hasDeleteFailure: Bool
-    var hasAudioRetention: Bool
 }
 
 /// Routing for the single Home alert presenter. Kept Foundation-pure so the
@@ -34,7 +32,6 @@ enum HomeRootAlertPolicy {
     static func activeSlot(_ states: HomeRootAlertStates) -> HomeRootAlertSlot? {
         if states.hasDeleteConfirmation { return .deleteConfirmation }
         if states.hasDeleteFailure { return .deleteFailure }
-        if states.hasAudioRetention { return .audioRetention }
         return nil
     }
 }

--- a/Sources/UI/Settings/Pages/StorageSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/StorageSettingsPage.swift
@@ -1,9 +1,8 @@
 import Foundation
 import SwiftUI
 
-/// The Settings > Storage page. Storage state and filesystem work stay in
-/// `TranscriptedSettingsView`; this view only renders current state and routes
-/// user actions back through injected closures.
+/// The Settings > Storage page. Local disclosure and confirmation state lives
+/// here; persisted state and filesystem work route through injected callbacks.
 struct StorageSettingsPage<FailureDetailsButton: View>: View {
     let captureLibraryURL: URL
     let meetingCapturesURL: URL
@@ -15,7 +14,7 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
     let captureLibraryChoicePromptBinding: Binding<Bool>
     let pendingCaptureLibraryChoice: PendingCaptureLibraryChoice?
 
-    @Binding var audioRetentionWindow: AudioRetentionWindow
+    let audioRetentionWindow: AudioRetentionWindow
 
     let modelCacheSnapshot: ModelCacheSnapshot?
     let modelCacheLoading: Bool
@@ -23,11 +22,7 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
     let modelCacheCleanupStatus: String?
     let modelCacheCleanupStatusDetails: String?
     let effectiveTranscriptionModelIsWhisper: Bool
-    @Binding var showReclaimableCacheCleanupConfirmation: Bool
-    @Binding var showModelCacheCleanupConfirmation: Bool
-    @Binding var showWhisperCacheCleanupConfirmation: Bool
 
-    @Binding var showSupportFolders: Bool
     let appStateFolder: URL
     let cacheFolder: URL
     let logsFolder: URL
@@ -42,7 +37,14 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
     let onRemoveWhisperModelCache: () -> Void
     let onLoadModelCacheSnapshot: () -> Void
     let onRefreshModelCacheSnapshot: () -> Void
+    let onApplyAudioRetentionWindow: (AudioRetentionWindow) -> Void
     let failureDetailsButton: (String?) -> FailureDetailsButton
+
+    @State private var pendingAudioRetentionWindow: AudioRetentionWindow?
+    @State private var showReclaimableCacheCleanupConfirmation = false
+    @State private var showModelCacheCleanupConfirmation = false
+    @State private var showWhisperCacheCleanupConfirmation = false
+    @State private var showSupportFolders = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
@@ -143,7 +145,7 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                     }
                 }
 
-                Picker("Delete audio after", selection: $audioRetentionWindow) {
+                Picker("Delete audio after", selection: audioRetentionWindowBinding) {
                     ForEach(AudioRetentionWindow.allCases) { window in
                         Text(window.title).tag(window)
                     }
@@ -158,6 +160,16 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                 Text("Choosing 7 or 30 days asks before deleting old replay audio.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+            .alert(item: $pendingAudioRetentionWindow) { window in
+                Alert(
+                    title: Text("Delete old replay audio?"),
+                    message: Text("Transcripted will keep your Markdown transcripts, but retained replay audio older than \(window.title) will be permanently removed now and cleaned up automatically later."),
+                    primaryButton: .cancel(),
+                    secondaryButton: .destructive(Text("Delete Old Audio")) {
+                        onApplyAudioRetentionWindow(window)
+                    }
+                )
             }
 
             SettingsSection(
@@ -319,6 +331,20 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
 
     private var captureLibraryMigrationBusyHelp: String {
         "Captures are still being copied to the new folder."
+    }
+
+    private var audioRetentionWindowBinding: Binding<AudioRetentionWindow> {
+        Binding(
+            get: { audioRetentionWindow },
+            set: { window in
+                guard window != audioRetentionWindow else { return }
+                if window.days == nil {
+                    onApplyAudioRetentionWindow(window)
+                } else {
+                    pendingAudioRetentionWindow = window
+                }
+            }
+        )
     }
 
     private var modelCacheBusyHelp: String {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -61,21 +61,16 @@ struct TranscriptedSettingsView: View {
     @State private var homeDashboardRefreshInFlight = false
     @State private var homeDashboardRefreshGeneration = 0
     @State private var lastHomeDashboardRefreshStartedAt: Date?
-    @State private var showSupportFolders = false
     @State private var modelCacheSnapshot: ModelCacheSnapshot?
     @State private var modelCacheLoading = false
     @State private var modelCacheCleanupInProgress = false
     @State private var modelCacheCleanupStatus: String?
-    @State private var showModelCacheCleanupConfirmation = false
-    @State private var showWhisperCacheCleanupConfirmation = false
-    @State private var showReclaimableCacheCleanupConfirmation = false
     @State private var meetingMicProcessingMode = MicrophoneProcessingPreferences.mode()
     @State private var splitLocalSpeakersEnabled = LocalSpeakerPreferences.isEnabled()
     @State private var confirmQuitDuringMeetingEnabled = QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecording()
     @State private var autoDetectCallsEnabled = AutoCallDetectionPreferences.isEnabled()
     @State private var missedCallNudgeEnabled = MissedCallNudgePreferences.isEnabled()
     @State private var audioRetentionWindow = AudioStoragePreferences.deleteAudioAfter()
-    @State private var pendingAudioRetentionWindow: AudioRetentionWindow?
     @StateObject private var homeViewModel = HomeViewModel()
     @State private var homeCopiedRowID: String?
     @State private var homeDeleteConfirmation: HomeDeleteConfirmation?
@@ -248,10 +243,10 @@ struct TranscriptedSettingsView: View {
                 }
             )
         }
-        // One alert modifier, not three. Stacking multiple legacy `.alert(item:)`
+        // One Home alert modifier, not two. Stacking multiple legacy `.alert(item:)`
         // on the same view shadows all but the last — which silently killed the
-        // meeting-delete confirmation (first of three). `rootAlertBinding` routes
-        // the three independent states through a single presenter so the active
+        // meeting-delete confirmation. `rootAlertBinding` routes
+        // the two independent states through a single presenter so the active
         // one always shows; every existing call site stays unchanged.
         .alert(item: rootAlertBinding) { alert in
             switch alert {
@@ -278,15 +273,6 @@ struct TranscriptedSettingsView: View {
                         if let details = failure.details {
                             copyHomeFailureDetails(details)
                         }
-                    }
-                )
-            case .audioRetention(let window):
-                return Alert(
-                    title: Text("Delete old replay audio?"),
-                    message: Text("Transcripted will keep your Markdown transcripts, but retained replay audio older than \(window.title) will be permanently removed now and cleaned up automatically later."),
-                    primaryButton: .cancel(),
-                    secondaryButton: .destructive(Text("Delete Old Audio")) {
-                        applyAudioRetentionWindow(window)
                     }
                 )
             }
@@ -1751,21 +1737,19 @@ struct TranscriptedSettingsView: View {
 
     // MARK: - Home root alert
 
-    /// The Home surface drives three independent confirmation/failure alerts
-    /// (`homeDeleteConfirmation`, `homeDeleteFailure`, `pendingAudioRetentionWindow`).
+    /// The Home surface drives two independent confirmation/failure alerts
+    /// (`homeDeleteConfirmation`, `homeDeleteFailure`).
     /// They are presented through a *single* `.alert(item:)` because SwiftUI
     /// shadows all but the last when several legacy `.alert(item:)` are stacked
     /// on one view — that is what silently broke the meeting-delete confirmation.
     private enum RootAlert: Identifiable {
         case deleteConfirmation(HomeDeleteConfirmation)
         case deleteFailure(HomeDeleteFailure)
-        case audioRetention(AudioRetentionWindow)
 
         var id: String {
             switch self {
             case .deleteConfirmation(let confirmation): return "delete-confirmation-\(confirmation.id)"
             case .deleteFailure(let failure): return "delete-failure-\(failure.id)"
-            case .audioRetention(let window): return "audio-retention-\(window.id)"
             }
         }
     }
@@ -1775,8 +1759,7 @@ struct TranscriptedSettingsView: View {
     private var rootAlertStates: HomeRootAlertStates {
         HomeRootAlertStates(
             hasDeleteConfirmation: homeDeleteConfirmation != nil,
-            hasDeleteFailure: homeDeleteFailure != nil,
-            hasAudioRetention: pendingAudioRetentionWindow != nil
+            hasDeleteFailure: homeDeleteFailure != nil
         )
     }
 
@@ -1785,13 +1768,12 @@ struct TranscriptedSettingsView: View {
         switch HomeRootAlertPolicy.activeSlot(rootAlertStates) {
         case .deleteConfirmation: return homeDeleteConfirmation.map(RootAlert.deleteConfirmation)
         case .deleteFailure: return homeDeleteFailure.map(RootAlert.deleteFailure)
-        case .audioRetention: return pendingAudioRetentionWindow.map(RootAlert.audioRetention)
         case .none: return nil
         }
     }
 
-    /// Binds the single alert presenter to the three underlying states. On
-    /// dismissal it clears only the alert being dismissed, not all three: a
+    /// Binds the single alert presenter to the two underlying states. On
+    /// dismissal it clears only the alert being dismissed, not both: a
     /// confirm action can set a follow-up alert (e.g. a delete failure) before
     /// SwiftUI writes nil, and clearing everything would wipe it before it can
     /// present. Call sites keep setting their own `@State` directly.
@@ -1803,7 +1785,6 @@ struct TranscriptedSettingsView: View {
                 switch activeRootAlert {
                 case .deleteConfirmation: homeDeleteConfirmation = nil
                 case .deleteFailure: homeDeleteFailure = nil
-                case .audioRetention: pendingAudioRetentionWindow = nil
                 case .none: break
                 }
             }
@@ -2981,20 +2962,13 @@ struct TranscriptedSettingsView: View {
             captureLibraryMigrationStatusDetails: captureLibraryMigrationStatusDetails,
             captureLibraryChoicePromptBinding: captureLibraryChoicePromptBinding,
             pendingCaptureLibraryChoice: pendingCaptureLibraryChoice,
-            audioRetentionWindow: Binding(
-                get: { audioRetentionWindow },
-                set: { updateAudioRetentionWindow($0) }
-            ),
+            audioRetentionWindow: audioRetentionWindow,
             modelCacheSnapshot: modelCacheSnapshot,
             modelCacheLoading: modelCacheLoading,
             modelCacheCleanupInProgress: modelCacheCleanupInProgress,
             modelCacheCleanupStatus: modelCacheCleanupStatus,
             modelCacheCleanupStatusDetails: modelCacheCleanupStatusDetails,
             effectiveTranscriptionModelIsWhisper: effectiveTranscriptionModel.isWhisper,
-            showReclaimableCacheCleanupConfirmation: $showReclaimableCacheCleanupConfirmation,
-            showModelCacheCleanupConfirmation: $showModelCacheCleanupConfirmation,
-            showWhisperCacheCleanupConfirmation: $showWhisperCacheCleanupConfirmation,
-            showSupportFolders: $showSupportFolders,
             appStateFolder: appStateFolder,
             cacheFolder: cacheFolder,
             logsFolder: logsFolder,
@@ -3028,6 +3002,9 @@ struct TranscriptedSettingsView: View {
             onRefreshModelCacheSnapshot: {
                 trackSettingsAction("refresh_model_cache_storage", page: .storage)
                 refreshModelCacheSnapshot()
+            },
+            onApplyAudioRetentionWindow: { window in
+                applyAudioRetentionWindow(window)
             },
             failureDetailsButton: { details in
                 settingsFailureDetailsButton(details)
@@ -4171,16 +4148,6 @@ struct TranscriptedSettingsView: View {
                 }
             }
         }
-    }
-
-    private func updateAudioRetentionWindow(_ window: AudioRetentionWindow) {
-        guard window != audioRetentionWindow else { return }
-        guard window.days == nil else {
-            pendingAudioRetentionWindow = window
-            return
-        }
-
-        applyAudioRetentionWindow(window)
     }
 
     private func applyAudioRetentionWindow(_ window: AudioRetentionWindow) {

--- a/Tests/HomeRootAlertPolicyTests.swift
+++ b/Tests/HomeRootAlertPolicyTests.swift
@@ -3,20 +3,18 @@ import Foundation
 func testHomeRootAlertPolicy() {
     func states(
         confirmation: Bool = false,
-        failure: Bool = false,
-        retention: Bool = false
+        failure: Bool = false
     ) -> HomeRootAlertStates {
         HomeRootAlertStates(
             hasDeleteConfirmation: confirmation,
-            hasDeleteFailure: failure,
-            hasAudioRetention: retention
+            hasDeleteFailure: failure
         )
     }
 
     runSuite("HomeRootAlertPolicy presents nothing when no state is set") {
         assertNil(
             HomeRootAlertPolicy.activeSlot(states()),
-            "no alert should present when none of the three states is set"
+            "no alert should present when neither state is set"
         )
     }
 
@@ -31,11 +29,6 @@ func testHomeRootAlertPolicy() {
             .deleteFailure,
             "a set delete failure should present"
         )
-        assertEqual(
-            HomeRootAlertPolicy.activeSlot(states(retention: true)),
-            .audioRetention,
-            "a set audio-retention prompt should present"
-        )
     }
 
     runSuite("HomeRootAlertPolicy dismisses the confirmation first so a follow-up failure survives") {
@@ -43,25 +36,12 @@ func testHomeRootAlertPolicy() {
         // failed-meeting delete returns false) sets homeDeleteFailure *before*
         // SwiftUI writes nil to dismiss the confirmation. The confirmation
         // outranks the failure, so dismissal clears the confirmation and the
-        // failure remains set to present next. If the binding cleared all three
+        // failure remains set to present next. If the binding cleared both
         // states instead, the failure alert would never appear.
         assertEqual(
             HomeRootAlertPolicy.activeSlot(states(confirmation: true, failure: true)),
             .deleteConfirmation,
             "with both a confirmation and a freshly-raised failure set, the confirmation is dismissed first and the failure is left to present"
-        )
-    }
-
-    runSuite("HomeRootAlertPolicy keeps a deterministic order across all states") {
-        assertEqual(
-            HomeRootAlertPolicy.activeSlot(states(confirmation: true, failure: true, retention: true)),
-            .deleteConfirmation,
-            "confirmation outranks failure and audio retention"
-        )
-        assertEqual(
-            HomeRootAlertPolicy.activeSlot(states(failure: true, retention: true)),
-            .deleteFailure,
-            "failure outranks audio retention"
         )
     }
 

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -335,9 +335,9 @@ func testUIAutomationSurfaceContract() {
         //   1. Row-menu handlers fired synchronously inside NSMenu.popUp's modal
         //      tracking loop, so the SwiftUI alert they set never presented.
         //      ClosureMenuItem must hop to the next main-runloop turn.
-        //   2. Three legacy `.alert(item:)` modifiers were stacked on the settings
-        //      root view; SwiftUI keeps only the last, shadowing the (first)
-        //      delete confirmation. The three states must share one presenter.
+        //   2. Multiple legacy `.alert(item:)` modifiers were stacked on the
+        //      settings root view; SwiftUI keeps only the last, shadowing the
+        //      delete confirmation. Home's two states must share one presenter.
         assertTrue(
             contractSource("Sources/UI/Settings/HomeView.swift").contains("DispatchQueue.main.async { [handler] in handler() }"),
             "ClosureMenuItem should defer its handler off the NSMenu.popUp tracking loop so menu-triggered SwiftUI alerts/sheets present"
@@ -346,25 +346,27 @@ func testUIAutomationSurfaceContract() {
             contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(".alert(item: rootAlertBinding)")
                 && contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("enum RootAlert")
                 && contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("case deleteConfirmation")
-                && contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("case deleteFailure")
-                && contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("case audioRetention"),
-            "the Home delete, delete-failure, and audio-retention alerts should present through one rootAlertBinding so none is shadowed"
+                && contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("case deleteFailure"),
+            "the Home delete and delete-failure alerts should present through one rootAlertBinding so neither is shadowed"
         )
         assertFalse(
             contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(".alert(item: $homeDeleteConfirmation)")
-                || contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(".alert(item: $homeDeleteFailure)")
-                || contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(".alert(item: $pendingAudioRetentionWindow)"),
+                || contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains(".alert(item: $homeDeleteFailure)"),
             "Home alerts must not be re-stacked as separate `.alert(item:)` modifiers — stacked legacy alerts shadow all but the last"
         )
+        assertTrue(
+            contractSource("Sources/UI/Settings/Pages/StorageSettingsPage.swift").contains(".alert(item: $pendingAudioRetentionWindow)"),
+            "audio-retention confirmation should stay on the Storage page that owns the picker"
+        )
         // The shared binding must dismiss only the active alert via
-        // HomeRootAlertPolicy, never clear all three. A confirm action can raise
+        // HomeRootAlertPolicy, never clear both. A confirm action can raise
         // a follow-up failure alert before SwiftUI writes nil; clearing
         // everything would wipe it before it presents. (HomeRootAlertPolicyTests
         // covers the priority/dismissal behavior directly.)
         assertTrue(
             contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("HomeRootAlertPolicy.activeSlot")
                 && contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift").contains("switch activeRootAlert"),
-            "the shared alert binding should clear only the dismissed alert through HomeRootAlertPolicy, not reset all three states"
+            "the shared alert binding should clear only the dismissed alert through HomeRootAlertPolicy, not reset both states"
         )
 
         // Own-file resolution contract (hardening/home-meeting-own-file-resolver).


### PR DESCRIPTION
## Summary
- let the Storage page own its temporary confirmation and disclosure state
- keep persisted preference changes and filesystem work behind parent callbacks
- narrow the Home root alert router to Home-only alerts
- update focused ownership and UI automation contracts

## Proof
- [x] Exact base: `7ddbb1e1`
- [x] `bash run-tests.sh` — 13,411/13,411 passed for the settings diff
- [x] `bash build.sh --no-open` — build, signing, launch smoke, and performance budget passed
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash scripts/ops/transcripted-qa-bench.sh --mode ui` — 3/3 passed (`qa-20260728-171717`)
- [x] Independent full-diff review: PASS at exact head `189c3861`
- [x] GitHub CI: all applicable checks passed

## Notes
The first UI QA attempt was invalid because a source comment changed while its build was running. The clean serialized rerun passed. Manual clicks through every destructive storage confirmation remain UNKNOWN; this PR does not claim hardware or user-interaction proof.

## Acceptance
- [x] Storage-local presentation state no longer lives in the settings shell
- [x] Home alert routing no longer knows about Storage confirmations
- [x] Persistent actions retain the existing parent callback boundary
- [x] Total UI code decreases rather than moving into a new abstraction