### PR TITLE
[settings] Remove unused page dependencies

### DIFF
--- a/Sources/UI/Settings/Pages/DictationsSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/DictationsSettingsPage.swift
@@ -2,12 +2,10 @@ import SwiftUI
 
 /// The Settings > Dictations page. Extracted from `TranscriptedSettingsView`
 /// (see `docs/` audit 2026-07-08 wave 2, spec W2-A). All the actual
-/// open/copy/flag/delete/track logic stays owned by the parent — this struct
-/// is a pure presentation wrapper that receives pre-built closures so
-/// behavior is unchanged.
+/// open/copy/flag/delete/track logic stays owned by the parent and arrives as
+/// focused closures.
 struct DictationsSettingsPage: View {
     @ObservedObject var homeViewModel: HomeViewModel
-    let actions: TranscriptedSettingsActions
     let homeCopiedRowID: String?
     let onStartDictation: () -> Void
     let onLoadMoreDictations: () -> Void

--- a/Sources/UI/Settings/Pages/SupportSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/SupportSettingsPage.swift
@@ -4,7 +4,6 @@ import SwiftUI
 /// (codebase audit 2026-07-08 wave 2, spec W2-A). Tracking and diagnostic
 /// dispatch stay owned by the parent and are passed in as closures.
 struct SupportSettingsPage: View {
-    let actions: TranscriptedSettingsActions
     let diagnosticsActionStatus: String?
     let crashReportingEnabled: Bool
     let onSubmitFeedback: () -> Void

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -674,7 +674,6 @@ struct TranscriptedSettingsView: View {
     private var dictationsPage: some View {
         DictationsSettingsPage(
             homeViewModel: homeViewModel,
-            actions: actions,
             homeCopiedRowID: homeCopiedRowID,
             onStartDictation: {
                 trackSettingsAction("empty_start_dictation", page: .dictations)
@@ -3695,7 +3694,6 @@ struct TranscriptedSettingsView: View {
 
     private var supportPage: some View {
         SupportSettingsPage(
-            actions: actions,
             diagnosticsActionStatus: diagnosticsActionStatus,
             crashReportingEnabled: crashReportingEnabled,
             onSubmitFeedback: {


### PR DESCRIPTION
## Summary
- stop passing the global settings action bundle into Dictations and Support pages that never read it
- keep the pages dependent only on the focused closures and values they actually use
- reduce settings coupling with no runtime behavior change

## Proof
- [x] exact base: `189c3861`
- [x] `git diff --check`
- [x] `bash run-tests.sh` on exact head — 13,412/13,412 passed
- [x] `bash build.sh --no-open` on product commit `6be03ef9` — build, signing, launch smoke, and performance budget passed; the later parent merge adds only a test assertion
- [x] independent full-diff review: PASS at exact head `d0b26963`
- [x] GitHub CI: all applicable checks passed

## Boundaries
- No user-facing behavior, persistence, audio, meeting, dictation, release, or packaging path changed.
- Manual hardware proof is not applicable to this dependency cleanup.