### PR TITLE
[settings] Remove unused action wiring

### DIFF
--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -150,16 +150,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         startDictation: { [weak self] in self?.startDictationFromSettings() },
         startMeeting: { [weak self] in self?.startMeetingFromSettings() },
         importAudioFile: { [weak self] in self?.importAudioFileFromSettings() },
-        pasteLastDictation: { [weak self] in self?.pasteLastDictationFromSettings() },
-        openConnectAgent: { [weak self] in self?.showSettingsWindow(page: .connectAgent, source: "settings_action") },
-        checkForUpdates: { [weak self] in self?.appState.sparkleUpdater.checkForUpdates() },
         sendFeedback: { [weak self] in
             guard let self else { return }
             TranscriptedSupportActions.sendFeedback(appState: self.appState)
-        },
-        copyDiagnostics: { [weak self] in
-            guard let self else { return false }
-            return TranscriptedSupportActions.copyDiagnostics(appState: self.appState)
         },
         sendDiagnosticEvent: { [weak self] in
             guard let self else { return nil }

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -91,7 +91,7 @@ onboarding connect stage. Both keep one mental model:
 - `Settings/SpeakerVoiceRowPresentation.swift` — Foundation-pure presentation/policy for the voice-to-name rows: the play/pause toggle state machine, overflow-menu actions, and name-autocomplete data source, kept view-free for unit tests
 - `Settings/TranscriptedSettingsGeneralControls.swift` — shared General-page headings, grouped rows, disclosure rows, and info popovers
 - `Settings/TranscriptedOnboardingWindowController.swift` — dedicated first-launch window that hosts onboarding before users drop into the menubar flow
-- `Settings/TranscriptedSettingsActions.swift` — struct of callbacks (start dictation, start meeting, import audio, paste, connect agent, check updates, send feedback, copy/send diagnostics) injected into the settings view
+- `Settings/TranscriptedSettingsActions.swift` — focused capture and support callbacks (start dictation, start meeting, import audio, send feedback, and send a diagnostic event) injected into the settings view
 - `Settings/TranscriptedSettingsComponents.swift` — shared SwiftUI building blocks (`SettingsPageIntro`, `SettingsSection`) used across settings pages
 - `Settings/TranscriptedSettingsNavigationModel.swift` — observable navigation state for the current `TranscriptedSettingsPage` selection
 - `Settings/TranscriptedSettingsPage.swift` — enum of window pages (home, dictations, people, connectAgent, plus the gear-gated settings pages) with titles, summaries, and SF Symbol names; legacy model, shortcut, and privacy cases remain deep-link aliases into General

--- a/Sources/UI/Settings/TranscriptedSettingsActions.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsActions.swift
@@ -5,10 +5,6 @@ struct TranscriptedSettingsActions {
     let startDictation: () -> Void
     let startMeeting: () -> Void
     let importAudioFile: () -> Void
-    let pasteLastDictation: () -> Void
-    let openConnectAgent: () -> Void
-    let checkForUpdates: () -> Void
     let sendFeedback: () -> Void
-    let copyDiagnostics: () -> Bool
     let sendDiagnosticEvent: () -> String?
 }


### PR DESCRIPTION
## Summary

- remove four action closures that no Settings page reads
- keep the live paste, agent, update, and diagnostics implementations unchanged
- reduce the Settings root wiring with no reachable behavior change

## Scope

This is the first net-deletion slice in the Settings root simplification sequence. It changes no audio, meeting, storage, or release behavior.

## Proof

- [x] Exact base: `eee07f29d127e47b330e1380d440d01806e75d9c`
- [x] Exact head: `aa2cb7ed13bd9d233d996688fa7b8a7008db2593`
- [x] `git diff --check`
- [x] `bash build.sh --no-open`
- [x] signed app and launch smoke passed (1164.9 ms)
- [x] `bash run-tests.sh` (13,412/13,412)
- [x] Independent exact-head review: PASS, no actionable findings
- [x] GitHub CI: all automated jobs passed

## Review notes

The independent reviewer verified that each removed field had no consumer beyond declaration and initialization. Paste, agent setup, updates, and diagnostics remain separately wired. No security or privacy regression was found.

## Manual proof

No manual hardware proof required: this only removes unreferenced closure fields. Real audio and meeting hardware behavior remains manual/unknown and unchanged.