### PR TITLE
Add canonical agent context contract

### DIFF
--- a/.agents/agent-contract.json
+++ b/.agents/agent-contract.json
@@ -80,6 +80,7 @@
     {
       "id": "meeting-core",
       "path_prefixes": ["Sources/TranscriptedCore/", "Tests/TranscriptedCoreTests/"],
+      "exact_paths": ["Package.swift"],
       "docs": ["Sources/TranscriptedCore/CLAUDE.md"],
       "keywords": ["transcriptedcore", "pipeline", "transcription queue", "speaker", "diarization", "imported audio"],
       "owns": "Reusable meeting transcription, audio processing, speaker logic, and queueing.",
@@ -140,7 +141,7 @@
     {
       "id": "beta-release",
       "path_prefixes": ["scripts/release/", "Casks/"],
-      "exact_paths": ["build-beta.sh", "docs/appcast.xml"],
+      "exact_paths": ["build-beta.sh", "scripts/entrypoints/build-beta.sh", "docs/appcast.xml"],
       "docs": ["docs/release-packaging.md", "docs/sparkle-updates.md"],
       "keywords": ["release", "beta", "signing", "notarization", "sparkle", "homebrew", "appcast"],
       "owns": "Distribution configuration, packaging, signing, notarization, Sparkle, and Homebrew.",

--- a/.agents/agent-contract.json
+++ b/.agents/agent-contract.json
@@ -141,7 +141,13 @@
     {
       "id": "beta-release",
       "path_prefixes": ["scripts/release/", "Casks/"],
-      "exact_paths": ["build-beta.sh", "scripts/entrypoints/build-beta.sh", "docs/appcast.xml"],
+      "exact_paths": [
+        "build-beta.sh",
+        "scripts/entrypoints/build-beta.sh",
+        "docs/appcast.xml",
+        "docs/release-packaging.md",
+        "docs/sparkle-updates.md"
+      ],
       "docs": ["docs/release-packaging.md", "docs/sparkle-updates.md"],
       "keywords": ["release", "beta", "signing", "notarization", "sparkle", "homebrew", "appcast"],
       "owns": "Distribution configuration, packaging, signing, notarization, Sparkle, and Homebrew.",
@@ -199,6 +205,99 @@
       "invariants": [
         "Reports must stay bounded and privacy-safe.",
         "Fixture proof and live-service proof must be labeled separately."
+      ],
+      "manual_proof": []
+    },
+    {
+      "id": "app-shell",
+      "path_prefixes": ["Sources/"],
+      "fallback": true,
+      "docs": ["Sources/CLAUDE.md"],
+      "keywords": ["app shell", "app delegate", "bootstrap", "application state"],
+      "owns": "Top-level application bootstrap, shared app state, and subsystem wiring.",
+      "invariants": [
+        "Keep product decisions in the owning subsystem instead of the app shell.",
+        "Preserve the TranscriptedCore library boundary."
+      ],
+      "manual_proof": ["Real app launch and menu-bar behavior when bootstrap wiring changes."]
+    },
+    {
+      "id": "build-system",
+      "path_prefixes": ["scripts/entrypoints/"],
+      "exact_paths": [
+        "build-deps.sh",
+        "build.sh",
+        "build-beta.sh",
+        "run-tests.sh",
+        "run-integration-smoke.sh",
+        "run-e2e-smoke.sh",
+        "run-slow-pasteback-smoke.sh",
+        "run-live-capture-smoke.sh",
+        "run-daily-audio-reliability.sh"
+      ],
+      "docs": ["scripts/README.md"],
+      "keywords": ["build", "dependency", "entrypoint", "test runner"],
+      "owns": "Root build and test wrappers plus their canonical entrypoints.",
+      "invariants": [
+        "Keep root wrappers thin and preserve non-interactive agent entrypoints.",
+        "Run build and test commands sequentially because they share build output."
+      ],
+      "manual_proof": []
+    },
+    {
+      "id": "scripts",
+      "path_prefixes": ["scripts/"],
+      "fallback": true,
+      "docs": ["scripts/README.md"],
+      "keywords": ["script", "automation"],
+      "owns": "Repository automation not owned by a narrower build, development, operations, or release area.",
+      "invariants": [
+        "Do not add an unconsumed script.",
+        "Keep automation non-interactive when it is part of an agent proof path."
+      ],
+      "manual_proof": []
+    },
+    {
+      "id": "documentation",
+      "path_prefixes": ["docs/"],
+      "exact_paths": [
+        "README.md",
+        "CHANGELOG.md",
+        "CODE_OF_CONDUCT.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md"
+      ],
+      "docs": ["docs/docs.md"],
+      "keywords": ["documentation", "readme", "guide"],
+      "owns": "Product, engineering, support, and release documentation.",
+      "invariants": [
+        "Current source and machine-readable contracts outrank dated planning documents.",
+        "Do not duplicate executable check rules in prose."
+      ],
+      "manual_proof": []
+    },
+    {
+      "id": "resources-config",
+      "path_prefixes": ["Resources/", "config/"],
+      "docs": ["docs/repo-layout.md"],
+      "keywords": ["resource", "entitlement", "configuration", "asset"],
+      "owns": "Bundled resources, app assets, entitlements, and security configuration.",
+      "invariants": [
+        "Never commit secrets or private customer data.",
+        "Keep bundled runtime resources aligned with packaging proof."
+      ],
+      "manual_proof": ["Installed-app resource loading when packaged assets change."]
+    },
+    {
+      "id": "repository-fallback",
+      "path_prefixes": [""],
+      "fallback": true,
+      "docs": ["docs/repo-layout.md"],
+      "keywords": ["repository", "metadata", "license"],
+      "owns": "Repository metadata and uncommon paths without a narrower subsystem owner.",
+      "invariants": [
+        "Find the nearest concrete consumer before changing an uncommon path.",
+        "Do not infer product behavior from archived or generated material."
       ],
       "manual_proof": []
     }

--- a/.agents/agent-contract.json
+++ b/.agents/agent-contract.json
@@ -1,0 +1,205 @@
+{
+  "schema_version": 1,
+  "start_doc": "AGENT_START.md",
+  "test_matrix": ".agents/test-matrix.yml",
+  "proof_classes": {
+    "deterministic": "A command completed against the exact branch head.",
+    "hosted": "A hosted CI, release, or telemetry surface was checked separately.",
+    "manual": "A person verified real UI, audio hardware, permissions, or another client.",
+    "unknown": "Required proof was not run or could not run. Unknown is never green."
+  },
+  "global_invariants": [
+    "Keep Transcripted local-first.",
+    "Never send or print private transcript text, audio references, meeting titles, speaker names, emails, tokens, absolute paths, raw URLs, or raw device names.",
+    "Keep Sources/TranscriptedCore as a library boundary consumed through Sources/Meeting.",
+    "Run mapped checks sequentially because build.sh and run-tests.sh share build output.",
+    "Keep deterministic, hosted, and manual proof separate.",
+    "Do not claim real microphone, system-audio, Bluetooth, pasteback, or UI proof from synthetic tests."
+  ],
+  "areas": [
+    {
+      "id": "accessibility",
+      "path_prefixes": ["Sources/Accessibility/"],
+      "docs": ["Sources/Accessibility/CLAUDE.md"],
+      "keywords": ["accessibility", "ax", "focus", "focused editor", "overlay placement", "paste target"],
+      "owns": "Focused-editor metadata, AX reads, and overlay placement context.",
+      "invariants": [
+        "Re-resolve the destination before writing.",
+        "Do not infer real pasteback success from overlay placement alone."
+      ],
+      "manual_proof": ["Focused-app and pasteback behavior in the real target app."]
+    },
+    {
+      "id": "capture",
+      "path_prefixes": ["Sources/Capture/"],
+      "docs": ["Sources/Capture/CLAUDE.md"],
+      "keywords": ["hotkey", "shortcut", "keyboard", "physical trigger"],
+      "owns": "Global hotkeys and physical dictation trigger routing.",
+      "invariants": ["Preserve key-up/key-down ordering and wake recovery."],
+      "manual_proof": ["Global shortcut behavior with real Accessibility permission."]
+    },
+    {
+      "id": "dictation",
+      "path_prefixes": ["Sources/Dictation/", "Sources/UI/Overlay/"],
+      "docs": ["Sources/Dictation/CLAUDE.md", "Sources/UI/CLAUDE.md"],
+      "keywords": ["dictation", "pasteback", "clipboard", "auto enter", "overlay", "no speech"],
+      "owns": "Dictation lifecycle, persistence, overlay state, pasteback orchestration, and timeout helpers.",
+      "invariants": [
+        "Restore the clipboard after pasteback.",
+        "Save agent-readable Markdown even when pasteback cannot be confirmed.",
+        "Keep stop and cancellation idempotent."
+      ],
+      "manual_proof": ["Real microphone capture and pasteback in representative target apps."]
+    },
+    {
+      "id": "speech",
+      "path_prefixes": ["Sources/Speech/"],
+      "docs": ["Sources/Speech/CLAUDE.md", "docs/audio-reliability-daily-check.md"],
+      "keywords": ["speech", "stt", "model download", "model readiness", "parakeet", "bluetooth", "airpods", "audio route", "microphone"],
+      "owns": "Local STT, model provisioning, microphone capture, device routing, and audio recovery.",
+      "invariants": [
+        "Model installation must be atomic and recoverable.",
+        "Audio route changes must not silently strand an active capture.",
+        "Never treat a synthetic source as real hardware proof."
+      ],
+      "manual_proof": ["Model download on a clean machine, microphone capture, and Bluetooth route changes."]
+    },
+    {
+      "id": "meeting-app",
+      "path_prefixes": ["Sources/Meeting/"],
+      "docs": ["Sources/Meeting/CLAUDE.md", "docs/qa-issue-500-meeting-audio.md"],
+      "keywords": ["meeting", "zoom", "google meet", "system audio", "quiet mic", "meeting prompt", "retained audio"],
+      "owns": "App-side meeting state, meeting prompts, capture bridge, retries, and saved-meeting UI.",
+      "invariants": [
+        "Keep mic and system-audio evidence distinct.",
+        "Retain recoverable audio when transcription fails.",
+        "Expose failed or queued work instead of silently dropping it."
+      ],
+      "manual_proof": ["A real Zoom or Meet session with microphone and system audio."]
+    },
+    {
+      "id": "meeting-core",
+      "path_prefixes": ["Sources/TranscriptedCore/", "Tests/TranscriptedCoreTests/"],
+      "docs": ["Sources/TranscriptedCore/CLAUDE.md"],
+      "keywords": ["transcriptedcore", "pipeline", "transcription queue", "speaker", "diarization", "imported audio"],
+      "owns": "Reusable meeting transcription, audio processing, speaker logic, and queueing.",
+      "invariants": [
+        "The app consumes this library through Sources/Meeting.",
+        "Public package behavior requires swift test and integration smoke.",
+        "Retries and task state must remain deterministic."
+      ],
+      "manual_proof": ["Imported-audio output quality when fixture proof is insufficient."]
+    },
+    {
+      "id": "support",
+      "path_prefixes": ["Sources/Support/"],
+      "docs": ["Sources/Support/CLAUDE.md", "docs/storage-paths.md"],
+      "keywords": ["preferences", "permissions", "storage", "path", "clipboard", "launch", "install"],
+      "owns": "Shared preferences, permissions, paths, paste helpers, and launch behavior.",
+      "invariants": [
+        "Keep app-owned state under Transcripted Application Support.",
+        "Preserve legacy migration fallbacks without writing new data to legacy paths."
+      ],
+      "manual_proof": ["macOS permission prompts and target-app paste behavior when touched."]
+    },
+    {
+      "id": "ui",
+      "path_prefixes": ["Sources/UI/"],
+      "docs": ["Sources/UI/CLAUDE.md"],
+      "keywords": ["ui", "menu bar", "home", "settings", "onboarding", "agent connect"],
+      "owns": "Menu bar, Home, Settings, onboarding, overlay presentation, and agent-connect UI.",
+      "invariants": [
+        "Keep UI state backed by the owning runtime state.",
+        "Do not claim visual correctness without a real UI check."
+      ],
+      "manual_proof": ["Visual layout, navigation, and permission-dependent controls."]
+    },
+    {
+      "id": "observability",
+      "path_prefixes": ["Sources/Observability/"],
+      "exact_paths": ["Info.plist"],
+      "docs": ["Sources/Observability/CLAUDE.md", "docs/privacy-first-observability.md"],
+      "keywords": ["sentry", "posthog", "analytics", "telemetry", "crash", "sparkle", "update"],
+      "owns": "Local diagnostics, bounded Sentry/PostHog forwarding, and app updates.",
+      "invariants": [
+        "Only allowlisted, sanitized events may leave the device.",
+        "Aggregate telemetry cannot prove an individual hardware flow.",
+        "Settings must preserve user-facing telemetry controls."
+      ],
+      "manual_proof": ["Live integration delivery when production configuration changes."]
+    },
+    {
+      "id": "reliability",
+      "path_prefixes": ["Sources/Reliability/"],
+      "docs": ["Sources/Reliability/CLAUDE.md"],
+      "keywords": ["wake", "sleep", "recovery", "resume", "hotkey recovery"],
+      "owns": "Wake, sleep, hotkey, and active-capture recovery.",
+      "invariants": ["Recovery must be idempotent and must not duplicate active capture state."],
+      "manual_proof": ["Real sleep and wake during representative app states."]
+    },
+    {
+      "id": "beta-release",
+      "path_prefixes": ["scripts/release/", "Casks/"],
+      "exact_paths": ["build-beta.sh", "docs/appcast.xml"],
+      "docs": ["docs/release-packaging.md", "docs/sparkle-updates.md"],
+      "keywords": ["release", "beta", "signing", "notarization", "sparkle", "homebrew", "appcast"],
+      "owns": "Distribution configuration, packaging, signing, notarization, Sparkle, and Homebrew.",
+      "invariants": [
+        "A DMG alone is not a complete release.",
+        "Release, appcast, download redirect, and Homebrew truth must agree.",
+        "Do not publish, tag, notarize, or update release surfaces without explicit authorization."
+      ],
+      "manual_proof": ["Installed-app update and launch behavior on a clean machine."]
+    },
+    {
+      "id": "tests",
+      "path_prefixes": ["Tests/"],
+      "docs": ["Tests/README.md"],
+      "keywords": ["test", "fast tests", "integration", "e2e", "fixture", "qa"],
+      "owns": "Fast tests, package tests, deterministic smoke fixtures, and test contracts.",
+      "invariants": [
+        "Fast tests use convention discovery, not a hand-maintained manifest.",
+        "Skipped permission or hardware proof remains unknown."
+      ],
+      "manual_proof": []
+    },
+    {
+      "id": "agent-workflow",
+      "path_prefixes": [".agents/", ".github/", "scripts/dev/"],
+      "exact_paths": ["AGENT_START.md", "AGENTS.md", "CLAUDE.md", "WORKFLOW.md"],
+      "docs": ["AGENT_START.md", "docs/agent-closeout.md"],
+      "keywords": ["agent", "codex", "claude", "preflight", "workflow", "review", "context"],
+      "owns": "Agent routing, path-to-check selection, review policy, and handoff proof.",
+      "invariants": [
+        "Use one machine-readable source for ownership and proof routing.",
+        "Do not duplicate executable check rules in prose.",
+        "Scale orchestration with risk instead of file count alone."
+      ],
+      "manual_proof": []
+    },
+    {
+      "id": "tools",
+      "path_prefixes": ["Tools/"],
+      "docs": ["Tools/README.md"],
+      "keywords": ["cli", "mcp", "qa tool", "capture kit", "speaker eval"],
+      "owns": "Standalone CLI, MCP, QA, capture-kit, and evaluation packages.",
+      "invariants": [
+        "Tools remain local-first and consume saved artifacts through documented seams.",
+        "Run the owning package tests for every tool change."
+      ],
+      "manual_proof": ["Host-client connection behavior for MCP or installed tooling changes."]
+    },
+    {
+      "id": "scripts-ops",
+      "path_prefixes": ["scripts/ops/"],
+      "docs": ["scripts/README.md"],
+      "keywords": ["operations", "qa bench", "health", "nightly", "report"],
+      "owns": "Operational QA, health, security, privacy, and reporting commands.",
+      "invariants": [
+        "Reports must stay bounded and privacy-safe.",
+        "Fixture proof and live-service proof must be labeled separately."
+      ],
+      "manual_proof": []
+    }
+  ]
+}

--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -118,6 +118,14 @@ rules:
       - "python3 scripts/dev/check-build-source-lists.py"
 
   - paths:
+      - ".agents/agent-contract.json"
+      - "scripts/dev/agent-context.py"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "python3 -m py_compile scripts/dev/agent-context.py"
+      - "python3 scripts/dev/agent-context.py --self-test"
+
+  - paths:
       - ".agents/test-matrix.yml"
       - "scripts/dev/agent-preflight.sh"
       - "scripts/dev/test-matrix-checks.py"
@@ -402,6 +410,7 @@ rules:
       - ".agents/**"
       - ".github/**"
       - "scripts/dev/agent-preflight.sh"
+      - "scripts/dev/agent-context.py"
       - "scripts/dev/test-matrix-checks.py"
     checks:
       - "scripts/dev/agent-preflight.sh"

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -35,6 +35,10 @@ jobs:
         shell: bash
         run: python3 scripts/dev/test-matrix-checks.py --self-test
 
+      - name: Agent contract
+        shell: bash
+        run: python3 scripts/dev/agent-context.py --self-test
+
       - name: Shell syntax
         shell: bash
         run: |

--- a/AGENT_START.md
+++ b/AGENT_START.md
@@ -61,8 +61,12 @@ Common routing shortcuts:
 
 ## Verification
 
-Use `scripts/dev/agent-preflight.sh` to inspect the branch and get suggested
-checks for the files changed.
+Use `python3 scripts/dev/agent-context.py` to get the owner docs, invariants,
+mapped checks, and manual-proof boundaries for the files changed. Add
+`--symptom "short description"` when the failing area is unclear.
+
+Use `scripts/dev/agent-preflight.sh` to inspect the branch before editing or
+handing it off.
 
 Default rules:
 

--- a/scripts/dev/agent-context.py
+++ b/scripts/dev/agent-context.py
@@ -151,6 +151,27 @@ def area_matches_symptom(area: dict[str, Any], symptom: str) -> bool:
     )
 
 
+def normalize_repo_path(raw_path: str) -> str:
+    candidate = Path(raw_path)
+    resolved = candidate.resolve(strict=False) if candidate.is_absolute() else (
+        REPO_ROOT / candidate
+    ).resolve(strict=False)
+    try:
+        return resolved.relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError as error:
+        raise ContractError(f"path is outside the repo: {raw_path}") from error
+
+
+def nearest_local_doc(path: str) -> str | None:
+    current = (REPO_ROOT / path).parent
+    while current != REPO_ROOT and REPO_ROOT in current.parents:
+        guide = current / "CLAUDE.md"
+        if guide.is_file():
+            return guide.relative_to(REPO_ROOT).as_posix()
+        current = current.parent
+    return None
+
+
 def select_areas(
     contract: dict[str, Any], paths: list[str], symptom: str | None
 ) -> list[dict[str, Any]]:
@@ -189,6 +210,7 @@ def build_context(
 ) -> dict[str, Any]:
     areas = select_areas(contract, paths, symptom)
     docs = [contract["start_doc"]]
+    docs.extend(guide for path in paths if (guide := nearest_local_doc(path)))
     invariants = list(contract["global_invariants"])
     manual_proof: list[str] = []
     for area in areas:
@@ -270,6 +292,16 @@ def self_test(contract_path: Path) -> None:
     }
     if "ui" in unrelated_ids:
         raise ContractError("short symptom keywords must match on word boundaries")
+    sample_path = "Sources/Speech/ParakeetEngine.swift"
+    if normalize_repo_path(f"./{sample_path}") != sample_path:
+        raise ContractError("relative paths must normalize before routing")
+    if normalize_repo_path(str(REPO_ROOT / sample_path)) != sample_path:
+        raise ContractError("absolute repo paths must normalize before routing")
+    nested_context = build_context(
+        contract, ["Tools/TranscriptedMCP/Sources/TranscriptedMCP/Server.swift"], None
+    )
+    if "Tools/TranscriptedMCP/CLAUDE.md" not in nested_context["docs"]:
+        raise ContractError("nested paths must include their nearest local guide")
     try:
         changed_paths("refs/heads/__agent_context_missing_base__")
     except ContractError:
@@ -295,7 +327,11 @@ def main() -> int:
             return 0
         contract = load_contract(args.contract)
         validate_contract(contract, REPO_ROOT)
-        paths = sorted(set(args.paths or changed_paths(args.base)))
+        paths = sorted(
+            {normalize_repo_path(path) for path in args.paths}
+            if args.paths
+            else changed_paths(args.base)
+        )
         context = build_context(contract, paths, args.symptom)
         if args.json:
             print(json.dumps(context, indent=2, sort_keys=True))

--- a/scripts/dev/agent-context.py
+++ b/scripts/dev/agent-context.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Print bounded, machine-backed context for a Transcripted change or symptom."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONTRACT = REPO_ROOT / ".agents/agent-contract.json"
+MATRIX_SELECTOR = REPO_ROOT / "scripts/dev/test-matrix-checks.py"
+
+
+class ContractError(ValueError):
+    pass
+
+
+def load_contract(path: Path) -> dict[str, Any]:
+    try:
+        contract = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ContractError(f"invalid JSON: {error.msg}") from error
+    if not isinstance(contract, dict):
+        raise ContractError("contract root must be an object")
+    if contract.get("schema_version") != 1:
+        raise ContractError("schema_version must be 1")
+    areas = contract.get("areas")
+    if not isinstance(areas, list) or not areas:
+        raise ContractError("areas must be a non-empty list")
+    return contract
+
+
+def validate_contract(contract: dict[str, Any], repo_root: Path) -> None:
+    required_root = {
+        "schema_version",
+        "start_doc",
+        "test_matrix",
+        "proof_classes",
+        "global_invariants",
+        "areas",
+    }
+    missing_root = required_root.difference(contract)
+    if missing_root:
+        raise ContractError(f"missing root keys: {sorted(missing_root)}")
+
+    referenced_files = [contract["start_doc"], contract["test_matrix"]]
+    area_ids: set[str] = set()
+    path_claims = 0
+    for index, area in enumerate(contract["areas"]):
+        if not isinstance(area, dict):
+            raise ContractError(f"area {index} must be an object")
+        required_area = {
+            "id",
+            "path_prefixes",
+            "docs",
+            "keywords",
+            "owns",
+            "invariants",
+            "manual_proof",
+        }
+        missing_area = required_area.difference(area)
+        if missing_area:
+            raise ContractError(f"area {index} is missing keys: {sorted(missing_area)}")
+        area_id = area["id"]
+        if not isinstance(area_id, str) or not area_id:
+            raise ContractError(f"area {index} has an invalid id")
+        if area_id in area_ids:
+            raise ContractError(f"duplicate area id: {area_id}")
+        area_ids.add(area_id)
+        for list_key in ("path_prefixes", "docs", "keywords", "invariants", "manual_proof"):
+            value = area[list_key]
+            if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+                raise ContractError(f"{area_id}.{list_key} must be a string list")
+        exact_paths = area.get("exact_paths", [])
+        if not isinstance(exact_paths, list) or any(not isinstance(item, str) for item in exact_paths):
+            raise ContractError(f"{area_id}.exact_paths must be a string list")
+        path_claims += len(area["path_prefixes"]) + len(exact_paths)
+        referenced_files.extend(area["docs"])
+
+    if len(area_ids) < 12 or path_claims < 20:
+        raise ContractError("contract is too small to describe the live repo")
+    for relative_path in sorted(set(referenced_files)):
+        if not (repo_root / relative_path).exists():
+            raise ContractError(f"referenced file does not exist: {relative_path}")
+
+
+def _git_lines(*arguments: str) -> list[str]:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def changed_paths(base_ref: str) -> list[str]:
+    merge_base_result = subprocess.run(
+        ["git", "merge-base", "HEAD", base_ref],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    diff_base = merge_base_result.stdout.strip() if merge_base_result.returncode == 0 else base_ref
+    paths = set(_git_lines("diff", "--name-only", f"{diff_base}...HEAD"))
+    paths.update(_git_lines("diff", "--cached", "--name-only"))
+    paths.update(_git_lines("diff", "--name-only"))
+    paths.update(_git_lines("ls-files", "--others", "--exclude-standard"))
+    return sorted(paths)
+
+
+def area_matches_path(area: dict[str, Any], path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in area["path_prefixes"]) or path in area.get(
+        "exact_paths", []
+    )
+
+
+def area_matches_symptom(area: dict[str, Any], symptom: str) -> bool:
+    lowered = symptom.casefold()
+    return any(keyword.casefold() in lowered for keyword in area["keywords"])
+
+
+def select_areas(
+    contract: dict[str, Any], paths: list[str], symptom: str | None
+) -> list[dict[str, Any]]:
+    selected = []
+    for area in contract["areas"]:
+        if any(area_matches_path(area, path) for path in paths) or (
+            symptom and area_matches_symptom(area, symptom)
+        ):
+            selected.append(area)
+    return selected
+
+
+def select_checks(contract: dict[str, Any], paths: list[str]) -> list[str]:
+    if not paths:
+        return []
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(MATRIX_SELECTOR),
+            "--matrix",
+            str(REPO_ROOT / contract["test_matrix"]),
+            *paths,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ContractError(result.stderr.strip() or "test matrix selection failed")
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def build_context(
+    contract: dict[str, Any], paths: list[str], symptom: str | None
+) -> dict[str, Any]:
+    areas = select_areas(contract, paths, symptom)
+    docs = [contract["start_doc"]]
+    invariants = list(contract["global_invariants"])
+    manual_proof: list[str] = []
+    for area in areas:
+        docs.extend(area["docs"])
+        invariants.extend(area["invariants"])
+        manual_proof.extend(area["manual_proof"])
+    return {
+        "schema_version": contract["schema_version"],
+        "paths": paths,
+        "areas": [{"id": area["id"], "owns": area["owns"]} for area in areas],
+        "docs": list(dict.fromkeys(docs)),
+        "invariants": list(dict.fromkeys(invariants)),
+        "checks": select_checks(contract, paths),
+        "manual_proof": list(dict.fromkeys(manual_proof)),
+        "proof_classes": contract["proof_classes"],
+    }
+
+
+def print_human(context: dict[str, Any]) -> None:
+    print("Transcripted agent context")
+    print()
+    print("Changed paths:")
+    for path in context["paths"]:
+        print(f"- {path}")
+    if not context["paths"]:
+        print("- none")
+    print()
+    print("Owners:")
+    for area in context["areas"]:
+        print(f"- {area['id']}: {area['owns']}")
+    if not context["areas"]:
+        print("- no matching area; use AGENT_START.md and inspect the nearest owner")
+    print()
+    print("Read:")
+    for doc in context["docs"]:
+        print(f"- {doc}")
+    print()
+    print("Keep true:")
+    for invariant in context["invariants"]:
+        print(f"- {invariant}")
+    print()
+    print("Mapped checks:")
+    for check in context["checks"]:
+        print(f"- {check}")
+    if not context["checks"]:
+        print("- scripts/dev/agent-preflight.sh")
+    print()
+    print("Manual or hardware proof:")
+    for proof in context["manual_proof"]:
+        print(f"- UNKNOWN until verified: {proof}")
+    if not context["manual_proof"]:
+        print("- none mapped")
+
+
+def self_test(contract_path: Path) -> None:
+    contract = load_contract(contract_path)
+    validate_contract(contract, REPO_ROOT)
+    cases = {
+        "Sources/Speech/ParakeetEngine.swift": {"speech"},
+        "Sources/Meeting/MeetingSessionController.swift": {"meeting-app"},
+        "Sources/TranscriptedCore/Audio/Audio.swift": {"meeting-core"},
+        "Tools/TranscriptedMCP/Package.swift": {"tools"},
+        "AGENTS.md": {"agent-workflow"},
+    }
+    for path, expected_ids in cases.items():
+        actual_ids = {area["id"] for area in select_areas(contract, [path], None)}
+        missing = expected_ids.difference(actual_ids)
+        if missing:
+            raise ContractError(f"{path} is missing owners: {sorted(missing)}")
+    symptom_ids = {
+        area["id"] for area in select_areas(contract, [], "model download stuck with AirPods")
+    }
+    if "speech" not in symptom_ids:
+        raise ContractError("symptom routing did not select speech")
+    print("Agent contract self-test passed.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="repo-relative paths")
+    parser.add_argument("--base", default="origin/main", help="base ref for automatic change detection")
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--symptom", help="short symptom description; never persisted")
+    parser.add_argument("--json", action="store_true", help="emit bounded JSON")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.self_test:
+            self_test(args.contract)
+            return 0
+        contract = load_contract(args.contract)
+        validate_contract(contract, REPO_ROOT)
+        paths = sorted(set(args.paths or changed_paths(args.base)))
+        context = build_context(contract, paths, args.symptom)
+        if args.json:
+            print(json.dumps(context, indent=2, sort_keys=True))
+        else:
+            print_human(context)
+        return 0
+    except (OSError, ContractError) as error:
+        print(f"Agent context failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/agent-context.py
+++ b/scripts/dev/agent-context.py
@@ -199,7 +199,7 @@ def normalize_repo_path(raw_path: str) -> str:
     try:
         return resolved.relative_to(REPO_ROOT.resolve()).as_posix()
     except ValueError as error:
-        raise ContractError(f"path is outside the repo: {raw_path}") from error
+        raise ContractError("path is outside the repo") from error
 
 
 def nearest_local_doc(path: str) -> str | None:
@@ -370,6 +370,14 @@ def self_test(contract_path: Path) -> None:
         raise ContractError("relative paths must normalize before routing")
     if normalize_repo_path(str(REPO_ROOT / sample_path)) != sample_path:
         raise ContractError("absolute repo paths must normalize before routing")
+    outside_path = REPO_ROOT.parent / "private-customer-data.txt"
+    try:
+        normalize_repo_path(str(outside_path))
+    except ContractError as error:
+        if str(outside_path) in str(error):
+            raise ContractError("outside-repo errors must not echo absolute paths") from error
+    else:
+        raise ContractError("outside-repo paths must fail closed")
     nested_context = build_context(
         contract, ["Tools/TranscriptedMCP/Sources/TranscriptedMCP/Server.swift"], None
     )

--- a/scripts/dev/agent-context.py
+++ b/scripts/dev/agent-context.py
@@ -48,6 +48,20 @@ def validate_contract(contract: dict[str, Any], repo_root: Path) -> None:
     missing_root = required_root.difference(contract)
     if missing_root:
         raise ContractError(f"missing root keys: {sorted(missing_root)}")
+    for path_key in ("start_doc", "test_matrix"):
+        if not isinstance(contract[path_key], str) or not contract[path_key]:
+            raise ContractError(f"{path_key} must be a non-empty string")
+    proof_classes = contract["proof_classes"]
+    required_proof_classes = {"deterministic", "hosted", "manual", "unknown"}
+    if not isinstance(proof_classes, dict) or required_proof_classes.difference(proof_classes):
+        raise ContractError("proof_classes must define deterministic, hosted, manual, and unknown")
+    if any(not isinstance(value, str) or not value for value in proof_classes.values()):
+        raise ContractError("proof_classes values must be non-empty strings")
+    global_invariants = contract["global_invariants"]
+    if not isinstance(global_invariants, list) or any(
+        not isinstance(item, str) or not item for item in global_invariants
+    ):
+        raise ContractError("global_invariants must be a non-empty string list")
 
     referenced_files = [contract["start_doc"], contract["test_matrix"]]
     area_ids: set[str] = set()
@@ -73,12 +87,27 @@ def validate_contract(contract: dict[str, Any], repo_root: Path) -> None:
         if area_id in area_ids:
             raise ContractError(f"duplicate area id: {area_id}")
         area_ids.add(area_id)
+        owns = area["owns"]
+        if not isinstance(owns, str) or not owns:
+            raise ContractError(f"{area_id}.owns must be a non-empty string")
+        fallback = area.get("fallback", False)
+        if not isinstance(fallback, bool):
+            raise ContractError(f"{area_id}.fallback must be a boolean")
         for list_key in ("path_prefixes", "docs", "keywords", "invariants", "manual_proof"):
             value = area[list_key]
-            if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            if not isinstance(value, list) or any(
+                not isinstance(item, str) or (not item and list_key != "path_prefixes")
+                for item in value
+            ):
                 raise ContractError(f"{area_id}.{list_key} must be a string list")
+        if not area["path_prefixes"] and not area.get("exact_paths"):
+            raise ContractError(f"{area_id} must claim at least one path")
+        if "" in area["path_prefixes"] and not fallback:
+            raise ContractError(f"{area_id} may use an empty prefix only as a fallback")
         exact_paths = area.get("exact_paths", [])
-        if not isinstance(exact_paths, list) or any(not isinstance(item, str) for item in exact_paths):
+        if not isinstance(exact_paths, list) or any(
+            not isinstance(item, str) or not item for item in exact_paths
+        ):
             raise ContractError(f"{area_id}.exact_paths must be a string list")
         path_claims += len(area["path_prefixes"]) + len(exact_paths)
         referenced_files.extend(area["docs"])
@@ -138,8 +167,10 @@ def changed_paths(base_ref: str) -> list[str]:
 
 
 def area_matches_path(area: dict[str, Any], path: str) -> bool:
-    return any(path.startswith(prefix) for prefix in area["path_prefixes"]) or path in area.get(
-        "exact_paths", []
+    return (
+        any(path.startswith(prefix) for prefix in area["path_prefixes"])
+        or path in area.get("exact_paths", [])
+        or path in area["docs"]
     )
 
 
@@ -175,13 +206,21 @@ def nearest_local_doc(path: str) -> str | None:
 def select_areas(
     contract: dict[str, Any], paths: list[str], symptom: str | None
 ) -> list[dict[str, Any]]:
-    selected = []
+    selected_ids: set[str] = set()
+    specific_areas = [area for area in contract["areas"] if not area.get("fallback", False)]
+    fallback_areas = [area for area in contract["areas"] if area.get("fallback", False)]
+
+    for path in paths:
+        path_matches = [area for area in specific_areas if area_matches_path(area, path)]
+        if not path_matches:
+            path_matches = [area for area in fallback_areas if area_matches_path(area, path)]
+        selected_ids.update(area["id"] for area in path_matches)
+
     for area in contract["areas"]:
-        if any(area_matches_path(area, path) for path in paths) or (
-            symptom and area_matches_symptom(area, symptom)
-        ):
-            selected.append(area)
-    return selected
+        if symptom and area_matches_symptom(area, symptom):
+            selected_ids.add(area["id"])
+
+    return [area for area in contract["areas"] if area["id"] in selected_ids]
 
 
 def select_checks(contract: dict[str, Any], paths: list[str]) -> list[str]:
@@ -272,8 +311,15 @@ def self_test(contract_path: Path) -> None:
         "Sources/Speech/ParakeetEngine.swift": {"speech"},
         "Sources/Meeting/MeetingSessionController.swift": {"meeting-app"},
         "Sources/TranscriptedCore/Audio/Audio.swift": {"meeting-core"},
+        "Sources/TranscriptedApp.swift": {"app-shell"},
         "Package.swift": {"meeting-core"},
-        "scripts/entrypoints/build-beta.sh": {"beta-release"},
+        "build.sh": {"build-system"},
+        "scripts/entrypoints/build-beta.sh": {"beta-release", "build-system"},
+        "scripts/download_ami.sh": {"scripts"},
+        "docs/agent-onboarding.md": {"documentation"},
+        "docs/release-packaging.md": {"beta-release", "documentation"},
+        "Resources/Transcripted.icns": {"resources-config"},
+        "archive/README.md": {"repository-fallback"},
         "Tools/TranscriptedMCP/Package.swift": {"tools"},
         "AGENTS.md": {"agent-workflow"},
     }
@@ -302,6 +348,12 @@ def self_test(contract_path: Path) -> None:
     )
     if "Tools/TranscriptedMCP/CLAUDE.md" not in nested_context["docs"]:
         raise ContractError("nested paths must include their nearest local guide")
+    tracked_paths = _git_lines("ls-files")
+    unmapped_paths = [
+        path for path in tracked_paths if not select_areas(contract, [path], None)
+    ]
+    if unmapped_paths:
+        raise ContractError(f"tracked paths without an owner: {unmapped_paths[:5]}")
     try:
         changed_paths("refs/heads/__agent_context_missing_base__")
     except ContractError:

--- a/scripts/dev/agent-context.py
+++ b/scripts/dev/agent-context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -103,6 +104,15 @@ def _git_lines(*arguments: str) -> list[str]:
 
 
 def changed_paths(base_ref: str) -> list[str]:
+    verify_result = subprocess.run(
+        ["git", "rev-parse", "--verify", base_ref],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if verify_result.returncode != 0:
+        raise ContractError(f"base ref does not exist: {base_ref}")
     merge_base_result = subprocess.run(
         ["git", "merge-base", "HEAD", base_ref],
         cwd=REPO_ROOT,
@@ -111,7 +121,16 @@ def changed_paths(base_ref: str) -> list[str]:
         text=True,
     )
     diff_base = merge_base_result.stdout.strip() if merge_base_result.returncode == 0 else base_ref
-    paths = set(_git_lines("diff", "--name-only", f"{diff_base}...HEAD"))
+    committed_diff = subprocess.run(
+        ["git", "diff", "--name-only", f"{diff_base}...HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if committed_diff.returncode != 0:
+        raise ContractError(f"could not compare HEAD with base ref: {base_ref}")
+    paths = {line.strip() for line in committed_diff.stdout.splitlines() if line.strip()}
     paths.update(_git_lines("diff", "--cached", "--name-only"))
     paths.update(_git_lines("diff", "--name-only"))
     paths.update(_git_lines("ls-files", "--others", "--exclude-standard"))
@@ -126,7 +145,10 @@ def area_matches_path(area: dict[str, Any], path: str) -> bool:
 
 def area_matches_symptom(area: dict[str, Any], symptom: str) -> bool:
     lowered = symptom.casefold()
-    return any(keyword.casefold() in lowered for keyword in area["keywords"])
+    return any(
+        re.search(rf"(?<!\w){re.escape(keyword.casefold())}(?!\w)", lowered)
+        for keyword in area["keywords"]
+    )
 
 
 def select_areas(
@@ -228,6 +250,8 @@ def self_test(contract_path: Path) -> None:
         "Sources/Speech/ParakeetEngine.swift": {"speech"},
         "Sources/Meeting/MeetingSessionController.swift": {"meeting-app"},
         "Sources/TranscriptedCore/Audio/Audio.swift": {"meeting-core"},
+        "Package.swift": {"meeting-core"},
+        "scripts/entrypoints/build-beta.sh": {"beta-release"},
         "Tools/TranscriptedMCP/Package.swift": {"tools"},
         "AGENTS.md": {"agent-workflow"},
     }
@@ -241,6 +265,17 @@ def self_test(contract_path: Path) -> None:
     }
     if "speech" not in symptom_ids:
         raise ContractError("symptom routing did not select speech")
+    unrelated_ids = {
+        area["id"] for area in select_areas(contract, [], "build failure")
+    }
+    if "ui" in unrelated_ids:
+        raise ContractError("short symptom keywords must match on word boundaries")
+    try:
+        changed_paths("refs/heads/__agent_context_missing_base__")
+    except ContractError:
+        pass
+    else:
+        raise ContractError("an invalid base ref must fail closed")
     print("Agent contract self-test passed.")
 
 

--- a/scripts/dev/agent-context.py
+++ b/scripts/dev/agent-context.py
@@ -174,6 +174,15 @@ def area_matches_path(area: dict[str, Any], path: str) -> bool:
     )
 
 
+def area_path_specificity(area: dict[str, Any], path: str) -> int:
+    if path in area.get("exact_paths", []) or path in area["docs"]:
+        return len(path) + 1
+    matching_prefixes = [
+        len(prefix) for prefix in area["path_prefixes"] if path.startswith(prefix)
+    ]
+    return max(matching_prefixes, default=-1)
+
+
 def area_matches_symptom(area: dict[str, Any], symptom: str) -> bool:
     lowered = symptom.casefold()
     return any(
@@ -213,7 +222,14 @@ def select_areas(
     for path in paths:
         path_matches = [area for area in specific_areas if area_matches_path(area, path)]
         if not path_matches:
-            path_matches = [area for area in fallback_areas if area_matches_path(area, path)]
+            fallback_matches = [
+                area for area in fallback_areas if area_matches_path(area, path)
+            ]
+            path_matches = (
+                [max(fallback_matches, key=lambda area: area_path_specificity(area, path))]
+                if fallback_matches
+                else []
+            )
         selected_ids.update(area["id"] for area in path_matches)
 
     for area in contract["areas"]:
@@ -328,6 +344,17 @@ def self_test(contract_path: Path) -> None:
         missing = expected_ids.difference(actual_ids)
         if missing:
             raise ContractError(f"{path} is missing owners: {sorted(missing)}")
+    fallback_cases = {
+        "Sources/TranscriptedApp.swift": {"app-shell"},
+        "scripts/download_ami.sh": {"scripts"},
+        "archive/README.md": {"repository-fallback"},
+    }
+    for path, expected_ids in fallback_cases.items():
+        actual_ids = {area["id"] for area in select_areas(contract, [path], None)}
+        if actual_ids != expected_ids:
+            raise ContractError(
+                f"{path} fallback owners must be {sorted(expected_ids)}, got {sorted(actual_ids)}"
+            )
     symptom_ids = {
         area["id"] for area in select_areas(contract, [], "model download stuck with AirPods")
     }


### PR DESCRIPTION
## Summary
- add one machine-readable ownership, invariant, privacy, and proof contract
- add `agent-context.py` for path and symptom routing
- make Repo Hygiene validate the contract on every PR

## Acceptance
- [x] every tracked path has a specific or explicit fallback owner
- [x] path queries identify owning subsystem docs
- [x] symptom queries route model-download and Bluetooth failures to Speech
- [x] output separates deterministic checks from manual hardware proof
- [x] contract references only files that exist on current main
- [x] no product runtime behavior changes

## Proof
- `python3 -m py_compile scripts/dev/agent-context.py`
- `python3 scripts/dev/agent-context.py --self-test`
- `python3 scripts/dev/test-matrix-checks.py --self-test`
- `bash -n scripts/dev/agent-preflight.sh`
- `bash scripts/dev/agent-preflight.sh origin/main`
- `git diff --check`

## Independent review
Codex reviewed the full diff against `origin/main`. Findings fixed before merge:
- invalid base refs now fail closed
- symptom keywords use word boundaries
- beta build and package-root routing are explicit
- relative and absolute in-repo paths normalize consistently
- nearest nested `CLAUDE.md` guides are returned
- every tracked path has an owner
- broad fallback owners no longer accompany a more specific fallback
- outside-repo errors no longer echo absolute input paths

Final focused review of the last privacy fix: **No actionable findings.**

## Privacy
The context command persists no symptom text and emits no raw logs, environment, absolute paths, transcripts, audio, user identifiers, or device names.
