### PR TITLE
Add runnable agent proof reports

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -126,6 +126,14 @@ rules:
       - "python3 scripts/dev/agent-context.py --self-test"
 
   - paths:
+      - "scripts/dev/agent-check.py"
+      - "scripts/dev/agent-preflight.sh"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "python3 -m py_compile scripts/dev/agent-check.py"
+      - "python3 scripts/dev/agent-check.py --self-test"
+
+  - paths:
       - ".agents/test-matrix.yml"
       - "scripts/dev/agent-preflight.sh"
       - "scripts/dev/test-matrix-checks.py"
@@ -409,6 +417,7 @@ rules:
       - "Tools/**/CLAUDE.md"
       - ".agents/**"
       - ".github/**"
+      - "scripts/dev/agent-check.py"
       - "scripts/dev/agent-preflight.sh"
       - "scripts/dev/agent-context.py"
       - "scripts/dev/test-matrix-checks.py"

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -39,6 +39,10 @@ jobs:
         shell: bash
         run: python3 scripts/dev/agent-context.py --self-test
 
+      - name: Agent proof runner
+        shell: bash
+        run: python3 scripts/dev/agent-check.py --self-test
+
       - name: Shell syntax
         shell: bash
         run: |

--- a/AGENT_START.md
+++ b/AGENT_START.md
@@ -66,7 +66,8 @@ mapped checks, and manual-proof boundaries for the files changed. Add
 `--symptom "short description"` when the failing area is unclear.
 
 Use `scripts/dev/agent-preflight.sh` to inspect the branch before editing or
-handing it off.
+handing it off. Add `--run` to execute mapped checks sequentially and write the
+bounded result to `build/agent-proof.json`.
 
 Default rules:
 

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -20,6 +20,8 @@ from typing import Any, Callable
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTEXT_COMMAND = REPO_ROOT / "scripts/dev/agent-context.py"
 DEFAULT_REPORT = REPO_ROOT / "build/agent-proof.json"
+TRUSTED_MATRIX_PATH = ".agents/test-matrix.yml"
+TRUSTED_SELECTOR_PATH = "scripts/dev/test-matrix-checks.py"
 PLACEHOLDER_PATTERN = re.compile(r"<[^>\n]+>")
 PREFLIGHT_COMMAND_PATTERN = re.compile(
     r"^(?:bash[ \t]+)?scripts/dev/agent-preflight\.sh(?:[ \t]|$)"
@@ -64,20 +66,23 @@ def git_bytes(*arguments: str) -> bytes:
     return result.stdout
 
 
-def trusted_matrix_commands(base_sha: str) -> set[str]:
+def git_file(base_sha: str, relative_path: str) -> bytes:
     result = subprocess.run(
-        ["git", "show", f"{base_sha}:.agents/test-matrix.yml"],
+        ["git", "show", f"{base_sha}:{relative_path}"],
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,
-        text=True,
     )
     if result.returncode != 0:
-        raise ProofError("trusted base does not contain the test matrix")
+        raise ProofError("trusted base is missing a proof dependency")
+    return result.stdout
 
+
+def trusted_matrix_commands(base_sha: str) -> set[str]:
     commands: set[str] = set()
     in_checks = False
-    for raw_line in result.stdout.splitlines():
+    matrix = git_file(base_sha, TRUSTED_MATRIX_PATH).decode("utf-8")
+    for raw_line in matrix.splitlines():
         stripped = raw_line.strip()
         if stripped == "checks:":
             in_checks = True
@@ -97,6 +102,66 @@ def trusted_matrix_commands(base_sha: str) -> set[str]:
     if not commands:
         raise ProofError("trusted test matrix contains no commands")
     return commands
+
+
+def trusted_checks_for_paths(base_sha: str, paths: list[str]) -> list[str]:
+    if not paths:
+        return []
+    with tempfile.TemporaryDirectory(prefix="transcripted-agent-proof-") as directory:
+        temporary_root = Path(directory)
+        matrix_path = temporary_root / "test-matrix.yml"
+        selector_path = temporary_root / "test-matrix-checks.py"
+        matrix_path.write_bytes(git_file(base_sha, TRUSTED_MATRIX_PATH))
+        selector_path.write_bytes(git_file(base_sha, TRUSTED_SELECTOR_PATH))
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(selector_path),
+                "--matrix",
+                str(matrix_path),
+                *paths,
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    if result.returncode != 0:
+        raise ProofError("trusted base check selection failed")
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def normalize_repo_path(raw_path: str) -> str:
+    candidate = Path(raw_path)
+    resolved = candidate.resolve(strict=False) if candidate.is_absolute() else (
+        REPO_ROOT / candidate
+    ).resolve(strict=False)
+    try:
+        return resolved.relative_to(REPO_ROOT.resolve()).as_posix()
+    except ValueError as error:
+        raise ProofError("proof path must stay inside the repo") from error
+
+
+def git_path_list(*arguments: str) -> list[str]:
+    output = git_bytes(*arguments)
+    return [
+        normalize_repo_path(raw_path.decode("utf-8"))
+        for raw_path in output.split(b"\0")
+        if raw_path
+    ]
+
+
+def changed_repo_paths(base_ref: str) -> list[str]:
+    merge_base_sha = git_value("merge-base", "HEAD", base_ref)
+    paths = set(git_path_list("diff", "--name-only", "-z", f"{merge_base_sha}...HEAD"))
+    paths.update(git_path_list("diff", "--cached", "--name-only", "-z"))
+    paths.update(git_path_list("diff", "--name-only", "-z"))
+    paths.update(git_path_list("ls-files", "--others", "--exclude-standard", "-z"))
+    return sorted(paths)
+
+
+def proof_commands(selected: list[str], required: list[str]) -> list[str]:
+    return list(dict.fromkeys([*required, *selected]))
 
 
 def path_state_fingerprint(paths: list[str]) -> str:
@@ -321,10 +386,12 @@ def normalize_report_path(raw_path: Path) -> Path:
     resolved = raw_path.resolve(strict=False) if raw_path.is_absolute() else (
         REPO_ROOT / raw_path
     ).resolve(strict=False)
+    report_root = (REPO_ROOT / "build").resolve(strict=False)
     try:
         resolved.relative_to(REPO_ROOT.resolve())
+        resolved.relative_to(report_root)
     except ValueError as error:
-        raise ProofError("report path must stay inside the repo") from error
+        raise ProofError("report path must stay inside the build directory") from error
     return resolved
 
 
@@ -399,6 +466,20 @@ def self_test() -> None:
     trusted_commands = trusted_matrix_commands(git_value("rev-parse", "HEAD"))
     if "bash build.sh --no-open" not in trusted_commands:
         raise ProofError("trusted matrix commands were not loaded from git")
+    required_checks = trusted_checks_for_paths(
+        git_value("rev-parse", "HEAD"),
+        ["Tests/RepoCommandContractTests.swift"],
+    )
+    if not {"bash build.sh --no-open", "bash run-tests.sh"}.issubset(
+        required_checks
+    ):
+        raise ProofError("trusted path-specific checks were not selected")
+    merged_checks = proof_commands(
+        ["python3 scripts/dev/agent-check.py --self-test"],
+        required_checks,
+    )
+    if merged_checks[:2] != ["bash build.sh --no-open", "bash run-tests.sh"]:
+        raise ProofError("trusted path-specific checks must run before branch additions")
 
     source_snapshot = capture_source_snapshot(
         "HEAD",
@@ -438,6 +519,12 @@ def self_test() -> None:
             raise ProofError("outside-repo report errors must not echo absolute paths") from error
     else:
         raise ProofError("outside-repo report paths must fail closed")
+    try:
+        normalize_report_path(REPO_ROOT / "AGENT_START.md")
+    except ProofError:
+        pass
+    else:
+        raise ProofError("report paths must not overwrite repository source")
     print("Agent proof runner self-test passed.")
 
 
@@ -453,7 +540,14 @@ def main() -> int:
         if args.self_test:
             self_test()
             return 0
-        context = load_context(args.base, args.paths)
+        initial_head_sha = git_value("rev-parse", "HEAD")
+        initial_base_sha = git_value("rev-parse", args.base)
+        requested_paths = (
+            sorted({normalize_repo_path(path) for path in args.paths})
+            if args.paths
+            else changed_repo_paths(args.base)
+        )
+        context = load_context(args.base, requested_paths)
         checks = context.get("checks")
         if not isinstance(checks, list) or any(not isinstance(check, str) for check in checks):
             raise ProofError("agent context returned invalid checks")
@@ -462,11 +556,23 @@ def main() -> int:
             not isinstance(path, str) or not path for path in context_paths
         ):
             raise ProofError("agent context returned invalid paths")
+        if context_paths != requested_paths:
+            raise ProofError("agent context changed the requested proof paths")
 
         report_path = normalize_report_path(args.report)
         source_snapshot = capture_source_snapshot(args.base, context_paths)
+        if (
+            source_snapshot["head_sha"] != initial_head_sha
+            or source_snapshot["base_sha"] != initial_base_sha
+        ):
+            raise ProofError("source identity changed during proof setup")
         trusted_commands = trusted_matrix_commands(source_snapshot["base_sha"])
-        results = run_commands(checks, trusted_commands=trusted_commands)
+        required_checks = trusted_checks_for_paths(
+            source_snapshot["base_sha"],
+            context_paths,
+        )
+        commands = proof_commands(checks, required_checks)
+        results = run_commands(commands, trusted_commands=trusted_commands)
         source_stable = source_snapshot_is_stable(source_snapshot, context_paths)
         if not source_stable:
             results.append(

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Run mapped Transcripted checks sequentially and write a bounded proof report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTEXT_COMMAND = REPO_ROOT / "scripts/dev/agent-context.py"
+DEFAULT_REPORT = REPO_ROOT / "build/agent-proof.json"
+PLACEHOLDER_PATTERN = re.compile(r"<[^>\n]+>")
+PREFLIGHT_COMMAND_PATTERN = re.compile(
+    r"^(?:bash[ \t]+)?scripts/dev/agent-preflight\.sh(?:[ \t]|$)"
+)
+MAX_COMMAND_LENGTH = 512
+MANUAL_COMMAND_FRAGMENTS = (
+    "run-live-capture-smoke.sh",
+)
+
+
+class ProofError(ValueError):
+    pass
+
+
+def git_value(*arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ProofError("could not resolve git proof identity")
+    return result.stdout.strip()
+
+
+def load_context(base_ref: str, paths: list[str]) -> dict[str, Any]:
+    arguments = [sys.executable, str(CONTEXT_COMMAND), "--json"]
+    if paths:
+        arguments.extend(paths)
+    else:
+        arguments.extend(["--base", base_ref])
+    result = subprocess.run(
+        arguments,
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ProofError("agent context selection failed")
+    try:
+        context = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ProofError("agent context returned invalid JSON") from error
+    if not isinstance(context, dict):
+        raise ProofError("agent context must return an object")
+    return context
+
+
+def classify_command(command: str) -> tuple[str, str | None]:
+    if not command or len(command) > MAX_COMMAND_LENGTH or "\n" in command:
+        return "BLOCKED", "invalid-command"
+    if PREFLIGHT_COMMAND_PATTERN.search(command):
+        return "SKIPPED", "orchestration-command"
+    if PLACEHOLDER_PATTERN.search(command):
+        return "BLOCKED", "operator-input-required"
+    if any(fragment in command for fragment in MANUAL_COMMAND_FRAGMENTS):
+        return "BLOCKED", "manual-proof-required"
+    return "RUN", None
+
+
+def shell_runner(command: str) -> int:
+    return subprocess.run(
+        ["/bin/bash", "-lc", command],
+        cwd=REPO_ROOT,
+        check=False,
+    ).returncode
+
+
+def run_commands(
+    commands: list[str],
+    runner: Callable[[str], int] = shell_runner,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    runnable_total = sum(classify_command(command)[0] == "RUN" for command in commands)
+    runnable_index = 0
+
+    for command in commands:
+        disposition, reason = classify_command(command)
+        if disposition != "RUN":
+            results.append(
+                {
+                    "command": command,
+                    "status": disposition,
+                    "exit_code": None,
+                    "duration_ms": 0,
+                    "reason": reason,
+                }
+            )
+            continue
+
+        runnable_index += 1
+        print(f"\n[{runnable_index}/{runnable_total}] {command}", flush=True)
+        started = time.monotonic()
+        exit_code = runner(command)
+        duration_ms = max(0, round((time.monotonic() - started) * 1000))
+        results.append(
+            {
+                "command": command,
+                "status": "PASS" if exit_code == 0 else "FAIL",
+                "exit_code": exit_code,
+                "duration_ms": duration_ms,
+                "reason": None,
+            }
+        )
+
+    return results
+
+
+def deterministic_status(results: list[dict[str, Any]]) -> str:
+    statuses = {result["status"] for result in results}
+    if "FAIL" in statuses:
+        return "FAIL"
+    if "BLOCKED" in statuses:
+        return "BLOCKED"
+    if "PASS" in statuses:
+        return "PASS"
+    return "NO_CHECKS"
+
+
+def build_report(
+    base_ref: str,
+    context: dict[str, Any],
+    results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    manual_requirements = context.get("manual_proof", [])
+    return {
+        "schema_version": 1,
+        "head_sha": git_value("rev-parse", "HEAD"),
+        "base": {
+            "ref": base_ref,
+            "sha": git_value("rev-parse", base_ref),
+            "merge_base_sha": git_value("merge-base", "HEAD", base_ref),
+        },
+        "paths": context.get("paths", []),
+        "areas": [area.get("id") for area in context.get("areas", [])],
+        "proof": {
+            "deterministic": {
+                "status": deterministic_status(results),
+                "checks": results,
+            },
+            "hosted": {
+                "status": "UNKNOWN",
+                "reason": "hosted checks are verified separately",
+            },
+            "manual": {
+                "status": "UNKNOWN" if manual_requirements else "NOT_REQUIRED",
+                "requirements": manual_requirements,
+            },
+        },
+    }
+
+
+def normalize_report_path(raw_path: Path) -> Path:
+    resolved = raw_path.resolve(strict=False) if raw_path.is_absolute() else (
+        REPO_ROOT / raw_path
+    ).resolve(strict=False)
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as error:
+        raise ProofError("report path must stay inside the repo") from error
+    return resolved
+
+
+def write_report(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        delete=False,
+    ) as handle:
+        json.dump(report, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temporary_path = Path(handle.name)
+    os.replace(temporary_path, path)
+
+
+def self_test() -> None:
+    classifications = {
+        "bash scripts/dev/agent-preflight.sh": ("SKIPPED", "orchestration-command"),
+        "bash -n scripts/dev/agent-preflight.sh": ("RUN", None),
+        "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>": (
+            "BLOCKED",
+            "operator-input-required",
+        ),
+        "python3 -m py_compile scripts/dev/agent-check.py": ("RUN", None),
+        "bash run-live-capture-smoke.sh --skip-build": (
+            "BLOCKED",
+            "manual-proof-required",
+        ),
+        "echo first\necho second": ("BLOCKED", "invalid-command"),
+    }
+    for command, expected in classifications.items():
+        actual = classify_command(command)
+        if actual != expected:
+            raise ProofError(f"unexpected command classification: {actual}")
+
+    exit_codes = {"pass": 0, "fail": 7}
+    results = run_commands(
+        [
+            "bash scripts/dev/agent-preflight.sh",
+            "pass",
+            "fail",
+            "release <operator>",
+        ],
+        runner=lambda command: exit_codes[command],
+    )
+    if [result["status"] for result in results] != [
+        "SKIPPED",
+        "PASS",
+        "FAIL",
+        "BLOCKED",
+    ]:
+        raise ProofError("check execution statuses are incorrect")
+    if deterministic_status(results) != "FAIL":
+        raise ProofError("a failed check must fail deterministic proof")
+    forbidden_keys = {"stdout", "stderr", "environment", "cwd"}
+    if any(forbidden_keys.intersection(result) for result in results):
+        raise ProofError("proof results must not retain command output or environment")
+    try:
+        normalize_report_path(REPO_ROOT.parent / "private-proof.json")
+    except ProofError as error:
+        if str(REPO_ROOT.parent) in str(error):
+            raise ProofError("outside-repo report errors must not echo absolute paths") from error
+    else:
+        raise ProofError("outside-repo report paths must fail closed")
+    print("Agent proof runner self-test passed.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="optional repo-relative changed paths")
+    parser.add_argument("--base", default="origin/main", help="verified git base ref")
+    parser.add_argument("--report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.self_test:
+            self_test()
+            return 0
+        context = load_context(args.base, args.paths)
+        checks = context.get("checks")
+        if not isinstance(checks, list) or any(not isinstance(check, str) for check in checks):
+            raise ProofError("agent context returned invalid checks")
+        results = run_commands(checks)
+        report_path = normalize_report_path(args.report)
+        report = build_report(args.base, context, results)
+        write_report(report_path, report)
+        deterministic = report["proof"]["deterministic"]["status"]
+        print(f"\nDeterministic proof: {deterministic}")
+        print(f"Proof report: {report_path.relative_to(REPO_ROOT)}")
+        if report["proof"]["manual"]["status"] == "UNKNOWN":
+            print("Manual proof: UNKNOWN")
+        return 1 if deterministic in {"FAIL", "BLOCKED"} else 0
+    except (OSError, ProofError) as error:
+        print(f"Agent proof failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -125,6 +125,7 @@ def select_checks_from_matrix(
                 str(selector_path),
                 "--matrix",
                 str(matrix_path),
+                "--",
                 *paths,
             ],
             cwd=REPO_ROOT,
@@ -146,9 +147,13 @@ def trusted_checks_for_paths(base_sha: str, paths: list[str]) -> list[str]:
     )
 
 
-def branch_checks_for_paths(base_sha: str, paths: list[str]) -> list[str]:
+def branch_checks_for_paths(
+    head_sha: str,
+    base_sha: str,
+    paths: list[str],
+) -> list[str]:
     return select_checks_from_matrix(
-        (REPO_ROOT / TRUSTED_MATRIX_PATH).read_bytes(),
+        git_file(head_sha, TRUSTED_MATRIX_PATH),
         git_file(base_sha, TRUSTED_SELECTOR_PATH),
         paths,
         "branch check selection failed",
@@ -328,6 +333,7 @@ def source_snapshot_is_stable(snapshot: dict[str, Any], paths: list[str]) -> boo
 def load_context(base_ref: str, paths: list[str]) -> dict[str, Any]:
     arguments = [sys.executable, str(CONTEXT_COMMAND), "--json"]
     if paths:
+        arguments.append("--")
         arguments.extend(paths)
     else:
         arguments.extend(["--base", base_ref])
@@ -607,6 +613,21 @@ def self_test() -> None:
     )
     if selected_new_checks != [new_check]:
         raise ProofError("branch matrix additions must be selectable before merge")
+    hyphen_check = "python3 scripts/dev/hyphen-path-check.py --self-test"
+    hyphen_matrix = f"""rules:
+  - paths:
+      - "--self-test"
+    checks:
+      - "{hyphen_check}"
+""".encode()
+    selected_hyphen_checks = select_checks_from_matrix(
+        hyphen_matrix,
+        git_file(git_value("rev-parse", "HEAD"), TRUSTED_SELECTOR_PATH),
+        ["--self-test"],
+        "hyphen-prefixed path selection failed",
+    )
+    if selected_hyphen_checks != [hyphen_check]:
+        raise ProofError("hyphen-prefixed paths must not become selector options")
     if classify_command(
         new_check,
         trusted_commands=trusted_commands.union(selected_new_checks),
@@ -777,6 +798,7 @@ def main() -> int:
             context_paths,
         )
         branch_checks = branch_checks_for_paths(
+            source_snapshot["head_sha"],
             source_snapshot["base_sha"],
             context_paths,
         )

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -516,7 +516,12 @@ def build_report(
     results: list[dict[str, Any]],
     source_stable: bool,
 ) -> dict[str, Any]:
-    manual_requirements = context.get("manual_proof", [])
+    manual_requirements = list(context.get("manual_proof", []))
+    if any(result.get("reason") == "manual-proof-required" for result in results):
+        manual_requirements.append(
+            "Run the blocked manual check with its required local permissions and hardware."
+        )
+    manual_requirements = list(dict.fromkeys(manual_requirements))
     return {
         "schema_version": 1,
         "head_sha": source_snapshot["head_sha"],
@@ -787,6 +792,22 @@ def self_test() -> None:
         raise ProofError("proof reports must retain the pre-run source identity")
     if report["source"]["stable"] is not True:
         raise ProofError("proof reports must record source stability")
+    manual_report = build_report(
+        source_snapshot,
+        {"paths": ["run-live-capture-smoke.sh"], "areas": [], "manual_proof": []},
+        [
+            {
+                "command": "bash run-live-capture-smoke.sh --skip-build",
+                "status": "BLOCKED",
+                "exit_code": None,
+                "duration_ms": 0,
+                "reason": "manual-proof-required",
+            }
+        ],
+        source_stable=True,
+    )
+    if manual_report["proof"]["manual"]["status"] != "UNKNOWN":
+        raise ProofError("blocked live checks must leave manual proof unknown")
     serialized_report = json.dumps(report)
     if any(key in serialized_report for key in forbidden_keys):
         raise ProofError("proof reports must not retain output or environment")

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -366,12 +366,63 @@ def command_argv(command: str) -> list[str]:
     if executable not in ALLOWED_EXECUTABLES and not executable.startswith("scripts/"):
         raise ProofError("command executable is not allowed")
     if executable.startswith("scripts/"):
-        resolved = (REPO_ROOT / executable).resolve(strict=False)
-        try:
-            resolved.relative_to(REPO_ROOT.resolve())
-        except ValueError as error:
-            raise ProofError("command executable must stay inside the repo") from error
+        validate_repo_path(executable, "command executable")
+    elif executable == "bash":
+        validate_bash_arguments(arguments[1:])
+    elif executable == "python3":
+        validate_python_arguments(arguments[1:])
+    elif executable == "ruby":
+        validate_ruby_arguments(arguments[1:])
+    elif executable == "swift":
+        validate_swift_arguments(arguments[1:])
     return arguments
+
+
+def validate_repo_path(raw_path: str, label: str, suffix: str | None = None) -> None:
+    path = Path(raw_path)
+    if path.is_absolute() or raw_path.startswith("-"):
+        raise ProofError(f"{label} must be a repo-relative path")
+    resolved = (REPO_ROOT / path).resolve(strict=False)
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as error:
+        raise ProofError(f"{label} must stay inside the repo") from error
+    if suffix is not None and path.suffix != suffix:
+        raise ProofError(f"{label} must end in {suffix}")
+
+
+def validate_bash_arguments(arguments: list[str]) -> None:
+    if arguments[:1] == ["-n"]:
+        arguments = arguments[1:]
+    if not arguments:
+        raise ProofError("bash command must name a repo script")
+    validate_repo_path(arguments[0], "bash script", ".sh")
+
+
+def validate_python_arguments(arguments: list[str]) -> None:
+    if arguments[:2] == ["-m", "py_compile"]:
+        paths = arguments[2:]
+        if not paths:
+            raise ProofError("py_compile must name a repo Python file")
+        for path in paths:
+            validate_repo_path(path, "Python source", ".py")
+        return
+    if not arguments:
+        raise ProofError("python3 command must name a repo script")
+    validate_repo_path(arguments[0], "Python script", ".py")
+
+
+def validate_ruby_arguments(arguments: list[str]) -> None:
+    if arguments[:1] == ["-c"]:
+        arguments = arguments[1:]
+    if not arguments:
+        raise ProofError("ruby command must name a repo script")
+    validate_repo_path(arguments[0], "Ruby script", ".rb")
+
+
+def validate_swift_arguments(arguments: list[str]) -> None:
+    if not arguments or arguments[0] not in {"build", "package", "test"}:
+        raise ProofError("swift command must use an allowed package subcommand")
 
 
 def classify_command(
@@ -542,6 +593,14 @@ def self_test() -> None:
         ),
         "echo first\necho second": ("BLOCKED", "invalid-command"),
         "python3 scripts/dev/untrusted-proof.py": ("RUN", None),
+        "bash -c 'echo unsafe'": ("BLOCKED", "invalid-command"),
+        "bash -s": ("BLOCKED", "invalid-command"),
+        "python3 -c 'print(1)'": ("BLOCKED", "invalid-command"),
+        "python3 -": ("BLOCKED", "invalid-command"),
+        "python3 -m http.server": ("BLOCKED", "invalid-command"),
+        "ruby -e 'puts 1'": ("BLOCKED", "invalid-command"),
+        "swift -e 'print(1)'": ("BLOCKED", "invalid-command"),
+        "python3 /tmp/untrusted-proof.py": ("BLOCKED", "invalid-command"),
     }
     for command, expected in classifications.items():
         actual = classify_command(command)

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -22,6 +22,7 @@ CONTEXT_COMMAND = REPO_ROOT / "scripts/dev/agent-context.py"
 DEFAULT_REPORT = REPO_ROOT / "build/agent-proof.json"
 TRUSTED_MATRIX_PATH = ".agents/test-matrix.yml"
 TRUSTED_SELECTOR_PATH = "scripts/dev/test-matrix-checks.py"
+TRUSTED_CONTRACT_PATH = ".agents/agent-contract.json"
 PLACEHOLDER_PATTERN = re.compile(r"<[^>\n]+>")
 PREFLIGHT_COMMAND_PATTERN = re.compile(
     r"^(?:bash[ \t]+)?scripts/dev/agent-preflight\.sh(?:[ \t]|$)"
@@ -176,11 +177,98 @@ def git_path_list(*arguments: str) -> list[str]:
 
 def changed_repo_paths(base_ref: str) -> list[str]:
     merge_base_sha = git_value("merge-base", "HEAD", base_ref)
-    paths = set(git_path_list("diff", "--name-only", "-z", f"{merge_base_sha}...HEAD"))
-    paths.update(git_path_list("diff", "--cached", "--name-only", "-z"))
-    paths.update(git_path_list("diff", "--name-only", "-z"))
+    paths = set(
+        git_path_list(
+            "diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            f"{merge_base_sha}...HEAD",
+        )
+    )
+    paths.update(
+        git_path_list("diff", "--no-renames", "--cached", "--name-only", "-z")
+    )
+    paths.update(git_path_list("diff", "--no-renames", "--name-only", "-z"))
     paths.update(git_path_list("ls-files", "--others", "--exclude-standard", "-z"))
     return sorted(paths)
+
+
+def area_matches_path(area: dict[str, Any], path: str) -> bool:
+    prefixes = area.get("path_prefixes", [])
+    exact_paths = area.get("exact_paths", [])
+    docs = area.get("docs", [])
+    if not all(isinstance(items, list) for items in (prefixes, exact_paths, docs)):
+        raise ProofError("trusted agent contract contains invalid paths")
+    return (
+        any(isinstance(prefix, str) and path.startswith(prefix) for prefix in prefixes)
+        or path in exact_paths
+        or path in docs
+    )
+
+
+def area_path_specificity(area: dict[str, Any], path: str) -> int:
+    if path in area.get("exact_paths", []) or path in area.get("docs", []):
+        return len(path) + 1
+    return max(
+        (
+            len(prefix)
+            for prefix in area.get("path_prefixes", [])
+            if isinstance(prefix, str) and path.startswith(prefix)
+        ),
+        default=-1,
+    )
+
+
+def manual_requirements_for_paths(
+    contract: dict[str, Any],
+    paths: list[str],
+) -> list[str]:
+    areas = contract.get("areas")
+    if not isinstance(areas, list):
+        raise ProofError("trusted agent contract contains invalid areas")
+    specific_areas = [
+        area for area in areas if isinstance(area, dict) and not area.get("fallback", False)
+    ]
+    fallback_areas = [
+        area for area in areas if isinstance(area, dict) and area.get("fallback", False)
+    ]
+    selected: list[dict[str, Any]] = []
+    for path in paths:
+        matches = [area for area in specific_areas if area_matches_path(area, path)]
+        if not matches:
+            fallback_matches = [
+                area for area in fallback_areas if area_matches_path(area, path)
+            ]
+            if fallback_matches:
+                matches = [
+                    max(
+                        fallback_matches,
+                        key=lambda area: area_path_specificity(area, path),
+                    )
+                ]
+        selected.extend(matches)
+
+    requirements: list[str] = []
+    for area in selected:
+        manual_proof = area.get("manual_proof")
+        if not isinstance(manual_proof, list) or any(
+            not isinstance(requirement, str) or not requirement
+            for requirement in manual_proof
+        ):
+            raise ProofError("trusted agent contract contains invalid manual proof")
+        requirements.extend(manual_proof)
+    return list(dict.fromkeys(requirements))
+
+
+def trusted_manual_requirements(base_sha: str, paths: list[str]) -> list[str]:
+    try:
+        contract = json.loads(git_file(base_sha, TRUSTED_CONTRACT_PATH))
+    except json.JSONDecodeError as error:
+        raise ProofError("trusted agent contract is invalid") from error
+    if not isinstance(contract, dict):
+        raise ProofError("trusted agent contract must be an object")
+    return manual_requirements_for_paths(contract, paths)
 
 
 def proof_commands(selected: list[str], required: list[str]) -> list[str]:
@@ -525,6 +613,73 @@ def self_test() -> None:
     ) != ("RUN", None):
         raise ProofError("selected branch matrix additions must be runnable")
 
+    trusted_contract = json.loads(
+        git_file(git_value("rev-parse", "HEAD"), TRUSTED_CONTRACT_PATH)
+    )
+    meeting_manual = manual_requirements_for_paths(
+        trusted_contract,
+        ["Sources/Meeting/MeetingSessionController.swift"],
+    )
+    if "A real Zoom or Meet session with microphone and system audio." not in meeting_manual:
+        raise ProofError("trusted manual proof must survive branch contract changes")
+
+    with tempfile.TemporaryDirectory(prefix="transcripted-agent-rename-") as directory:
+        temporary_repo = Path(directory)
+        subprocess.run(["git", "init", "-q"], cwd=temporary_repo, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "agent-proof@example.invalid"],
+            cwd=temporary_repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Agent Proof"],
+            cwd=temporary_repo,
+            check=True,
+        )
+        source = temporary_repo / "Sources/Meeting/Old.swift"
+        destination = temporary_repo / "docs/New.swift"
+        source.parent.mkdir(parents=True)
+        destination.parent.mkdir(parents=True)
+        source.write_text("let value = 1\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=temporary_repo, check=True)
+        subprocess.run(["git", "commit", "-qm", "base"], cwd=temporary_repo, check=True)
+        rename_base = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=temporary_repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            [
+                "git",
+                "mv",
+                source.relative_to(temporary_repo),
+                destination.relative_to(temporary_repo),
+            ],
+            cwd=temporary_repo,
+            check=True,
+        )
+        subprocess.run(["git", "commit", "-qm", "rename"], cwd=temporary_repo, check=True)
+        rename_paths = subprocess.run(
+            [
+                "git",
+                "diff",
+                "--no-renames",
+                "--name-only",
+                "-z",
+                f"{rename_base}...HEAD",
+            ],
+            cwd=temporary_repo,
+            check=True,
+            capture_output=True,
+        ).stdout.split(b"\0")
+    if {path.decode("utf-8") for path in rename_paths if path} != {
+        "Sources/Meeting/Old.swift",
+        "docs/New.swift",
+    }:
+        raise ProofError("renames must retain both source and destination paths")
+
     source_snapshot = capture_source_snapshot(
         "HEAD",
         ["scripts/dev/agent-check.py"],
@@ -602,6 +757,12 @@ def main() -> int:
             raise ProofError("agent context returned invalid paths")
         if context_paths != requested_paths:
             raise ProofError("agent context changed the requested proof paths")
+        branch_manual_requirements = context.get("manual_proof")
+        if not isinstance(branch_manual_requirements, list) or any(
+            not isinstance(requirement, str) or not requirement
+            for requirement in branch_manual_requirements
+        ):
+            raise ProofError("agent context returned invalid manual proof")
 
         report_path = normalize_report_path(args.report)
         source_snapshot = capture_source_snapshot(args.base, context_paths)
@@ -622,6 +783,17 @@ def main() -> int:
         if checks != branch_checks:
             raise ProofError("agent context changed the branch matrix checks")
         trusted_commands.update(branch_checks)
+        context["manual_proof"] = list(
+            dict.fromkeys(
+                [
+                    *trusted_manual_requirements(
+                        source_snapshot["base_sha"],
+                        context_paths,
+                    ),
+                    *branch_manual_requirements,
+                ]
+            )
+        )
         commands = proof_commands(checks, required_checks)
         results = run_commands(commands, trusted_commands=trusted_commands)
         source_stable = source_snapshot_is_stable(source_snapshot, context_paths)

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -104,15 +104,20 @@ def trusted_matrix_commands(base_sha: str) -> set[str]:
     return commands
 
 
-def trusted_checks_for_paths(base_sha: str, paths: list[str]) -> list[str]:
+def select_checks_from_matrix(
+    matrix: bytes,
+    selector: bytes,
+    paths: list[str],
+    failure_message: str,
+) -> list[str]:
     if not paths:
         return []
     with tempfile.TemporaryDirectory(prefix="transcripted-agent-proof-") as directory:
         temporary_root = Path(directory)
         matrix_path = temporary_root / "test-matrix.yml"
         selector_path = temporary_root / "test-matrix-checks.py"
-        matrix_path.write_bytes(git_file(base_sha, TRUSTED_MATRIX_PATH))
-        selector_path.write_bytes(git_file(base_sha, TRUSTED_SELECTOR_PATH))
+        matrix_path.write_bytes(matrix)
+        selector_path.write_bytes(selector)
         result = subprocess.run(
             [
                 sys.executable,
@@ -127,8 +132,26 @@ def trusted_checks_for_paths(base_sha: str, paths: list[str]) -> list[str]:
             text=True,
         )
     if result.returncode != 0:
-        raise ProofError("trusted base check selection failed")
+        raise ProofError(failure_message)
     return [line for line in result.stdout.splitlines() if line]
+
+
+def trusted_checks_for_paths(base_sha: str, paths: list[str]) -> list[str]:
+    return select_checks_from_matrix(
+        git_file(base_sha, TRUSTED_MATRIX_PATH),
+        git_file(base_sha, TRUSTED_SELECTOR_PATH),
+        paths,
+        "trusted base check selection failed",
+    )
+
+
+def branch_checks_for_paths(base_sha: str, paths: list[str]) -> list[str]:
+    return select_checks_from_matrix(
+        (REPO_ROOT / TRUSTED_MATRIX_PATH).read_bytes(),
+        git_file(base_sha, TRUSTED_SELECTOR_PATH),
+        paths,
+        "branch check selection failed",
+    )
 
 
 def normalize_repo_path(raw_path: str) -> str:
@@ -481,6 +504,27 @@ def self_test() -> None:
     if merged_checks[:2] != ["bash build.sh --no-open", "bash run-tests.sh"]:
         raise ProofError("trusted path-specific checks must run before branch additions")
 
+    new_check = "python3 scripts/dev/new-proof-check.py --self-test"
+    new_matrix = f"""rules:
+  - paths:
+      - "scripts/dev/new-proof-check.py"
+    checks:
+      - "{new_check}"
+""".encode()
+    selected_new_checks = select_checks_from_matrix(
+        new_matrix,
+        git_file(git_value("rev-parse", "HEAD"), TRUSTED_SELECTOR_PATH),
+        ["scripts/dev/new-proof-check.py"],
+        "new matrix check selection failed",
+    )
+    if selected_new_checks != [new_check]:
+        raise ProofError("branch matrix additions must be selectable before merge")
+    if classify_command(
+        new_check,
+        trusted_commands=trusted_commands.union(selected_new_checks),
+    ) != ("RUN", None):
+        raise ProofError("selected branch matrix additions must be runnable")
+
     source_snapshot = capture_source_snapshot(
         "HEAD",
         ["scripts/dev/agent-check.py"],
@@ -571,6 +615,13 @@ def main() -> int:
             source_snapshot["base_sha"],
             context_paths,
         )
+        branch_checks = branch_checks_for_paths(
+            source_snapshot["base_sha"],
+            context_paths,
+        )
+        if checks != branch_checks:
+            raise ProofError("agent context changed the branch matrix checks")
+        trusted_commands.update(branch_checks)
         commands = proof_commands(checks, required_checks)
         results = run_commands(commands, trusted_commands=trusted_commands)
         source_stable = source_snapshot_is_stable(source_snapshot, context_paths)

--- a/scripts/dev/agent-check.py
+++ b/scripts/dev/agent-check.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -26,6 +28,11 @@ MAX_COMMAND_LENGTH = 512
 MANUAL_COMMAND_FRAGMENTS = (
     "run-live-capture-smoke.sh",
 )
+ALLOWED_EXECUTABLES = {"bash", "python3", "ruby", "swift"}
+BOOTSTRAP_COMMANDS = {
+    "python3 -m py_compile scripts/dev/agent-check.py",
+    "python3 scripts/dev/agent-check.py --self-test",
+}
 
 
 class ProofError(ValueError):
@@ -43,6 +50,103 @@ def git_value(*arguments: str) -> str:
     if result.returncode != 0:
         raise ProofError("could not resolve git proof identity")
     return result.stdout.strip()
+
+
+def git_bytes(*arguments: str) -> bytes:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise ProofError("could not capture git proof state")
+    return result.stdout
+
+
+def trusted_matrix_commands(base_sha: str) -> set[str]:
+    result = subprocess.run(
+        ["git", "show", f"{base_sha}:.agents/test-matrix.yml"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise ProofError("trusted base does not contain the test matrix")
+
+    commands: set[str] = set()
+    in_checks = False
+    for raw_line in result.stdout.splitlines():
+        stripped = raw_line.strip()
+        if stripped == "checks:":
+            in_checks = True
+            continue
+        if stripped in {"- paths:", "notes:"}:
+            in_checks = False
+            continue
+        if not in_checks or not stripped.startswith("- "):
+            continue
+        try:
+            value = json.loads(stripped[2:].strip())
+        except json.JSONDecodeError as error:
+            raise ProofError("trusted test matrix is invalid") from error
+        if not isinstance(value, str) or not value:
+            raise ProofError("trusted test matrix contains an invalid command")
+        commands.add(value)
+    if not commands:
+        raise ProofError("trusted test matrix contains no commands")
+    return commands
+
+
+def path_state_fingerprint(paths: list[str]) -> str:
+    digest = hashlib.sha256()
+    repo_root = REPO_ROOT.resolve()
+    for relative_path in sorted(paths):
+        resolved = (REPO_ROOT / relative_path).resolve(strict=False)
+        try:
+            resolved.relative_to(repo_root)
+        except ValueError as error:
+            raise ProofError("proof path must stay inside the repo") from error
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        if not resolved.exists():
+            digest.update(b"missing\0")
+            continue
+        stat_result = resolved.stat()
+        digest.update(f"{stat_result.st_mode:o}".encode("ascii"))
+        digest.update(b"\0")
+        if resolved.is_file():
+            with resolved.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        else:
+            digest.update(b"non-file")
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def capture_source_snapshot(base_ref: str, paths: list[str]) -> dict[str, Any]:
+    head_sha = git_value("rev-parse", "HEAD")
+    base_sha = git_value("rev-parse", base_ref)
+    merge_base_sha = git_value("merge-base", "HEAD", base_ref)
+    worktree_state = git_bytes("status", "--porcelain=v1", "-z", "--untracked-files=all")
+    return {
+        "head_sha": head_sha,
+        "base_ref": base_ref,
+        "base_sha": base_sha,
+        "merge_base_sha": merge_base_sha,
+        "worktree_clean": not worktree_state,
+        "worktree_state_sha256": hashlib.sha256(worktree_state).hexdigest(),
+        "path_state_sha256": path_state_fingerprint(paths),
+    }
+
+
+def source_snapshot_is_stable(snapshot: dict[str, Any], paths: list[str]) -> bool:
+    try:
+        return capture_source_snapshot(snapshot["base_ref"], paths) == snapshot
+    except (OSError, ProofError):
+        return False
 
 
 def load_context(base_ref: str, paths: list[str]) -> dict[str, Any]:
@@ -69,7 +173,29 @@ def load_context(base_ref: str, paths: list[str]) -> dict[str, Any]:
     return context
 
 
-def classify_command(command: str) -> tuple[str, str | None]:
+def command_argv(command: str) -> list[str]:
+    try:
+        arguments = shlex.split(command)
+    except ValueError as error:
+        raise ProofError("invalid command syntax") from error
+    if not arguments:
+        raise ProofError("empty command")
+    executable = arguments[0]
+    if executable not in ALLOWED_EXECUTABLES and not executable.startswith("scripts/"):
+        raise ProofError("command executable is not allowed")
+    if executable.startswith("scripts/"):
+        resolved = (REPO_ROOT / executable).resolve(strict=False)
+        try:
+            resolved.relative_to(REPO_ROOT.resolve())
+        except ValueError as error:
+            raise ProofError("command executable must stay inside the repo") from error
+    return arguments
+
+
+def classify_command(
+    command: str,
+    trusted_commands: set[str] | None = None,
+) -> tuple[str, str | None]:
     if not command or len(command) > MAX_COMMAND_LENGTH or "\n" in command:
         return "BLOCKED", "invalid-command"
     if PREFLIGHT_COMMAND_PATTERN.search(command):
@@ -78,12 +204,20 @@ def classify_command(command: str) -> tuple[str, str | None]:
         return "BLOCKED", "operator-input-required"
     if any(fragment in command for fragment in MANUAL_COMMAND_FRAGMENTS):
         return "BLOCKED", "manual-proof-required"
+    if trusted_commands is not None and (
+        command not in trusted_commands and command not in BOOTSTRAP_COMMANDS
+    ):
+        return "BLOCKED", "untrusted-matrix-command"
+    try:
+        command_argv(command)
+    except ProofError:
+        return "BLOCKED", "invalid-command"
     return "RUN", None
 
 
-def shell_runner(command: str) -> int:
+def command_runner(command: str) -> int:
     return subprocess.run(
-        ["/bin/bash", "-lc", command],
+        command_argv(command),
         cwd=REPO_ROOT,
         check=False,
     ).returncode
@@ -91,14 +225,17 @@ def shell_runner(command: str) -> int:
 
 def run_commands(
     commands: list[str],
-    runner: Callable[[str], int] = shell_runner,
+    trusted_commands: set[str] | None = None,
+    runner: Callable[[str], int] = command_runner,
 ) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
-    runnable_total = sum(classify_command(command)[0] == "RUN" for command in commands)
+    runnable_total = sum(
+        classify_command(command, trusted_commands)[0] == "RUN" for command in commands
+    )
     runnable_index = 0
 
     for command in commands:
-        disposition, reason = classify_command(command)
+        disposition, reason = classify_command(command, trusted_commands)
         if disposition != "RUN":
             results.append(
                 {
@@ -141,18 +278,25 @@ def deterministic_status(results: list[dict[str, Any]]) -> str:
 
 
 def build_report(
-    base_ref: str,
+    source_snapshot: dict[str, Any],
     context: dict[str, Any],
     results: list[dict[str, Any]],
+    source_stable: bool,
 ) -> dict[str, Any]:
     manual_requirements = context.get("manual_proof", [])
     return {
         "schema_version": 1,
-        "head_sha": git_value("rev-parse", "HEAD"),
+        "head_sha": source_snapshot["head_sha"],
         "base": {
-            "ref": base_ref,
-            "sha": git_value("rev-parse", base_ref),
-            "merge_base_sha": git_value("merge-base", "HEAD", base_ref),
+            "ref": source_snapshot["base_ref"],
+            "sha": source_snapshot["base_sha"],
+            "merge_base_sha": source_snapshot["merge_base_sha"],
+        },
+        "source": {
+            "worktree_clean": source_snapshot["worktree_clean"],
+            "worktree_state_sha256": source_snapshot["worktree_state_sha256"],
+            "path_state_sha256": source_snapshot["path_state_sha256"],
+            "stable": source_stable,
         },
         "paths": context.get("paths", []),
         "areas": [area.get("id") for area in context.get("areas", [])],
@@ -213,20 +357,30 @@ def self_test() -> None:
             "manual-proof-required",
         ),
         "echo first\necho second": ("BLOCKED", "invalid-command"),
+        "python3 scripts/dev/untrusted-proof.py": ("RUN", None),
     }
     for command, expected in classifications.items():
         actual = classify_command(command)
         if actual != expected:
             raise ProofError(f"unexpected command classification: {actual}")
 
-    exit_codes = {"pass": 0, "fail": 7}
+    untrusted_command = "python3 scripts/dev/test-matrix-checks.py --self-test"
+    if classify_command(
+        "python3 scripts/dev/untrusted-proof.py",
+        trusted_commands=set(),
+    ) != ("BLOCKED", "untrusted-matrix-command"):
+        raise ProofError("commands absent from the trusted base must fail closed")
+
+    pass_command = "python3 scripts/dev/agent-check.py --self-test"
+    exit_codes = {pass_command: 0, untrusted_command: 7}
     results = run_commands(
         [
             "bash scripts/dev/agent-preflight.sh",
-            "pass",
-            "fail",
+            pass_command,
+            untrusted_command,
             "release <operator>",
         ],
+        trusted_commands={untrusted_command},
         runner=lambda command: exit_codes[command],
     )
     if [result["status"] for result in results] != [
@@ -241,6 +395,42 @@ def self_test() -> None:
     forbidden_keys = {"stdout", "stderr", "environment", "cwd"}
     if any(forbidden_keys.intersection(result) for result in results):
         raise ProofError("proof results must not retain command output or environment")
+
+    trusted_commands = trusted_matrix_commands(git_value("rev-parse", "HEAD"))
+    if "bash build.sh --no-open" not in trusted_commands:
+        raise ProofError("trusted matrix commands were not loaded from git")
+
+    source_snapshot = capture_source_snapshot(
+        "HEAD",
+        ["scripts/dev/agent-check.py"],
+    )
+    if not source_snapshot_is_stable(
+        source_snapshot,
+        ["scripts/dev/agent-check.py"],
+    ):
+        raise ProofError("an unchanged source snapshot must remain stable")
+    changed_snapshot = dict(source_snapshot)
+    changed_snapshot["head_sha"] = "0" * 40
+    if source_snapshot_is_stable(
+        changed_snapshot,
+        ["scripts/dev/agent-check.py"],
+    ):
+        raise ProofError("a changed source snapshot must fail closed")
+
+    report = build_report(
+        source_snapshot,
+        {"paths": ["scripts/dev/agent-check.py"], "areas": [], "manual_proof": []},
+        results,
+        source_stable=True,
+    )
+    if report["head_sha"] != source_snapshot["head_sha"]:
+        raise ProofError("proof reports must retain the pre-run source identity")
+    if report["source"]["stable"] is not True:
+        raise ProofError("proof reports must record source stability")
+    serialized_report = json.dumps(report)
+    if any(key in serialized_report for key in forbidden_keys):
+        raise ProofError("proof reports must not retain output or environment")
+
     try:
         normalize_report_path(REPO_ROOT.parent / "private-proof.json")
     except ProofError as error:
@@ -267,9 +457,33 @@ def main() -> int:
         checks = context.get("checks")
         if not isinstance(checks, list) or any(not isinstance(check, str) for check in checks):
             raise ProofError("agent context returned invalid checks")
-        results = run_commands(checks)
+        context_paths = context.get("paths")
+        if not isinstance(context_paths, list) or any(
+            not isinstance(path, str) or not path for path in context_paths
+        ):
+            raise ProofError("agent context returned invalid paths")
+
         report_path = normalize_report_path(args.report)
-        report = build_report(args.base, context, results)
+        source_snapshot = capture_source_snapshot(args.base, context_paths)
+        trusted_commands = trusted_matrix_commands(source_snapshot["base_sha"])
+        results = run_commands(checks, trusted_commands=trusted_commands)
+        source_stable = source_snapshot_is_stable(source_snapshot, context_paths)
+        if not source_stable:
+            results.append(
+                {
+                    "command": "source-stability",
+                    "status": "FAIL",
+                    "exit_code": None,
+                    "duration_ms": 0,
+                    "reason": "source-changed-during-proof",
+                }
+            )
+        report = build_report(
+            source_snapshot,
+            context,
+            results,
+            source_stable=source_stable,
+        )
         write_report(report_path, report)
         deterministic = report["proof"]["deterministic"]["status"]
         print(f"\nDeterministic proof: {deterministic}")

--- a/scripts/dev/agent-context.py
+++ b/scripts/dev/agent-context.py
@@ -248,6 +248,7 @@ def select_checks(contract: dict[str, Any], paths: list[str]) -> list[str]:
             str(MATRIX_SELECTOR),
             "--matrix",
             str(REPO_ROOT / contract["test_matrix"]),
+            "--",
             *paths,
         ],
         cwd=REPO_ROOT,
@@ -370,6 +371,8 @@ def self_test(contract_path: Path) -> None:
         raise ContractError("relative paths must normalize before routing")
     if normalize_repo_path(str(REPO_ROOT / sample_path)) != sample_path:
         raise ContractError("absolute repo paths must normalize before routing")
+    if select_checks(contract, ["--self-test"]):
+        raise ContractError("hyphen-prefixed paths must not become selector options")
     outside_path = REPO_ROOT.parent / "private-customer-data.txt"
     try:
         normalize_repo_path(str(outside_path))

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -7,7 +7,53 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
-base_ref="${1:-origin/main}"
+base_ref="origin/main"
+run_checks="false"
+report_path="build/agent-proof.json"
+base_was_set="false"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --run)
+            run_checks="true"
+            shift
+            ;;
+        --report)
+            if [ "$#" -lt 2 ]; then
+                echo "--report requires a repo-relative path."
+                exit 2
+            fi
+            report_path="$2"
+            shift 2
+            ;;
+        --base)
+            if [ "$#" -lt 2 ]; then
+                echo "--base requires a git ref."
+                exit 2
+            fi
+            base_ref="$2"
+            base_was_set="true"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: scripts/dev/agent-preflight.sh [--run] [--report PATH] [--base REF] [REF]"
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            exit 2
+            ;;
+        *)
+            if [ "$base_was_set" = "true" ]; then
+                echo "Only one base ref may be provided."
+                exit 2
+            fi
+            base_ref="$1"
+            base_was_set="true"
+            shift
+            ;;
+    esac
+done
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "Not inside a git worktree."
@@ -15,7 +61,8 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
-    base_ref="HEAD"
+    echo "Base ref does not exist."
+    exit 1
 fi
 
 if merge_base="$(git merge-base HEAD "$base_ref" 2>/dev/null)"; then
@@ -106,3 +153,9 @@ echo ""
 echo "Coordinator closeout:"
 echo "COORD_DONE: GREEN/BRIEF/RED | PR URL if any | changes made | GitHub cleanup recommendations | decisions needed | tests/checks run | smallest next action"
 echo "See docs/agent-closeout.md for status meanings and cleanup boundaries."
+
+if [ "$run_checks" = "true" ]; then
+    echo ""
+    echo "Running mapped checks sequentially..."
+    python3 scripts/dev/agent-check.py --base "$base_ref" --report "$report_path"
+fi


### PR DESCRIPTION
## Summary
- add `agent-preflight.sh --run` as the single entrypoint for mapped verification
- preserve trusted base checks while allowing bounded, committed branch additions
- execute only reviewed repo scripts and known build/test subcommands without a shell
- bind each report to the exact pre-run head, base, worktree state, and changed-path content
- write privacy-bounded JSON reports only under ignored `build/`
- keep deterministic, hosted, and manual proof separate

## Acceptance
- [x] mapped safe checks execute sequentially
- [x] trusted path-specific checks cannot be replaced by cheaper branch checks
- [x] recursive preflight is skipped while its syntax check still runs
- [x] operator placeholders and real live-capture commands are blocked
- [x] interpreter eval/stdin modes such as `bash -c`, `python3 -c`, and `ruby -e` fail closed
- [x] cross-area renames retain both source and destination proof requirements
- [x] source drift during a run fails deterministic proof
- [x] report records exact head/base identity and bounded hashes without command output, environment, or absolute paths
- [x] report paths outside `build/` fail closed
- [x] blocked live checks leave manual proof `UNKNOWN`

## Independent review
Accepted and fixed:
- proof identity was resolved after checks and dirty contents were not bound
- branch matrix commands were executed through a shell
- global command trust did not enforce base path-to-check mappings
- configurable reports could overwrite tracked source
- base manual requirements and rename source paths could be lost
- hyphen-prefixed paths could become selector options
- proof inputs could come from uncommitted matrix contents
- interpreter eval modes could execute arbitrary inline text
- blocked live checks could contradictorily report manual proof as not required

No findings were rejected. Final `codex review --base origin/main` reported no actionable findings at exact head.

## Proof
- `python3 -m py_compile scripts/dev/agent-check.py scripts/dev/agent-context.py`
- `python3 scripts/dev/agent-context.py --self-test`
- `python3 scripts/dev/agent-check.py --self-test`
- `bash scripts/dev/agent-preflight.sh --run --report build/agent-proof.json origin/main`
- `git diff --check`
- `codex review --base origin/main`

## Proof boundaries
- deterministic: PASS at exact head `6dfb771f4a615356012fa97ee74ef735e30705cf`
- hosted: repo hygiene PASS; Swift CI must pass before merge
- manual/hardware: not required for this workflow-only change
