### PR TITLE
Measure dictation pre-decode latency

### DIFF
--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -973,19 +973,23 @@ class DictationSessionController: ObservableObject {
                   self.currentDictationSessionID == taskSessionID else { return }
 
             do {
+                stopTiming.snapshotStartedAt = CFAbsoluteTimeGetCurrent()
                 if let recording = await appState.sttRouter.snapshotRecordedSamplesForPersistence() {
+                    stopTiming.snapshotFinishedAt = CFAbsoluteTimeGetCurrent()
                     guard DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
                         taskCancelled: Task.isCancelled,
                         isDictating: self.isDictating,
                         taskSessionID: taskSessionID,
                         currentSessionID: self.currentDictationSessionID
                     ) else { return }
+                    stopTiming.recoveryCheckpointStartedAt = CFAbsoluteTimeGetCurrent()
                     let recovery = try await Task.detached(priority: .userInitiated) {
                         try DictationStoppedAudioRecoveryStore.persist(
                             samples16k: recording.samples16k,
                             sessionID: taskSessionID
                         )
                     }.value
+                    stopTiming.recoveryCheckpointFinishedAt = CFAbsoluteTimeGetCurrent()
                     guard DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
                         taskCancelled: Task.isCancelled,
                         isDictating: self.isDictating,
@@ -1007,8 +1011,11 @@ class DictationSessionController: ObservableObject {
                     }
                     self.stoppedAudioRecovery = recovery
                     stoppedRecordingSnapshot = recording
+                } else {
+                    stopTiming.snapshotFinishedAt = CFAbsoluteTimeGetCurrent()
                 }
             } catch {
+                stopTiming.recoveryCheckpointFinishedAt = CFAbsoluteTimeGetCurrent()
                 guard DictationStoppedAudioRecoveryCommitPolicy.shouldPersist(
                     taskCancelled: Task.isCancelled,
                     isDictating: self.isDictating,
@@ -2427,6 +2434,10 @@ private struct DictationReadinessRefreshTimeout {
 private struct DictationStopTiming {
     let requestedAt: CFAbsoluteTime
     var micStoppedAt: CFAbsoluteTime?
+    var snapshotStartedAt: CFAbsoluteTime?
+    var snapshotFinishedAt: CFAbsoluteTime?
+    var recoveryCheckpointStartedAt: CFAbsoluteTime?
+    var recoveryCheckpointFinishedAt: CFAbsoluteTime?
     var modelWaitStartedAt: CFAbsoluteTime?
     var modelReadyAt: CFAbsoluteTime?
     var transcriptionStartedAt: CFAbsoluteTime?
@@ -2443,6 +2454,11 @@ private struct DictationStopTiming {
     func measurements() -> [String: Int] {
         var values: [String: Int] = [:]
         values["stop_to_mic_stop_ms"] = milliseconds(from: requestedAt, to: micStoppedAt)
+        values["snapshot_resample_ms"] = milliseconds(from: snapshotStartedAt, to: snapshotFinishedAt)
+        values["recovery_checkpoint_ms"] = milliseconds(
+            from: recoveryCheckpointStartedAt,
+            to: recoveryCheckpointFinishedAt
+        )
         values["mic_stop_to_decode_start_ms"] = milliseconds(from: micStoppedAt, to: transcriptionStartedAt)
         values["model_wait_ms"] = milliseconds(from: modelWaitStartedAt, to: modelReadyAt)
         values["decode_ms"] = milliseconds(from: transcriptionStartedAt, to: transcribedAt)

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1434,9 +1434,11 @@ func testRepoCommandContract() {
         )
         assertTrue(
             contents.contains("STOP_LATENCY_STAGE_KEYS")
+                && contents.contains("STOP_LATENCY_AGGREGATE_KEYS")
                 && contents.contains("Dictation stop stage p95s:")
+                && contents.contains("Dictation stop aggregate p95s:")
                 && contents.contains("Dictation stop slowest stage:"),
-            "performance budget should report per-stage stop latency and identify the slowest stop segment"
+            "performance budget should separate independent stages from overlapping aggregates and identify the slowest stop segment"
         )
         assertTrue(
             contents.contains("dictation_request_to_recording_ms"),
@@ -1666,6 +1668,10 @@ func testRepoCommandContract() {
         assertTrue(
             contents.contains("DictationStopTiming(requestedAt: stopRequestedAt)")
                 && contents.contains("stopTiming.micStoppedAt")
+                && contents.contains("stopTiming.snapshotStartedAt")
+                && contents.contains("stopTiming.snapshotFinishedAt")
+                && contents.contains("stopTiming.recoveryCheckpointStartedAt")
+                && contents.contains("stopTiming.recoveryCheckpointFinishedAt")
                 && contents.contains("stopTiming.transcriptionStartedAt")
                 && contents.contains("stopTiming.pastedAt")
                 && contents.contains("stopTiming.savedAt"),
@@ -1673,6 +1679,8 @@ func testRepoCommandContract() {
         )
         assertTrue(
             contents.contains("dictation_stop_latency_measured")
+                && contents.contains("snapshot_resample_ms")
+                && contents.contains("recovery_checkpoint_ms")
                 && contents.contains("stop_to_paste_ms")
                 && contents.contains("stop_to_done_ms"),
             "dictation stop path should emit local raw stop latency measurements"

--- a/scripts/ops/performance-budget.rb
+++ b/scripts/ops/performance-budget.rb
@@ -36,13 +36,17 @@ MIN_STARTUP_SAMPLES = 3
 MIN_MEETING_SAMPLES = 10
 STOP_LATENCY_STAGE_KEYS = [
   "stop_to_mic_stop_ms",
-  "mic_stop_to_decode_start_ms",
+  "snapshot_resample_ms",
+  "recovery_checkpoint_ms",
   "model_wait_ms",
   "decode_ms",
   "cleanup_ms",
   "paste_ms",
   "auto_enter_ms",
   "save_ms"
+].freeze
+STOP_LATENCY_AGGREGATE_KEYS = [
+  "mic_stop_to_decode_start_ms"
 ].freeze
 
 options = {
@@ -356,6 +360,10 @@ if options[:events_path]
       dictation_stop_latency_events,
       STOP_LATENCY_STAGE_KEYS
     )
+    dictation_stop_aggregate_summary = latency_stage_summary(
+      dictation_stop_latency_events,
+      STOP_LATENCY_AGGREGATE_KEYS
+    )
 
     if transcription_elapsed.length < options[:min_transcription_samples]
       errors << "Only #{transcription_elapsed.length} transcription samples, need at least #{options[:min_transcription_samples]}"
@@ -433,6 +441,7 @@ if options[:events_path]
       dictation_stop_to_paste_p95: percentile(dictation_stop_to_paste_ms, 0.95),
       dictation_stop_to_done_p95: percentile(dictation_stop_to_done_ms, 0.95),
       dictation_stop_stage_summary: dictation_stop_stage_summary,
+      dictation_stop_aggregate_summary: dictation_stop_aggregate_summary,
       dictation_stop_slowest_stage: slowest_latency_stage(dictation_stop_stage_summary),
       events_since: options[:events_since]
     }
@@ -563,6 +572,15 @@ if runtime_summary
     puts "Dictation stop stage p95s:"
     STOP_LATENCY_STAGE_KEYS.each do |stage|
       summary = runtime_summary[:dictation_stop_stage_summary][stage]
+      next unless summary
+
+      puts "  #{stage}: p95=#{format("%.1fms", summary[:p95])} max=#{format("%.1fms", summary[:max])} n=#{summary[:count]}"
+    end
+  end
+  unless runtime_summary[:dictation_stop_aggregate_summary].empty?
+    puts "Dictation stop aggregate p95s:"
+    STOP_LATENCY_AGGREGATE_KEYS.each do |stage|
+      summary = runtime_summary[:dictation_stop_aggregate_summary][stage]
       next unless summary
 
       puts "  #{stage}: p95=#{format("%.1fms", summary[:p95])} max=#{format("%.1fms", summary[:max])} n=#{summary[:count]}"


### PR DESCRIPTION
## Summary
- measure stopped-audio resampling separately from durable recovery checkpoint writes
- keep both timings local-only and out of PostHog
- separate independent performance stages from overlapping aggregate timing

## Why
The existing `mic_stop_to_decode_start_ms` value hides two different costs. This makes the next speed change evidence-backed without weakening crash recovery.

## Baseline
Current-main synthetic warm stop-to-text averages:
- very short (3.9s audio): 56ms
- short (10.9s): 106ms
- medium (36.5s): 149ms
- long (111.8s): 303ms
- model initialization: 11.985s

## Acceptance checklist
- [x] Production behavior is unchanged
- [x] Raw timings remain local only
- [x] Performance output identifies independent stages
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` (13,402 passed)
- [x] `ruby -c scripts/ops/performance-budget.rb`
- [x] `bash scripts/dev/agent-preflight.sh`
- [x] Independent `codex review --base origin/main`: CLEAN
- [x] Hosted Swift CI and repo hygiene: green at exact head `2c62858b35bdee165757808f0b990dd26cfc94e0`

## Review
Independent full-diff review found no actionable issues. It specifically verified timing semantics, cancellation/error paths, and separation of independent stages from the overlapping aggregate.

## Proof boundary
Synthetic/local and hosted proof are green. Real microphone, Bluetooth, cold-model, and target-app pasteback performance remain manual hardware UNKNOWN.