### PR TITLE
Benchmark the production dictation stop path

### DIFF
--- a/Sources/Dictation/CLAUDE.md
+++ b/Sources/Dictation/CLAUDE.md
@@ -12,7 +12,7 @@
 - `DictationTranscriptWriter.swift` — groups completed dictations into one markdown file per day; serializes day-file writes through `DictationTranscriptMutationLock`
 - `DictationTranscriptStore.swift` — shared seam for saving dictation markdown and reading the newest saved dictation back out
 - `DictationStopFinalizationPolicy.swift` — chooses whether the Markdown save runs before or after the optional Auto Enter keystroke; the default is `saveBeforeAutoEnter`
-- `DictationStopBenchmarkRunner.swift` — env-gated in-app benchmark for stop-to-text, stop-to-saved, and stop-to-delivery timing on synthetic audio fixtures; it does not touch the real clipboard or focused app
+- `DictationStopBenchmarkRunner.swift` — env-gated in-app benchmark for stop-to-text, stop-to-saved, and stop-to-delivery timing on synthetic audio fixtures; its `production` variant also measures the real snapshot/resample and durable recovery-checkpoint path without touching the real clipboard or focused app
 
 ## Flow
 

--- a/Sources/Dictation/DictationStopBenchmarkRunner.swift
+++ b/Sources/Dictation/DictationStopBenchmarkRunner.swift
@@ -325,7 +325,7 @@ enum DictationStopBenchmarkRunner {
         decodeSeconds: Double,
         stopToText: Double
     ) -> [String: Any] {
-        [
+        var payload: [String: Any] = [
             "record_type": "case_result",
             "timestamp": iso8601.string(from: Date()),
             "case_id": benchmarkCase.id,
@@ -340,11 +340,14 @@ enum DictationStopBenchmarkRunner {
             "bench_samples": preprocessed.samples.count,
             "resampled_samples": preprocessed.resampledSampleCount,
             "preprocess_s": rounded(preprocessed.preprocessSeconds),
-            "snapshot_resample_s": rounded(preprocessed.preprocessSeconds),
-            "recovery_checkpoint_s": rounded(preprocessed.recoveryCheckpointSeconds),
-            "decode_s": rounded(decodeSeconds),
             "stop_to_text_s": rounded(stopToText)
         ]
+        if case .production = config.variant {
+            payload["snapshot_resample_s"] = rounded(preprocessed.preprocessSeconds)
+            payload["recovery_checkpoint_s"] = rounded(preprocessed.recoveryCheckpointSeconds)
+            payload["decode_s"] = rounded(decodeSeconds)
+        }
+        return payload
     }
 
     private static func estimatedResampledSampleCount(inputCount: Int, inputRate: Double) -> Int {

--- a/Sources/Dictation/DictationStopBenchmarkRunner.swift
+++ b/Sources/Dictation/DictationStopBenchmarkRunner.swift
@@ -31,6 +31,7 @@ enum DictationStopBenchmarkRunner {
                 withIntermediateDirectories: true
             )
             try FileManager.default.createDirectory(at: config.saveDirectory, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: config.recoveryDirectory, withIntermediateDirectories: true)
             try? FileManager.default.removeItem(at: config.outputURL)
 
             let cases = try benchmarkCases(in: config.audioDirectory)
@@ -88,6 +89,16 @@ enum DictationStopBenchmarkRunner {
         let stopStarted = CFAbsoluteTimeGetCurrent()
         let preprocessed: PreprocessedAudio
         let rawText: String?
+        let decodeSeconds: Double
+        var stoppedAudioRecovery: DictationStoppedAudioRecovery?
+        defer {
+            if let stoppedAudioRecovery {
+                DictationStoppedAudioRecoveryStore.cleanup(
+                    stoppedAudioRecovery,
+                    explicitDiscard: true
+                )
+            }
+        }
 
         switch config.variant {
         case .native:
@@ -95,13 +106,16 @@ enum DictationStopBenchmarkRunner {
                 samples: loaded.samples,
                 sampleRate: loaded.sampleRate,
                 preprocessSeconds: 0,
+                recoveryCheckpointSeconds: 0,
                 resampledSampleCount: estimatedResampledSampleCount(
                     inputCount: loaded.samples.count,
                     inputRate: loaded.sampleRate
                 )
             )
             engine.loadRecordedSamplesForDictationBenchmark(preprocessed.samples, sampleRate: preprocessed.sampleRate)
+            let decodeStarted = CFAbsoluteTimeGetCurrent()
             rawText = await engine.transcribe()
+            decodeSeconds = CFAbsoluteTimeGetCurrent() - decodeStarted
         case .preResampled:
             let preprocessStarted = CFAbsoluteTimeGetCurrent()
             let resampled = AudioResampler.resample(
@@ -113,10 +127,13 @@ enum DictationStopBenchmarkRunner {
                 samples: resampled,
                 sampleRate: TranscriptedConstants.parakeetSampleRate,
                 preprocessSeconds: CFAbsoluteTimeGetCurrent() - preprocessStarted,
+                recoveryCheckpointSeconds: 0,
                 resampledSampleCount: resampled.count
             )
             engine.loadRecordedSamplesForDictationBenchmark(preprocessed.samples, sampleRate: preprocessed.sampleRate)
+            let decodeStarted = CFAbsoluteTimeGetCurrent()
             rawText = await engine.transcribe()
+            decodeSeconds = CFAbsoluteTimeGetCurrent() - decodeStarted
         case .chunked:
             let preprocessStarted = CFAbsoluteTimeGetCurrent()
             let resampled = AudioResampler.resample(
@@ -128,13 +145,43 @@ enum DictationStopBenchmarkRunner {
                 samples: resampled,
                 sampleRate: TranscriptedConstants.parakeetSampleRate,
                 preprocessSeconds: CFAbsoluteTimeGetCurrent() - preprocessStarted,
+                recoveryCheckpointSeconds: 0,
                 resampledSampleCount: resampled.count
             )
+            let decodeStarted = CFAbsoluteTimeGetCurrent()
             rawText = try await transcribeInChunks(
                 samples16k: preprocessed.samples,
                 chunkSeconds: config.chunkSeconds,
                 engine: engine
             )
+            decodeSeconds = CFAbsoluteTimeGetCurrent() - decodeStarted
+        case .production:
+            engine.loadRecordedSamplesForDictationBenchmark(loaded.samples, sampleRate: loaded.sampleRate)
+            let snapshotStarted = CFAbsoluteTimeGetCurrent()
+            guard let recording = await engine.snapshotRecordedSamplesForPersistence() else {
+                throw BenchmarkError("Production snapshot did not return audio for \(benchmarkCase.id)")
+            }
+            let snapshotSeconds = CFAbsoluteTimeGetCurrent() - snapshotStarted
+            let checkpointStarted = CFAbsoluteTimeGetCurrent()
+            let recovery = try await Task.detached(priority: .userInitiated) {
+                try DictationStoppedAudioRecoveryStore.persist(
+                    samples16k: recording.samples16k,
+                    sessionID: UUID(),
+                    directory: config.recoveryDirectory
+                )
+            }.value
+            let checkpointSeconds = CFAbsoluteTimeGetCurrent() - checkpointStarted
+            stoppedAudioRecovery = recovery
+            preprocessed = PreprocessedAudio(
+                samples: recording.samples16k,
+                sampleRate: TranscriptedConstants.parakeetSampleRate,
+                preprocessSeconds: snapshotSeconds,
+                recoveryCheckpointSeconds: checkpointSeconds,
+                resampledSampleCount: recording.samples16k.count
+            )
+            let decodeStarted = CFAbsoluteTimeGetCurrent()
+            rawText = await engine.transcribe(preparedRecording: recording)
+            decodeSeconds = CFAbsoluteTimeGetCurrent() - decodeStarted
         }
 
         let cleanupResult = rawText.map { text in
@@ -157,6 +204,7 @@ enum DictationStopBenchmarkRunner {
                 loaded: loaded,
                 audioDuration: audioDuration,
                 preprocessed: preprocessed,
+                decodeSeconds: decodeSeconds,
                 stopToText: stopToText
             ).merging([
                 "no_speech": true,
@@ -167,6 +215,11 @@ enum DictationStopBenchmarkRunner {
                 "text_hash": "",
                 "stop_to_delivery_s": rounded(stopToText)
             ]) { _, new in new }, to: config.outputURL)
+            DictationStoppedAudioRecoveryStore.cleanup(
+                stoppedAudioRecovery,
+                explicitDiscard: true
+            )
+            stoppedAudioRecovery = nil
             return
         }
 
@@ -205,6 +258,7 @@ enum DictationStopBenchmarkRunner {
             loaded: loaded,
             audioDuration: audioDuration,
             preprocessed: preprocessed,
+            decodeSeconds: decodeSeconds,
             stopToText: stopToText
         ).merging([
             "no_speech": false,
@@ -218,6 +272,11 @@ enum DictationStopBenchmarkRunner {
             "stop_to_saved_s": rounded(savedAt - stopStarted),
             "stop_to_delivery_s": rounded(deliveredAt - stopStarted)
         ]) { _, new in new }, to: config.outputURL)
+        DictationStoppedAudioRecoveryStore.cleanup(
+            stoppedAudioRecovery,
+            transcriptPersisted: true
+        )
+        stoppedAudioRecovery = nil
     }
 
     private static func transcribeInChunks(
@@ -263,6 +322,7 @@ enum DictationStopBenchmarkRunner {
         loaded: (samples: [Float], sampleRate: Double),
         audioDuration: Double,
         preprocessed: PreprocessedAudio,
+        decodeSeconds: Double,
         stopToText: Double
     ) -> [String: Any] {
         [
@@ -280,6 +340,9 @@ enum DictationStopBenchmarkRunner {
             "bench_samples": preprocessed.samples.count,
             "resampled_samples": preprocessed.resampledSampleCount,
             "preprocess_s": rounded(preprocessed.preprocessSeconds),
+            "snapshot_resample_s": rounded(preprocessed.preprocessSeconds),
+            "recovery_checkpoint_s": rounded(preprocessed.recoveryCheckpointSeconds),
+            "decode_s": rounded(decodeSeconds),
             "stop_to_text_s": rounded(stopToText)
         ]
     }
@@ -324,6 +387,7 @@ enum DictationStopBenchmarkRunner {
         let samples: [Float]
         let sampleRate: Double
         let preprocessSeconds: Double
+        let recoveryCheckpointSeconds: Double
         let resampledSampleCount: Int
     }
 
@@ -331,12 +395,14 @@ enum DictationStopBenchmarkRunner {
         case native
         case preResampled = "pre_resampled"
         case chunked
+        case production
     }
 
     private struct Configuration {
         let audioDirectory: URL
         let outputURL: URL
         let saveDirectory: URL
+        let recoveryDirectory: URL
         let iterations: Int
         let variant: Variant
         let finalizationOrder: DictationStopFinalizationOrder
@@ -352,6 +418,8 @@ enum DictationStopBenchmarkRunner {
             }
             let saveDir = environment["TRANSCRIPTED_DICTATION_STOP_BENCH_SAVE_DIR"]
                 ?? URL(fileURLWithPath: output).deletingLastPathComponent().appendingPathComponent("saved").path
+            let recoveryDir = environment["TRANSCRIPTED_DICTATION_STOP_BENCH_RECOVERY_DIR"]
+                ?? URL(fileURLWithPath: output).deletingLastPathComponent().appendingPathComponent("recovery").path
             let iterationValue = environment["TRANSCRIPTED_DICTATION_STOP_BENCH_ITERATIONS"].flatMap(Int.init) ?? 3
             let variantValue = environment["TRANSCRIPTED_DICTATION_STOP_BENCH_VARIANT"] ?? Variant.native.rawValue
             guard let variant = Variant(rawValue: variantValue) else {
@@ -366,6 +434,7 @@ enum DictationStopBenchmarkRunner {
             audioDirectory = URL(fileURLWithPath: audioDir).standardizedFileURL
             outputURL = URL(fileURLWithPath: output).standardizedFileURL
             saveDirectory = URL(fileURLWithPath: saveDir).standardizedFileURL
+            recoveryDirectory = URL(fileURLWithPath: recoveryDir).standardizedFileURL
             iterations = max(1, iterationValue)
             self.variant = variant
             self.finalizationOrder = finalizationOrder

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1440,6 +1440,25 @@ func testRepoCommandContract() {
                 && contents.contains("Dictation stop slowest stage:"),
             "performance budget should separate independent stages from overlapping aggregates and identify the slowest stop segment"
         )
+        let dictationBenchmark = readRepoTextFile("Sources/Dictation/DictationStopBenchmarkRunner.swift")
+        assertTrue(
+            dictationBenchmark.contains("case .production")
+                && dictationBenchmark.contains("snapshotRecordedSamplesForPersistence()")
+                && dictationBenchmark.contains("DictationStoppedAudioRecoveryStore.persist(")
+                && dictationBenchmark.contains("transcribe(preparedRecording: recording)")
+                && dictationBenchmark.contains("\"snapshot_resample_s\"")
+                && dictationBenchmark.contains("\"recovery_checkpoint_s\"")
+                && dictationBenchmark.contains("\"decode_s\""),
+            "dictation stop autoeval should expose a production-faithful snapshot, checkpoint, and decode path"
+        )
+        let dictationBenchmarkScript = readRepoTextFile("scripts/ops/dictation-stop-autoeval.sh")
+        assertTrue(
+            dictationBenchmarkScript.contains("native|pre_resampled|chunked|production")
+                && dictationBenchmarkScript.contains("TRANSCRIPTED_DICTATION_STOP_BENCH_RECOVERY_DIR")
+                && dictationBenchmarkScript.contains("avg checkpoint_s")
+                && dictationBenchmarkScript.contains("avg decode_s"),
+            "dictation stop autoeval should run and summarize its production variant"
+        )
         assertTrue(
             contents.contains("dictation_request_to_recording_ms"),
             "performance budget should surface true request-to-recording timing when logs include it"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -127,7 +127,8 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - CI-safe Home list/action budget: `scripts/ops/performance-budget.rb --check-home-recent-captures --allow-missing-parakeet-model --max-app-mb 220 --max-resources-mb 80`
   - Manual hardware proof still owns meeting-list 120fps on Apple Silicon; CI checks deterministic loader latency (<750 ms for the 10k stress fixture) and cancellation acknowledgement (<100 ms) only.
 - `scripts/ops/dictation-stop-autoeval.sh` — synthetic local-audio benchmark for dictation stop-to-text, stop-to-saved, and stop-to-delivery timing
-  - Usage: `bash scripts/ops/dictation-stop-autoeval.sh --label baseline --variant native`
+  - Production-path usage: `bash scripts/ops/dictation-stop-autoeval.sh --label baseline --variant production`
+  - The `production` variant includes snapshot/resampling plus the durable recovery checkpoint, but not a real microphone, clipboard, or target app.
   - Writes ignored scratch output under `.autoeval/dictation-stop/`
 - `scripts/ops/dictation-recovery-autoeval.rb` — deterministic policy lab for dictation start-readiness, recovery timing, and Bluetooth-settle guardrails
   - Usage: `ruby scripts/ops/dictation-recovery-autoeval.rb --details`

--- a/scripts/ops/dictation-stop-autoeval.sh
+++ b/scripts/ops/dictation-stop-autoeval.sh
@@ -23,7 +23,7 @@ Usage: scripts/ops/dictation-stop-autoeval.sh [options]
 
 Options:
   --label NAME          Result label (default: run)
-  --variant NAME        native, pre_resampled, or chunked (default: native)
+  --variant NAME        native, pre_resampled, chunked, or production (default: native)
   --iterations N        Iterations per case (default: 3)
   --skip-build          Reuse build/Transcripted.app
   --include-silence     Include the no-speech guardrail fixture
@@ -79,7 +79,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$VARIANT" in
-    native|pre_resampled|chunked) ;;
+    native|pre_resampled|chunked|production) ;;
     *)
         echo "Unknown variant: $VARIANT" >&2
         exit 1
@@ -197,8 +197,9 @@ RESULT_JSONL="$RESULT_DIR/$LABEL-$VARIANT.jsonl"
 RESULT_SUMMARY="$RESULT_DIR/$LABEL-$VARIANT.summary.md"
 RUN_HOME="$WORK_DIR/home-$LABEL-$VARIANT"
 SAVE_DIR="$WORK_DIR/saved-$LABEL-$VARIANT"
-rm -rf "$RUN_HOME" "$SAVE_DIR"
-mkdir -p "$RUN_HOME" "$SAVE_DIR"
+RECOVERY_DIR="$WORK_DIR/recovery-$LABEL-$VARIANT"
+rm -rf "$RUN_HOME" "$SAVE_DIR" "$RECOVERY_DIR"
+mkdir -p "$RUN_HOME" "$SAVE_DIR" "$RECOVERY_DIR"
 
 CFFIXED_USER_HOME="$RUN_HOME" \
 HOME="$RUN_HOME" \
@@ -208,6 +209,7 @@ TRANSCRIPTED_DISABLE_SINGLE_INSTANCE_GUARD=1 \
 TRANSCRIPTED_DICTATION_STOP_BENCH_AUDIO_DIR="$BENCH_FIXTURES" \
 TRANSCRIPTED_DICTATION_STOP_BENCH_OUTPUT="$RESULT_JSONL" \
 TRANSCRIPTED_DICTATION_STOP_BENCH_SAVE_DIR="$SAVE_DIR" \
+TRANSCRIPTED_DICTATION_STOP_BENCH_RECOVERY_DIR="$RECOVERY_DIR" \
 TRANSCRIPTED_DICTATION_STOP_BENCH_ITERATIONS="$ITERATIONS" \
 TRANSCRIPTED_DICTATION_STOP_BENCH_VARIANT="$VARIANT" \
 TRANSCRIPTED_DICTATION_STOP_BENCH_FINALIZATION_ORDER="$FINALIZATION_ORDER" \
@@ -241,8 +243,8 @@ lines << "- Iterations: `#{run["iterations"]}`"
 lines << "- Model init: #{fmt(run["model_init_s"])}s"
 lines << "- Auto Enter simulated: `#{run["simulate_auto_enter"]}`"
 lines << ""
-lines << "| case | n | audio_s | avg text_s | avg saved_s | avg delivery_s | hashes | words |"
-lines << "|---|---:|---:|---:|---:|---:|---|---:|"
+lines << "| case | n | audio_s | avg snapshot_s | avg checkpoint_s | avg decode_s | avg text_s | avg saved_s | avg delivery_s | hashes | words |"
+lines << "|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---:|"
 
 cases.group_by { |record| record["case_id"] }.sort.each do |case_id, rows|
   hashes = rows.map { |row| row["text_hash"] }.uniq.reject(&:empty?)
@@ -251,6 +253,9 @@ cases.group_by { |record| record["case_id"] }.sort.each do |case_id, rows|
     case_id,
     rows.length,
     fmt(avg(rows.map { |row| row["audio_duration_s"] })),
+    fmt(avg(rows.map { |row| row["snapshot_resample_s"] })),
+    fmt(avg(rows.map { |row| row["recovery_checkpoint_s"] })),
+    fmt(avg(rows.map { |row| row["decode_s"] })),
     fmt(avg(rows.map { |row| row["stop_to_text_s"] })),
     fmt(avg(rows.map { |row| row["stop_to_saved_s"] })),
     fmt(avg(rows.map { |row| row["stop_to_delivery_s"] })),


### PR DESCRIPTION
## Summary
- add a `production` dictation-stop benchmark variant
- run the real snapshot/resample, durable recovery checkpoint, prepared-recording decode, and cleanup sequence
- report production-only snapshot, checkpoint, and decode timings separately

## Why
The previous benchmark fed fixtures directly to Parakeet. That was useful for model throughput, but it skipped the production stop path and could not tell us whether recovery safety was causing user-visible delay.

## Measured result
Five deterministic iterations per case on this Mac:

| audio | snapshot | checkpoint | decode | stop to text |
|---|---:|---:|---:|---:|
| 3.9s | ~0ms | 3ms | 65ms | 68ms |
| 10.9s | ~0ms | 5ms | 94ms | 99ms |
| 36.5s | 1ms | 13ms | 140ms | 155ms |
| 111.8s | 3ms | 35ms | 290ms | 328ms |

Model initialization was 12.195s. Recovery checkpointing is not the dominant warm-path cost.

## Acceptance checklist
- [x] No production dictation behavior changes
- [x] Benchmark uses the production snapshot and prepared-recording seams
- [x] Recovery files are cleaned after each case
- [x] Stable transcript hashes across all five iterations
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` (13,404 passed)
- [x] `bash -n scripts/ops/dictation-stop-autoeval.sh`
- [x] `ruby -c scripts/ops/dictation-recovery-autoeval.rb`
- [x] `bash scripts/ops/dictation-stop-autoeval.sh --label production-baseline --variant production --iterations 5`

## Independent review
- Initial review found that stage fields on legacy variants could imply an invalid apples-to-apples decode comparison.
- Fixed in `f802f106` by emitting split stage timings only for the production variant.
- Exact-head review rerun: CLEAN. It independently reran the app build and all 13,404 fast tests.
- Local model lane was attempted but returned HTTP 400; Codex remained the independent final reviewer.

## Proof boundary
This proves deterministic warm-model processing of local fixtures. It does not prove real microphone capture, Bluetooth routing, cold-model behavior in the installed app, clipboard pasteback, or target-app UI timing; those remain manual hardware UNKNOWN.