### PR TITLE
Measure dictation paste phases

### DIFF
--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -14,7 +14,7 @@
 - `CaptureLibraryMigrationPlanner.swift` — copy-only planning and execution for capture-library relocation: detects captures in the old folder, enumerates meeting Markdown plus retained `audio/*_audio/` directories plus dictation day files, skips destination collisions, and never deletes originals
 - `CaptureLibrarySize.swift` — once-per-launch on-disk size measurement/bucketing for the capture library, reported next to the retention setting so unbounded retained-audio growth is visible in the event log
 - `ClaudeDesktopIntegrationInstaller.swift` — installs the bundled read-only MCP helper for Claude Desktop, safely merges `mcpServers` JSON configs, runs the helper self-test, and silently refreshes a stale installed helper at app launch
-- `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app
+- `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app; its local-only timing separates clipboard preparation, Cmd+V dispatch, target read, and confirmation wait
 - `CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements plus text post-processing helpers
 - `DockVisibilityPreferences.swift` — persisted General setting for whether Transcripted should stay visible in the Dock while idle
 - `DictationAutoSendPreferences.swift` — persisted auto-send rules, allowed bundle list, and keypress-sending helpers for pasted dictation

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -67,14 +67,25 @@ struct ClipboardPasteTiming: Equatable {
     let dispatchStartedAt: CFAbsoluteTime?
     let dispatchFinishedAt: CFAbsoluteTime?
     let clipboardReadAt: CFAbsoluteTime?
-    let finishedAt: CFAbsoluteTime
+    let confirmationStartedAt: CFAbsoluteTime?
+    let confirmationFinishedAt: CFAbsoluteTime?
 
     func measurements() -> [String: Int] {
         var values: [String: Int] = [:]
         values["paste_prepare_ms"] = milliseconds(from: startedAt, to: dispatchStartedAt)
         values["paste_dispatch_ms"] = milliseconds(from: dispatchStartedAt, to: dispatchFinishedAt)
-        values["paste_clipboard_read_ms"] = milliseconds(from: dispatchStartedAt, to: clipboardReadAt)
-        values["paste_confirmation_wait_ms"] = milliseconds(from: dispatchFinishedAt, to: finishedAt)
+        if let dispatchStartedAt,
+           let clipboardReadAt,
+           clipboardReadAt >= dispatchStartedAt {
+            values["paste_clipboard_read_ms"] = milliseconds(
+                from: dispatchStartedAt,
+                to: clipboardReadAt
+            )
+        }
+        values["paste_confirmation_wait_ms"] = milliseconds(
+            from: confirmationStartedAt,
+            to: confirmationFinishedAt
+        )
         return values
     }
 
@@ -723,6 +734,8 @@ final class ClipboardRestoringTextPaster {
         let timingStartedAt = CFAbsoluteTimeGetCurrent()
         var timingDispatchStartedAt: CFAbsoluteTime?
         var timingDispatchFinishedAt: CFAbsoluteTime?
+        var timingConfirmationStartedAt: CFAbsoluteTime?
+        var timingConfirmationFinishedAt: CFAbsoluteTime?
         var timingProvider: TemporaryPasteboardStringProvider?
         defer {
             lastPasteTiming = ClipboardPasteTiming(
@@ -730,7 +743,8 @@ final class ClipboardRestoringTextPaster {
                 dispatchStartedAt: timingDispatchStartedAt,
                 dispatchFinishedAt: timingDispatchFinishedAt,
                 clipboardReadAt: timingProvider?.firstReadAt,
-                finishedAt: CFAbsoluteTimeGetCurrent()
+                confirmationStartedAt: timingConfirmationStartedAt,
+                confirmationFinishedAt: timingConfirmationFinishedAt
             )
         }
         discardPasteRetry()
@@ -817,11 +831,13 @@ final class ClipboardRestoringTextPaster {
             return false
         }
 
+        timingConfirmationStartedAt = CFAbsoluteTimeGetCurrent()
         let pasteConfirmationResult = waitForPasteConfirmation(
             targetIsFrontmost: targetRemainsFrontmost,
             pasteConfirmed: confirmPasteReceived,
             timeout: pasteConfirmationWait
         )
+        timingConfirmationFinishedAt = CFAbsoluteTimeGetCurrent()
         guard pasteConfirmationResult == .confirmed else {
             var diagnostics = accessibilityConfirmation?.diagnosticsContext(
                 clipboardReadAt: temporaryProvider?.firstReadAt,

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -62,6 +62,28 @@ struct ClipboardPasteConfirmationDiagnostic: Equatable {
     let context: [String: String]
 }
 
+struct ClipboardPasteTiming: Equatable {
+    let startedAt: CFAbsoluteTime
+    let dispatchStartedAt: CFAbsoluteTime?
+    let dispatchFinishedAt: CFAbsoluteTime?
+    let clipboardReadAt: CFAbsoluteTime?
+    let finishedAt: CFAbsoluteTime
+
+    func measurements() -> [String: Int] {
+        var values: [String: Int] = [:]
+        values["paste_prepare_ms"] = milliseconds(from: startedAt, to: dispatchStartedAt)
+        values["paste_dispatch_ms"] = milliseconds(from: dispatchStartedAt, to: dispatchFinishedAt)
+        values["paste_clipboard_read_ms"] = milliseconds(from: dispatchStartedAt, to: clipboardReadAt)
+        values["paste_confirmation_wait_ms"] = milliseconds(from: dispatchFinishedAt, to: finishedAt)
+        return values
+    }
+
+    private func milliseconds(from start: CFAbsoluteTime?, to end: CFAbsoluteTime?) -> Int? {
+        guard let start, let end else { return nil }
+        return max(0, Int(((end - start) * 1_000).rounded()))
+    }
+}
+
 enum DictationTargetConfirmationMode: String, Equatable {
     case textValue = "text_value"
     case selectionRange = "selection_range"
@@ -589,6 +611,7 @@ final class ClipboardRestoringTextPaster {
     private var temporaryPasteboardDataProvider: TemporaryPasteboardStringProvider?
     private var pasteGeneration = 0
     private(set) var lastConfirmationDiagnostic: ClipboardPasteConfirmationDiagnostic?
+    private(set) var lastPasteTiming: ClipboardPasteTiming?
 
     deinit {
         clipboardRestoreTask?.cancel()
@@ -696,6 +719,20 @@ final class ClipboardRestoringTextPaster {
         pasteConfirmationWait: TimeInterval = TranscriptedConstants.clipboardPasteConfirmationWait
     ) -> TextPasteOutcome {
         lastConfirmationDiagnostic = nil
+        lastPasteTiming = nil
+        let timingStartedAt = CFAbsoluteTimeGetCurrent()
+        var timingDispatchStartedAt: CFAbsoluteTime?
+        var timingDispatchFinishedAt: CFAbsoluteTime?
+        var timingProvider: TemporaryPasteboardStringProvider?
+        defer {
+            lastPasteTiming = ClipboardPasteTiming(
+                startedAt: timingStartedAt,
+                dispatchStartedAt: timingDispatchStartedAt,
+                dispatchFinishedAt: timingDispatchFinishedAt,
+                clipboardReadAt: timingProvider?.firstReadAt,
+                finishedAt: CFAbsoluteTimeGetCurrent()
+            )
+        }
         discardPasteRetry()
         restorePendingClipboardBeforeNewPaste()
 
@@ -738,6 +775,7 @@ final class ClipboardRestoringTextPaster {
         }
         temporaryChangeCount = pasteboard.changeCount
         let temporaryProvider = temporaryPasteboardDataProvider
+        timingProvider = temporaryProvider
 
         scheduleClipboardRestore(
             savedItems,
@@ -749,7 +787,9 @@ final class ClipboardRestoringTextPaster {
         )
 
         let pasteDispatchedAt = CFAbsoluteTimeGetCurrent()
+        timingDispatchStartedAt = pasteDispatchedAt
         guard pasteDispatcher() else {
+            timingDispatchFinishedAt = CFAbsoluteTimeGetCurrent()
             restorePendingClipboardNow()
             guard copyTextToClipboard(text, to: pasteboard) else {
                 return .failed("Couldn't paste or copy the text automatically. It's still saved in your dictation history.")
@@ -759,6 +799,7 @@ final class ClipboardRestoringTextPaster {
                 reason: .pasteEventCreationFailed
             )
         }
+        timingDispatchFinishedAt = CFAbsoluteTimeGetCurrent()
 
         let confirmationUnavailable = pasteConfirmed == nil && accessibilityConfirmation?.canObservePaste != true
         let targetRemainsFrontmost = targetIsFrontmost ?? {

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1187,6 +1187,7 @@ class DictationSessionController: ObservableObject {
             stopTiming.pasteStartedAt = CFAbsoluteTimeGetCurrent()
             let pasteOutcome = self.pasteWithClipboardRestore(text)
             stopTiming.pastedAt = CFAbsoluteTimeGetCurrent()
+            stopTiming.pasteBreakdown = self.textPaster.lastPasteTiming
             let finalization = await DictationStopFinalizer.finalize(
                 order: DictationStopFinalizationPolicy.order,
                 startSaving: {
@@ -2445,6 +2446,7 @@ private struct DictationStopTiming {
     var cleanedAt: CFAbsoluteTime?
     var pasteStartedAt: CFAbsoluteTime?
     var pastedAt: CFAbsoluteTime?
+    var pasteBreakdown: ClipboardPasteTiming?
     var autoEnterStartedAt: CFAbsoluteTime?
     var autoEnterFinishedAt: CFAbsoluteTime?
     var saveStartedAt: CFAbsoluteTime?
@@ -2464,6 +2466,13 @@ private struct DictationStopTiming {
         values["decode_ms"] = milliseconds(from: transcriptionStartedAt, to: transcribedAt)
         values["cleanup_ms"] = milliseconds(from: transcribedAt, to: cleanedAt)
         values["paste_ms"] = milliseconds(from: pasteStartedAt, to: pastedAt)
+        if let pasteBreakdown {
+            values.merge(pasteBreakdown.measurements()) { _, new in new }
+            values["stop_to_paste_dispatch_ms"] = milliseconds(
+                from: requestedAt,
+                to: pasteBreakdown.dispatchFinishedAt
+            )
+        }
         values["auto_enter_ms"] = milliseconds(from: autoEnterStartedAt, to: autoEnterFinishedAt)
         values["save_ms"] = milliseconds(from: saveStartedAt, to: savedAt)
         values["stop_to_paste_ms"] = milliseconds(from: requestedAt, to: pastedAt)

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -56,6 +56,50 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster timing separates dispatch from confirmation") {
+            let pasteboard = NSPasteboard(
+                name: NSPasteboard.Name("TranscriptedPasteTiming-\(UUID().uuidString)")
+            )
+            let paster = ClipboardRestoringTextPaster()
+            let dictationText = "synthetic paste timing"
+            var dispatchedAt: CFAbsoluteTime?
+
+            pasteboard.clearContents()
+            pasteboard.setString("synthetic original clipboard", forType: .string)
+            let outcome = paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    dispatchedAt = CFAbsoluteTimeGetCurrent()
+                    _ = pasteboard.string(forType: .string)
+                    return true
+                },
+                pasteConfirmed: {
+                    guard let dispatchedAt else { return false }
+                    return CFAbsoluteTimeGetCurrent() - dispatchedAt >= 0.06
+                },
+                restoreDelay: 5_000_000,
+                fallbackRestoreDelay: 20_000_000,
+                pasteConfirmationWait: 0.15
+            )
+
+            let measurements = paster.lastPasteTiming?.measurements() ?? [:]
+            assertEqual(outcome, .pasted, "the delayed synthetic confirmation should succeed")
+            assertNotNil(measurements["paste_prepare_ms"], "paste preparation should be measured")
+            assertNotNil(measurements["paste_dispatch_ms"], "Cmd+V dispatch should be measured")
+            assertNotNil(measurements["paste_clipboard_read_ms"], "the target clipboard read should be measured")
+            assertTrue(
+                (measurements["paste_clipboard_read_ms"] ?? 1_000) < 30,
+                "an immediate target clipboard read should stay separate from the later confirmation"
+            )
+            assertTrue(
+                (measurements["paste_confirmation_wait_ms"] ?? 0) >= 40,
+                "the delayed confirmation should be visible as confirmation wait instead of dispatch time"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.capture — focused element cast is crash-proof") {
             // Regression: kAXFocusedUIElementAttribute's CFTypeRef was force-cast
             // straight to AXUIElement with no type check. AXUIElement is a toll-free

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -100,6 +100,49 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster timing excludes non-confirmation work") {
+            let pasteboard = NSPasteboard(
+                name: NSPasteboard.Name("TranscriptedPasteTimingFailure-\(UUID().uuidString)")
+            )
+            let paster = ClipboardRestoringTextPaster()
+
+            pasteboard.clearContents()
+            pasteboard.setString("synthetic original clipboard", forType: .string)
+            let outcome = paster.paste(
+                "synthetic failed dispatch",
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: { false },
+                restoreDelay: 5_000_000,
+                fallbackRestoreDelay: 20_000_000
+            )
+
+            let measurements = paster.lastPasteTiming?.measurements() ?? [:]
+            assertEqual(
+                outcome.copyReason,
+                .pasteEventCreationFailed,
+                "the synthetic dispatcher failure should use the manual-copy fallback"
+            )
+            assertNil(
+                measurements["paste_confirmation_wait_ms"],
+                "fallback clipboard work must not be mislabeled as confirmation waiting"
+            )
+
+            let preDispatchRead = ClipboardPasteTiming(
+                startedAt: 10,
+                dispatchStartedAt: 11,
+                dispatchFinishedAt: 11.01,
+                clipboardReadAt: 10.5,
+                confirmationStartedAt: nil,
+                confirmationFinishedAt: nil
+            ).measurements()
+            assertNil(
+                preDispatchRead["paste_clipboard_read_ms"],
+                "a clipboard manager read before Cmd+V must not look like an immediate target read"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.capture — focused element cast is crash-proof") {
             // Regression: kAXFocusedUIElementAttribute's CFTypeRef was force-cast
             // straight to AXUIElement with no type check. AXUIElement is a toll-free

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1429,6 +1429,8 @@ func testRepoCommandContract() {
         assertTrue(
             contents.contains("dictation_stop_latency_measured")
                 && contents.contains("stop_to_paste_ms")
+                && contents.contains("stop_to_paste_dispatch_ms")
+                && contents.contains("paste_confirmation_wait_ms")
                 && contents.contains("stop_to_done_ms"),
             "performance budget should parse measured dictation stop latency samples"
         )
@@ -1696,6 +1698,7 @@ func testRepoCommandContract() {
 
     runSuite("Repo command contract - dictation stop path emits paste latency proof") {
         let contents = readRepoTextFile("Sources/UI/Overlay/DictationSessionController.swift")
+        let pasterContents = readRepoTextFile("Sources/Support/ClipboardRestoringTextPaster.swift")
         assertTrue(
             contents.contains("DictationStopTiming(requestedAt: stopRequestedAt)")
                 && contents.contains("stopTiming.micStoppedAt")
@@ -1712,9 +1715,18 @@ func testRepoCommandContract() {
             contents.contains("dictation_stop_latency_measured")
                 && contents.contains("snapshot_resample_ms")
                 && contents.contains("recovery_checkpoint_ms")
+                && contents.contains("pasteBreakdown.measurements()")
+                && contents.contains("stop_to_paste_dispatch_ms")
                 && contents.contains("stop_to_paste_ms")
                 && contents.contains("stop_to_done_ms"),
             "dictation stop path should emit local raw stop latency measurements"
+        )
+        assertTrue(
+            pasterContents.contains("paste_prepare_ms")
+                && pasterContents.contains("paste_dispatch_ms")
+                && pasterContents.contains("paste_clipboard_read_ms")
+                && pasterContents.contains("paste_confirmation_wait_ms"),
+            "paste timing should separate preparation, dispatch, target read, and confirmation wait"
         )
         assertTrue(
             contents.contains("AnalyticsReporter.latencyBucket(milliseconds:")

--- a/scripts/ops/performance-budget.rb
+++ b/scripts/ops/performance-budget.rb
@@ -41,12 +41,17 @@ STOP_LATENCY_STAGE_KEYS = [
   "model_wait_ms",
   "decode_ms",
   "cleanup_ms",
-  "paste_ms",
+  "paste_prepare_ms",
+  "paste_dispatch_ms",
+  "paste_confirmation_wait_ms",
   "auto_enter_ms",
   "save_ms"
 ].freeze
 STOP_LATENCY_AGGREGATE_KEYS = [
-  "mic_stop_to_decode_start_ms"
+  "mic_stop_to_decode_start_ms",
+  "paste_ms",
+  "paste_clipboard_read_ms",
+  "stop_to_paste_dispatch_ms"
 ].freeze
 
 options = {


### PR DESCRIPTION
## What changed
- split dictation paste timing into preparation, Cmd+V dispatch, target clipboard read, and confirmation wait
- report stop-to-paste-dispatch separately from overlapping paste bookkeeping
- keep existing paste, clipboard restoration, Auto Enter, and telemetry behavior unchanged

## Why
The existing `paste_ms` number made a 350 ms confirmation budget look like a 350 ms delay before text appeared. This change gives us the evidence needed to remove unnecessary waiting without weakening paste safety.

## Behavior impact
- Production paste behavior: unchanged
- Off-device analytics shape: unchanged
- Local diagnostics: more precise phase timing
- Manual target-app proof: UNKNOWN

## Acceptance checklist
- [x] Cmd+V dispatch and target clipboard read are measured separately from confirmation waiting
- [x] Slowest-stage reporting uses independent phases
- [x] Failed dispatch recovery is excluded from confirmation timing
- [x] Clipboard-manager reads before Cmd+V are excluded from target-read timing
- [x] Existing clipboard restoration and retry behavior remains covered
- [x] No raw transcript text or target identifiers are logged
- [x] `bash build.sh --no-open`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (13,415/13,415)
- [x] `python3 scripts/dev/check-build-source-lists.py`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-slow-pasteback-smoke.sh` (9/9)
- [x] `ruby -c scripts/ops/performance-budget.rb`
- [x] `bash scripts/dev/agent-preflight.sh`
- [x] Independent full-diff review
- [ ] Required GitHub checks

## Independent review
`codex review --base origin/main` first found two timing-boundary errors: fallback work mislabeled as confirmation wait, and pre-dispatch clipboard reads mislabeled as target reads. Both were fixed in `f0ec40d9`. The final exact-head review reported no accepted/actionable findings.

Claude risk review proof for the original timing path: `/Users/redbars/.codex/maestro/runs/20260729T163144Z-paste-timing-risk-review-claude`. The final Codex review is authoritative because a later Claude helper response read stale compute-benchmark context.