### PR TITLE
Skip redundant dictation paste wait

### DIFF
--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -14,7 +14,7 @@
 - `CaptureLibraryMigrationPlanner.swift` — copy-only planning and execution for capture-library relocation: detects captures in the old folder, enumerates meeting Markdown plus retained `audio/*_audio/` directories plus dictation day files, skips destination collisions, and never deletes originals
 - `CaptureLibrarySize.swift` — once-per-launch on-disk size measurement/bucketing for the capture library, reported next to the retention setting so unbounded retained-audio growth is visible in the event log
 - `ClaudeDesktopIntegrationInstaller.swift` — installs the bundled read-only MCP helper for Claude Desktop, safely merges `mcpServers` JSON configs, runs the helper self-test, and silently refreshes a stale installed helper at app launch
-- `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app; its local-only timing separates clipboard preparation, Cmd+V dispatch, target read, and confirmation wait
+- `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app; its local-only timing separates clipboard preparation, Cmd+V dispatch, target read, and confirmation wait. Non-Auto-Enter pastes stop waiting once a post-dispatch target read is visible, while Auto Enter keeps the stricter confirmation path.
 - `CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements plus text post-processing helpers
 - `DockVisibilityPreferences.swift` — persisted General setting for whether Transcripted should stay visible in the Dock while idle
 - `DictationAutoSendPreferences.swift` — persisted auto-send rules, allowed bundle list, and keypress-sending helpers for pasted dictation

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -830,11 +830,20 @@ final class ClipboardRestoringTextPaster {
             }
             return false
         }
+        let stopWaitingAfterClipboardRead = {
+            guard confirmationUnavailable,
+                  !prepareForAutoSend,
+                  let clipboardReadAt = temporaryProvider?.firstReadAt else {
+                return false
+            }
+            return clipboardReadAt >= pasteDispatchedAt
+        }
 
         timingConfirmationStartedAt = CFAbsoluteTimeGetCurrent()
         let pasteConfirmationResult = waitForPasteConfirmation(
             targetIsFrontmost: targetRemainsFrontmost,
             pasteConfirmed: confirmPasteReceived,
+            stopWaitingUnconfirmed: stopWaitingAfterClipboardRead,
             timeout: pasteConfirmationWait
         )
         timingConfirmationFinishedAt = CFAbsoluteTimeGetCurrent()
@@ -1142,6 +1151,7 @@ final class ClipboardRestoringTextPaster {
     private func waitForPasteConfirmation(
         targetIsFrontmost: @MainActor () -> Bool,
         pasteConfirmed: @MainActor () -> Bool,
+        stopWaitingUnconfirmed: @MainActor () -> Bool,
         timeout: TimeInterval
     ) -> ClipboardPasteConfirmationWaitResult {
         guard targetIsFrontmost() else { return .focusChanged }
@@ -1149,6 +1159,9 @@ final class ClipboardRestoringTextPaster {
             return targetIsFrontmost() ? .confirmed : .focusChanged
         }
         guard targetIsFrontmost() else { return .focusChanged }
+        if stopWaitingUnconfirmed() {
+            return .unconfirmed
+        }
         guard timeout > 0 else { return .unconfirmed }
 
         let start = Date()
@@ -1157,6 +1170,9 @@ final class ClipboardRestoringTextPaster {
             guard targetIsFrontmost() else { return .focusChanged }
             if pasteConfirmed() {
                 return targetIsFrontmost() ? .confirmed : .focusChanged
+            }
+            if stopWaitingUnconfirmed() {
+                return .unconfirmed
             }
         }
         guard targetIsFrontmost() else { return .focusChanged }

--- a/Tests/CIWorkflowContractTests.swift
+++ b/Tests/CIWorkflowContractTests.swift
@@ -79,8 +79,8 @@ func testCIWorkflowContract() {
         )
         let skipMarkerCount = occurrences(of: "    SKIPPED: wall-clock timing proof", in: clipboardTests)
 
-        assertEqual(guardCount, 3, "exactly three clipboard timing proofs should guard on the timing-skip env")
-        assertEqual(skipMarkerCount, 3, "exactly three clipboard timing proofs should print a SKIPPED marker")
+        assertEqual(guardCount, 4, "exactly four clipboard timing proofs should guard on the timing-skip env")
+        assertEqual(skipMarkerCount, 4, "exactly four clipboard timing proofs should print a SKIPPED marker")
     }
 }
 

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -143,6 +143,48 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster stops waiting after a non-sending target reads") {
+            if ProcessInfo.processInfo.environment["TRANSCRIPTED_SKIP_TIMING_SENSITIVE_TESTS"] == "1" {
+                print("    SKIPPED: wall-clock timing proof — covered by local runs")
+                return
+            }
+            let pasteboard = NSPasteboard(
+                name: NSPasteboard.Name("TranscriptedPasteReadExit-\(UUID().uuidString)")
+            )
+            let paster = ClipboardRestoringTextPaster()
+            let dictationText = "synthetic immediate target read"
+
+            pasteboard.clearContents()
+            pasteboard.setString("synthetic original clipboard", forType: .string)
+            let outcome = paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    _ = pasteboard.string(forType: .string)
+                    return true
+                },
+                restoreDelay: 5_000_000,
+                fallbackRestoreDelay: 20_000_000,
+                pasteConfirmationWait: 0.35
+            )
+
+            let measurements = paster.lastPasteTiming?.measurements() ?? [:]
+            assertEqual(
+                outcome,
+                .copied(
+                    "Transcripted sent paste, but this target did not expose paste confirmation. The text stays copied.",
+                    reason: .pasteConfirmationUnavailable
+                ),
+                "a read-only target should keep the existing honest copied outcome"
+            )
+            assertTrue(
+                (measurements["paste_confirmation_wait_ms"] ?? 350) < 50,
+                "a post-dispatch clipboard read should avoid the remaining 350ms wait when Auto Enter is off"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.capture — focused element cast is crash-proof") {
             // Regression: kAXFocusedUIElementAttribute's CFTypeRef was force-cast
             // straight to AXUIElement with no type check. AXUIElement is a toll-free


### PR DESCRIPTION
## What changed
- stop the paste-confirmation loop after a post-Cmd+V clipboard read when Auto Enter is off
- keep the existing honest `copied / confirmation unavailable` result and recovery clipboard
- preserve the full confirmation wait for Auto Enter and targets that never read the clipboard

## Why
The 350 ms value is a safety ceiling, not useful work. On the common path where the target has already read the borrowed clipboard, continuing to wait only delays overlay finalization and makes dictation feel slower.

## Measured result
The focused timing proof uses the production 350 ms ceiling and observes the non-Auto-Enter read path finishing in under 50 ms.

## Safety boundaries
- [x] Auto Enter cannot use the early exit
- [x] Unread targets keep the full confirmation ceiling
- [x] Outcome remains copied/unconfirmed rather than falsely claiming paste success
- [x] Dictation text remains available for manual recovery
- [x] Clipboard restore/retry behavior is unchanged
- [x] No analytics or privacy payload changes

## Verification
- [x] `bash build.sh --no-open`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (13,417/13,417)
- [x] `python3 scripts/dev/check-build-source-lists.py`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-slow-pasteback-smoke.sh` (9/9)
- [x] `bash scripts/dev/agent-preflight.sh`
- [x] Independent full-diff review: `codex-review --mode branch` clean, no actionable findings
- [x] Required GitHub software checks

## Manual proof
Real TextEdit, Notes, browser, and Codex paste feel remains UNKNOWN until tested on the installed app. The skipped hardware-smokes job is not treated as green.