### PR TITLE
Preload dictation model quietly after launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Fast tests are top-level functions, not XCTest cases. To run one in isolation, u
 Top-level entry points (see `Sources/CLAUDE.md` for the full list):
 
 - `TranscriptedApp.swift` — app entry, menubar wiring, popover/overlay setup, detected-meeting prompts, activation-policy switching so active recordings stay visible in the force-quit dialog
-- `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, wake-recovery coordination, and the lazy `MeetingSessionController`
+- `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, quiet background dictation-model warmup, wake-recovery coordination, and the lazy `MeetingSessionController`
 - `TranscriptedMenuCommands.swift` — menubar/menu command wiring
 
 Subsystem boundaries (each has a local `CLAUDE.md`):

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -12,7 +12,7 @@
 Important entry points:
 
 - `TranscriptedApp.swift` — app entry point, menubar wiring, popover, overlay setup, detected-meeting prompt wiring, and activation-policy switching so active recordings stay visible in the macOS force-quit dialog
-- `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, wake-recovery coordination, and lazy `MeetingSessionController`
+- `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, quiet background dictation-model warmup, wake-recovery coordination, and lazy `MeetingSessionController`
 - `TranscriptedMenuCommands.swift` — app-active macOS command menus for capture, import, navigation, and speaker search; these are additive window-scoped shortcuts and do not replace global physical triggers
 - `Support/TranscriptedStoragePaths.swift` — app-support path helpers for the Transcripted capture-library, state, cache, logs, and tmp layout
 - `Support/HotkeyPreferences.swift` — persisted dictation shortcut mode, meeting shortcut compatibility, and legacy hotkey migration helpers

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -29,7 +29,7 @@ Important entry points:
 - `UI/Overlay/DictationSessionController.swift` — dictation session orchestration
 - `Meeting/MeetingPromptDetector.swift` — Calendar and runtime-app meeting detection used to offer one-tap meeting capture prompts
 - `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including live capture, imported-audio handoff, queued meeting transcription, and local-speaker-split settings
-- `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter; model selection cancels only unclaimed launch warmup, while any dictation, meeting, or import that joins the load promotes it to protected foreground work; Parakeet CoreAudio lookup and startup support live in the adjacent `ParakeetAudio*` support files
+- `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter; model selection cancels only unclaimed background warmup, while any dictation, meeting, or import that joins the load promotes it to protected foreground work; Parakeet CoreAudio lookup and startup support live in the adjacent `ParakeetAudio*` support files
 
 ## Directory map
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -29,7 +29,7 @@ Important entry points:
 - `UI/Overlay/DictationSessionController.swift` — dictation session orchestration
 - `Meeting/MeetingPromptDetector.swift` — Calendar and runtime-app meeting detection used to offer one-tap meeting capture prompts
 - `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including live capture, imported-audio handoff, queued meeting transcription, and local-speaker-split settings
-- `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter; Parakeet CoreAudio lookup and startup support live in the adjacent `ParakeetAudio*` support files
+- `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter; model selection cancels obsolete background model work while preserving the engine needed by an active recording; Parakeet CoreAudio lookup and startup support live in the adjacent `ParakeetAudio*` support files
 
 ## Directory map
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -29,7 +29,7 @@ Important entry points:
 - `UI/Overlay/DictationSessionController.swift` — dictation session orchestration
 - `Meeting/MeetingPromptDetector.swift` — Calendar and runtime-app meeting detection used to offer one-tap meeting capture prompts
 - `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including live capture, imported-audio handoff, queued meeting transcription, and local-speaker-split settings
-- `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter; model selection cancels obsolete background model work while preserving the engine needed by an active recording; Parakeet CoreAudio lookup and startup support live in the adjacent `ParakeetAudio*` support files
+- `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter; model selection cancels only unclaimed launch warmup, while any dictation, meeting, or import that joins the load promotes it to protected foreground work; Parakeet CoreAudio lookup and startup support live in the adjacent `ParakeetAudio*` support files
 
 ## Directory map
 

--- a/Sources/Meeting/MeetingSTTAdapter.swift
+++ b/Sources/Meeting/MeetingSTTAdapter.swift
@@ -50,6 +50,7 @@ final class MeetingSTTAdapter: ObservableObject, SpeechToTextEngine {
 
     func selectPreparedModel(_ model: TranscriptionModelChoice) {
         preparedModel = model
+        router.claimModelForForegroundUse(model)
     }
 
     func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String {

--- a/Sources/Speech/NemotronEngine.swift
+++ b/Sources/Speech/NemotronEngine.swift
@@ -21,6 +21,7 @@ final class NemotronEngine: ObservableObject {
 
     private var manager: (any StreamingAsrManager)?
     private var initializationTask: Task<Void, Never>?
+    private var initializationGeneration: UInt64 = 0
     // Serializes transcribeSamples calls: the streaming manager is stateful
     // (appendAudio → processBufferedAudio → finish → reset), so overlapping
     // segments must never interleave on the same manager.
@@ -40,13 +41,15 @@ final class NemotronEngine: ObservableObject {
             return
         }
 
+        initializationGeneration &+= 1
+        let generation = initializationGeneration
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.load()
+            await self.load(generation: generation)
         }
         initializationTask = task
         await task.value
-        if initializationTask == task {
+        if initializationGeneration == generation, initializationTask == task {
             initializationTask = nil
         }
     }
@@ -74,6 +77,7 @@ final class NemotronEngine: ObservableObject {
     }
 
     func cleanup() {
+        initializationGeneration &+= 1
         initializationTask?.cancel()
         initializationTask = nil
         inFlightTranscription?.cancel()
@@ -184,7 +188,8 @@ final class NemotronEngine: ObservableObject {
         }
     }
 
-    private func load() async {
+    private func load(generation: UInt64) async {
+        guard generation == initializationGeneration, !Task.isCancelled else { return }
         if manager == nil {
             manager = Self.variant.createManager()
         }
@@ -199,7 +204,7 @@ final class NemotronEngine: ObservableObject {
         do {
             try await manager.loadModels()
 
-            guard !Task.isCancelled else { return }
+            guard generation == initializationGeneration, !Task.isCancelled else { return }
             modelDownloadState = .ready
             EventReporter.shared.capture(
                 level: .info,
@@ -209,6 +214,7 @@ final class NemotronEngine: ObservableObject {
                 context: ["model": Self.model.rawValue]
             )
         } catch {
+            guard generation == initializationGeneration, !Task.isCancelled else { return }
             let friendlyMessage = "Couldn't load \(Self.model.title): \(error.localizedDescription)"
             AppLogger.transcription.error("NEMOTRON | \(friendlyMessage)")
             modelDownloadState = .failed(friendlyMessage)

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -24,6 +24,7 @@ class STTRouter: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private var activeRecordingModel: TranscriptionModelChoice?
     private var backgroundWarmupModel: TranscriptionModelChoice?
+    private var foregroundOwnedModels: Set<TranscriptionModelChoice> = []
 
     var isModelLoaded: Bool {
         isModelLoaded(for: selectedModel)
@@ -141,13 +142,18 @@ class STTRouter: ObservableObject {
 
     func initializeSelectedModelInBackground() async {
         let model = selectedModel
-        backgroundWarmupModel = model
-        defer {
-            if backgroundWarmupModel == model {
-                backgroundWarmupModel = nil
-            }
+        // A loaded model may already belong to active or prior foreground use.
+        // Do not reclassify it as disposable launch work during wake recovery.
+        guard !isModelLoaded(for: model), !foregroundOwnedModels.contains(model) else {
+            refreshModelDownloadState()
+            return
         }
+
+        backgroundWarmupModel = model
         await initializeModel(model)
+        if backgroundWarmupModel == model, !isModelLoaded(for: model) {
+            backgroundWarmupModel = nil
+        }
     }
 
     func prefetchSelectedModelFilesForExistingInstall() async {
@@ -157,12 +163,18 @@ class STTRouter: ObservableObject {
     }
 
     func initialize(model: TranscriptionModelChoice) async {
-        // Any real dictation, meeting, or import that joins launch warmup owns
-        // that work now. A later preference change must not cancel it.
+        claimModelForForegroundUse(model)
+        await initializeModel(model)
+    }
+
+    /// Promote launch-preloaded work to foreground ownership. Once dictation,
+    /// meetings, or imports use a model, preference changes must not tear it
+    /// down as obsolete background work.
+    func claimModelForForegroundUse(_ model: TranscriptionModelChoice) {
+        foregroundOwnedModels.insert(model)
         if backgroundWarmupModel == model {
             backgroundWarmupModel = nil
         }
-        await initializeModel(model)
     }
 
     private func initializeModel(_ model: TranscriptionModelChoice) async {
@@ -201,16 +213,19 @@ class STTRouter: ObservableObject {
     }
 
     func startRecording() async -> Bool {
+        claimModelForForegroundUse(selectedModel)
         activeRecordingModel = selectedModel
         return await parakeetEngine.startRecording()
     }
 
     func startRecordingRecoveryAttempt() async -> Bool {
+        claimModelForForegroundUse(selectedModel)
         activeRecordingModel = selectedModel
         return await parakeetEngine.startRecording(isRecoveryAttempt: true)
     }
 
     func startRecordingFromSharedMeetingMic() -> Bool {
+        claimModelForForegroundUse(selectedModel)
         activeRecordingModel = selectedModel
         return parakeetEngine.startSharedMeetingMicRecording()
     }
@@ -344,6 +359,7 @@ class STTRouter: ObservableObject {
         model: TranscriptionModelChoice? = nil
     ) async throws -> String {
         let resolvedModel = model ?? selectedModel
+        claimModelForForegroundUse(resolvedModel)
         // The meeting pipeline calls this once per diarized segment (hundreds
         // of times for a long recording). Models are loaded once before the
         // pipeline starts (Transcription.ensureModelsReadyForPipeline via
@@ -374,6 +390,8 @@ class STTRouter: ObservableObject {
     }
 
     func cleanup() {
+        backgroundWarmupModel = nil
+        foregroundOwnedModels.removeAll()
         parakeetEngine.cleanup()
         whisperEngine.cleanup()
         nemotronEngine.cleanup()

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -120,7 +120,7 @@ class STTRouter: ObservableObject {
         selectedModel = nextModel
         refreshModelDownloadState()
         Task { @MainActor [weak self] in
-            await self?.initializeSelectedModel()
+            await self?.initializeSelectedModelInBackground()
         }
     }
 
@@ -143,15 +143,20 @@ class STTRouter: ObservableObject {
     func initializeSelectedModelInBackground() async {
         let model = selectedModel
         // A loaded model may already belong to active or prior foreground use.
-        // Do not reclassify it as disposable launch work during wake recovery.
-        guard !isModelLoaded(for: model), !foregroundOwnedModels.contains(model) else {
+        // Do not reclassify it as disposable background work during wake recovery.
+        guard !isModelLoaded(for: model) else {
             refreshModelDownloadState()
             return
         }
 
-        backgroundWarmupModel = model
+        let ownsBackgroundWarmup = !foregroundOwnedModels.contains(model)
+        if ownsBackgroundWarmup {
+            backgroundWarmupModel = model
+        }
         await initializeModel(model)
-        if backgroundWarmupModel == model, !isModelLoaded(for: model) {
+        if ownsBackgroundWarmup,
+           backgroundWarmupModel == model,
+           !isModelLoaded(for: model) {
             backgroundWarmupModel = nil
         }
     }
@@ -167,7 +172,7 @@ class STTRouter: ObservableObject {
         await initializeModel(model)
     }
 
-    /// Promote launch-preloaded work to foreground ownership. Once dictation,
+    /// Promote background-preloaded work to foreground ownership. Once dictation,
     /// meetings, or imports use a model, preference changes must not tear it
     /// down as obsolete background work.
     func claimModelForForegroundUse(_ model: TranscriptionModelChoice) {

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -23,6 +23,7 @@ class STTRouter: ObservableObject {
 
     private var cancellables: Set<AnyCancellable> = []
     private var activeRecordingModel: TranscriptionModelChoice?
+    private var backgroundWarmupModel: TranscriptionModelChoice?
 
     var isModelLoaded: Bool {
         isModelLoaded(for: selectedModel)
@@ -111,7 +112,10 @@ class STTRouter: ObservableObject {
         let nextModel = TranscriptionModelPreferences.effectiveModel()
         guard nextModel != selectedModel else { return }
 
-        cancelObsoleteModelWork(for: selectedModel)
+        if backgroundWarmupModel == selectedModel {
+            cancelBackgroundWarmup(for: selectedModel)
+            backgroundWarmupModel = nil
+        }
         selectedModel = nextModel
         refreshModelDownloadState()
         Task { @MainActor [weak self] in
@@ -119,11 +123,7 @@ class STTRouter: ObservableObject {
         }
     }
 
-    private func cancelObsoleteModelWork(for model: TranscriptionModelChoice) {
-        // A model assigned to the active recording must stay alive until that
-        // recording has been transcribed.
-        guard activeRecordingModel != model else { return }
-
+    private func cancelBackgroundWarmup(for model: TranscriptionModelChoice) {
         switch model {
         case .parakeetTDTv3:
             parakeetEngine.cancelModelWork()
@@ -139,6 +139,17 @@ class STTRouter: ObservableObject {
         await initialize(model: selectedModel)
     }
 
+    func initializeSelectedModelInBackground() async {
+        let model = selectedModel
+        backgroundWarmupModel = model
+        defer {
+            if backgroundWarmupModel == model {
+                backgroundWarmupModel = nil
+            }
+        }
+        await initializeModel(model)
+    }
+
     func prefetchSelectedModelFilesForExistingInstall() async {
         guard selectedModel == .parakeetTDTv3 else { return }
         await parakeetEngine.prefetchModelFilesIfNeeded()
@@ -146,6 +157,15 @@ class STTRouter: ObservableObject {
     }
 
     func initialize(model: TranscriptionModelChoice) async {
+        // Any real dictation, meeting, or import that joins launch warmup owns
+        // that work now. A later preference change must not cancel it.
+        if backgroundWarmupModel == model {
+            backgroundWarmupModel = nil
+        }
+        await initializeModel(model)
+    }
+
+    private func initializeModel(_ model: TranscriptionModelChoice) async {
         guard !isModelLoaded(for: model) else {
             refreshModelDownloadState()
             return

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -108,10 +108,30 @@ class STTRouter: ObservableObject {
     }
 
     private func handleModelSelectionChange() {
-        selectedModel = TranscriptionModelPreferences.effectiveModel()
+        let nextModel = TranscriptionModelPreferences.effectiveModel()
+        guard nextModel != selectedModel else { return }
+
+        cancelObsoleteModelWork(for: selectedModel)
+        selectedModel = nextModel
         refreshModelDownloadState()
         Task { @MainActor [weak self] in
             await self?.initializeSelectedModel()
+        }
+    }
+
+    private func cancelObsoleteModelWork(for model: TranscriptionModelChoice) {
+        // A model assigned to the active recording must stay alive until that
+        // recording has been transcribed.
+        guard activeRecordingModel != model else { return }
+
+        switch model {
+        case .parakeetTDTv3:
+            parakeetEngine.cancelModelWork()
+            parakeetEngine.teardownModel()
+        case .whisperLargeV3Turbo, .whisperLargeV3:
+            whisperEngine.cleanup()
+        case .nemotronStreaming:
+            nemotronEngine.cleanup()
         }
     }
 

--- a/Sources/Speech/WhisperEngine.swift
+++ b/Sources/Speech/WhisperEngine.swift
@@ -15,6 +15,7 @@ final class WhisperEngine: ObservableObject {
     private var loadedModel: TranscriptionModelChoice?
     private var initializingModel: TranscriptionModelChoice?
     private var initializationTask: Task<Void, Never>?
+    private var initializationGeneration: UInt64 = 0
 
     var activeModel: TranscriptionModelChoice? {
         loadedModel
@@ -37,16 +38,18 @@ final class WhisperEngine: ObservableObject {
         }
 
         initializationTask?.cancel()
+        initializationGeneration &+= 1
+        let generation = initializationGeneration
         initializingModel = model
 
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.load(model: model)
+            await self.load(model: model, generation: generation)
         }
         initializationTask = task
         await task.value
 
-        if initializingModel == model {
+        if initializationGeneration == generation {
             initializationTask = nil
             initializingModel = nil
         }
@@ -162,6 +165,7 @@ final class WhisperEngine: ObservableObject {
     }
 
     func cleanup() {
+        initializationGeneration &+= 1
         initializationTask?.cancel()
         initializationTask = nil
         initializingModel = nil
@@ -174,14 +178,16 @@ final class WhisperEngine: ObservableObject {
         }
     }
 
-    private func load(model: TranscriptionModelChoice) async {
+    private func load(model: TranscriptionModelChoice, generation: UInt64) async {
         guard let variant = model.whisperKitModelName else { return }
+        guard generation == initializationGeneration, !Task.isCancelled else { return }
 
         if loadedModel != model {
             let existing = whisperKit
             whisperKit = nil
             loadedModel = nil
             await existing?.unloadModels()
+            guard generation == initializationGeneration, !Task.isCancelled else { return }
         }
 
         modelDownloadState = .downloading(progress: 0)
@@ -196,12 +202,16 @@ final class WhisperEngine: ObservableObject {
                 from: modelRepo
             ) { [weak self] progress in
                 Task { @MainActor in
-                    guard let self, self.initializingModel == model else { return }
+                    guard
+                        let self,
+                        self.initializationGeneration == generation,
+                        self.initializingModel == model
+                    else { return }
                     self.modelDownloadState = .downloading(progress: progress.fractionCompleted)
                 }
             }
 
-            guard !Task.isCancelled else { return }
+            guard generation == initializationGeneration, !Task.isCancelled else { return }
             modelDownloadState = .loading
             AppLogger.transcription.info("WHISPER | loading \(model.title) from \(modelFolder.path)")
 
@@ -219,7 +229,7 @@ final class WhisperEngine: ObservableObject {
             )
             let pipe = try await WhisperKit(config)
 
-            guard !Task.isCancelled else {
+            guard generation == initializationGeneration, !Task.isCancelled else {
                 await pipe.unloadModels()
                 return
             }
@@ -240,6 +250,7 @@ final class WhisperEngine: ObservableObject {
                 ]
             )
         } catch {
+            guard generation == initializationGeneration, !Task.isCancelled else { return }
             let friendlyMessage = "Couldn't load \(model.title): \(error.localizedDescription)"
             AppLogger.transcription.error("WHISPER | \(friendlyMessage)")
             modelDownloadState = .failed(friendlyMessage)

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -33,7 +33,7 @@ class TranscriptedAppState: ObservableObject {
     private var isInitialized = false
     private var isShutDown = false
     private let eagerModelWarmupEnabled =
-        ProcessInfo.processInfo.environment["TRANSCRIPTED_EAGER_MODEL_WARMUP"] == "1"
+        ProcessInfo.processInfo.environment["TRANSCRIPTED_EAGER_MODEL_WARMUP"] != "0"
     private lazy var wakeRecoveryCoordinator = WakeRecoveryCoordinator(
         hotkeyRetryAttempts: Self.wakeHotkeyRetryAttempts,
         hotkeyRetryDelay: Self.wakeHotkeyRetryDelay,
@@ -100,7 +100,7 @@ class TranscriptedAppState: ObservableObject {
         }
         AppSoundPlayer.shared.preload()
 
-        if eagerModelWarmupEnabled {
+        if eagerModelWarmupEnabled && !Self.isLaunchSmokeMode {
             startRuntimeReadinessIfNeeded()
         } else {
             startExistingInstallModelPrefetchIfNeeded()
@@ -255,13 +255,12 @@ class TranscriptedAppState: ObservableObject {
     private func startRuntimeReadinessIfNeeded() {
         guard runtimeReadinessTask == nil else { return }
 
-        runtimeReadinessTask = Task { @MainActor [weak self] in
+        runtimeReadinessTask = Task(priority: .utility) { @MainActor [weak self] in
             guard let self else { return }
             defer { self.runtimeReadinessTask = nil }
 
-            // Keep default launch lightweight. Dictation, imports, model
-            // preference changes, and the optional eager-warmup env flag load
-            // the selected model only when that work is actually needed.
+            // UI setup is complete before this task starts. Load the selected
+            // model quietly so first dictation can begin without a cold start.
             guard !Task.isCancelled else { return }
             await self.sttRouter.initializeSelectedModel()
             // Keep heavier meeting diarization lazy. Meeting start/import paths

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -262,7 +262,7 @@ class TranscriptedAppState: ObservableObject {
             // UI setup is complete before this task starts. Load the selected
             // model quietly so first dictation can begin without a cold start.
             guard !Task.isCancelled else { return }
-            await self.sttRouter.initializeSelectedModel()
+            await self.sttRouter.initializeSelectedModelInBackground()
             // Keep heavier meeting diarization lazy. Meeting start/import paths
             // call prepareModels() with visible loading state when needed.
         }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -3811,7 +3811,7 @@ struct TranscriptedSettingsView: View {
         return {
             trackSettingsAction("download_model", page: page)
             Task { @MainActor in
-                await sttRouter.initializeSelectedModel()
+                await sttRouter.initializeSelectedModelInBackground()
             }
         }
     }
@@ -4323,7 +4323,7 @@ struct TranscriptedSettingsView: View {
         trackSettingsAction("switch_model", page: page)
         TranscriptionModelPreferences.setPreferredModel(model)
         Task { @MainActor in
-            await sttRouter.initializeSelectedModel()
+            await sttRouter.initializeSelectedModelInBackground()
         }
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2191,13 +2191,22 @@ func testRepoCommandContract() {
             "background readiness should load the selected dictation model"
         )
         let routerContents = readRepoTextFile("Sources/Speech/STTRouter.swift")
+        let meetingAdapterContents = readRepoTextFile("Sources/Meeting/MeetingSTTAdapter.swift")
         assertTrue(
             routerContents.contains("if backgroundWarmupModel == selectedModel")
                 && routerContents.contains("cancelBackgroundWarmup(for: selectedModel)")
                 && routerContents.contains("parakeetEngine.cancelModelWork()")
                 && routerContents.contains("parakeetEngine.teardownModel()")
                 && routerContents.contains("func initializeSelectedModelInBackground() async")
-                && routerContents.contains("if backgroundWarmupModel == model"),
+                && routerContents.contains(
+                    "guard !isModelLoaded(for: model), !foregroundOwnedModels.contains(model) else"
+                )
+                && routerContents.contains("if backgroundWarmupModel == model, !isModelLoaded(for: model)")
+                && routerContents.contains("func claimModelForForegroundUse(_ model: TranscriptionModelChoice)")
+                && routerContents.contains("foregroundOwnedModels.insert(model)")
+                && routerContents.contains("claimModelForForegroundUse(selectedModel)")
+                && routerContents.contains("claimModelForForegroundUse(resolvedModel)")
+                && meetingAdapterContents.contains("router.claimModelForForegroundUse(model)"),
             "model changes should cancel only unclaimed launch warmup and preserve work joined by dictation or meetings"
         )
         assertFalse(

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2187,16 +2187,18 @@ func testRepoCommandContract() {
             "background voice-model warmup should not compete with interactive UI work"
         )
         assertTrue(
-            warmupBlock.contains("await self.sttRouter.initializeSelectedModel()"),
+            warmupBlock.contains("await self.sttRouter.initializeSelectedModelInBackground()"),
             "background readiness should load the selected dictation model"
         )
         let routerContents = readRepoTextFile("Sources/Speech/STTRouter.swift")
         assertTrue(
-            routerContents.contains("cancelObsoleteModelWork(for: selectedModel)")
+            routerContents.contains("if backgroundWarmupModel == selectedModel")
+                && routerContents.contains("cancelBackgroundWarmup(for: selectedModel)")
                 && routerContents.contains("parakeetEngine.cancelModelWork()")
                 && routerContents.contains("parakeetEngine.teardownModel()")
-                && routerContents.contains("guard activeRecordingModel != model else { return }"),
-            "changing the selected model should cancel obsolete launch warmup without tearing down an active recording"
+                && routerContents.contains("func initializeSelectedModelInBackground() async")
+                && routerContents.contains("if backgroundWarmupModel == model"),
+            "model changes should cancel only unclaimed launch warmup and preserve work joined by dictation or meetings"
         )
         assertFalse(
             warmupBlock.contains("meetingSession.prepareModels(showLoadingUI: false)"),

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2149,7 +2149,7 @@ func testRepoCommandContract() {
         )
     }
 
-    runSuite("Repo command contract - launch warmup stays on demand") {
+    runSuite("Repo command contract - launch quietly warms the selected model") {
         let contents = readRepoTextFile("Sources/TranscriptedAppState.swift")
         guard
             let initializeStart = contents.range(of: "func initialize() async"),
@@ -2169,22 +2169,26 @@ func testRepoCommandContract() {
 
         let initializeBlock = String(contents[initializeStart.lowerBound..<wakeRecoveryStart.lowerBound])
         assertTrue(
-            initializeBlock.contains("if eagerModelWarmupEnabled"),
-            "launch voice-model warmup should be behind an explicit opt-in"
+            initializeBlock.contains("if eagerModelWarmupEnabled && !Self.isLaunchSmokeMode"),
+            "launch voice-model warmup should run by default without burdening synthetic launch smokes"
         )
         assertTrue(
             initializeBlock.contains("startRuntimeReadinessIfNeeded()"),
-            "the explicit eager-warmup path should still reuse runtime readiness"
+            "background launch warmup should reuse runtime readiness"
         )
         assertTrue(
-            contents.contains("TRANSCRIPTED_EAGER_MODEL_WARMUP"),
-            "eager voice-model warmup should stay an explicit opt-in for testing or diagnostics"
+            contents.contains("[\"TRANSCRIPTED_EAGER_MODEL_WARMUP\"] != \"0\""),
+            "voice-model warmup should default on while retaining an explicit diagnostic opt-out"
         )
 
         let warmupBlock = String(contents[warmupStart.lowerBound..<nextFunction.lowerBound])
         assertTrue(
+            warmupBlock.contains("Task(priority: .utility)"),
+            "background voice-model warmup should not compete with interactive UI work"
+        )
+        assertTrue(
             warmupBlock.contains("await self.sttRouter.initializeSelectedModel()"),
-            "on-demand readiness should load the selected dictation model when requested"
+            "background readiness should load the selected dictation model"
         )
         assertFalse(
             warmupBlock.contains("meetingSession.prepareModels(showLoadingUI: false)"),

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1514,7 +1514,7 @@ func testRepoCommandContract() {
         )
         assertTrue(
             localBuildScript.contains("--thin"),
-            "local build should support a thin app variant that downloads the model on first use"
+            "local build should support a thin app variant that downloads the model after launch"
         )
         assertTrue(
             localBuildScript.contains("BUNDLE_PARAKEET_MODELS=\"${BUNDLE_PARAKEET_MODELS:-0}\""),
@@ -2189,6 +2189,14 @@ func testRepoCommandContract() {
         assertTrue(
             warmupBlock.contains("await self.sttRouter.initializeSelectedModel()"),
             "background readiness should load the selected dictation model"
+        )
+        let routerContents = readRepoTextFile("Sources/Speech/STTRouter.swift")
+        assertTrue(
+            routerContents.contains("cancelObsoleteModelWork(for: selectedModel)")
+                && routerContents.contains("parakeetEngine.cancelModelWork()")
+                && routerContents.contains("parakeetEngine.teardownModel()")
+                && routerContents.contains("guard activeRecordingModel != model else { return }"),
+            "changing the selected model should cancel obsolete launch warmup without tearing down an active recording"
         )
         assertFalse(
             warmupBlock.contains("meetingSession.prepareModels(showLoadingUI: false)"),

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2198,16 +2198,30 @@ func testRepoCommandContract() {
                 && routerContents.contains("parakeetEngine.cancelModelWork()")
                 && routerContents.contains("parakeetEngine.teardownModel()")
                 && routerContents.contains("func initializeSelectedModelInBackground() async")
-                && routerContents.contains(
-                    "guard !isModelLoaded(for: model), !foregroundOwnedModels.contains(model) else"
-                )
-                && routerContents.contains("if backgroundWarmupModel == model, !isModelLoaded(for: model)")
+                && routerContents.contains("await self?.initializeSelectedModelInBackground()")
+                && routerContents.contains("let ownsBackgroundWarmup = !foregroundOwnedModels.contains(model)")
+                && routerContents.contains("if ownsBackgroundWarmup")
+                && routerContents.contains("backgroundWarmupModel == model")
                 && routerContents.contains("func claimModelForForegroundUse(_ model: TranscriptionModelChoice)")
                 && routerContents.contains("foregroundOwnedModels.insert(model)")
                 && routerContents.contains("claimModelForForegroundUse(selectedModel)")
                 && routerContents.contains("claimModelForForegroundUse(resolvedModel)")
                 && meetingAdapterContents.contains("router.claimModelForForegroundUse(model)"),
-            "model changes should cancel only unclaimed launch warmup and preserve work joined by dictation or meetings"
+            "model changes should cancel only unclaimed background warmup and preserve work joined by dictation or meetings"
+        )
+        let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        assertTrue(
+            settingsContents.contains("await sttRouter.initializeSelectedModelInBackground()"),
+            "settings-driven model loads should stay background-owned until real work claims them"
+        )
+        let whisperContents = readRepoTextFile("Sources/Speech/WhisperEngine.swift")
+        let nemotronContents = readRepoTextFile("Sources/Speech/NemotronEngine.swift")
+        assertTrue(
+            whisperContents.contains("private var initializationGeneration: UInt64 = 0")
+                && whisperContents.contains("generation == initializationGeneration")
+                && nemotronContents.contains("private var initializationGeneration: UInt64 = 0")
+                && nemotronContents.contains("generation == initializationGeneration"),
+            "cancelled advanced-model warmups should not publish over newer initialization work"
         )
         assertFalse(
             warmupBlock.contains("meetingSession.prepareModels(showLoadingUI: false)"),

--- a/docs/performance-audit-2026-05-10.md
+++ b/docs/performance-audit-2026-05-10.md
@@ -5,6 +5,8 @@ Repo snapshot: `5136fc24913cb3556fdb329f413837fdbd816587` (`origin/main`)
 Audited build: local signed `build/Transcripted.app`, version `1.1.33`
 Goal: raise every category toward A+/100 with measured fixes, not cosmetic scoring.
 
+> Update 2026-07-29: background dictation-model warmup now defaults on after UI setup, superseding the on-demand launch choice recorded in section 12. Set `TRANSCRIPTED_EAGER_MODEL_WARMUP=0` only for controlled diagnostics.
+
 ## Executive Score
 
 Current implementation score after twenty-six audit/fix loops: **100/100, A+**

--- a/docs/performance-audit-2026-05-10.md
+++ b/docs/performance-audit-2026-05-10.md
@@ -21,7 +21,7 @@ The current branch now meets the A+ implementation target across the runtime, bu
 | --- | ---: | ---: | --- | --- |
 | Warm dictation transcription latency | A+ | 99 | `transcription_complete` p50 0.118s, p90 0.300s, avg RTF 0.013 | Keep p95 under 0.500s and p95 RTF under 0.050 on local logs |
 | Dictation start responsiveness | A+ | 98 | Live UI-triggered dictation emitted `dictation_recording_fast_start` at 112 ms, then `audio_samples_detected`; strict event budget passed with 1 fast-start sample and 0 fallback/retry events | Keep ready-engine start p95 under 250 ms with no fallback/retry events after the first fast-start sample |
-| App launch and model readiness | A+ | 98 | Dictation and meeting models now stay on demand by default; latest smoke launch reported `stt_model_loaded=false`; existing installs now get delayed Parakeet file prefetch so the thin update is quiet for current users without keeping the full speech model loaded while idle | Keep first-use loading explicit for new users, preserve the `TRANSCRIPTED_EAGER_MODEL_WARMUP=1` diagnostic escape hatch, and keep existing-user prefetch delayed/off the launch path |
+| App launch and model readiness | A+ | 98 | UI setup completes first, then the selected dictation model quietly warms in a utility-priority task; launch smokes skip the real warmup, and meeting diarization models remain lazy | Keep launch interactive under 3 seconds, never activate the microphone during warmup, preserve `TRANSCRIPTED_EAGER_MODEL_WARMUP=0` as a diagnostic opt-out, and keep meeting-only models lazy |
 | Idle CPU | A+ | 99 | Latest signed thin build idled at 0.0% CPU after 15s with no duplicate Transcripted processes | Stay below 1% CPU idle after warmup |
 | Idle memory | A+ | 99 | Latest signed thin build idled at 81,248 KB RSS after 15s, then exited cleanly after proof cleanup | Single process under 250 MB warm idle, no duplicate resident copies |
 | Bundle and download size | A+ | 98 | Default local and beta builds now produce the 104.7 MiB thin app with 1.9 MiB resources; explicit full/offline build remains available | Keep default/beta builds under 150 MB and cut the next public release from the thin default |
@@ -333,7 +333,11 @@ Measured proof:
 - `bash build.sh --no-open`: signed build passed, launch smoke passed, performance budget passed.
 - After the no-open build, no Transcripted process from the temp build remained running.
 
-### 12. Made launch model loading on demand
+### 12. Historical: made launch model loading on demand
+
+This May 10 change was superseded on July 29, 2026. The current app quietly
+warms the selected dictation model after UI setup; only meeting-specific models
+remain on demand.
 
 Files:
 
@@ -350,11 +354,17 @@ Why:
 - The launch path still loaded the selected dictation model eagerly.
 - That kept first-use dictation fast, but made a fresh app launch feel heavier than needed for users who only want the menu, settings, or meeting/import setup later.
 
-Change made:
+Change made at the time:
 
 - Default launch no longer calls runtime model readiness.
-- Dictation, meetings, imports, model preference changes, wake recovery for an already loaded model, and `TRANSCRIPTED_EAGER_MODEL_WARMUP=1` can still load the selected model when needed.
+- Dictation, meetings, imports, model preference changes, wake recovery for an already loaded model, and the then-current `TRANSCRIPTED_EAGER_MODEL_WARMUP=1` override could still load the selected model when needed.
 - Menu bar, onboarding, settings, and shared warmup status copy now describe the default state as on-demand instead of fake startup progress.
+
+Current behavior:
+
+- Launch calls runtime model readiness after UI setup in a utility-priority task.
+- `TRANSCRIPTED_EAGER_MODEL_WARMUP=0` disables that warmup for controlled diagnostics.
+- Synthetic launch smokes skip real model loading, and meeting diarization remains lazy.
 
 Measured proof:
 
@@ -674,7 +684,11 @@ Measured proof:
 - The faster build still signed with Developer ID, verified the signature, ran launch smoke, ran the performance budget, and left no app process running.
 - `bash run-tests.sh --filter RepoCommandContractTests`: fast-test runner compiled and ran the full manifest; `1599 tests, 1599 passed, 0 failed`.
 
-### 26. Made the thin update quieter for existing users
+### 26. Historical: made the thin update quieter for existing users
+
+This prefetch-only policy was superseded on July 29, 2026. The current launch
+warms the selected dictation model for both new and existing users after UI
+setup.
 
 Files:
 
@@ -690,19 +704,27 @@ Why:
 
 - The thin app keeps normal updates around app size instead of shipping the ~600 MB Parakeet model every time.
 - Existing users who only had the old bundled model could otherwise hit the first model download right when they tried to dictate after updating.
-- The fix needed to protect current users without making brand-new installs heavier or reintroducing launch-time model loading.
+- At the time, the fix needed to protect current users without making brand-new installs heavier or reintroducing launch-time model loading.
 
-Change made:
+Change made at the time:
 
 - Added an existing-install detector based on completed onboarding, saved capture-library content, or an explicit launch-at-login preference.
 - For existing Parakeet users only, the app schedules delayed background model-file prefetch after launch.
-- Brand-new installs remain explicitly on-demand.
+- Brand-new installs remained explicitly on-demand.
 - Users who selected Whisper do not get Parakeet downloaded behind their model choice.
 - Active downloads/loads and already-ready models are not duplicated.
 - The prefetch task is cancelled during shutdown and delayed so it stays out of the main launch path.
 - The background path caches files only; it does not keep the full speech model loaded in idle memory.
 - Dictation start now joins an in-progress background prefetch and then loads the model, so first use cannot stall waiting for a ready state that file prefetch intentionally does not set.
 - Added a distinct cached state so Settings, menu-bar status, onboarding, and meeting warmup do not show cached files as a missing download or as a fully loaded model.
+
+Current behavior:
+
+- The selected dictation model downloads or loads quietly after UI setup on new
+  and existing installs.
+- The existing single-flight initialization still prevents duplicate work when
+  dictation starts during background warmup.
+- Meeting diarization remains on demand.
 
 Expected user experience:
 
@@ -830,9 +852,17 @@ This area is now A+ for the current machine. The remaining model footprint is ac
 
 ### Startup
 
-The default launch path now keeps both voice and meeting models out of memory. `TranscriptedAppState.startRuntimeReadinessIfNeeded()` still exists, but it is reached only from explicit work such as dictation/import/meeting use, model preference changes, wake recovery for an already loaded model, or `TRANSCRIPTED_EAGER_MODEL_WARMUP=1`.
+After UI setup, the default launch path calls
+`TranscriptedAppState.startRuntimeReadinessIfNeeded()` in a utility-priority
+task. This quietly downloads or loads the selected dictation model so a first
+dictation can reuse the same single-flight initialization instead of paying the
+full cold-start wait. It does not activate the microphone or request microphone
+permission. Meeting diarization models remain on demand.
 
-This trades a slower first dictation after a cold launch for a much lighter default app launch. The UI now says the models are on demand instead of showing fake startup progress.
+Set `TRANSCRIPTED_EAGER_MODEL_WARMUP=0` only for controlled diagnostics.
+Synthetic launch-smoke modes also skip the real warmup so launch timing remains
+deterministic. This trades higher post-launch memory and background work for a
+faster first dictation while keeping the UI setup itself ahead of model loading.
 
 ### Dictation
 
@@ -875,13 +905,13 @@ Every implementation category in this report is now A+. These are the follow-up 
    - Keep this strict gate in release-candidate checks so the category stays A+.
 
 2. **Launch readiness policy**
-   - Done in loop 13, with existing-user thin-update protection added in loop 26.
-   - Dictation and meeting models now stay on demand by default, with explicit UI/status copy and an eager-warmup env escape hatch for diagnostics.
-   - Existing Parakeet installs get delayed background model-file prefetch so the first thin update is quieter without blocking launch or keeping the speech model loaded while idle.
+   - The historical on-demand policy from loop 13 and prefetch-only protection from loop 26 were superseded on July 29, 2026.
+   - UI setup completes first, then the selected dictation model warms in a utility-priority task; meeting models stay on demand.
+   - `TRANSCRIPTED_EAGER_MODEL_WARMUP=0` is the controlled diagnostic opt-out.
 
 3. **Distribution strategy**
    - Done for the branch in loop 17, reproved in loop 25.
-   - Default local and beta builds now create the 104.7 MiB thin app and download the model on first use.
+   - Default local and beta builds create the 104.7 MiB thin app; a fresh install downloads the selected dictation model quietly after UI setup.
    - Release rollout gate: cut and verify a public thin DMG under 150 MB, then update appcast/cask/download surfaces.
 
 4. **Meeting performance harness**

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -481,7 +481,7 @@ if [ ! -d "$model_src" ]; then
     model_src="$PARAKEET_MODELS_ROOT/parakeet-tdt-0.6b-v3-coreml"
 fi
 if [ "$BUNDLE_PARAKEET_MODELS" = "0" ]; then
-    echo "Skipping bundled Parakeet models (--thin); runtime download will occur on first use."
+    echo "Skipping bundled Parakeet models (--thin); runtime download starts quietly after launch."
 else
     mkdir -p "$PARAKEET_BUNDLE_DIR"
     # JointDecisionv3.mlmodelc is required by FluidAudio 0.15.x; bundling without it

--- a/scripts/ops/performance-budget.rb
+++ b/scripts/ops/performance-budget.rb
@@ -114,7 +114,7 @@ OptionParser.new do |parser|
   parser.on("--require-dictation-stop-latency-samples N", Integer, "Require at least N stop-latency samples in --events logs") { |count| options[:require_dictation_stop_latency_samples] = count }
   parser.on("--events-since ISO8601", "Only score runtime events at or after this timestamp") { |value| options[:events_since] = Time.parse(value) }
   parser.on("--stats-since ISO8601", "Only score meeting stats at or after this timestamp") { |value| options[:stats_since] = Time.parse(value) }
-  parser.on("--allow-missing-parakeet-model", "Allow thin builds that download the Parakeet model on first use") { options[:allow_missing_parakeet_model] = true }
+  parser.on("--allow-missing-parakeet-model", "Allow thin builds that download the Parakeet model after launch") { options[:allow_missing_parakeet_model] = true }
 end.parse!
 
 def directory_size(path)


### PR DESCRIPTION
## What changed
- make the existing single-flight dictation model warmup default-on after UI setup
- run the warmup task at utility priority so it does not block launch interaction
- keep Settings-triggered downloads background-owned until dictation, meetings, or imports actually use them
- cancel and release only unused background warmups when the selected model changes
- guard Whisper and Nemotron initialization generations so canceled work cannot overwrite a newer load
- keep `TRANSCRIPTED_EAGER_MODEL_WARMUP=0` as a controlled diagnostic opt-out
- skip background warmup in synthetic launch-smoke modes
- keep meeting diarization models lazy

## User impact
Transcripted now starts loading the selected local dictation model quietly after the UI appears. If the app has had a few seconds to warm, first dictation should avoid the measured cold model-load wait. Starting dictation while warmup is still running joins the same load instead of starting another one.

## Safety boundaries
- [x] model warmup does not activate the microphone or request permissions
- [x] model initialization remains single-flight
- [x] app launch does not await the model load
- [x] real dictation, meeting, and import use protects the claimed model from background cancellation
- [x] unused Settings/background model loads can be released after a model switch
- [x] canceled advanced-model loads cannot publish stale ready/failure state
- [x] synthetic launch-smoke runs do not pay the warmup cost
- [x] meeting diarization models remain on demand
- [x] no telemetry or privacy payload changes

## Verification
Exact head: `10e01828f8d78caf8fdaf5e818a846baf120e562`

- [x] focused `RepoCommandContractTests` (607/607)
- [x] `bash build.sh --no-open` (signed; launch interactive 935.2ms / 3000ms budget)
- [x] `bash run-tests.sh` (13,421/13,421)
- [x] `bash build-deps.sh --force`
- [x] `bash run-integration-smoke.sh` (core + wake + 7/7 recovery merge tests)
- [x] `python3 scripts/dev/check-build-source-lists.py`
- [x] build-script and performance-budget syntax checks
- [x] `bash scripts/dev/agent-preflight.sh`
- [x] independent exact-diff `codex-review` clean with no accepted/actionable findings; reviewer independently reran full tests, signed build (971.4ms launch), dependency rebuild, and integration smoke
- [x] required GitHub checks complete

## Manual proof
Real installed-app confirmation that the selected model reaches ready state before first dictation, plus real RSS/energy impact, remains UNKNOWN. Hardware smoke is not claimed. No release or publication work is included.