### PR TITLE
Fix Swift dependency cache compatibility

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -127,6 +127,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Fingerprint Swift toolchain
+        id: swift-toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          fingerprint="$(swiftc --version | shasum -a 256 | awk '{print $1}')"
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
       - name: Restore prebuilt dependencies
         id: deps-cache
         uses: actions/cache/restore@v4
@@ -136,12 +144,11 @@ jobs:
             deps-modules
             deps-frameworks
             deps-tools
-          key: deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/entrypoints/build-deps.sh', 'Package.swift', 'Sources/TranscriptedCore/**') }}
-          # Fall back to the newest dep cache for this OS/arch when the exact key
-          # misses, so build-deps.sh warm-starts from a partial cache and only
-          # rebuilds the stale artifacts.
+          key: deps-${{ runner.os }}-${{ runner.arch }}-swift-${{ steps.swift-toolchain.outputs.fingerprint }}-${{ hashFiles('scripts/entrypoints/build-deps.sh', 'Package.swift', 'Sources/TranscriptedCore/**') }}
+          # Fall back only within the active Swift toolchain. Swift modules are
+          # compiler-version-specific and cannot safely warm-start across upgrades.
           restore-keys: |
-            deps-${{ runner.os }}-${{ runner.arch }}-
+            deps-${{ runner.os }}-${{ runner.arch }}-swift-${{ steps.swift-toolchain.outputs.fingerprint }}-
 
       - name: Build dependencies
         shell: bash
@@ -190,6 +197,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Fingerprint Swift toolchain
+        id: swift-toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          fingerprint="$(swiftc --version | shasum -a 256 | awk '{print $1}')"
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
       - name: Cache prebuilt dependencies
         id: deps-cache
         uses: actions/cache@v4
@@ -199,12 +214,11 @@ jobs:
             deps-modules
             deps-frameworks
             deps-tools
-          key: deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/entrypoints/build-deps.sh', 'Package.swift', 'Sources/TranscriptedCore/**') }}
-          # Fall back to the newest dep cache for this OS/arch when the exact key
-          # misses, so build-deps.sh warm-starts from a partial cache and only
-          # rebuilds the stale artifacts.
+          key: deps-${{ runner.os }}-${{ runner.arch }}-swift-${{ steps.swift-toolchain.outputs.fingerprint }}-${{ hashFiles('scripts/entrypoints/build-deps.sh', 'Package.swift', 'Sources/TranscriptedCore/**') }}
+          # Fall back only within the active Swift toolchain. Swift modules are
+          # compiler-version-specific and cannot safely warm-start across upgrades.
           restore-keys: |
-            deps-${{ runner.os }}-${{ runner.arch }}-
+            deps-${{ runner.os }}-${{ runner.arch }}-swift-${{ steps.swift-toolchain.outputs.fingerprint }}-
 
       - name: Build dependencies
         shell: bash

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -331,6 +331,27 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - dependency caches are Swift-toolchain-specific") {
+        let workflow = readRepoTextFile(".github/workflows/swift-ci.yml")
+        let fingerprintStep = "fingerprint=\"$(swiftc --version | shasum -a 256 | awk '{print $1}')\""
+        let toolchainCachePrefix = "deps-${{ runner.os }}-${{ runner.arch }}-swift-${{ steps.swift-toolchain.outputs.fingerprint }}-"
+
+        assertEqual(
+            workflow.components(separatedBy: fingerprintStep).count - 1,
+            2,
+            "both dependency-consuming CI jobs should fingerprint their active Swift compiler"
+        )
+        assertEqual(
+            workflow.components(separatedBy: toolchainCachePrefix).count - 1,
+            4,
+            "exact and fallback dependency cache keys should remain inside the active Swift toolchain"
+        )
+        assertFalse(
+            workflow.contains("deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles"),
+            "CI must not restore compiler-specific Swift modules from a toolchain-agnostic cache key"
+        )
+    }
+
     runSuite("Repo command contract - fast test runner generation is per-process") {
         let contents = readRepoTextFile("scripts/entrypoints/run-tests.sh")
         assertTrue(


### PR DESCRIPTION
## What changed
- fingerprint the active `swiftc` toolchain in both dependency-consuming CI jobs
- scope exact and fallback dependency cache keys to that fingerprint
- add a repository contract test so compiler-agnostic Swift module caches cannot return

## Why
Merged-main CI restored `FluidAudio.swiftmodule` from a cache produced by Swift `6.3.2.1.108`, then tried to consume it with a different compiler. The preload product code passed its exact-head PR checks; package tests failed before executing because the binary module cache was incompatible.

## Acceptance checklist
- [x] cache keys include the active Swift compiler fingerprint
- [x] fallback keys cannot cross Swift toolchains
- [x] focused repository contract passes (610/610)
- [x] `bash build.sh --no-open` passes (launch-to-interactive 894.8ms / 3000ms)
- [x] `bash run-tests.sh` passes (13,424/13,424)
- [x] `scripts/dev/agent-preflight.sh` passes
- [x] workflow YAML parses
- [x] `git diff --check` passes
- [x] independent full-diff review passes with no actionable findings
- [x] hosted CI passes at exact head `1d28498e`

## Review
Independent exact-head review inspected the complete diff, cache prefix semantics, the failed merged-main job, and the replacement hosted run. Verdict: PASS, no actionable findings.

## Proof boundaries
- Deterministic/local: green as listed above.
- Hosted: green, including `spm-tests` and required `build-and-test`.
- Hardware/manual: not applicable to this CI-only repair; quiet model preload manual installed-app proof remains unknown.