### PR TITLE
Recover meeting starts when mic frames stall

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -456,21 +456,34 @@ public class Audio: ObservableObject, @unchecked Sendable {
     }
     var watchdogTimer: Timer?
 
-    // Mic recovery guard (prevents concurrent recovery attempts)
-    // Thread-safe: accessed from watchdog (main) and recovery (background) threads
-    private var _isMicRecovering: Bool = false
+    // Mic recovery ownership (prevents concurrent recovery attempts across
+    // recording-session boundaries). The owner stays set until the background
+    // recovery actually returns; a fast stop/start cannot clear it from under
+    // the older recovery with an unscoped Bool assignment.
+    private var _micRecoverySessionGeneration: UInt64?
     private let micRecoveryLock = NSLock()
     var isMicRecovering: Bool {
         get {
             micRecoveryLock.lock()
             defer { micRecoveryLock.unlock() }
-            return _isMicRecovering
+            return _micRecoverySessionGeneration != nil
         }
-        set {
-            micRecoveryLock.lock()
-            defer { micRecoveryLock.unlock() }
-            _isMicRecovering = newValue
-        }
+    }
+
+    @discardableResult
+    func beginMicRecovery(for sessionGeneration: UInt64) -> Bool {
+        micRecoveryLock.lock()
+        defer { micRecoveryLock.unlock() }
+        guard _micRecoverySessionGeneration == nil else { return false }
+        _micRecoverySessionGeneration = sessionGeneration
+        return true
+    }
+
+    func endMicRecovery(for sessionGeneration: UInt64) {
+        micRecoveryLock.lock()
+        defer { micRecoveryLock.unlock() }
+        guard _micRecoverySessionGeneration == sessionGeneration else { return }
+        _micRecoverySessionGeneration = nil
     }
     var lastRecoveryTime: Date?
     private var _recoveryAttemptCount: Int = 0
@@ -1486,7 +1499,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // and buffer timestamp.
         stopWatchdog()
         error = nil
-        isMicRecovering = false
         systemBufferCount = 0  // Reset debug counter (lock-protected)
         micBufferCount = 0
         micAudioStreaming = false  // Re-gate readiness on a fresh first buffer
@@ -1778,7 +1790,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
             self.systemAudioStatus = .unknown  // Reset status when not recording
             self.stopTimer()
             self.stopWatchdog()
-            self.isMicRecovering = false
             cueHandler?(.recordingStopped)
         }
 

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -356,6 +356,28 @@ public class Audio: ObservableObject, @unchecked Sendable {
         _recordingGaps.append(gap)
     }
 
+    /// Commit recovery artifacts only while the recovery still owns the
+    /// current recording generation. The generation lock also blocks a
+    /// concurrent stop/start from advancing the session between the check and
+    /// the array/journal mutations.
+    @discardableResult
+    func finalizeMicRecoveryArtifacts(
+        gap: AudioGap,
+        recoverySegment: MicRecordingSegment?,
+        sessionGeneration: UInt64
+    ) -> Bool {
+        recordingSessionGenerationLock.lock()
+        defer { recordingSessionGenerationLock.unlock() }
+        guard _recordingSessionGeneration == sessionGeneration else { return false }
+
+        appendRecordingGap(gap)
+        if let recoverySegment {
+            appendMicSegment(recoverySegment)
+        }
+        recoveryAttemptCount = 0
+        return true
+    }
+
     /// Count of device switches during this recording
     /// Thread-safe: reset on main thread, incremented on background recovery thread
     private var _deviceSwitchCount: Int = 0

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1655,13 +1655,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         isRecording = true
         isStarting = false
-        // The first mic buffer can arrive before the async start completion
-        // reaches MainActor. If its one-shot arm callback observed
-        // `isRecording == false`, arm here so a later route stall is still
-        // detected.
+        // Arm even when the graph has not delivered its first mic frame yet.
+        // A Bluetooth-to-built-in handoff can pass device/rate validation and
+        // `engine.start()` while still producing zero frames. The watchdog's
+        // bounded, generation-guarded recovery then gets one chance before the
+        // outer meeting-start deadline fails closed.
         if MicWatchdogArmingPolicy.shouldArmAfterSuccessfulStart(
-            nonemptyBufferCount: micBufferCount
-        ), watchdogTimer == nil {
+            watchdogIsArmed: watchdogTimer != nil
+        ) {
             startWatchdog()
         }
         restoreSystemAudioHealthyStatusAfterSuccessfulStart()

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1481,6 +1481,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
     }
 
     func prepareForNewRecordingStart() {
+        // A fast retry can begin before stop()'s deferred main-thread cleanup.
+        // Reset the old timer here so every recording gets a fresh watchdog
+        // and buffer timestamp.
+        stopWatchdog()
         error = nil
         isMicRecovering = false
         systemBufferCount = 0  // Reset debug counter (lock-protected)

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -169,14 +169,15 @@ extension Audio {
             return
         }
 
-        // CRITICAL: Prevent concurrent recovery attempts
-        // AVAudioEngine notifications can fire multiple times during rapid device changes
-        guard !isMicRecovering else {
+        // CRITICAL: Prevent concurrent recovery attempts, including across a
+        // fast stop/start. The owner remains set until the old background
+        // recovery returns, so its defer cannot clear a newer session's state.
+        guard beginMicRecovery(for: sessionGeneration) else {
             AppLogger.audioMic.warning("Recovery already in progress, skipping duplicate request")
             return
         }
-        isMicRecovering = true
-        defer { isMicRecovering = false }
+        defer { endMicRecovery(for: sessionGeneration) }
+        guard sessionGeneration == recordingSessionGeneration else { return }
         lastRecoveryTime = Date()
 
         guard let currentEngine = engine, let currentInputNode = inputNode else { return }

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -144,10 +144,9 @@ extension Audio {
 
                 // Audio stopped → device likely changed
                 AppLogger.audioMic.warning("Audio device disconnected or changed, switching to default")
-                let sessionGeneration = self.recordingSessionGeneration
                 // Dispatch to background — recovery uses Thread.sleep for HAL settle time
                 DispatchQueue.global(qos: .userInitiated).async {
-                    self.recoverFromDeviceChange(sessionGeneration: sessionGeneration)
+                    self.recoverFromDeviceChange(sessionGeneration: watchdogGeneration)
                 }
             }
         }

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -81,8 +81,8 @@ enum MicWatchdogArmingPolicy {
         bufferCount == 1
     }
 
-    static func shouldArmAfterSuccessfulStart(nonemptyBufferCount: Int) -> Bool {
-        nonemptyBufferCount > 0
+    static func shouldArmAfterSuccessfulStart(watchdogIsArmed: Bool) -> Bool {
+        !watchdogIsArmed
     }
 }
 /// Extension handling mic device recovery, watchdog timer, and sleep/wake resilience.

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -131,7 +131,11 @@ extension Audio {
                     ])
                     let savedError = "Audio device unavailable \u{2014} recording stopped after \(self.recoveryAttemptCount) recovery attempts. Reconnect your microphone and try again."
                     DispatchQueue.main.async {
+                        guard self.recordingSessionGeneration == watchdogGeneration,
+                              self.isRecording,
+                              !self.isMicRecovering else { return }
                         self.stop()
+                        guard self.recordingSessionGeneration == watchdogGeneration &+ 1 else { return }
                         // Re-apply error after stop() clears it
                         self.error = savedError
                     }
@@ -409,6 +413,9 @@ extension Audio {
                     userInfo: [NSLocalizedDescriptionKey: "The microphone restarted but did not deliver audio."]
                 )
             }
+            guard sessionGeneration == recordingSessionGeneration else {
+                throw AudioCaptureStaleSessionError()
+            }
 
             // Recovery notices are status, not errors. `Audio.error` is a
             // terminal bridge channel and must only carry real failures.
@@ -430,6 +437,9 @@ extension Audio {
                 duration: gapDuration,
                 reason: reason == .processingChange ? "Mic processing change" : "Device switch"
             )
+            guard sessionGeneration == recordingSessionGeneration else {
+                throw AudioCaptureStaleSessionError()
+            }
             appendRecordingGap(gap)
             if let recoverySegmentURL {
                 appendMicSegment(MicRecordingSegment(url: recoverySegmentURL, gapBeforeDuration: gap.duration))
@@ -471,6 +481,7 @@ extension Audio {
             }
             Thread.sleep(forTimeInterval: 0.02)
         }
+        guard sessionGeneration == recordingSessionGeneration else { return false }
         return MicRecoveryReadinessPolicy.deliveredNewBuffer(
             before: previousBufferCount,
             after: micBufferCount

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -85,6 +85,17 @@ enum MicWatchdogArmingPolicy {
         !watchdogIsArmed
     }
 }
+
+enum MicWatchdogSessionPolicy {
+    static func shouldRun(
+        watchdogGeneration: UInt64,
+        currentGeneration: UInt64,
+        isRecording: Bool,
+        isRecovering: Bool
+    ) -> Bool {
+        watchdogGeneration == currentGeneration && isRecording && !isRecovering
+    }
+}
 /// Extension handling mic device recovery, watchdog timer, and sleep/wake resilience.
 /// Runs on background threads — NOT @MainActor.
 extension Audio {
@@ -94,8 +105,15 @@ extension Audio {
     func startWatchdog() {
         lastBufferTime = CACurrentMediaTime()
         watchdogTimer?.invalidate()
+        let watchdogGeneration = recordingSessionGeneration
         watchdogTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
-            guard let self = self, self.isRecording, !self.isMicRecovering else { return }
+            guard let self,
+                  MicWatchdogSessionPolicy.shouldRun(
+                      watchdogGeneration: watchdogGeneration,
+                      currentGeneration: self.recordingSessionGeneration,
+                      isRecording: self.isRecording,
+                      isRecovering: self.isMicRecovering
+                  ) else { return }
 
             let timeSinceLastBuffer = CACurrentMediaTime() - self.lastBufferTime
 

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -437,15 +437,19 @@ extension Audio {
                 duration: gapDuration,
                 reason: reason == .processingChange ? "Mic processing change" : "Device switch"
             )
-            guard sessionGeneration == recordingSessionGeneration else {
+            let finalized = finalizeMicRecoveryArtifacts(
+                gap: gap,
+                recoverySegment: recoverySegmentURL.map {
+                    MicRecordingSegment(url: $0, gapBeforeDuration: gap.duration)
+                },
+                sessionGeneration: sessionGeneration
+            )
+            guard finalized else {
                 throw AudioCaptureStaleSessionError()
             }
-            appendRecordingGap(gap)
-            if let recoverySegmentURL {
-                appendMicSegment(MicRecordingSegment(url: recoverySegmentURL, gapBeforeDuration: gap.duration))
+            if recoverySegmentURL != nil {
                 shouldKeepRecoverySegment = true
             }
-            recoveryAttemptCount = 0
             AppLogger.audioMic.info("Device recovery complete, recording continues", ["gap": gap.description])
         } catch {
             if error is AudioCaptureStaleSessionError {

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -662,6 +662,7 @@ final class AudioInitializationTests: XCTestCase {
         )
 
         let audio = Audio(paths: paths)
+        audio.watchdogTimer = Timer(timeInterval: 2, repeats: true) { _ in }
         audio.originalMicAudioFileURL = root.appendingPathComponent("stale-mic.wav")
         audio.micAudioFileURL = root.appendingPathComponent("stale-mic.wav")
         audio.systemAudioFileURL = root.appendingPathComponent("stale-system.wav")
@@ -675,6 +676,7 @@ final class AudioInitializationTests: XCTestCase {
         XCTAssertNil(audio.systemAudioFileURL)
         XCTAssertFalse(audio.systemAudioFailed)
         XCTAssertTrue(audio.micSegments.isEmpty)
+        XCTAssertNil(audio.watchdogTimer)
     }
 
     func testSuccessfulStartRestoresHealthySystemAudioStatusAfterEarlyNilUpdate() {

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -28,10 +28,10 @@ final class AudioInitializationTests: XCTestCase {
         )
     }
 
-    func testMicWatchdogArmsOnlyAfterTheFirstNonemptyBuffer() {
+    func testMicBufferCallbackArmsWatchdogOnlyOnce() {
         XCTAssertFalse(
             MicWatchdogArmingPolicy.shouldArm(afterNonemptyBufferCount: 0),
-            "startup must not race route recovery before a mic frame arrives"
+            "the buffer callback has nothing to arm before a mic frame arrives"
         )
         XCTAssertTrue(
             MicWatchdogArmingPolicy.shouldArm(afterNonemptyBufferCount: 1)
@@ -40,17 +40,16 @@ final class AudioInitializationTests: XCTestCase {
             MicWatchdogArmingPolicy.shouldArm(afterNonemptyBufferCount: 2),
             "later frames must not create duplicate watchdog timers"
         )
+    }
+
+    func testSuccessfulStartArmsWatchdogBeforeTheFirstMicFrame() {
+        XCTAssertTrue(
+            MicWatchdogArmingPolicy.shouldArmAfterSuccessfulStart(watchdogIsArmed: false),
+            "a started graph with zero frames still needs bounded recovery"
+        )
         XCTAssertFalse(
-            MicWatchdogArmingPolicy.shouldArmAfterSuccessfulStart(nonemptyBufferCount: 0),
-            "start completion must not arm recovery before any mic frame arrives"
-        )
-        XCTAssertTrue(
-            MicWatchdogArmingPolicy.shouldArmAfterSuccessfulStart(nonemptyBufferCount: 1),
-            "start completion must recover the arm when the first frame won the startup race"
-        )
-        XCTAssertTrue(
-            MicWatchdogArmingPolicy.shouldArmAfterSuccessfulStart(nonemptyBufferCount: 2),
-            "any observed mic frame is enough to arm after startup completes"
+            MicWatchdogArmingPolicy.shouldArmAfterSuccessfulStart(watchdogIsArmed: true),
+            "the first mic frame may already have armed the watchdog"
         )
     }
 

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -53,6 +53,34 @@ final class AudioInitializationTests: XCTestCase {
         )
     }
 
+    func testWatchdogStopsForACompletedRecordingSession() {
+        XCTAssertFalse(
+            MicWatchdogSessionPolicy.shouldRun(
+                watchdogGeneration: 7,
+                currentGeneration: 8,
+                isRecording: true,
+                isRecovering: false
+            ),
+            "a timer from the stopped session must not recover during teardown"
+        )
+        XCTAssertTrue(
+            MicWatchdogSessionPolicy.shouldRun(
+                watchdogGeneration: 8,
+                currentGeneration: 8,
+                isRecording: true,
+                isRecovering: false
+            )
+        )
+        XCTAssertFalse(
+            MicWatchdogSessionPolicy.shouldRun(
+                watchdogGeneration: 8,
+                currentGeneration: 8,
+                isRecording: false,
+                isRecovering: false
+            )
+        )
+    }
+
     func testStaleMeetingGraphAttemptDoesNotClaimAnInputEngine() {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("StaleMeetingGraphAttempt-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -107,6 +107,43 @@ final class AudioInitializationTests: XCTestCase {
         audio.endMicRecovery(for: 12)
     }
 
+    func testMicRecoveryFinalizationIsAtomicToTheOwningGeneration() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let audio = Audio(paths: makeCoreStoragePaths(root: root))
+        audio.prepareForNewRecordingStart()
+        let generation = audio.recordingSessionGeneration
+        let gap = Audio.AudioGap(start: Date(), duration: 0.5, reason: "Device switch")
+        let segment = MicRecordingSegment(
+            url: root.appendingPathComponent("recovery.wav"),
+            gapBeforeDuration: gap.duration
+        )
+
+        XCTAssertTrue(
+            audio.finalizeMicRecoveryArtifacts(
+                gap: gap,
+                recoverySegment: segment,
+                sessionGeneration: generation
+            )
+        )
+        XCTAssertEqual(audio.recordingGaps.count, 1)
+        XCTAssertEqual(audio.micSegments.count, 1)
+
+        audio.prepareForNewRecordingStart()
+        XCTAssertFalse(
+            audio.finalizeMicRecoveryArtifacts(
+                gap: gap,
+                recoverySegment: segment,
+                sessionGeneration: generation
+            ),
+            "a stale recovery must not append artifacts after a new session begins"
+        )
+        XCTAssertTrue(audio.recordingGaps.isEmpty)
+        XCTAssertTrue(audio.micSegments.isEmpty)
+    }
+
     func testStaleMeetingGraphAttemptDoesNotClaimAnInputEngine() {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("StaleMeetingGraphAttempt-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -81,6 +81,32 @@ final class AudioInitializationTests: XCTestCase {
         )
     }
 
+    func testMicRecoveryOwnershipRemainsWithTheActiveSession() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let audio = Audio(paths: makeCoreStoragePaths(root: root))
+
+        XCTAssertTrue(audio.beginMicRecovery(for: 11))
+        XCTAssertTrue(audio.isMicRecovering)
+        XCTAssertFalse(
+            audio.beginMicRecovery(for: 12),
+            "a new session must not overlap an in-flight recovery from the previous session"
+        )
+
+        audio.endMicRecovery(for: 12)
+        XCTAssertTrue(
+            audio.isMicRecovering,
+            "a stale session must not clear the active recovery owner"
+        )
+
+        audio.endMicRecovery(for: 11)
+        XCTAssertFalse(audio.isMicRecovering)
+        XCTAssertTrue(audio.beginMicRecovery(for: 12))
+        audio.endMicRecovery(for: 12)
+    }
+
     func testStaleMeetingGraphAttemptDoesNotClaimAnInputEngine() {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("StaleMeetingGraphAttempt-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

- arm the existing mic watchdog as soon as the audio engine starts, including before the first mic frame
- give zero-frame Bluetooth/built-in handoffs the existing bounded, generation-safe fresh-graph recovery before the 12-second meeting deadline
- cover zero-frame arming and duplicate-watchdog prevention

## Root cause and signal

The engine can accept a valid selected device and start while delivering zero mic frames. Before this change, the watchdog only armed from the first non-empty buffer, so this state had no recovery path and the outer meeting start eventually failed.

Privacy-safe aggregate review of 1.1.51 over seven days found 68 PostHog and 74 Sentry start-failure events. These are overlapping backends for real outer attempts, not additive counts or delivery duplicates. Mic unavailable dominated (66 PostHog / 67 Sentry), and all 68 PostHog failures reported zero recovery attempts. Current main already includes the separate 12-second/system-audio handoff fix from #1585. Recent model-preload ownership changes finish before this path and do not touch mic graph startup.

Apple voice processing was requested in 63 of the 68 PostHog failures, including all 34 Bluetooth-class failures. That is directional because a few anonymous devices dominate the sample; this PR does not change the saved processing preference or weaken the fail-closed Bluetooth routing policy.

## Verification

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 13,478 passed
- `bash run-integration-smoke.sh` — passed
- `swift test --jobs 1` — 869 passed, 13 skipped, 0 failed
- `swift test --jobs 1 --filter AudioInitializationTests` — 29 passed
- `bash scripts/dev/agent-preflight.sh`
- Computer Use permission preflight — 12 passed, 0 failed, 0 warnings
- Computer Use against the signed `build/Transcripted.app`: meeting prompt → recording timer remained active beyond 23 seconds → clean stop → app confirmed audio was found; no permission prompt appeared
- independent full-diff review — pass, no findings

## Hardware boundary

The live UI proof used the connected built-in route. No Bluetooth input was connected, so AirPods/Zoom plus Apple voice processing remains a manual hardware check. The next test is one Zoom call with AirPods connected and Apple voice processing enabled, verifying either a normal first frame or exactly one recovery before the start deadline.