### PR TITLE
Fix cached Parakeet detection after restart

### DIFF
--- a/Sources/Support/ModelCacheInventory.swift
+++ b/Sources/Support/ModelCacheInventory.swift
@@ -257,9 +257,12 @@ enum ModelCacheInventory {
             return false
         }
 
+        // FluidAudio 0.15.x renamed the joint model directory. Checking the
+        // legacy name here makes a complete current cache look incomplete and
+        // can trigger the existing-install prefetch on every launch.
         let requiredDirectories = [
             "Encoder.mlmodelc",
-            "JointDecision.mlmodelc",
+            "JointDecisionv3.mlmodelc",
             "Decoder.mlmodelc",
             "Preprocessor.mlmodelc",
         ]

--- a/Tests/ModelCacheInventoryTests.swift
+++ b/Tests/ModelCacheInventoryTests.swift
@@ -28,7 +28,7 @@ func testModelCacheInventory() {
         assertEqual(snapshot.reclaimableBytes(includeWhisper: true), 40, "reclaimable total with Whisper should include stale and optional Whisper models")
     }
 
-    runSuite("ModelCacheInventory active Parakeet cache requires complete CoreML files") {
+    runSuite("ModelCacheInventory active Parakeet cache uses the current FluidAudio layout") {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("ModelCacheInventoryTests-\(UUID().uuidString)", isDirectory: true)
         let fluid = root.appendingPathComponent("FluidAudio/Models", isDirectory: true)
@@ -47,6 +47,13 @@ func testModelCacheInventory() {
         writeTestFile(active.appendingPathComponent("config.json"), bytes: 2)
         writeTestFile(active.appendingPathComponent("parakeet_v3_vocab.json"), bytes: 2)
         writeTestFile(active.appendingPathComponent("parakeet_vocab.json"), bytes: 2)
+
+        assertNil(
+            ModelCacheInventory.activeParakeetModelDirectory(fluidAudioModelsDirectory: fluid),
+            "legacy JointDecision filename should not satisfy the current FluidAudio cache layout"
+        )
+
+        writeTestFile(active.appendingPathComponent("JointDecisionv3.mlmodelc/coremldata.bin"), bytes: 11)
 
         assertEqual(
             ModelCacheInventory.activeParakeetModelDirectory(fluidAudioModelsDirectory: fluid)?.path,

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
@@ -1048,10 +1048,22 @@ final class FirstRunReliabilitySmokeRunner {
         workspace: FirstRunScenarioWorkspace
     ) -> FirstRunReliabilityScenario {
         seedActiveModelCache(in: workspace.homeURL)
-        let outcome = launch(
+        let first = launch(
             executableURL: executableURL,
             workspace: workspace,
-            tag: "cached-model",
+            tag: "cached-model-first",
+            options: FirstRunLaunchOptions(
+                onboardingCompleted: true,
+                forceOnboarding: false,
+                environmentOverrides: [
+                    "TRANSCRIPTED_FIRST_RUN_RELIABILITY_ACTIVATE_CACHED_MODEL": "1",
+                ]
+            )
+        )
+        let restart = launch(
+            executableURL: executableURL,
+            workspace: workspace,
+            tag: "cached-model-restart",
             options: FirstRunLaunchOptions(
                 onboardingCompleted: true,
                 forceOnboarding: false,
@@ -1062,20 +1074,28 @@ final class FirstRunReliabilitySmokeRunner {
         )
         return buildScenario(
             id: "cached-model-detected",
-            launches: [outcome],
-            successDetail: "A complete synthetic Parakeet cache was detected as cached files on second launch without starting a real download."
+            launches: [first, restart],
+            successDetail: "A complete synthetic Parakeet cache stayed cached across two packaged-app launches from the same isolated profile without entering the download state."
         ) { reports in
-            guard let report = reports.first else {
-                return ["expected cached-model launch report"]
+            guard reports.count == 2 else {
+                return ["expected cached-model first-launch and restart reports"]
             }
-            var failures = isolationFailures(in: report, workspace: workspace)
+            var failures = isolationFailures(in: reports[0], workspace: workspace)
+            failures.append(contentsOf: isolationFailures(in: reports[1], workspace: workspace))
             failures.append(contentsOf: expectedBooleanFailures(
-                report.actualModelState == "cached",
-                message: "active model cache should surface actual model state cached"
+                reports.allSatisfy { $0.actualModelState == "cached" },
+                message: "active model cache should remain cached on first launch and restart without entering the download state"
             ))
             failures.append(contentsOf: expectedBooleanFailures(
-                report.cachedModelDirectory?.hasSuffix("parakeet-tdt-0.6b-v3") == true,
-                message: "active model cache should report the synthetic Parakeet directory"
+                reports.allSatisfy {
+                    $0.cachedModelDirectory?.hasSuffix("parakeet-tdt-0.6b-v3") == true
+                },
+                message: "both cached-model launches should report the synthetic Parakeet directory"
+            ))
+            failures.append(contentsOf: expectedBooleanFailures(
+                reports[0].runtime.homePath == reports[1].runtime.homePath
+                    && reports[0].runtime.containerPath == reports[1].runtime.containerPath,
+                message: "cached-model restart should reuse the same isolated home and container"
             ))
             return failures
         }
@@ -1636,7 +1656,7 @@ final class FirstRunReliabilitySmokeRunner {
     private func seedActiveModelCache(in home: URL) {
         let activeRoot = home
             .appendingPathComponent("Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3", isDirectory: true)
-        for directory in ["Encoder.mlmodelc", "JointDecision.mlmodelc", "Decoder.mlmodelc", "Preprocessor.mlmodelc"] {
+        for directory in ["Encoder.mlmodelc", "JointDecisionv3.mlmodelc", "Decoder.mlmodelc", "Preprocessor.mlmodelc"] {
             let url = activeRoot.appendingPathComponent(directory, isDirectory: true)
                 .appendingPathComponent("coremldata.bin", isDirectory: false)
             try? writeFixtureFile(at: url, contents: directory)


### PR DESCRIPTION
## What changed

- recognize FluidAudio 0.15.4's current `JointDecisionv3.mlmodelc` Parakeet cache layout
- keep legacy/incomplete cache layouts rejected
- update the packaged-app cache fixture
- launch the packaged app twice from the same isolated home and assert both launches stay `cached` without entering the download state

## Root cause

Transcripted checked for the obsolete `JointDecision.mlmodelc` directory. On relaunch, a valid current cache was misclassified as missing, so startup published a downloading readiness state and showed “Downloading local dictation model.” FluidAudio then found its own valid cache and normally reused it without a fresh network transfer.

This composes with merged model work:
- #1579 stalled-download recovery
- #1584 bundled-model detection
- #1607 background preload
- #1609 model warmup ownership

## Privacy / telemetry

No telemetry, payload, network-policy, cleanup, or local-first boundary changes.

## Proof

- `bash run-tests.sh --filter ModelCacheInventory` — 39/39
- `swift test --package-path Tools/TranscriptedQA` — 55/55
- `bash build.sh --no-open` — pass, signed thin app
- `bash run-tests.sh` — 13,479/13,479
- packaged first-run reliability — PASS; two launches from the same isolated home both reported `actualModelState=cached`, the same valid cache directory, and no download state
- packaged privacy scan — PASS
- `git diff --check` — pass
- independent exact-head full-diff review — CLEAN, no actionable findings

Manual installed-app restart proof remains a separate release check.
