### PR TITLE
Simplify the compact meeting recorder

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -151,7 +151,6 @@ final class MeetingOverlayRootView: NSView {
     private let statusDot = NSView()
     private let titleLabel = NSTextField(labelWithString: "Meeting")
     private let timerLabel = NSTextField(labelWithString: "00:00")
-    private let systemAudioWarningIcon = NSImageView()
     private let detailLabel = NSTextField(labelWithString: "")
     private let micLabel = NSTextField(labelWithString: "Mic")
     private let systemLabel = NSTextField(labelWithString: "System audio")
@@ -211,8 +210,8 @@ final class MeetingOverlayRootView: NSView {
         layer?.borderWidth = 0.5
         layer?.borderColor = MeetingOverlayTokens.panelStroke.cgColor
 
-        // Status dot for the expanded recording strip and non-recording states.
-        // The resting capsule intentionally shows only the elapsed timer.
+        // Status dot for non-recording states. Recording uses the timer and
+        // waveform; capture trouble is written out in plain language.
         statusDot.wantsLayer = true
         statusDot.layer?.cornerRadius = MeetingOverlayTokens.dotSize / 2
         statusDot.layer?.shadowOffset = .zero
@@ -226,17 +225,6 @@ final class MeetingOverlayRootView: NSView {
         timerLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
         timerLabel.textColor = MeetingOverlayTokens.textSecondary
         addSubview(timerLabel)
-
-        systemAudioWarningIcon.image = NSImage(
-            systemSymbolName: "exclamationmark.triangle.fill",
-            accessibilityDescription: "System audio warning"
-        )
-        systemAudioWarningIcon.imageScaling = .scaleProportionallyUpOrDown
-        systemAudioWarningIcon.contentTintColor = MeetingOverlayTokens.dotPrompt
-        systemAudioWarningIcon.isHidden = true
-        systemAudioWarningIcon.setAccessibilityElement(true)
-        systemAudioWarningIcon.setAccessibilityRole(.image)
-        addSubview(systemAudioWarningIcon)
 
         detailLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
         detailLabel.textColor = MeetingOverlayTokens.textSecondary
@@ -475,16 +463,11 @@ final class MeetingOverlayRootView: NSView {
         // the flag flips while the panel is still tall mid-animation.
         let midY = bounds.height - tokens.panelHeight / 2
 
-        statusDot.frame = NSRect(
-            x: tokens.padLeft + 2,
-            y: midY - tokens.dotSize / 2,
-            width: tokens.dotSize,
-            height: tokens.dotSize
-        )
+        statusDot.frame = .zero
 
         let timerSize = timerLabel.fittingSize
         timerLabel.frame = NSRect(
-            x: statusDot.frame.maxX + tokens.headerGap,
+            x: tokens.padLeft,
             y: midY - timerSize.height / 2,
             width: timerSize.width,
             height: timerSize.height
@@ -497,31 +480,35 @@ final class MeetingOverlayRootView: NSView {
             height: tokens.stopHeight
         )
 
-        let warningIconSize: CGFloat = 14
-        let warningIconGap = systemAudioWarningIcon.isHidden ? 0 : tokens.headerGap
-        systemAudioWarningIcon.frame = systemAudioWarningIcon.isHidden
-            ? .zero
-            : NSRect(
-                x: timerLabel.frame.maxX + warningIconGap,
-                y: midY - warningIconSize / 2,
-                width: warningIconSize,
-                height: warningIconSize
+        let recordingContentRight: CGFloat
+        if titleLabel.isHidden {
+            titleLabel.frame = .zero
+            recordingContentRight = timerLabel.frame.maxX
+        } else {
+            let titleX = timerLabel.frame.maxX + tokens.headerGap
+            let titleWidth = max(0, closeButton.frame.minX - tokens.headerGap - titleX)
+            titleLabel.frame = NSRect(
+                x: titleX,
+                y: midY - titleLabel.fittingSize.height / 2,
+                width: titleWidth,
+                height: titleLabel.fittingSize.height
             )
-        let recordingContentRight = systemAudioWarningIcon.isHidden
-            ? timerLabel.frame.maxX
-            : systemAudioWarningIcon.frame.maxX
+            recordingContentRight = closeButton.frame.minX - tokens.headerGap
+        }
         let barsLeft = recordingContentRight + tokens.headerGap
         let barsRight = closeButton.frame.minX - tokens.headerGap
         let availableBarsWidth = max(0, barsRight - barsLeft)
         let barsWidth = min(tokens.recordingWaveformWidth, availableBarsWidth)
         let barsHeight: CGFloat = 22
         let barsY = midY - barsHeight / 2
-        audioWaveform.frame = NSRect(
-            x: barsLeft + (availableBarsWidth - barsWidth) / 2,
-            y: barsY,
-            width: barsWidth,
-            height: barsHeight
-        )
+        audioWaveform.frame = titleLabel.isHidden
+            ? NSRect(
+                x: barsLeft + (availableBarsWidth - barsWidth) / 2,
+                y: barsY,
+                width: barsWidth,
+                height: barsHeight
+            )
+            : .zero
 
         // The body covers the strip below the stop button so any click on
         // the pill itself toggles the transcript.
@@ -532,7 +519,6 @@ final class MeetingOverlayRootView: NSView {
             height: tokens.panelHeight
         )
 
-        titleLabel.frame = .zero
         detailLabel.frame = .zero
         micLabel.frame = .zero
         systemLabel.frame = .zero
@@ -568,8 +554,6 @@ final class MeetingOverlayRootView: NSView {
             width: timerSize.width,
             height: timerSize.height
         )
-        systemAudioWarningIcon.frame = .zero
-
         pillBodyView.frame = bounds
 
         // Keep real frames for the stop button and waveform: while the
@@ -612,19 +596,8 @@ final class MeetingOverlayRootView: NSView {
             height: timerSize.height
         )
 
-        let warningIconSize: CGFloat = 14
-        systemAudioWarningIcon.frame = systemAudioWarningIcon.isHidden
-            ? .zero
-            : NSRect(
-                x: timerLabel.frame.minX - 8 - warningIconSize,
-                y: topY - warningIconSize / 2,
-                width: warningIconSize,
-                height: warningIconSize
-            )
         let titleX = statusDot.frame.maxX + 8
-        let titleRight = systemAudioWarningIcon.isHidden
-            ? timerLabel.frame.minX
-            : systemAudioWarningIcon.frame.minX
+        let titleRight = timerLabel.frame.minX
         let titleWidth = max(0, titleRight - titleX - 8)
         let titleSize = titleLabel.fittingSize
         titleLabel.frame = NSRect(
@@ -730,7 +703,7 @@ final class MeetingOverlayRootView: NSView {
         currentLiveViewAffordance = liveView
         self.isTranscriptExpanded = state == .recording && !isCondensed && isTranscriptExpanded
         let wasCondensed = self.isCondensed
-        self.isCondensed = state == .recording && isCondensed
+        self.isCondensed = state == .recording && isCondensed && systemAudioWarning == nil
         if wasCondensed != self.isCondensed {
             hideTooltip()
         }
@@ -749,22 +722,9 @@ final class MeetingOverlayRootView: NSView {
         } else {
             isErrorState = false
         }
-        statusDot.isHidden = isPreparing || (state == .recording && self.isCondensed)
-        titleLabel.isHidden = isPreparing || state == .recording
+        statusDot.isHidden = isPreparing || state == .recording
+        titleLabel.isHidden = isPreparing || (state == .recording && systemAudioWarning == nil)
         timerLabel.isHidden = isPreparing || (state != .recording && !isPrompting)
-        systemAudioWarningIcon.isHidden = !(state == .recording || isPrompting)
-            || systemAudioWarning == nil
-            || (state == .recording && self.isCondensed)
-        if let systemAudioWarning {
-            let accessibilityLabel = MeetingSystemAudioDegradationCopy.accessibilityLabel(
-                for: systemAudioWarning
-            )
-            systemAudioWarningIcon.toolTip = accessibilityLabel
-            systemAudioWarningIcon.setAccessibilityLabel(accessibilityLabel)
-        } else {
-            systemAudioWarningIcon.toolTip = nil
-            systemAudioWarningIcon.setAccessibilityLabel("System audio warning")
-        }
         detailLabel.isHidden = !(isPrompting || isErrorState)
         micLabel.isHidden = true
         systemLabel.isHidden = true
@@ -825,7 +785,12 @@ final class MeetingOverlayRootView: NSView {
             recordButton.attributedTitle = primaryButtonTitle(prompt?.primaryTitle ?? "Record")
             recordButton.setAccessibilityLabel(prompt?.primaryAccessibilityLabel ?? startTooltip)
         case .recording:
-            titleLabel.stringValue = "Recording meeting"
+            titleLabel.stringValue = systemAudioWarning.map {
+                MeetingSystemAudioDegradationCopy.title(for: $0)
+            } ?? "Recording meeting"
+            titleLabel.toolTip = systemAudioWarning.map {
+                MeetingSystemAudioDegradationCopy.accessibilityLabel(for: $0)
+            }
             updateStatusDot(
                 color: systemAudioWarning == nil
                     ? MeetingOverlayTokens.dotRecording
@@ -903,6 +868,9 @@ final class MeetingOverlayRootView: NSView {
         currentSystemLevel = max(0, min(1, systemLevel))
         audioWaveform.primaryLevel = currentMicLevel
         audioWaveform.secondaryLevel = currentSystemLevel
+        if state == .recording, systemAudioWarning != nil {
+            audioWaveform.isHidden = true
+        }
         let shouldAnimate = state == .recording && !self.isCondensed
         audioWaveform.isActive = shouldAnimate
 
@@ -1696,6 +1664,9 @@ final class MeetingOverlayController: NSObject {
         _ warning: MeetingSystemAudioDegradationWarning?
     ) {
         systemAudioDegradationWarning = warning
+        if warning != nil {
+            bloomFromRest()
+        }
         guard MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt(
             warning: warning,
             hasAudioInactivityWarning: meetingSession?.audioInactivityWarning != nil
@@ -2250,7 +2221,8 @@ final class MeetingOverlayController: NSObject {
     /// directly — only the countdown does. That asymmetry is what makes the
     /// interaction immune to spurious enter/exit events during animations.
     private var isVisuallyCondensed: Bool {
-        MeetingPillRestPolicy.isCondensedRendered(
+        guard systemAudioDegradationWarning == nil else { return false }
+        return MeetingPillRestPolicy.isCondensedRendered(
             isResting: isRestingCondensed,
             isRecording: state == .recording,
             isTranscriptVisible: isTranscriptExpanded
@@ -2259,7 +2231,8 @@ final class MeetingOverlayController: NSObject {
 
     private func scheduleRestIfNeeded() {
         restTask?.cancel()
-        guard !isRestingCondensed,
+        guard systemAudioDegradationWarning == nil,
+              !isRestingCondensed,
               MeetingPillRestPolicy.canRest(
                 isRecording: state == .recording,
                 isTranscriptVisible: isTranscriptExpanded,
@@ -2272,7 +2245,8 @@ final class MeetingOverlayController: NSObject {
                 nanoseconds: UInt64(MeetingPillRestPolicy.restDelaySeconds * 1_000_000_000)
             )
             guard !Task.isCancelled, let self else { return }
-            guard MeetingPillRestPolicy.canRest(
+            guard self.systemAudioDegradationWarning == nil,
+                  MeetingPillRestPolicy.canRest(
                 isRecording: self.state == .recording,
                 isTranscriptVisible: self.isTranscriptExpanded,
                 keepControlsVisible: MeetingOverlayPillPreferences.keepControlsVisible(),

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -2222,11 +2222,11 @@ final class MeetingOverlayController: NSObject {
     /// directly — only the countdown does. That asymmetry is what makes the
     /// interaction immune to spurious enter/exit events during animations.
     private var isVisuallyCondensed: Bool {
-        guard systemAudioDegradationWarning == nil else { return false }
         return MeetingPillRestPolicy.isCondensedRendered(
             isResting: isRestingCondensed,
             isRecording: state == .recording,
-            isTranscriptVisible: isTranscriptExpanded
+            isTranscriptVisible: isTranscriptExpanded,
+            hasSystemAudioWarning: systemAudioDegradationWarning != nil
         )
     }
 
@@ -2238,7 +2238,8 @@ final class MeetingOverlayController: NSObject {
                 isRecording: state == .recording,
                 isTranscriptVisible: isTranscriptExpanded,
                 keepControlsVisible: MeetingOverlayPillPreferences.keepControlsVisible(),
-                isHovered: isPanelHovered
+                isHovered: isPanelHovered,
+                hasSystemAudioWarning: systemAudioDegradationWarning != nil
               ) else { return }
 
         restTask = Task { @MainActor [weak self] in
@@ -2246,12 +2247,12 @@ final class MeetingOverlayController: NSObject {
                 nanoseconds: UInt64(MeetingPillRestPolicy.restDelaySeconds * 1_000_000_000)
             )
             guard !Task.isCancelled, let self else { return }
-            guard self.systemAudioDegradationWarning == nil,
-                  MeetingPillRestPolicy.canRest(
+            guard MeetingPillRestPolicy.canRest(
                 isRecording: self.state == .recording,
                 isTranscriptVisible: self.isTranscriptExpanded,
                 keepControlsVisible: MeetingOverlayPillPreferences.keepControlsVisible(),
-                isHovered: self.isPanelHovered
+                isHovered: self.isPanelHovered,
+                hasSystemAudioWarning: self.systemAudioDegradationWarning != nil
             ) else { return }
             // Belt and braces against a lost exit/enter pair: never rest
             // while the pointer is physically over the panel, even if the

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -975,6 +975,7 @@ final class MeetingOverlayRootView: NSView {
     private func applyBaseVisualStyle() {
         titleLabel.font = .systemFont(ofSize: 11, weight: .semibold)
         titleLabel.textColor = MeetingOverlayTokens.textPrimary
+        titleLabel.toolTip = nil
         timerLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
         timerLabel.textColor = MeetingOverlayTokens.textSecondary
         detailLabel.font = .systemFont(ofSize: 11, weight: .medium)

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -211,7 +211,8 @@ final class MeetingOverlayRootView: NSView {
         layer?.borderWidth = 0.5
         layer?.borderColor = MeetingOverlayTokens.panelStroke.cgColor
 
-        // Record status dot (red during recording, orange while prep/transcribe, grey idle).
+        // Status dot for the expanded recording strip and non-recording states.
+        // The resting capsule intentionally shows only the elapsed timer.
         statusDot.wantsLayer = true
         statusDot.layer?.cornerRadius = MeetingOverlayTokens.dotSize / 2
         statusDot.layer?.shadowOffset = .zero
@@ -553,35 +554,21 @@ final class MeetingOverlayRootView: NSView {
     private func layoutCondensedRecording(midY: CGFloat) {
         let tokens = MeetingOverlayTokens.self
 
-        // Centered capsule content: dot, timer, and a latched warning icon.
+        // Keep the resting capsule calm and unambiguous: the elapsed timer is
+        // the complete compact recording state. Route trouble remains readable
+        // in the expanded system-audio prompt instead of becoming an unlabeled
+        // triangle beside an unlabeled colored dot.
         let timerSize = timerLabel.fittingSize
-        let warningIconSize: CGFloat = 14
-        let warningContentWidth = systemAudioWarningIcon.isHidden
-            ? 0
-            : tokens.condensedGap + warningIconSize
-        let contentWidth = tokens.dotSize + tokens.condensedGap + timerSize.width + warningContentWidth
-        let startX = max(tokens.condensedPadLeft, (bounds.width - contentWidth) / 2)
+        let startX = max(tokens.condensedPadLeft, (bounds.width - timerSize.width) / 2)
 
-        statusDot.frame = NSRect(
-            x: startX,
-            y: midY - tokens.dotSize / 2,
-            width: tokens.dotSize,
-            height: tokens.dotSize
-        )
+        statusDot.frame = .zero
         timerLabel.frame = NSRect(
-            x: statusDot.frame.maxX + tokens.condensedGap,
+            x: startX,
             y: midY - timerSize.height / 2,
             width: timerSize.width,
             height: timerSize.height
         )
-        systemAudioWarningIcon.frame = systemAudioWarningIcon.isHidden
-            ? .zero
-            : NSRect(
-                x: timerLabel.frame.maxX + tokens.condensedGap,
-                y: midY - warningIconSize / 2,
-                width: warningIconSize,
-                height: warningIconSize
-            )
+        systemAudioWarningIcon.frame = .zero
 
         pillBodyView.frame = bounds
 
@@ -596,9 +583,7 @@ final class MeetingOverlayRootView: NSView {
             width: tokens.stopHeight,
             height: tokens.stopHeight
         )
-        let recordingContentRight = systemAudioWarningIcon.isHidden
-            ? timerLabel.frame.maxX
-            : systemAudioWarningIcon.frame.maxX
+        let recordingContentRight = timerLabel.frame.maxX
         let barsLeft = recordingContentRight + tokens.headerGap
         let barsRight = closeButton.frame.minX - tokens.headerGap
         let barsWidth = max(0, min(tokens.recordingWaveformWidth, barsRight - barsLeft))
@@ -764,11 +749,12 @@ final class MeetingOverlayRootView: NSView {
         } else {
             isErrorState = false
         }
-        statusDot.isHidden = isPreparing
+        statusDot.isHidden = isPreparing || (state == .recording && self.isCondensed)
         titleLabel.isHidden = isPreparing || state == .recording
         timerLabel.isHidden = isPreparing || (state != .recording && !isPrompting)
         systemAudioWarningIcon.isHidden = !(state == .recording || isPrompting)
             || systemAudioWarning == nil
+            || (state == .recording && self.isCondensed)
         if let systemAudioWarning {
             let accessibilityLabel = MeetingSystemAudioDegradationCopy.accessibilityLabel(
                 for: systemAudioWarning

--- a/Sources/UI/Overlay/MeetingPillRestPolicy.swift
+++ b/Sources/UI/Overlay/MeetingPillRestPolicy.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Rest/wake policy for the meeting recording pill.
 ///
 /// Instead of a minimize button, the pill rests down to a compact capsule
-/// (status dot + timer) after a few seconds without attention. Hovering it
+/// (timer only) after a few seconds without attention. Hovering it
 /// WAKES it — the full strip returns and stays until another quiet stretch
 /// passes, exactly like the first rest. Hover-out never resizes anything
 /// directly; only the countdown does, and it re-verifies conditions when it
@@ -21,9 +21,14 @@ enum MeetingPillRestPolicy {
         isRecording: Bool,
         isTranscriptVisible: Bool,
         keepControlsVisible: Bool,
-        isHovered: Bool
+        isHovered: Bool,
+        hasSystemAudioWarning: Bool
     ) -> Bool {
-        isRecording && !isTranscriptVisible && !keepControlsVisible && !isHovered
+        isRecording
+            && !isTranscriptVisible
+            && !keepControlsVisible
+            && !isHovered
+            && !hasSystemAudioWarning
     }
 
     /// Whether the pill should render as the compact capsule. Hover is not
@@ -32,8 +37,9 @@ enum MeetingPillRestPolicy {
     static func isCondensedRendered(
         isResting: Bool,
         isRecording: Bool,
-        isTranscriptVisible: Bool
+        isTranscriptVisible: Bool,
+        hasSystemAudioWarning: Bool
     ) -> Bool {
-        isResting && isRecording && !isTranscriptVisible
+        isResting && isRecording && !isTranscriptVisible && !hasSystemAudioWarning
     }
 }

--- a/Tests/MeetingPillRestPolicyTests.swift
+++ b/Tests/MeetingPillRestPolicyTests.swift
@@ -7,7 +7,8 @@ func testMeetingPillRestPolicy() {
                 isRecording: true,
                 isTranscriptVisible: false,
                 keepControlsVisible: false,
-                isHovered: false
+                isHovered: false,
+                hasSystemAudioWarning: false
             ),
             "an idle recording pill should rest down to the capsule"
         )
@@ -16,7 +17,8 @@ func testMeetingPillRestPolicy() {
                 isRecording: false,
                 isTranscriptVisible: false,
                 keepControlsVisible: false,
-                isHovered: false
+                isHovered: false,
+                hasSystemAudioWarning: false
             ),
             "no recording means nothing to rest"
         )
@@ -25,7 +27,8 @@ func testMeetingPillRestPolicy() {
                 isRecording: true,
                 isTranscriptVisible: true,
                 keepControlsVisible: false,
-                isHovered: false
+                isHovered: false,
+                hasSystemAudioWarning: false
             ),
             "an open transcript means the user is watching — never rest under them"
         )
@@ -34,7 +37,8 @@ func testMeetingPillRestPolicy() {
                 isRecording: true,
                 isTranscriptVisible: false,
                 keepControlsVisible: true,
-                isHovered: false
+                isHovered: false,
+                hasSystemAudioWarning: false
             ),
             "the pin is the explicit opt-out of auto-resting"
         )
@@ -43,9 +47,20 @@ func testMeetingPillRestPolicy() {
                 isRecording: true,
                 isTranscriptVisible: false,
                 keepControlsVisible: false,
-                isHovered: true
+                isHovered: true,
+                hasSystemAudioWarning: false
             ),
             "a hovered pill is being attended to"
+        )
+        assertFalse(
+            MeetingPillRestPolicy.canRest(
+                isRecording: true,
+                isTranscriptVisible: false,
+                keepControlsVisible: false,
+                isHovered: false,
+                hasSystemAudioWarning: true
+            ),
+            "system-audio trouble must stay expanded as readable text"
         )
     }
 
@@ -54,7 +69,8 @@ func testMeetingPillRestPolicy() {
             MeetingPillRestPolicy.isCondensedRendered(
                 isResting: true,
                 isRecording: true,
-                isTranscriptVisible: false
+                isTranscriptVisible: false,
+                hasSystemAudioWarning: false
             ),
             "a resting pill renders as the capsule"
         )
@@ -62,7 +78,8 @@ func testMeetingPillRestPolicy() {
             MeetingPillRestPolicy.isCondensedRendered(
                 isResting: false,
                 isRecording: true,
-                isTranscriptVisible: false
+                isTranscriptVisible: false,
+                hasSystemAudioWarning: false
             ),
             "an awake pill renders full — hover wakes by clearing the resting state, not by overriding rendering"
         )
@@ -70,7 +87,8 @@ func testMeetingPillRestPolicy() {
             MeetingPillRestPolicy.isCondensedRendered(
                 isResting: true,
                 isRecording: true,
-                isTranscriptVisible: true
+                isTranscriptVisible: true,
+                hasSystemAudioWarning: false
             ),
             "an open transcript always renders the full strip"
         )
@@ -78,9 +96,19 @@ func testMeetingPillRestPolicy() {
             MeetingPillRestPolicy.isCondensedRendered(
                 isResting: true,
                 isRecording: false,
-                isTranscriptVisible: false
+                isTranscriptVisible: false,
+                hasSystemAudioWarning: false
             ),
             "non-recording states never render the capsule"
+        )
+        assertFalse(
+            MeetingPillRestPolicy.isCondensedRendered(
+                isResting: true,
+                isRecording: true,
+                isTranscriptVisible: false,
+                hasSystemAudioWarning: true
+            ),
+            "a latched warning must bloom from rest and remain readable"
         )
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3069,17 +3069,16 @@ func testRepoCommandContract() {
         )
         let overlayContents = readRepoTextFile("Sources/UI/Overlay/MeetingOverlayController.swift")
         assertTrue(
-            overlayContents.contains("exclamationmark.triangle.fill")
-                && overlayContents.contains("session.$systemAudioDegradationWarning")
+            overlayContents.contains("session.$systemAudioDegradationWarning")
                 && overlayContents.contains("case .systemAudio:")
                 && overlayContents.contains("acknowledgeSystemAudioDegradationWarning()"),
             "system-audio degradation should retain its explicit expanded prompt and acknowledgement path"
         )
         assertTrue(
             overlayContents.contains("statusDot.frame = .zero")
-                && overlayContents.contains("systemAudioWarningIcon.frame = .zero")
-                && overlayContents.contains("state == .recording && self.isCondensed"),
-            "the resting recording capsule should show only the elapsed timer, without ambiguous dot or triangle icons"
+                && !overlayContents.contains("exclamationmark.triangle.fill")
+                && overlayContents.contains("MeetingSystemAudioDegradationCopy.title(for: $0)"),
+            "recording should replace ambiguous dot and triangle icons with plain-language system-audio status"
         )
         let systemWarningBlock = sourceSlice(
             overlayContents,
@@ -3095,8 +3094,9 @@ func testRepoCommandContract() {
             systemWarningBlock.contains("MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt")
                 && systemWarningBlock.contains("meetingSession?.audioInactivityWarning != nil")
                 && !inactivityWarningBlock.contains("promptKind == .systemAudio")
-                && overlayContents.contains("state == .recording || isPrompting"),
-            "audio inactivity should retain prompt precedence while the system-audio warning stays latched and visible"
+                && overlayContents.contains("guard systemAudioDegradationWarning == nil else { return false }")
+                && overlayContents.contains("guard self.systemAudioDegradationWarning == nil,"),
+            "audio inactivity should retain prompt precedence while system-audio trouble keeps a plain-language expanded state"
         )
         let pipelineContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift")
         assertTrue(

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3077,7 +3077,8 @@ func testRepoCommandContract() {
         assertTrue(
             overlayContents.contains("statusDot.frame = .zero")
                 && !overlayContents.contains("exclamationmark.triangle.fill")
-                && overlayContents.contains("MeetingSystemAudioDegradationCopy.title(for: $0)"),
+                && overlayContents.contains("MeetingSystemAudioDegradationCopy.title(for: $0)")
+                && overlayContents.contains("titleLabel.toolTip = nil"),
             "recording should replace ambiguous dot and triangle icons with plain-language system-audio status"
         )
         let systemWarningBlock = sourceSlice(

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3095,8 +3095,8 @@ func testRepoCommandContract() {
             systemWarningBlock.contains("MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt")
                 && systemWarningBlock.contains("meetingSession?.audioInactivityWarning != nil")
                 && !inactivityWarningBlock.contains("promptKind == .systemAudio")
-                && overlayContents.contains("guard systemAudioDegradationWarning == nil else { return false }")
-                && overlayContents.contains("guard self.systemAudioDegradationWarning == nil,"),
+                && overlayContents.contains("hasSystemAudioWarning: systemAudioDegradationWarning != nil")
+                && overlayContents.contains("hasSystemAudioWarning: self.systemAudioDegradationWarning != nil"),
             "audio inactivity should retain prompt precedence while system-audio trouble keeps a plain-language expanded state"
         )
         let pipelineContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3073,7 +3073,13 @@ func testRepoCommandContract() {
                 && overlayContents.contains("session.$systemAudioDegradationWarning")
                 && overlayContents.contains("case .systemAudio:")
                 && overlayContents.contains("acknowledgeSystemAudioDegradationWarning()"),
-            "system-audio degradation should stay visible in the recording pill and offer an explicit persistent warning"
+            "system-audio degradation should retain its explicit expanded prompt and acknowledgement path"
+        )
+        assertTrue(
+            overlayContents.contains("statusDot.frame = .zero")
+                && overlayContents.contains("systemAudioWarningIcon.frame = .zero")
+                && overlayContents.contains("state == .recording && self.isCondensed"),
+            "the resting recording capsule should show only the elapsed timer, without ambiguous dot or triangle icons"
         )
         let systemWarningBlock = sourceSlice(
             overlayContents,


### PR DESCRIPTION
## Summary

- show only the timer in the compact recording pill
- remove the ambiguous green status dot and warning triangle from the compact state
- retain the plain-language expanded system-audio warning and acknowledgement flow

## Verification

- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh — 13,479 passed
- focused UI contract — 616 passed
- git diff --check