### PR TITLE
Fix voice-processed meeting mic startup

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1323,9 +1323,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
                         let selectedNominalRate = selection.flatMap {
                             try? $0.selectedInput.id.readNominalSampleRate()
                         }
+                        let actualInputDeviceID = freshInputNode.auAudioUnit.deviceID
+                        let actualInputTransportType =
+                            (try? actualInputDeviceID.readTransportType())
+                            ?? UInt32(kAudioDeviceTransportTypeUnknown)
                         let routeReadiness = MeetingInputDeviceSelectionPolicy.routeReadiness(
                             selection: selection,
-                            actualInputDeviceID: freshInputNode.auAudioUnit.deviceID,
+                            actualInputDeviceID: actualInputDeviceID,
+                            actualInputTransportType: actualInputTransportType,
                             capturedSampleRate: recordingSnapshot.sampleRate,
                             selectedNominalSampleRate: selectedNominalRate,
                             voiceProcessingEnabled: voiceProcessingEnabled

--- a/Sources/TranscriptedCore/Audio/MeetingInputDeviceSelectionPolicy.swift
+++ b/Sources/TranscriptedCore/Audio/MeetingInputDeviceSelectionPolicy.swift
@@ -100,12 +100,24 @@ enum MeetingInputDeviceSelectionPolicy {
     static func routeReadiness(
         selection: MeetingInputDeviceSelection?,
         actualInputDeviceID: AudioDeviceID,
+        actualInputTransportType: UInt32,
         capturedSampleRate: Double,
         selectedNominalSampleRate: Double?,
         voiceProcessingEnabled: Bool
     ) -> RouteReadiness {
         guard let selection else { return .ready }
-        guard actualInputDeviceID == selection.selectedInput.id else {
+        // AUVoiceProcessingIO replaces the physical input node with a private
+        // aggregate device after `applyMeetingInputDevice` has already bound
+        // the selected mic. Comparing that aggregate ID with the physical mic
+        // ID rejects a healthy built-in route before the engine can start.
+        // Only accept that different ID when CoreAudio identifies it as an
+        // aggregate device. Other Bluetooth, USB, or virtual-device mismatches
+        // must still fail instead of recording from the wrong microphone.
+        let isAggregateTransport = actualInputTransportType == kAudioDeviceTransportTypeAggregate
+            || actualInputTransportType == kAudioDeviceTransportTypeAutoAggregate
+        let isVoiceProcessingAggregate = voiceProcessingEnabled && isAggregateTransport
+        guard isVoiceProcessingAggregate
+                || actualInputDeviceID == selection.selectedInput.id else {
             return .deviceMismatch
         }
 

--- a/Tests/TranscriptedCoreTests/AudioTests/MeetingInputDeviceSelectionPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/MeetingInputDeviceSelectionPolicyTests.swift
@@ -17,6 +17,7 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
                 actualInputDeviceID: builtInMic.id,
+                actualInputTransportType: kAudioDeviceTransportTypeBuiltIn,
                 capturedSampleRate: 24_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: false
@@ -27,6 +28,7 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
                 actualInputDeviceID: builtInMic.id,
+                actualInputTransportType: kAudioDeviceTransportTypeBuiltIn,
                 capturedSampleRate: 48_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: false
@@ -35,7 +37,7 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         )
     }
 
-    func testRouteReadinessRejectsWrongDeviceButAllowsVoiceProcessingConverterRate() {
+    func testRouteReadinessRejectsWrongRawDeviceButAllowsVoiceProcessingAggregateDeviceAndConverterRate() {
         let bluetoothMic = device(id: 10, name: "Bluetooth Headset", transport: .bluetooth, channels: 1)
         let builtInMic = device(id: 20, name: "MacBook Pro Microphone", transport: .builtIn, channels: 1)
         let selection = MeetingInputDeviceSelection(
@@ -49,6 +51,7 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
                 actualInputDeviceID: bluetoothMic.id,
+                actualInputTransportType: kAudioDeviceTransportTypeBluetooth,
                 capturedSampleRate: 24_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: false
@@ -58,13 +61,67 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
-                actualInputDeviceID: builtInMic.id,
+                // VPIO exposes its private aggregate device here rather than
+                // the selected physical built-in mic.
+                actualInputDeviceID: 999,
+                actualInputTransportType: kAudioDeviceTransportTypeAggregate,
                 capturedSampleRate: 24_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: true
             ),
             .ready
         )
+        XCTAssertEqual(
+            MeetingInputDeviceSelectionPolicy.routeReadiness(
+                selection: selection,
+                actualInputDeviceID: 999,
+                actualInputTransportType: kAudioDeviceTransportTypeAutoAggregate,
+                capturedSampleRate: 24_000,
+                selectedNominalSampleRate: 48_000,
+                voiceProcessingEnabled: true
+            ),
+            .ready
+        )
+        XCTAssertEqual(
+            MeetingInputDeviceSelectionPolicy.routeReadiness(
+                selection: selection,
+                actualInputDeviceID: 999,
+                actualInputTransportType: kAudioDeviceTransportTypeAggregate,
+                capturedSampleRate: 48_000,
+                selectedNominalSampleRate: 48_000,
+                voiceProcessingEnabled: false
+            ),
+            .deviceMismatch
+        )
+    }
+
+    func testVoiceProcessingRejectsMismatchedNonAggregateDevices() {
+        let builtInMic = device(id: 20, name: "MacBook Pro Microphone", transport: .builtIn, channels: 1)
+        let selection = MeetingInputDeviceSelection(
+            defaultInput: builtInMic,
+            selectedInput: builtInMic,
+            defaultOutput: nil,
+            reason: .defaultIsSafe
+        )
+        let mismatchedRoutes: [(AudioDeviceID, UInt32)] = [
+            (30, kAudioDeviceTransportTypeBluetooth),
+            (40, kAudioDeviceTransportTypeUSB),
+            (50, kAudioDeviceTransportTypeVirtual),
+        ]
+
+        for (deviceID, transportType) in mismatchedRoutes {
+            XCTAssertEqual(
+                MeetingInputDeviceSelectionPolicy.routeReadiness(
+                    selection: selection,
+                    actualInputDeviceID: deviceID,
+                    actualInputTransportType: transportType,
+                    capturedSampleRate: 48_000,
+                    selectedNominalSampleRate: 48_000,
+                    voiceProcessingEnabled: true
+                ),
+                .deviceMismatch
+            )
+        }
     }
 
     func testFailedStartTimeSwitchDoesNotPersistUnappliedBuiltInSelection() {


### PR DESCRIPTION
## Summary

- recognize the private Aggregate and AutoAggregate devices created by AUVoiceProcessingIO after the selected physical mic is bound
- preserve fail-closed rejection for unknown, Bluetooth, USB, virtual, and raw-path device mismatches
- add deterministic coverage for valid VPIO wrappers and invalid mismatches

## Root cause

Enabling Apple voice processing replaces the AVAudioInputNode device ID with a private aggregate device. Meeting startup compared that wrapper ID with the selected built-in mic ID and rejected a healthy route before the engine could start. Dictation remained healthy because it uses a different startup path.

## Validation

- `swift test --filter MeetingInputDeviceSelectionPolicyTests` (14 passed)
- `bash build-deps.sh --force`
- `bash scripts/ops/transcripted-qa-bench.sh --mode full` (PASS: 17 checks; one non-blocking warning from inherited local artifacts)
- independent Terra exact-diff review: GREEN
- Developer ID signature verification: PASS

## Proof boundary

Automated route policy, app build, package, integration, and synthetic audio checks are green. A real built-in mic/system-audio capture still needs manual proof before cutting a release.

## Privacy

No telemetry schema, off-device payload, transcript/audio handling, or local-first boundary changed.