### PR TITLE
Fix meeting VPIO route readiness

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1309,6 +1309,13 @@ public class Audio: ObservableObject, @unchecked Sendable {
                             )
                         }
 
+                        // Verify the selected physical microphone before VPIO
+                        // replaces the node's device identity with its private
+                        // wrapper. The wrapper ID is not a reliable indication
+                        // of which physical input CoreAudio already bound.
+                        let selection = meetingInputSelectionSnapshot()
+                        let boundInputDeviceIDBeforeVoiceProcessing =
+                            freshInputNode.auAudioUnit.deviceID
                         armVoiceProcessing(on: freshInputNode)
                         let recordingFormat = self.recordingFormat(for: freshInputNode)
                         guard let recordingSnapshot = AudioRecordingFormatPolicy.snapshot(recordingFormat) else {
@@ -1319,18 +1326,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
                             )
                         }
 
-                        let selection = meetingInputSelectionSnapshot()
                         let selectedNominalRate = selection.flatMap {
                             try? $0.selectedInput.id.readNominalSampleRate()
                         }
                         let actualInputDeviceID = freshInputNode.auAudioUnit.deviceID
-                        let actualInputTransportType =
-                            (try? actualInputDeviceID.readTransportType())
-                            ?? UInt32(kAudioDeviceTransportTypeUnknown)
                         let routeReadiness = MeetingInputDeviceSelectionPolicy.routeReadiness(
                             selection: selection,
+                            boundInputDeviceIDBeforeVoiceProcessing: boundInputDeviceIDBeforeVoiceProcessing,
                             actualInputDeviceID: actualInputDeviceID,
-                            actualInputTransportType: actualInputTransportType,
                             capturedSampleRate: recordingSnapshot.sampleRate,
                             selectedNominalSampleRate: selectedNominalRate,
                             voiceProcessingEnabled: voiceProcessingEnabled

--- a/Sources/TranscriptedCore/Audio/MeetingInputDeviceSelectionPolicy.swift
+++ b/Sources/TranscriptedCore/Audio/MeetingInputDeviceSelectionPolicy.swift
@@ -99,24 +99,24 @@ enum MeetingInputDeviceSelectionPolicy {
 
     static func routeReadiness(
         selection: MeetingInputDeviceSelection?,
+        boundInputDeviceIDBeforeVoiceProcessing: AudioDeviceID,
         actualInputDeviceID: AudioDeviceID,
-        actualInputTransportType: UInt32,
         capturedSampleRate: Double,
         selectedNominalSampleRate: Double?,
         voiceProcessingEnabled: Bool
     ) -> RouteReadiness {
         guard let selection else { return .ready }
-        // AUVoiceProcessingIO replaces the physical input node with a private
-        // aggregate device after `applyMeetingInputDevice` has already bound
-        // the selected mic. Comparing that aggregate ID with the physical mic
-        // ID rejects a healthy built-in route before the engine can start.
-        // Only accept that different ID when CoreAudio identifies it as an
-        // aggregate device. Other Bluetooth, USB, or virtual-device mismatches
-        // must still fail instead of recording from the wrong microphone.
-        let isAggregateTransport = actualInputTransportType == kAudioDeviceTransportTypeAggregate
-            || actualInputTransportType == kAudioDeviceTransportTypeAutoAggregate
-        let isVoiceProcessingAggregate = voiceProcessingEnabled && isAggregateTransport
-        guard isVoiceProcessingAggregate
+        // Prove the selected physical microphone was bound before VPIO wraps
+        // the node. Once enabled, AUVoiceProcessingIO may expose an unknown or
+        // private device ID, so its post-wrap identity cannot safely validate
+        // the physical route. Actual audio frames remain the final start gate.
+        guard boundInputDeviceIDBeforeVoiceProcessing == selection.selectedInput.id else {
+            return .deviceMismatch
+        }
+
+        // The raw path does not replace the device identity, so it must still
+        // report the exact selected microphone after graph configuration.
+        guard voiceProcessingEnabled
                 || actualInputDeviceID == selection.selectedInput.id else {
             return .deviceMismatch
         }

--- a/Tests/TranscriptedCoreTests/AudioTests/MeetingInputDeviceSelectionPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/MeetingInputDeviceSelectionPolicyTests.swift
@@ -16,8 +16,8 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
+                boundInputDeviceIDBeforeVoiceProcessing: builtInMic.id,
                 actualInputDeviceID: builtInMic.id,
-                actualInputTransportType: kAudioDeviceTransportTypeBuiltIn,
                 capturedSampleRate: 24_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: false
@@ -27,8 +27,8 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
+                boundInputDeviceIDBeforeVoiceProcessing: builtInMic.id,
                 actualInputDeviceID: builtInMic.id,
-                actualInputTransportType: kAudioDeviceTransportTypeBuiltIn,
                 capturedSampleRate: 48_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: false
@@ -37,7 +37,7 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         )
     }
 
-    func testRouteReadinessRejectsWrongRawDeviceButAllowsVoiceProcessingAggregateDeviceAndConverterRate() {
+    func testVoiceProcessingAcceptsPrivatePostWrapIdentityOnlyAfterSelectedMicWasBound() {
         let bluetoothMic = device(id: 10, name: "Bluetooth Headset", transport: .bluetooth, channels: 1)
         let builtInMic = device(id: 20, name: "MacBook Pro Microphone", transport: .builtIn, channels: 1)
         let selection = MeetingInputDeviceSelection(
@@ -50,21 +50,10 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
-                actualInputDeviceID: bluetoothMic.id,
-                actualInputTransportType: kAudioDeviceTransportTypeBluetooth,
-                capturedSampleRate: 24_000,
-                selectedNominalSampleRate: 48_000,
-                voiceProcessingEnabled: false
-            ),
-            .deviceMismatch
-        )
-        XCTAssertEqual(
-            MeetingInputDeviceSelectionPolicy.routeReadiness(
-                selection: selection,
-                // VPIO exposes its private aggregate device here rather than
-                // the selected physical built-in mic.
-                actualInputDeviceID: 999,
-                actualInputTransportType: kAudioDeviceTransportTypeAggregate,
+                boundInputDeviceIDBeforeVoiceProcessing: builtInMic.id,
+                // VPIO can expose an unknown or private device ID after it
+                // wraps the already-bound physical microphone.
+                actualInputDeviceID: 0,
                 capturedSampleRate: 24_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: true
@@ -74,8 +63,8 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
+                boundInputDeviceIDBeforeVoiceProcessing: builtInMic.id,
                 actualInputDeviceID: 999,
-                actualInputTransportType: kAudioDeviceTransportTypeAutoAggregate,
                 capturedSampleRate: 24_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: true
@@ -85,43 +74,27 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         XCTAssertEqual(
             MeetingInputDeviceSelectionPolicy.routeReadiness(
                 selection: selection,
+                boundInputDeviceIDBeforeVoiceProcessing: bluetoothMic.id,
                 actualInputDeviceID: 999,
-                actualInputTransportType: kAudioDeviceTransportTypeAggregate,
+                capturedSampleRate: 24_000,
+                selectedNominalSampleRate: 48_000,
+                voiceProcessingEnabled: true
+            ),
+            .deviceMismatch,
+            "VPIO must not hide a wrong physical microphone before wrapping"
+        )
+        XCTAssertEqual(
+            MeetingInputDeviceSelectionPolicy.routeReadiness(
+                selection: selection,
+                boundInputDeviceIDBeforeVoiceProcessing: builtInMic.id,
+                actualInputDeviceID: 999,
                 capturedSampleRate: 48_000,
                 selectedNominalSampleRate: 48_000,
                 voiceProcessingEnabled: false
             ),
-            .deviceMismatch
+            .deviceMismatch,
+            "the raw path must keep reporting the exact selected microphone"
         )
-    }
-
-    func testVoiceProcessingRejectsMismatchedNonAggregateDevices() {
-        let builtInMic = device(id: 20, name: "MacBook Pro Microphone", transport: .builtIn, channels: 1)
-        let selection = MeetingInputDeviceSelection(
-            defaultInput: builtInMic,
-            selectedInput: builtInMic,
-            defaultOutput: nil,
-            reason: .defaultIsSafe
-        )
-        let mismatchedRoutes: [(AudioDeviceID, UInt32)] = [
-            (30, kAudioDeviceTransportTypeBluetooth),
-            (40, kAudioDeviceTransportTypeUSB),
-            (50, kAudioDeviceTransportTypeVirtual),
-        ]
-
-        for (deviceID, transportType) in mismatchedRoutes {
-            XCTAssertEqual(
-                MeetingInputDeviceSelectionPolicy.routeReadiness(
-                    selection: selection,
-                    actualInputDeviceID: deviceID,
-                    actualInputTransportType: transportType,
-                    capturedSampleRate: 48_000,
-                    selectedNominalSampleRate: 48_000,
-                    voiceProcessingEnabled: true
-                ),
-                .deviceMismatch
-            )
-        }
     }
 
     func testFailedStartTimeSwitchDoesNotPersistUnappliedBuiltInSelection() {


### PR DESCRIPTION
## What changed

- verify the exact selected physical microphone immediately before enabling Apple voice processing
- stop treating the post-VPIO device ID or transport as authoritative because CoreAudio may expose an unknown/private wrapper identity
- keep the raw capture path strict and retain the existing first-audio-frame start gate
- add deterministic coverage for the observed built-in-mic failure shape and wrong-mic rejection

## Root cause

The July 30/31 meeting-start failure was not a microphone permission or hardware failure. Dictation received real built-in-mic frames. Meeting mode successfully bound the built-in mic, then AUVoiceProcessingIO replaced the node identity. The readiness check tried to classify that post-wrap identity and rejected the healthy route as `device_mismatch` before capture could start.

## Safety

Wrong physical pre-binds still fail closed, raw capture still requires the selected device after graph setup, and first mic/system frames remain the final readiness proof. No telemetry, network, transcript, storage, or local-first boundary changed.

## Validation

- `bash build-deps.sh --force` — passed
- `bash build.sh --no-open` — passed; signed app and launch smoke valid
- `bash run-tests.sh` — 12,596/12,596 passed
- `bash run-integration-smoke.sh` — passed
- `swift test` — 872 passed, 13 model/hardware fixtures skipped, 0 failed
- `bash scripts/ops/transcripted-qa-bench.sh --mode full` — PASS, 17 checks; one expected warnings-only local artifact validation warning
- focused regression — 13/13 passed
- independent Terra review — CLEAN
- manual built-in mic + speaker proof on the affected Mac — PASS: meeting started, mic audio recorded, system audio recorded, and live transcript worked