### PR TITLE
Keep meeting recorder quiet during system silence

### DIFF
--- a/Sources/Meeting/MeetingSystemAudioStatusCopy.swift
+++ b/Sources/Meeting/MeetingSystemAudioStatusCopy.swift
@@ -37,9 +37,10 @@ enum MeetingSystemAudioStatusCopy {
 /// A recording-scoped, aggregate-only warning latch for system-audio loss.
 ///
 /// The latch deliberately survives a successful reconnect or explicit prompt
-/// dismissal. That keeps a compact warning visible until the meeting ends and
-/// lets the saved artifact remain labeled as degraded without retaining any
-/// audio, transcript, device, or app identity in UI state.
+/// dismissal so diagnostics and the saved artifact remain labeled as degraded.
+/// The normal recording strip stays quiet; only actionable interruption or
+/// failure states use the separate prompt UI. No audio, transcript, device, or
+/// app identity is retained in this state.
 struct MeetingSystemAudioDegradationWarning: Equatable {
     enum Cause: Equatable {
         case interruption

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -351,14 +351,6 @@ final class MeetingOverlayController: NSObject {
         systemAudioDegradationWarning = systemAudio
         audioRouteWarningOutcome = route
 
-        // A live system-audio warning keeps the pill fully expanded even
-        // while a higher-priority prompt (audio inactivity) is the one
-        // actually shown — isVisuallyCondensed/scheduleRestIfNeeded key off
-        // this raw signal, not the resolved prompt kind.
-        if systemAudio != nil {
-            bloomFromRest()
-        }
-
         let resolvedKind = MeetingPromptPriority.resolve(
             inactivity: inactivity,
             systemAudio: systemAudio,
@@ -852,8 +844,7 @@ final class MeetingOverlayController: NSObject {
 
     private func scheduleRestIfNeeded() {
         restTask?.cancel()
-        guard systemAudioDegradationWarning == nil,
-              !isRestingCondensed,
+        guard !isRestingCondensed,
               MeetingPillRestPolicy.canRest(
                 isRecording: state == .recording,
                 isTranscriptVisible: isTranscriptExpanded,
@@ -1239,7 +1230,6 @@ final class MeetingOverlayController: NSObject {
             participants: currentParticipants,
             warmupStatus: currentWarmupStatus,
             prompt: currentPrompt,
-            systemAudioWarning: systemAudioDegradationWarning,
             isCondensed: isVisuallyCondensed,
             liveView: MeetingLiveViewAffordancePolicy.affordance(
                 isRecording: state == .recording,

--- a/Sources/UI/Overlay/MeetingOverlayRootView.swift
+++ b/Sources/UI/Overlay/MeetingOverlayRootView.swift
@@ -556,7 +556,6 @@ final class MeetingOverlayRootView: NSView {
         participants: [String],
         warmupStatus: MeetingSessionController.ModelWarmupStatus?,
         prompt: MeetingOverlayController.PromptDisplay?,
-        systemAudioWarning: MeetingSystemAudioDegradationWarning?,
         isCondensed: Bool,
         liveView: MeetingLiveViewAffordancePolicy.Affordance?,
         isTranscriptExpanded: Bool
@@ -565,7 +564,7 @@ final class MeetingOverlayRootView: NSView {
         currentLiveViewAffordance = liveView
         self.isTranscriptExpanded = state == .recording && !isCondensed && isTranscriptExpanded
         let wasCondensed = self.isCondensed
-        self.isCondensed = state == .recording && isCondensed && systemAudioWarning == nil
+        self.isCondensed = state == .recording && isCondensed
         if wasCondensed != self.isCondensed {
             hideTooltip()
         }
@@ -585,7 +584,7 @@ final class MeetingOverlayRootView: NSView {
             isErrorState = false
         }
         statusDot.isHidden = isPreparing || state == .recording
-        titleLabel.isHidden = isPreparing || (state == .recording && systemAudioWarning == nil)
+        titleLabel.isHidden = isPreparing || state == .recording
         timerLabel.isHidden = isPreparing || (state != .recording && !isPrompting)
         detailLabel.isHidden = !(isPrompting || isErrorState)
         micLabel.isHidden = true
@@ -647,19 +646,9 @@ final class MeetingOverlayRootView: NSView {
             recordButton.attributedTitle = primaryButtonTitle(prompt?.primaryTitle ?? "Record")
             recordButton.setAccessibilityLabel(prompt?.primaryAccessibilityLabel ?? startTooltip)
         case .recording:
-            titleLabel.stringValue = systemAudioWarning.map {
-                MeetingSystemAudioDegradationCopy.title(for: $0)
-            } ?? "Recording meeting"
-            titleLabel.toolTip = systemAudioWarning.map {
-                MeetingSystemAudioDegradationCopy.accessibilityLabel(for: $0)
-            }
-            updateStatusDot(
-                color: systemAudioWarning == nil
-                    ? MeetingOverlayTokens.dotRecording
-                    : MeetingOverlayTokens.dotPrompt,
-                haloOpacity: 0.24,
-                haloRadius: 3
-            )
+            titleLabel.stringValue = "Recording meeting"
+            titleLabel.toolTip = nil
+            updateStatusDot(color: MeetingOverlayTokens.dotRecording, haloOpacity: 0.24, haloRadius: 3)
             timerLabel.font = .monospacedDigitSystemFont(ofSize: MeetingOverlayTokens.timerFontSize, weight: .medium)
             timerLabel.textColor = MeetingOverlayTokens.textPrimary
             closeButton.attributedTitle = buttonTitle("", size: 12, weight: .semibold)
@@ -730,9 +719,6 @@ final class MeetingOverlayRootView: NSView {
         currentSystemLevel = max(0, min(1, systemLevel))
         audioWaveform.primaryLevel = currentMicLevel
         audioWaveform.secondaryLevel = currentSystemLevel
-        if state == .recording, systemAudioWarning != nil {
-            audioWaveform.isHidden = true
-        }
         let shouldAnimate = state == .recording && !self.isCondensed
         audioWaveform.isActive = shouldAnimate
 

--- a/Sources/UI/Overlay/MeetingPillRestPolicy.swift
+++ b/Sources/UI/Overlay/MeetingPillRestPolicy.swift
@@ -24,11 +24,13 @@ enum MeetingPillRestPolicy {
         isHovered: Bool,
         hasSystemAudioWarning: Bool
     ) -> Bool {
-        isRecording
+        // The warning latch protects diagnostics and saved-artifact health.
+        // It must not turn the normal recorder into a persistent status banner.
+        _ = hasSystemAudioWarning
+        return isRecording
             && !isTranscriptVisible
             && !keepControlsVisible
             && !isHovered
-            && !hasSystemAudioWarning
     }
 
     /// Whether the pill should render as the compact capsule. Hover is not
@@ -40,6 +42,7 @@ enum MeetingPillRestPolicy {
         isTranscriptVisible: Bool,
         hasSystemAudioWarning: Bool
     ) -> Bool {
-        isResting && isRecording && !isTranscriptVisible && !hasSystemAudioWarning
+        _ = hasSystemAudioWarning
+        return isResting && isRecording && !isTranscriptVisible
     }
 }

--- a/Tests/MeetingPillRestPolicyTests.swift
+++ b/Tests/MeetingPillRestPolicyTests.swift
@@ -52,7 +52,7 @@ func testMeetingPillRestPolicy() {
             ),
             "a hovered pill is being attended to"
         )
-        assertFalse(
+        assertTrue(
             MeetingPillRestPolicy.canRest(
                 isRecording: true,
                 isTranscriptVisible: false,
@@ -60,7 +60,7 @@ func testMeetingPillRestPolicy() {
                 isHovered: false,
                 hasSystemAudioWarning: true
             ),
-            "system-audio trouble must stay expanded as readable text"
+            "a diagnostic system-audio latch must not hold the normal recorder open"
         )
     }
 
@@ -101,14 +101,14 @@ func testMeetingPillRestPolicy() {
             ),
             "non-recording states never render the capsule"
         )
-        assertFalse(
+        assertTrue(
             MeetingPillRestPolicy.isCondensedRendered(
                 isResting: true,
                 isRecording: true,
                 isTranscriptVisible: false,
                 hasSystemAudioWarning: true
             ),
-            "a latched warning must bloom from rest and remain readable"
+            "a diagnostic system-audio latch must not replace the compact timer"
         )
     }
 

--- a/Tests/MeetingStartFailureClassifierTests.swift
+++ b/Tests/MeetingStartFailureClassifierTests.swift
@@ -140,7 +140,7 @@ func testMeetingStartFailureClassifier() {
         )
     }
 
-    runSuite("Meeting system-audio silence uses a persistent nonmodal warning") {
+    runSuite("Meeting system-audio silence stays diagnostic-only in the recorder") {
         let silent = MeetingSystemAudioDegradationPolicy.next(
             current: nil,
             status: .silent,
@@ -152,6 +152,13 @@ func testMeetingStartFailureClassifier() {
             "prolonged system silence should create a warning latch"
         )
         assertTrue(silent?.shouldPresentPrompt == false, "ordinary silence should not force a capture restart or modal prompt")
+        assertTrue(
+            !MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt(
+                warning: silent,
+                hasAudioInactivityWarning: false
+            ),
+            "ordinary silence must not replace the timer and waveform with a prompt"
+        )
 
         let recovered = MeetingSystemAudioDegradationPolicy.next(
             current: silent,
@@ -162,6 +169,13 @@ func testMeetingStartFailureClassifier() {
             recovered?.phase,
             MeetingSystemAudioDegradationWarning.Phase.recovered,
             "audible system audio should mark the latched warning recovered"
+        )
+        assertTrue(
+            !MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt(
+                warning: recovered,
+                hasAudioInactivityWarning: false
+            ),
+            "resumed system audio must stay out of the normal recording strip"
         )
         assertEqual(
             MeetingSystemAudioDegradationPolicy.next(
@@ -225,7 +239,7 @@ func testMeetingStartFailureClassifier() {
                 warning: warning?.dismissingPrompt(),
                 hasAudioInactivityWarning: false
             ),
-            "an acknowledged system warning should remain icon-only"
+            "an acknowledged system warning should stay latched without reopening the prompt"
         )
     }
 


### PR DESCRIPTION
## What changed

- keep the normal meeting recorder on timer + waveform when system audio is silent or resumes
- stop benign system-audio health updates from waking the pill or blocking its timer-only resting state
- keep actionable interruption/failure warnings in the existing full prompt
- preserve the recording-scoped warning latch for local diagnostics and degraded saved-artifact metadata

## Why

Ordinary system silence is valid before anyone speaks or media starts. The recorder was treating its internal health latch as persistent inline UI, replacing the waveform with “System audio is silent” and later “System audio resumed,” then refusing to minimize. That looked like transcript content or a failure even though recording was healthy.

## Regression

Deterministic tests now force a latched system-audio warning and prove:

- silence and recovery do not present a prompt
- the recorder can still enter its timer-only resting state
- an actionable interruption/failure still presents the full prompt
- the warning remains latched internally through recovery

## Safety

No capture, transcription, telemetry, network, storage, or local-first behavior changed. The warning object no longer reaches the normal recording-strip renderer, but it remains available to prompt, diagnostics, and finalization paths.

## Validation

- focused regressions — 49/49 passed
- `bash run-tests.sh` — 12,598/12,598 passed
- `bash build-deps.sh --force` — passed
- `bash run-integration-smoke.sh` — passed
- `bash build.sh --no-open` — passed twice; signed app and launch smoke valid
- independent Terra review — CLEAN
- manual silence → resumed recorder presentation proof — pending