### PR TITLE
Stop repeated dictation recovery after route changes

### DIFF
--- a/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
+++ b/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
@@ -70,6 +70,44 @@ struct DictationInputDeviceSelection: Equatable {
     }
 }
 
+enum DictationVoiceProcessingRouteDecision: Equatable {
+    case disabledByPreference
+    case enabled
+    case deferredForSplitBluetoothOutput
+
+    var shouldEnable: Bool {
+        self == .enabled
+    }
+}
+
+/// Apple voice processing owns a coupled input/output voice-call graph. On a
+/// split route (for example, a built-in or USB mic with Bluetooth playback),
+/// enabling it can pull CoreAudio toward the headset input and repeatedly
+/// renegotiate the live mic format. Keep the user's preference for matched
+/// routes, but use the stable regular input graph for split Bluetooth output.
+enum DictationVoiceProcessingRoutePolicy {
+    static func decision(
+        requested: Bool,
+        selection: DictationInputDeviceSelection?
+    ) -> DictationVoiceProcessingRouteDecision {
+        guard requested else { return .disabledByPreference }
+        guard let selection, let defaultOutput = selection.defaultOutput else {
+            return .enabled
+        }
+
+        let inputClass = DictationInputDeviceSelectionPolicy.deviceClass(
+            for: selection.selectedInput
+        )
+        let outputClass = DictationInputDeviceSelectionPolicy.deviceClass(
+            for: defaultOutput
+        )
+        guard outputClass == "bluetooth", inputClass != "bluetooth" else {
+            return .enabled
+        }
+        return .deferredForSplitBluetoothOutput
+    }
+}
+
 enum DictationInputDeviceSelectionPolicy {
     static func selection(
         defaultInput: DictationAudioDevice,

--- a/Sources/Speech/ParakeetDeviceRecovery.swift
+++ b/Sources/Speech/ParakeetDeviceRecovery.swift
@@ -151,7 +151,7 @@ extension ParakeetEngine {
 
         // The route lookup above suspends outside the audio graph. Recheck all
         // lifecycle owners before this handler mutates recovery state.
-        guard !sharedMeetingMicRecording,
+        guard !isSharedMeetingMicClaimCurrent,
               !audioStartInProgress,
               !audioStopInProgress,
               observationGeneration == audioConfigObservationGeneration,
@@ -175,7 +175,7 @@ extension ParakeetEngine {
             try? await Task.sleep(
                 nanoseconds: TranscriptedConstants.audioConfigChangeDebounceDelay
             )
-            guard !sharedMeetingMicRecording,
+            guard !isSharedMeetingMicClaimCurrent,
                   !audioStartInProgress,
                   !audioStopInProgress,
                   observationGeneration == audioConfigObservationGeneration,
@@ -506,7 +506,12 @@ extension ParakeetEngine {
                 // samples. The watchdog gets one retry before giving up.
                 if shouldRestartRecording {
                     var restarted = false
-                    for attempt in 1...TranscriptedConstants.recordingRestartAttempts {
+                    var restartBudget = ParakeetRecordingRestartBudget(
+                        startedAtUptime: ProcessInfo.processInfo.systemUptime
+                    )
+                    while let attempt = restartBudget.takeNextAttempt(
+                        nowUptime: ProcessInfo.processInfo.systemUptime
+                    ) {
                         guard !Task.isCancelled else { return }
                         guard !self.recoveryState.isStale(generation: myGeneration) else { return }
                         let startSucceeded = await self.startRecording()
@@ -526,8 +531,18 @@ extension ParakeetEngine {
                             finishWorkflowRecovery(result: "success", artifactRetained: true)
                             break
                         }
-                        // BT format negotiation can take ~1-2s; wait between attempts.
-                        try? await Task.sleep(nanoseconds: TranscriptedConstants.recordingRestartRetryDelay)
+                        guard ParakeetDeviceRecoveryStartRetryPolicy.shouldRetry(
+                            after: self.lastRecordingStartFailureReason,
+                            inputCanStartRecording: self.recoveryState.canStartRecording
+                        ) else { break }
+                        // A measured split Bluetooth route needed one more probe
+                        // after the old two-second window. Wait only when another
+                        // bounded attempt remains; do not add dead time after the
+                        // terminal failure.
+                        guard let delay = restartBudget.delayBeforeNextAttempt(
+                            nowUptime: ProcessInfo.processInfo.systemUptime
+                        ) else { break }
+                        try? await Task.sleep(nanoseconds: delay)
                     }
                     if !restarted {
                         self.interruptRecordingAndClearRecoveredTimeline()

--- a/Sources/Speech/ParakeetDeviceRecovery.swift
+++ b/Sources/Speech/ParakeetDeviceRecovery.swift
@@ -136,6 +136,10 @@ extension ParakeetEngine {
             return
         }
 
+        audioConfigObservationGeneration &+= 1
+        let observationGeneration = audioConfigObservationGeneration
+        let configChangeObservedAt = CFAbsoluteTimeGetCurrent()
+
         let currentSelection: DictationInputDeviceSelection?
         if let observedSelection {
             currentSelection = observedSelection
@@ -150,8 +154,53 @@ extension ParakeetEngine {
         guard !sharedMeetingMicRecording,
               !audioStartInProgress,
               !audioStopInProgress,
+              observationGeneration == audioConfigObservationGeneration,
               CFAbsoluteTimeGetCurrent() >= ignoreInputSelectionConfigChangesUntil else {
             return
+        }
+
+        let observedRouteIdentity = currentSelection.map {
+            ParakeetAudioRouteIdentity(selection: $0)
+        }
+        let graphEndpointsMatch = stableAudioRouteIdentity.map { stableIdentity in
+            observedRouteIdentity.map(stableIdentity.matchesGraphEndpoints) ?? false
+        } ?? false
+
+        if ParakeetConfigChangeContinuityPolicy.shouldProbe(
+            wasRecording: isRecording,
+            hadSampleFlow: hasReceivedAudioSamples,
+            inputWasReady: recoveryState.canStartRecording,
+            graphEndpointsMatch: graphEndpointsMatch
+        ) {
+            try? await Task.sleep(
+                nanoseconds: TranscriptedConstants.audioConfigChangeDebounceDelay
+            )
+            guard !sharedMeetingMicRecording,
+                  !audioStartInProgress,
+                  !audioStopInProgress,
+                  observationGeneration == audioConfigObservationGeneration,
+                  CFAbsoluteTimeGetCurrent() >= ignoreInputSelectionConfigChangesUntil else {
+                return
+            }
+            if ParakeetConfigChangeContinuityPolicy.shouldIgnoreAfterProbe(
+                wasRecording: isRecording,
+                inputWasReady: recoveryState.canStartRecording,
+                graphEndpointsMatch: graphEndpointsMatch,
+                sampleArrivedAfterNotification: receivedAudioSamples(
+                    since: configChangeObservedAt
+                )
+            ) {
+                if let currentSelection {
+                    routeTransitionDebounceState.observe(
+                        categoricalAudioRoute(for: currentSelection)
+                    )
+                    updateCachedInputDeviceSelection(currentSelection)
+                }
+                AppLogger.transcription.info(
+                    "PARAKEET | configuration change ignored; current audio samples are still flowing"
+                )
+                return
+            }
         }
 
         let graphStrategy = ParakeetConfigChangeGraphPolicy.strategy(
@@ -160,7 +209,7 @@ extension ParakeetEngine {
             hadSampleFlow: hasReceivedAudioSamples,
             inputWasReady: recoveryState.canStartRecording,
             stableRouteIdentity: stableAudioRouteIdentity,
-            observedRouteIdentity: currentSelection.map { ParakeetAudioRouteIdentity(selection: $0) }
+            observedRouteIdentity: observedRouteIdentity
         )
         audioGraphGeneration += 1
 

--- a/Sources/Speech/ParakeetDeviceRecovery.swift
+++ b/Sources/Speech/ParakeetDeviceRecovery.swift
@@ -29,7 +29,7 @@ extension ParakeetEngine {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
-                await self?.handleAudioConfigChange()
+                await self?.handleAudioConfigChange(source: .audioEngine)
             }
         }
     }
@@ -95,11 +95,17 @@ extension ParakeetEngine {
         routeTransitionDebounceState.observe(categoricalAudioRoute(for: selection))
         updateCachedInputDeviceSelection(selection)
         Task { @MainActor [weak self] in
-            await self?.handleAudioConfigChange()
+            await self?.handleAudioConfigChange(
+                source: .defaultInputDevice,
+                observedSelection: selection
+            )
         }
     }
 
-    private func handleAudioConfigChange() async {
+    private func handleAudioConfigChange(
+        source: ParakeetConfigChangeSource,
+        observedSelection: DictationInputDeviceSelection? = nil
+    ) async {
         // Meeting capture owns the live audio graph while dictation borrows
         // its PCM. A system route change belongs to the meeting recovery path;
         // do not wake or rebuild the dormant dictation AVAudioEngine — but
@@ -129,6 +135,33 @@ extension ParakeetEngine {
         if CFAbsoluteTimeGetCurrent() < ignoreInputSelectionConfigChangesUntil {
             return
         }
+
+        let currentSelection: DictationInputDeviceSelection?
+        if let observedSelection {
+            currentSelection = observedSelection
+        } else {
+            currentSelection = await Task.detached(priority: .utility) {
+                Self.loadDictationInputDeviceSelection()
+            }.value
+        }
+
+        // The route lookup above suspends outside the audio graph. Recheck all
+        // lifecycle owners before this handler mutates recovery state.
+        guard !sharedMeetingMicRecording,
+              !audioStartInProgress,
+              !audioStopInProgress,
+              CFAbsoluteTimeGetCurrent() >= ignoreInputSelectionConfigChangesUntil else {
+            return
+        }
+
+        let graphStrategy = ParakeetConfigChangeGraphPolicy.strategy(
+            source: source,
+            wasRecording: isRecording,
+            hadSampleFlow: hasReceivedAudioSamples,
+            inputWasReady: recoveryState.canStartRecording,
+            stableRouteIdentity: stableAudioRouteIdentity,
+            observedRouteIdentity: currentSelection.map { ParakeetAudioRouteIdentity(selection: $0) }
+        )
         audioGraphGeneration += 1
 
         // Track whether any config change in the current burst interrupted a
@@ -174,13 +207,23 @@ extension ParakeetEngine {
             return
         }
         isEnginePrewarmed = false
-        guard let rebuiltOwner = await rebuildAudioEngine(reason: "configuration_change") else {
-            cancelConfigRecoveryIfCurrent(generation: recoveryGeneration)
-            return
-        }
-        guard ownsAudioGraph(rebuiltOwner) else {
-            cancelConfigRecoveryIfCurrent(generation: recoveryGeneration)
-            return
+
+        switch graphStrategy {
+        case .reuseCurrentGraph:
+            // CoreAudio already stopped this graph. Leave it in place so the
+            // normal recovery snapshot + recording restart can rebind the tap
+            // without retiring another AVAudioEngine and scheduling another
+            // late configuration echo.
+            AppLogger.transcription.info("PARAKEET | stable configuration change → reusing current audio graph")
+        case .rebuildGraph:
+            guard let rebuiltOwner = await rebuildAudioEngine(reason: "configuration_change") else {
+                cancelConfigRecoveryIfCurrent(generation: recoveryGeneration)
+                return
+            }
+            guard ownsAudioGraph(rebuiltOwner) else {
+                cancelConfigRecoveryIfCurrent(generation: recoveryGeneration)
+                return
+            }
         }
 
         // Cancel any in-flight recovery — the latest device change wins.
@@ -222,6 +265,7 @@ extension ParakeetEngine {
         }
         routeTransitionDebounceState.observe(categoricalAudioRoute(for: selection))
         updateCachedInputDeviceSelection(selection)
+        stableAudioRouteIdentity = ParakeetAudioRouteIdentity(selection: selection)
         guard let stableRoute = routeTransitionDebounceState.commitPendingRoute() else { return }
 
         AppLogger.transcription.info("PARAKEET | stable input route changed → \(stableRoute.routeShape)")

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -56,6 +56,7 @@ class ParakeetEngine: ObservableObject {
     private nonisolated(unsafe) var audioStartReferenceTime: CFAbsoluteTime?
     let pendingSamplesLock = NSLock()
     var pendingSamples: [Float] = []
+    private var lastAudioSampleAt: CFAbsoluteTime = 0
     var didReportPendingSampleTruncation = false
     private nonisolated(unsafe) var lastLevelUpdate: CFAbsoluteTime = 0
     var isEnginePrewarmed = false
@@ -70,6 +71,7 @@ class ParakeetEngine: ObservableObject {
     var configRecoveryTimeoutTask: Task<Void, Never>?
     var routeTransitionDebounceState = ParakeetRouteTransitionDebounceState()
     var stableAudioRouteIdentity: ParakeetAudioRouteIdentity?
+    var audioConfigObservationGeneration: UInt64 = 0
     /// Tracks whether a recording was active when the first config change in a
     /// burst arrived. Subsequent changes during recovery inherit this flag so
     /// the final recovery attempt knows to restart recording.
@@ -124,6 +126,12 @@ class ParakeetEngine: ObservableObject {
     var inputDeviceName: String { cachedInputDeviceName }
     var isRecordingFromSharedMeetingMic: Bool { sharedMeetingMicClaim != nil }
     var hasReceivedAudioSamples: Bool { didReceiveAudioSamples }
+
+    func receivedAudioSamples(since observationTime: CFAbsoluteTime) -> Bool {
+        pendingSamplesLock.withLock {
+            lastAudioSampleAt >= observationTime
+        }
+    }
 
     var currentAudioRouteAnalyticsContext: [String: String] {
         // Served from the cached selection: a live lookup enumerates every
@@ -1023,7 +1031,8 @@ class ParakeetEngine: ObservableObject {
 
     private func installTapAndStartEngine(
         startLeaseOwner: ParakeetAudioEngineQueueOwnerToken,
-        startCancellationState: ParakeetAudioStartCancellationState
+        startCancellationState: ParakeetAudioStartCancellationState,
+        voiceProcessingEnabled: Bool
     ) async throws -> ParakeetAudioStartSnapshot {
         let wasPrewarmed = isEnginePrewarmed
         let workOwnership = audioEngineWorkOwnership
@@ -1047,9 +1056,8 @@ class ParakeetEngine: ObservableObject {
             let tapRemoveStartedAt = CFAbsoluteTimeGetCurrent()
             inputNode.removeTap(onBus: 0)
             stageTimings["audio_tap_remove_ms"] = Self.elapsedMilliseconds(since: tapRemoveStartedAt)
-            let voiceProcessingRequested = MicrophoneProcessingPreferences.isVoiceProcessingEnabled()
             let voiceProcessingStartedAt = CFAbsoluteTimeGetCurrent()
-            Self.applyDictationVoiceProcessingPreference(voiceProcessingRequested, to: inputNode)
+            Self.applyDictationVoiceProcessingPreference(voiceProcessingEnabled, to: inputNode)
             stageTimings["audio_voice_processing_apply_ms"] = Self.elapsedMilliseconds(since: voiceProcessingStartedAt)
             let tapInstallStartedAt = CFAbsoluteTimeGetCurrent()
             inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil) { [weak self] buffer, _ in
@@ -1089,7 +1097,9 @@ class ParakeetEngine: ObservableObject {
                     }
                 }
 
+                let sampleArrivalTime = CFAbsoluteTimeGetCurrent()
                 let truncatedSamples: Int = self.pendingSamplesLock.withLock {
+                    self.lastAudioSampleAt = sampleArrivalTime
                     self.pendingSamples.append(contentsOf: monoSamples)
                     let maxSamples = ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
                         sampleRate: effectiveSampleRate,
@@ -1670,6 +1680,7 @@ class ParakeetEngine: ObservableObject {
         }
         pendingSamplesLock.withLock {
             pendingSamples.removeAll(keepingCapacity: true)
+            lastAudioSampleAt = 0
             didReportPendingSampleTruncation = false
         }
         sampleBuffer.removeAll(keepingCapacity: true)
@@ -1816,6 +1827,15 @@ class ParakeetEngine: ObservableObject {
                 inputRate: snapshot.hwFormat.sampleRate,
                 outputRate: snapshot.outputFormat.sampleRate
             )
+            let voiceProcessingDecision = DictationVoiceProcessingRoutePolicy.decision(
+                requested: MicrophoneProcessingPreferences.isVoiceProcessingEnabled(),
+                selection: snapshot.selection
+            )
+            if voiceProcessingDecision == .deferredForSplitBluetoothOutput {
+                AppLogger.transcription.info(
+                    "PARAKEET | Apple voice processing deferred for split Bluetooth output route"
+                )
+            }
             reserveNativeSampleBufferCapacity()
 
             if let generation = zombieRecoveryStartGeneration {
@@ -1831,7 +1851,8 @@ class ParakeetEngine: ObservableObject {
             do {
                 let startSnapshot = try await installTapAndStartEngine(
                     startLeaseOwner: attemptOwner,
-                    startCancellationState: startCancellationState
+                    startCancellationState: startCancellationState,
+                    voiceProcessingEnabled: voiceProcessingDecision.shouldEnable
                 )
                 guard ownsAudioEngineQueue(attemptOwner) else {
                     startCancellationState.cancel()

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -69,6 +69,7 @@ class ParakeetEngine: ObservableObject {
     var configRecoveryTask: Task<Void, Never>?
     var configRecoveryTimeoutTask: Task<Void, Never>?
     var routeTransitionDebounceState = ParakeetRouteTransitionDebounceState()
+    var stableAudioRouteIdentity: ParakeetAudioRouteIdentity?
     /// Tracks whether a recording was active when the first config change in a
     /// burst arrived. Subsequent changes during recovery inherit this flag so
     /// the final recovery attempt knows to restart recording.
@@ -122,6 +123,7 @@ class ParakeetEngine: ObservableObject {
     var isModelLoaded: Bool { asrManagerReady }
     var inputDeviceName: String { cachedInputDeviceName }
     var isRecordingFromSharedMeetingMic: Bool { sharedMeetingMicClaim != nil }
+    var hasReceivedAudioSamples: Bool { didReceiveAudioSamples }
 
     var currentAudioRouteAnalyticsContext: [String: String] {
         // Served from the cached selection: a live lookup enumerates every
@@ -362,6 +364,9 @@ class ParakeetEngine: ObservableObject {
     func updateCachedInputDeviceSelection(_ selection: DictationInputDeviceSelection) {
         cachedInputDeviceName = selection.selectedInput.name
         cachedInputDeviceSelection = selection
+        if stableAudioRouteIdentity == nil {
+            stableAudioRouteIdentity = ParakeetAudioRouteIdentity(selection: selection)
+        }
         routeTransitionDebounceState.seedStableRouteIfNeeded(
             categoricalAudioRoute(for: selection)
         )

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -116,6 +116,7 @@ class ParakeetEngine: ObservableObject {
     /// analytics callers without a live CoreAudio device enumeration.
     var cachedInputDeviceSelection: DictationInputDeviceSelection?
     private var lastAudioStartFailureReportAt: TimeInterval?
+    private(set) var lastRecordingStartFailureReason: ParakeetStartRecordingFailureReason?
     private var lastInputSelectionReportKey: String?
     var ignoreInputSelectionConfigChangesUntil: CFAbsoluteTime = 0
     var pendingSystemInputRestore = ParakeetOwnerBoundPendingState<ParakeetSystemInputRestoreTarget>()
@@ -1610,6 +1611,7 @@ class ParakeetEngine: ObservableObject {
     }
 
     func startRecording(isRecoveryAttempt: Bool = false) async -> Bool {
+        lastRecordingStartFailureReason = nil
         guard !isShuttingDown, !Task.isCancelled else { return false }
         guard !isRecording else { return true }
         guard !audioStartInProgress else {
@@ -1735,6 +1737,9 @@ class ParakeetEngine: ObservableObject {
                 let audioEngineTimedOut = error is ParakeetAudioEngineWorkError
                 let operationTimedOut = audioEngineTimedOut
                     || error is ParakeetSystemInputWorkError
+                lastRecordingStartFailureReason = operationTimedOut
+                    ? .audioEngineStartTimedOut
+                    : .invalidAudioFormat
                 EventReporter.shared.capture(
                     level: operationTimedOut ? .error : .warning,
                     engine: "parakeet",
@@ -1780,8 +1785,10 @@ class ParakeetEngine: ObservableObject {
                 selection: snapshot.selection
             )
             guard readiness == .ready else {
+                let failureReason = readiness.startFailureReason ?? .invalidAudioFormat
+                lastRecordingStartFailureReason = failureReason
                 let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
-                    for: readiness.startFailureReason ?? .invalidAudioFormat,
+                    for: failureReason,
                     isRecoveryAttempt: isRecoveryAttempt
                 )
                 AppLogger.transcription.warning("PARAKEET | input format unavailable (\(readiness.rawValue)): output=\(snapshot.outputFormat.sampleRate)Hz/\(snapshot.outputFormat.channelCount)ch hw=\(snapshot.hwFormat.sampleRate)Hz/\(snapshot.hwFormat.channelCount)ch")
@@ -1934,6 +1941,7 @@ class ParakeetEngine: ObservableObject {
                 let failureReason = operationTimedOut
                     ? ParakeetStartRecordingFailureReason.audioEngineStartTimedOut
                     : ParakeetAudioFormatReadinessPolicy.startFailureReason(for: error as NSError)
+                lastRecordingStartFailureReason = failureReason
                 let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
                     for: failureReason,
                     isRecoveryAttempt: isRecoveryAttempt

--- a/Sources/Speech/ParakeetRecoveryState.swift
+++ b/Sources/Speech/ParakeetRecoveryState.swift
@@ -106,6 +106,16 @@ struct ParakeetAudioRouteIdentity: Equatable {
         defaultOutputUID = selection.defaultOutput?.uid
         selectionReason = selection.reason
     }
+
+    /// The actual endpoints owned by the AVAudioEngine graph. The system
+    /// default input and selection reason can churn while Transcripted keeps
+    /// the same explicitly selected mic and output.
+    func matchesGraphEndpoints(_ other: ParakeetAudioRouteIdentity) -> Bool {
+        selectedInputID == other.selectedInputID
+            && selectedInputUID == other.selectedInputUID
+            && defaultOutputID == other.defaultOutputID
+            && defaultOutputUID == other.defaultOutputUID
+    }
 }
 
 /// Coalesces noisy CoreAudio notifications into one categorical route transition.

--- a/Sources/Speech/ParakeetRecoveryState.swift
+++ b/Sources/Speech/ParakeetRecoveryState.swift
@@ -85,6 +85,29 @@ struct ParakeetCategoricalAudioRoute: Equatable {
     let routeShape: String
 }
 
+/// Exact, process-local route identity used only for recovery admission. Raw
+/// device identity never leaves the app; analytics continue to use the coarse
+/// categorical route above.
+struct ParakeetAudioRouteIdentity: Equatable {
+    let defaultInputID: UInt32
+    let defaultInputUID: String?
+    let selectedInputID: UInt32
+    let selectedInputUID: String?
+    let defaultOutputID: UInt32?
+    let defaultOutputUID: String?
+    let selectionReason: DictationInputDeviceSelectionReason
+
+    init(selection: DictationInputDeviceSelection) {
+        defaultInputID = selection.defaultInput.id
+        defaultInputUID = selection.defaultInput.uid
+        selectedInputID = selection.selectedInput.id
+        selectedInputUID = selection.selectedInput.uid
+        defaultOutputID = selection.defaultOutput?.id
+        defaultOutputUID = selection.defaultOutput?.uid
+        selectionReason = selection.reason
+    }
+}
+
 /// Coalesces noisy CoreAudio notifications into one categorical route transition.
 /// The side-effecting recovery path still runs for every debounced config-change
 /// burst; this state only decides whether that burst is new analytics signal.

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -46,8 +46,10 @@ enum ParakeetConfigChangeGraphStrategy: Equatable {
 /// engine and post a late configuration notification even though the physical
 /// route did not change. Rebuilding again for that notification retires another
 /// engine and creates a self-sustaining five-second recovery loop. A proven
-/// recording on the exact same process-local device identity can safely reuse
-/// its current graph; changed, unknown, or explicitly selected input routes
+/// recording on the exact same process-local graph endpoints can safely reuse
+/// its current graph. The system default input and selection reason are not
+/// graph endpoints: they may change while Transcripted keeps the same explicit
+/// mic and output. Changed, unknown, idle, unready, or sample-unproven graphs
 /// keep the full rebuild path. Telemetry remains categorical and never receives
 /// this identity.
 enum ParakeetConfigChangeGraphPolicy {
@@ -59,15 +61,38 @@ enum ParakeetConfigChangeGraphPolicy {
         stableRouteIdentity: ParakeetAudioRouteIdentity?,
         observedRouteIdentity: ParakeetAudioRouteIdentity?
     ) -> ParakeetConfigChangeGraphStrategy {
-        guard source == .audioEngine,
-              wasRecording,
+        guard wasRecording,
               hadSampleFlow,
               inputWasReady,
               let stableRouteIdentity,
-              observedRouteIdentity == stableRouteIdentity else {
+              let observedRouteIdentity,
+              stableRouteIdentity.matchesGraphEndpoints(observedRouteIdentity) else {
             return .rebuildGraph
         }
         return .reuseCurrentGraph
+    }
+}
+
+enum ParakeetConfigChangeContinuityPolicy {
+    static func shouldProbe(
+        wasRecording: Bool,
+        hadSampleFlow: Bool,
+        inputWasReady: Bool,
+        graphEndpointsMatch: Bool
+    ) -> Bool {
+        wasRecording && hadSampleFlow && inputWasReady && graphEndpointsMatch
+    }
+
+    static func shouldIgnoreAfterProbe(
+        wasRecording: Bool,
+        inputWasReady: Bool,
+        graphEndpointsMatch: Bool,
+        sampleArrivedAfterNotification: Bool
+    ) -> Bool {
+        wasRecording
+            && inputWasReady
+            && graphEndpointsMatch
+            && sampleArrivedAfterNotification
     }
 }
 

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -29,6 +29,48 @@ enum ParakeetAudioEngineRebuildStrategy: Equatable {
     case abandonBlockedAudioGraph
 }
 
+enum ParakeetConfigChangeSource: Equatable {
+    case audioEngine
+    case defaultInputDevice
+}
+
+enum ParakeetConfigChangeGraphStrategy: Equatable {
+    case reuseCurrentGraph
+    case rebuildGraph
+}
+
+/// Chooses whether a configuration notification requires replacing the whole
+/// AVAudioEngine or whether recovery can restart the current graph in place.
+///
+/// Releasing a retired AVAudioEngine can make CoreAudio stop the replacement
+/// engine and post a late configuration notification even though the physical
+/// route did not change. Rebuilding again for that notification retires another
+/// engine and creates a self-sustaining five-second recovery loop. A proven
+/// recording on the exact same process-local device identity can safely reuse
+/// its current graph; changed, unknown, or explicitly selected input routes
+/// keep the full rebuild path. Telemetry remains categorical and never receives
+/// this identity.
+enum ParakeetConfigChangeGraphPolicy {
+    static func strategy(
+        source: ParakeetConfigChangeSource,
+        wasRecording: Bool,
+        hadSampleFlow: Bool,
+        inputWasReady: Bool,
+        stableRouteIdentity: ParakeetAudioRouteIdentity?,
+        observedRouteIdentity: ParakeetAudioRouteIdentity?
+    ) -> ParakeetConfigChangeGraphStrategy {
+        guard source == .audioEngine,
+              wasRecording,
+              hadSampleFlow,
+              inputWasReady,
+              let stableRouteIdentity,
+              observedRouteIdentity == stableRouteIdentity else {
+            return .rebuildGraph
+        }
+        return .reuseCurrentGraph
+    }
+}
+
 struct ParakeetDeviceRecoveryTimeoutAction: Equatable {
     let failureAction: ParakeetDeviceRecoveryFailureAction
     let rebuildStrategy: ParakeetAudioEngineRebuildStrategy

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -165,6 +165,59 @@ enum ParakeetDeviceRecoveryReadinessPolicy {
     }
 }
 
+enum ParakeetDeviceRecoveryStartRetryPolicy {
+    static func shouldRetry(
+        after failureReason: ParakeetStartRecordingFailureReason?,
+        inputCanStartRecording: Bool
+    ) -> Bool {
+        guard let failureReason else {
+            return !inputCanStartRecording
+        }
+        switch failureReason {
+        case .invalidAudioFormat, .audioRouteNotSettled:
+            return true
+        case .audioEngineStartFailed, .audioEngineStartTimedOut:
+            return false
+        }
+    }
+}
+
+/// Bounded attempt state for restarting an interrupted recording after a real
+/// endpoint change. CoreAudio can report a usable snapshot and then renegotiate
+/// the split Bluetooth route again while the microphone graph starts. Keeping
+/// this as explicit state guarantees one post-settle attempt without restoring
+/// the old unbounded recovery loop.
+struct ParakeetRecordingRestartBudget: Equatable {
+    let maxAttempts: Int
+    let retryDelayNanoseconds: UInt64
+    let deadlineUptime: TimeInterval
+    private(set) var attemptsMade = 0
+
+    init(
+        maxAttempts: Int = TranscriptedConstants.recordingRestartAttempts,
+        retryDelayNanoseconds: UInt64 = TranscriptedConstants.recordingRestartRetryDelay,
+        admissionWindow: TimeInterval = TranscriptedConstants.recordingRestartAdmissionWindow,
+        startedAtUptime: TimeInterval
+    ) {
+        self.maxAttempts = max(0, maxAttempts)
+        self.retryDelayNanoseconds = retryDelayNanoseconds
+        deadlineUptime = startedAtUptime + max(0, admissionWindow)
+    }
+
+    mutating func takeNextAttempt(nowUptime: TimeInterval) -> Int? {
+        guard attemptsMade < maxAttempts, nowUptime < deadlineUptime else { return nil }
+        attemptsMade += 1
+        return attemptsMade
+    }
+
+    func delayBeforeNextAttempt(nowUptime: TimeInterval) -> UInt64? {
+        guard attemptsMade < maxAttempts else { return nil }
+        let retryDelaySeconds = Double(retryDelayNanoseconds) / 1_000_000_000
+        guard nowUptime + retryDelaySeconds < deadlineUptime else { return nil }
+        return retryDelayNanoseconds
+    }
+}
+
 enum ParakeetDeviceRecoveryTimeoutPolicy {
     static func action(wasRecording: Bool) -> ParakeetDeviceRecoveryTimeoutAction {
         ParakeetDeviceRecoveryTimeoutAction(

--- a/Sources/Speech/PersistentDictationInputController.swift
+++ b/Sources/Speech/PersistentDictationInputController.swift
@@ -22,6 +22,11 @@ final class PersistentDictationInputController {
     private var pendingDeviceListChange = false
     private var runtimeOwnershipRelinquished = false
     private var lastMaintainedInput: AudioDeviceID?
+    private let isDictationActive: () -> Bool
+
+    init(isDictationActive: @escaping () -> Bool = { false }) {
+        self.isDictationActive = isDictationActive
+    }
 
     func start() {
         guard preferenceObserver == nil else { return }
@@ -31,9 +36,10 @@ final class PersistentDictationInputController {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.runtimeOwnershipRelinquished = false
-                self?.lastMaintainedInput = nil
-                self?.reconcileCurrentPreference()
+                guard let self else { return }
+                self.runtimeOwnershipRelinquished = false
+                self.lastMaintainedInput = nil
+                self.scheduleTopologyRefresh(preferenceChanged: true)
             }
         }
         installDefaultInputListener()
@@ -144,17 +150,27 @@ final class PersistentDictationInputController {
 
     private func scheduleTopologyRefresh(
         defaultInputChanged: Bool = false,
-        deviceListChanged: Bool = false
+        deviceListChanged: Bool = false,
+        preferenceChanged: Bool = false
     ) {
-        guard DictationPersistentInputPreferences.isEnabled()
-                || DictationPersistentInputPreferences.recoveryMarker() != nil
-                || shouldRecoverInheritedTemporaryOverride else { return }
+        guard DictationPersistentInputRefreshPolicy.shouldSchedule(
+            preferenceChanged: preferenceChanged,
+            preferenceEnabled: DictationPersistentInputPreferences.isEnabled(),
+            hasRecoveryMarker: DictationPersistentInputPreferences.recoveryMarker() != nil,
+            shouldRecoverInheritedTemporaryOverride: shouldRecoverInheritedTemporaryOverride
+        ) else { return }
         pendingDefaultInputChange = pendingDefaultInputChange || defaultInputChanged
         pendingDeviceListChange = pendingDeviceListChange || deviceListChanged
         topologyRefreshTask?.cancel()
         topologyRefreshTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
             guard !Task.isCancelled, let self else { return }
+            while DictationPersistentInputRefreshPolicy.shouldDefer(
+                isDictationActive: self.isDictationActive()
+            ) {
+                try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+                guard !Task.isCancelled else { return }
+            }
             let defaultInputChanged = self.pendingDefaultInputChange
             let deviceListChanged = self.pendingDeviceListChange
             self.pendingDefaultInputChange = false

--- a/Sources/Support/DictationPersistentInputPreferences.swift
+++ b/Sources/Support/DictationPersistentInputPreferences.swift
@@ -159,3 +159,25 @@ enum DictationPersistentInputRuntimePolicy {
         return deviceListChanged ? .reconcile : .preserveExternalSelection
     }
 }
+
+enum DictationPersistentInputRefreshPolicy {
+    static func shouldSchedule(
+        preferenceChanged: Bool,
+        preferenceEnabled: Bool,
+        hasRecoveryMarker: Bool,
+        shouldRecoverInheritedTemporaryOverride: Bool
+    ) -> Bool {
+        preferenceChanged
+            || preferenceEnabled
+            || hasRecoveryMarker
+            || shouldRecoverInheritedTemporaryOverride
+    }
+
+    /// The live speech engine already owns its selected input while dictation
+    /// is active. Changing the system-wide default at that point can stop an
+    /// otherwise healthy graph, so persistent preference maintenance waits
+    /// until the recording has finished.
+    static func shouldDefer(isDictationActive: Bool) -> Bool {
+        isDictationActive
+    }
+}

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -184,9 +184,15 @@ enum TranscriptedConstants {
     /// Prevents infinite Task chains when the mic is permanently unavailable.
     static let prewarmRetryBudget: Int = 18
 
-    /// Max attempts to restart recording after a device change. Each attempt waits
-    /// `recordingRestartRetryDelay` (500ms) to give Bluetooth format negotiation time to settle.
-    static let recordingRestartAttempts: Int = 4
+    /// Max attempts to restart recording after a device change. A real split
+    /// Bluetooth route can remain on its stale 24 kHz output bus until just after
+    /// the old fourth attempt. Eight attempts leave room for post-settle probes
+    /// while the separate admission window keeps the retry loop finite.
+    static let recordingRestartAttempts: Int = 8
+
+    /// Monotonic window in which a device-change recovery may begin another
+    /// recording start. The start operation itself has its own CoreAudio timeouts.
+    static let recordingRestartAdmissionWindow: TimeInterval = 4.0
 
     /// Delay between recording-restart attempts after a device change (nanoseconds).
     /// BT format negotiation can take ~1-2s; 500ms between attempts covers most cases.

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -210,7 +210,11 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     /// AppKit is ready.
     private var activationPolicyController: ActivationPolicyController?
     private var activationPolicySubscriptions: Set<AnyCancellable> = []
-    private let persistentDictationInputController = PersistentDictationInputController()
+    private lazy var persistentDictationInputController = PersistentDictationInputController(
+        isDictationActive: { [weak self] in
+            self?.sessionController.isDictating == true
+        }
+    )
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         if DictationStopBenchmarkRunner.runFromEnvironmentIfRequested() {

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -526,7 +526,7 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - stable recovery echoes do not retire another engine") {
-        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetDeviceRecovery.swift")
+        let source = readSourceFixture("Sources/Speech/ParakeetDeviceRecovery.swift")
         guard let strategyStart = source.range(of: "switch graphStrategy"),
               let reuseCase = source.range(of: "case .reuseCurrentGraph:", range: strategyStart.upperBound..<source.endIndex),
               let rebuildCase = source.range(of: "case .rebuildGraph:", range: reuseCase.upperBound..<source.endIndex),
@@ -594,7 +594,7 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - preference changes wait for active dictation") {
-        let source = readBluetoothRouteContractFile("Sources/Speech/PersistentDictationInputController.swift")
+        let source = readSourceFixture("Sources/Speech/PersistentDictationInputController.swift")
         guard let observerStart = source.range(of: "forName: .dictationPersistentInputPreferenceChanged"),
               let observerEnd = source.range(of: "installDefaultInputListener()", range: observerStart.upperBound..<source.endIndex),
               let schedulerStart = source.range(of: "private func scheduleTopologyRefresh("),

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -483,7 +483,7 @@ func testBluetoothRouteContract() {
         // Device-change detection/recovery lives in ParakeetDeviceRecovery.swift
         // (codebase audit 2026-07-08 wave 2).
         let source = readSourceFixture("Sources/Speech/ParakeetDeviceRecovery.swift")
-        guard let handlerStart = source.range(of: "private func handleAudioConfigChange() async"),
+        guard let handlerStart = source.range(of: "private func handleAudioConfigChange("),
               let handlerEnd = source.range(of: "private func recordStableRouteChangeAnalytics", range: handlerStart.upperBound..<source.endIndex) else {
             assertTrue(false, "test should find the audio config-change handler")
             return
@@ -502,7 +502,7 @@ func testBluetoothRouteContract() {
 
     runSuite("Bluetooth route contract - route telemetry commits only after debounce without gating recovery") {
         let source = readSourceFixture("Sources/Speech/ParakeetDeviceRecovery.swift")
-        guard let handlerStart = source.range(of: "private func handleAudioConfigChange() async"),
+        guard let handlerStart = source.range(of: "private func handleAudioConfigChange("),
               let handlerEnd = source.range(of: "private func recordStableRouteChangeAnalytics", range: handlerStart.upperBound..<source.endIndex),
               let reporterEnd = source.range(of: "// MARK: - Recovery execution", range: handlerEnd.upperBound..<source.endIndex) else {
             assertTrue(false, "test should find the route debounce and reporter bodies")
@@ -523,6 +523,31 @@ func testBluetoothRouteContract() {
         assertTrue(reporter.contains("commitPendingRoute()"), "analytics should require a genuinely new categorical route")
         assertTrue(reporter.contains("dictation_audio_route_changed"), "a stable transition should keep the existing product event")
         assertFalse(handler.contains("AnalyticsReporter.track("), "raw config notifications must not emit analytics before debounce")
+    }
+
+    runSuite("Bluetooth route contract - stable recovery echoes do not retire another engine") {
+        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetDeviceRecovery.swift")
+        guard let strategyStart = source.range(of: "switch graphStrategy"),
+              let reuseCase = source.range(of: "case .reuseCurrentGraph:", range: strategyStart.upperBound..<source.endIndex),
+              let rebuildCase = source.range(of: "case .rebuildGraph:", range: reuseCase.upperBound..<source.endIndex),
+              let strategyEnd = source.range(
+                of: "// Cancel any in-flight recovery",
+                range: rebuildCase.upperBound..<source.endIndex
+              ) else {
+            assertTrue(false, "test should find the config-change graph strategy branches")
+            return
+        }
+
+        let reuseBody = String(source[reuseCase.upperBound..<rebuildCase.lowerBound])
+        let rebuildBody = String(source[rebuildCase.upperBound..<strategyEnd.lowerBound])
+        assertFalse(
+            reuseBody.contains("rebuildAudioEngine"),
+            "a stable same-route engine echo must keep the current graph instead of creating another retirement echo"
+        )
+        assertTrue(
+            rebuildBody.contains("rebuildAudioEngine(reason: \"configuration_change\")"),
+            "real or unproven route changes must keep the full graph replacement path"
+        )
     }
 
     runSuite("Bluetooth route contract - persistent input follows reconnects and restores on shutdown") {

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -568,9 +568,9 @@ func testBluetoothRouteContract() {
         assertTrue(installDeviceList.lowerBound < removeDeviceList.lowerBound, "USB device-list monitoring should have paired teardown")
         assertTrue(stop.lowerBound < restore.lowerBound, "shutdown should route through ownership-safe restoration")
         assertTrue(
-            source.contains("guard DictationPersistentInputPreferences.isEnabled()")
-                && source.contains("|| DictationPersistentInputPreferences.recoveryMarker() != nil")
-                && source.contains("|| shouldRecoverInheritedTemporaryOverride"),
+            source.contains("preferenceEnabled: DictationPersistentInputPreferences.isEnabled()")
+                && source.contains("hasRecoveryMarker: DictationPersistentInputPreferences.recoveryMarker() != nil")
+                && source.contains("shouldRecoverInheritedTemporaryOverride: shouldRecoverInheritedTemporaryOverride"),
             "device changes must retry inherited crash restoration without treating current-session overrides as inherited"
         )
         assertTrue(
@@ -590,6 +590,41 @@ func testBluetoothRouteContract() {
             source.contains("dictation_persistent_input_external_selection_preserved")
                 && source.contains("runtimeOwnershipRelinquished = true"),
             "an external microphone selection must relinquish persistent runtime ownership"
+        )
+    }
+
+    runSuite("Bluetooth route contract - preference changes wait for active dictation") {
+        let source = readBluetoothRouteContractFile("Sources/Speech/PersistentDictationInputController.swift")
+        guard let observerStart = source.range(of: "forName: .dictationPersistentInputPreferenceChanged"),
+              let observerEnd = source.range(of: "installDefaultInputListener()", range: observerStart.upperBound..<source.endIndex),
+              let schedulerStart = source.range(of: "private func scheduleTopologyRefresh("),
+              let schedulerEnd = source.range(of: "private func reconcileCurrentPreference(", range: schedulerStart.upperBound..<source.endIndex) else {
+            assertTrue(false, "test should find the preference observer and deferred refresh scheduler")
+            return
+        }
+
+        let observerBody = String(source[observerStart.lowerBound..<observerEnd.lowerBound])
+        let schedulerBody = String(source[schedulerStart.lowerBound..<schedulerEnd.lowerBound])
+        assertTrue(
+            observerBody.contains("scheduleTopologyRefresh(preferenceChanged: true)"),
+            "preference notifications must enter the same deferred maintenance path as route changes"
+        )
+        assertFalse(
+            observerBody.contains("reconcileCurrentPreference()"),
+            "preference notifications must never reconcile the system input directly during dictation"
+        )
+        guard let deferCheck = schedulerBody.range(of: "DictationPersistentInputRefreshPolicy.shouldDefer("),
+              let reconcile = schedulerBody.range(of: "self.reconcileCurrentPreference(") else {
+            assertTrue(false, "deferred refresh should wait for dictation before reconciling")
+            return
+        }
+        assertTrue(
+            deferCheck.lowerBound < reconcile.lowerBound,
+            "system input reconciliation must happen only after the active-dictation wait"
+        )
+        assertTrue(
+            schedulerBody.contains("topologyRefreshTask?.cancel()"),
+            "repeated preference notifications should coalesce into one post-dictation refresh"
         )
     }
 

--- a/Tests/DeviceRecoveryPolicyTests.swift
+++ b/Tests/DeviceRecoveryPolicyTests.swift
@@ -13,6 +13,45 @@
 import Foundation
 
 func testDeviceRecoveryPolicy() {
+    func routeIdentity(
+        defaultInputID: UInt32,
+        selectedInputID: UInt32,
+        outputID: UInt32?,
+        reason: DictationInputDeviceSelectionReason = .defaultIsSafe
+    ) -> ParakeetAudioRouteIdentity {
+        let defaultInput = DictationAudioDevice(
+            id: defaultInputID,
+            name: "Input \(defaultInputID)",
+            transport: .builtIn,
+            inputChannelCount: 1,
+            uid: "input-\(defaultInputID)"
+        )
+        let selectedInput = DictationAudioDevice(
+            id: selectedInputID,
+            name: "Selected \(selectedInputID)",
+            transport: .builtIn,
+            inputChannelCount: 1,
+            uid: "selected-\(selectedInputID)"
+        )
+        let output = outputID.map {
+            DictationAudioDevice(
+                id: $0,
+                name: "Output \($0)",
+                transport: .builtIn,
+                inputChannelCount: 0,
+                uid: "output-\($0)"
+            )
+        }
+        return ParakeetAudioRouteIdentity(
+            selection: DictationInputDeviceSelection(
+                defaultInput: defaultInput,
+                selectedInput: selectedInput,
+                defaultOutput: output,
+                reason: reason
+            )
+        )
+    }
+
     runSuite("ParakeetDeviceRecoveryReadinessPolicy — decision table over every readiness state") {
         let cases: [(readiness: ParakeetAudioFormatReadiness, expected: ParakeetDeviceRecoveryReadinessAction)] = [
             (.ready, .finishRecovery),
@@ -113,6 +152,68 @@ func testDeviceRecoveryPolicy() {
                 ParakeetDeviceRecoveryTimeoutPolicy.action(wasRecording: wasRecording).failureAction,
                 ParakeetDeviceRecoveryFailurePolicy.action(wasRecording: wasRecording),
                 "timeout failure action should equal the shared failure policy for wasRecording=\(wasRecording)"
+            )
+        }
+    }
+
+    runSuite("ParakeetConfigChangeGraphPolicy — a late stable engine echo reuses the current graph") {
+        let bluetooth = ParakeetCategoricalAudioRoute(
+            inputDeviceClass: "built_in",
+            outputDeviceClass: "bluetooth",
+            routeShape: "built_in_input_to_bluetooth_output"
+        )
+        let builtIn = ParakeetCategoricalAudioRoute(
+            inputDeviceClass: "built_in",
+            outputDeviceClass: "built_in",
+            routeShape: "built_in_input_to_built_in_output"
+        )
+        var routeState = ParakeetRouteTransitionDebounceState()
+        routeState.seedStableRouteIfNeeded(bluetooth)
+
+        // Model the observed sequence deterministically: one real Bluetooth
+        // disconnect commits the built-in route, recording restarts and proves
+        // sample flow, then the retired engine posts a same-route notification.
+        routeState.observe(builtIn)
+        assertEqual(routeState.commitPendingRoute(), builtIn, "the real disconnect should commit its new stable route")
+        let stableIdentity = routeIdentity(defaultInputID: 80, selectedInputID: 80, outputID: 73)
+        assertEqual(
+            ParakeetConfigChangeGraphPolicy.strategy(
+                source: .audioEngine,
+                wasRecording: true,
+                hadSampleFlow: true,
+                inputWasReady: true,
+                stableRouteIdentity: stableIdentity,
+                observedRouteIdentity: stableIdentity
+            ),
+            .reuseCurrentGraph,
+            "a late same-route engine echo must not retire another audio engine"
+        )
+    }
+
+    runSuite("ParakeetConfigChangeGraphPolicy — real or unproven route changes still rebuild") {
+        let stableIdentity = routeIdentity(defaultInputID: 80, selectedInputID: 80, outputID: 73)
+        let differentSameClassIdentity = routeIdentity(defaultInputID: 81, selectedInputID: 81, outputID: 74)
+        let cases: [(source: ParakeetConfigChangeSource, recording: Bool, samples: Bool, ready: Bool, observed: ParakeetAudioRouteIdentity?)] = [
+            (.defaultInputDevice, true, true, true, stableIdentity),
+            (.audioEngine, true, true, true, differentSameClassIdentity),
+            (.audioEngine, true, false, true, stableIdentity),
+            (.audioEngine, true, true, false, stableIdentity),
+            (.audioEngine, false, true, true, stableIdentity),
+            (.audioEngine, true, true, true, nil),
+        ]
+
+        for testCase in cases {
+            assertEqual(
+                ParakeetConfigChangeGraphPolicy.strategy(
+                    source: testCase.source,
+                    wasRecording: testCase.recording,
+                    hadSampleFlow: testCase.samples,
+                    inputWasReady: testCase.ready,
+                    stableRouteIdentity: stableIdentity,
+                    observedRouteIdentity: testCase.observed
+                ),
+                .rebuildGraph,
+                "changed identities, explicit input events, idle graphs, or unproven routes must retain the full recovery path"
             )
         }
     }

--- a/Tests/DeviceRecoveryPolicyTests.swift
+++ b/Tests/DeviceRecoveryPolicyTests.swift
@@ -188,13 +188,31 @@ func testDeviceRecoveryPolicy() {
             .reuseCurrentGraph,
             "a late same-route engine echo must not retire another audio engine"
         )
+
+        let defaultInputChurnIdentity = routeIdentity(
+            defaultInputID: 81,
+            selectedInputID: 80,
+            outputID: 73,
+            reason: .preferredBuiltInForBluetoothHeadset
+        )
+        assertEqual(
+            ParakeetConfigChangeGraphPolicy.strategy(
+                source: .defaultInputDevice,
+                wasRecording: true,
+                hadSampleFlow: true,
+                inputWasReady: true,
+                stableRouteIdentity: stableIdentity,
+                observedRouteIdentity: defaultInputChurnIdentity
+            ),
+            .reuseCurrentGraph,
+            "default-input churn must not replace a graph whose exact selected mic and output are unchanged"
+        )
     }
 
     runSuite("ParakeetConfigChangeGraphPolicy — real or unproven route changes still rebuild") {
         let stableIdentity = routeIdentity(defaultInputID: 80, selectedInputID: 80, outputID: 73)
         let differentSameClassIdentity = routeIdentity(defaultInputID: 81, selectedInputID: 81, outputID: 74)
         let cases: [(source: ParakeetConfigChangeSource, recording: Bool, samples: Bool, ready: Bool, observed: ParakeetAudioRouteIdentity?)] = [
-            (.defaultInputDevice, true, true, true, stableIdentity),
             (.audioEngine, true, true, true, differentSameClassIdentity),
             (.audioEngine, true, false, true, stableIdentity),
             (.audioEngine, true, true, false, stableIdentity),
@@ -213,7 +231,46 @@ func testDeviceRecoveryPolicy() {
                     observedRouteIdentity: testCase.observed
                 ),
                 .rebuildGraph,
-                "changed identities, explicit input events, idle graphs, or unproven routes must retain the full recovery path"
+                "changed endpoints, idle graphs, or unproven routes must retain the full recovery path"
+            )
+        }
+    }
+
+    runSuite("ParakeetConfigChangeContinuityPolicy ignores only proven live same-route notifications") {
+        assertTrue(
+            ParakeetConfigChangeContinuityPolicy.shouldProbe(
+                wasRecording: true,
+                hadSampleFlow: true,
+                inputWasReady: true,
+                graphEndpointsMatch: true
+            ),
+            "an active proven graph should get a short continuity probe before teardown"
+        )
+        assertTrue(
+            ParakeetConfigChangeContinuityPolicy.shouldIgnoreAfterProbe(
+                wasRecording: true,
+                inputWasReady: true,
+                graphEndpointsMatch: true,
+                sampleArrivedAfterNotification: true
+            ),
+            "fresh post-notification samples prove the graph never stopped"
+        )
+
+        let unsafeCases: [(recording: Bool, ready: Bool, sameRoute: Bool, freshSample: Bool)] = [
+            (false, true, true, true),
+            (true, false, true, true),
+            (true, true, false, true),
+            (true, true, true, false),
+        ]
+        for testCase in unsafeCases {
+            assertFalse(
+                ParakeetConfigChangeContinuityPolicy.shouldIgnoreAfterProbe(
+                    wasRecording: testCase.recording,
+                    inputWasReady: testCase.ready,
+                    graphEndpointsMatch: testCase.sameRoute,
+                    sampleArrivedAfterNotification: testCase.freshSample
+                ),
+                "stopped, unready, changed-route, or sample-stalled graphs must still recover"
             )
         }
     }

--- a/Tests/DeviceRecoveryPolicyTests.swift
+++ b/Tests/DeviceRecoveryPolicyTests.swift
@@ -67,6 +67,99 @@ func testDeviceRecoveryPolicy() {
         }
     }
 
+    runSuite("ParakeetRecordingRestartBudget — admits a post-settle Bluetooth restart and stays bounded") {
+        let startedAt = 100.0
+        var budget = ParakeetRecordingRestartBudget(startedAtUptime: startedAt)
+
+        // The live failure produced four unavailable starts while the split
+        // Bluetooth route moved from 24 kHz back to 48 kHz. The next attempt
+        // must still be available once CoreAudio finishes settling.
+        for expectedAttempt in 1...4 {
+            assertEqual(
+                budget.takeNextAttempt(nowUptime: startedAt + (Double(expectedAttempt - 1) * 0.5)),
+                expectedAttempt,
+                "the measured pre-settle attempt \(expectedAttempt) should stay inside the budget"
+            )
+        }
+        assertEqual(
+            budget.takeNextAttempt(nowUptime: startedAt + 2.0),
+            5,
+            "recovery must include the first post-settle attempt instead of aborting immediately before it"
+        )
+
+        for expectedAttempt in 6...TranscriptedConstants.recordingRestartAttempts {
+            assertEqual(
+                budget.takeNextAttempt(nowUptime: startedAt + (Double(expectedAttempt - 1) * 0.5)),
+                expectedAttempt
+            )
+        }
+        assertNil(
+            budget.delayBeforeNextAttempt(nowUptime: startedAt + 3.5),
+            "the terminal attempt must not add a dead retry delay"
+        )
+        assertNil(
+            budget.takeNextAttempt(nowUptime: startedAt + 3.6),
+            "recovery must stop after the bounded attempt count"
+        )
+
+        var expiredBudget = ParakeetRecordingRestartBudget(startedAtUptime: startedAt)
+        assertNil(
+            expiredBudget.takeNextAttempt(nowUptime: startedAt + TranscriptedConstants.recordingRestartAdmissionWindow),
+            "the monotonic admission deadline must stop retries even when attempts remain"
+        )
+
+        var disabledBudget = ParakeetRecordingRestartBudget(maxAttempts: 0, startedAtUptime: startedAt)
+        assertNil(
+            disabledBudget.takeNextAttempt(nowUptime: startedAt),
+            "a zero budget should make no attempts"
+        )
+    }
+
+    runSuite("ParakeetDeviceRecoveryStartRetryPolicy — retries settling formats but not failed engine work") {
+        assertTrue(
+            ParakeetDeviceRecoveryStartRetryPolicy.shouldRetry(
+                after: .audioRouteNotSettled,
+                inputCanStartRecording: false
+            ),
+            "the measured split-route mismatch should receive another bounded probe"
+        )
+        assertTrue(
+            ParakeetDeviceRecoveryStartRetryPolicy.shouldRetry(
+                after: .invalidAudioFormat,
+                inputCanStartRecording: false
+            ),
+            "a transient zero or invalid format should remain retryable"
+        )
+        assertTrue(
+            ParakeetDeviceRecoveryStartRetryPolicy.shouldRetry(
+                after: nil,
+                inputCanStartRecording: false
+            ),
+            "a prewarm still settling between probes should remain retryable"
+        )
+        assertFalse(
+            ParakeetDeviceRecoveryStartRetryPolicy.shouldRetry(
+                after: .audioEngineStartFailed,
+                inputCanStartRecording: false
+            ),
+            "a failed engine start already used its internal retry and must not multiply the outer budget"
+        )
+        assertFalse(
+            ParakeetDeviceRecoveryStartRetryPolicy.shouldRetry(
+                after: .audioEngineStartTimedOut,
+                inputCanStartRecording: false
+            ),
+            "a timed-out CoreAudio start must not multiply the outer budget"
+        )
+        assertFalse(
+            ParakeetDeviceRecoveryStartRetryPolicy.shouldRetry(
+                after: nil,
+                inputCanStartRecording: true
+            ),
+            "a non-route failure with a ready input should stop immediately"
+        )
+    }
+
     runSuite("ParakeetDeviceRecoveryFailurePolicy.action — decision table over wasRecording") {
         let cases: [(wasRecording: Bool, expected: ParakeetDeviceRecoveryFailureAction)] = [
             (

--- a/Tests/DictationInputDeviceSelectionPolicyTests.swift
+++ b/Tests/DictationInputDeviceSelectionPolicyTests.swift
@@ -160,6 +160,35 @@ func testDictationInputDeviceSelectionPolicy() {
         )
     }
 
+    runSuite("DictationPersistentInputRefreshPolicy defers system input writes during dictation") {
+        assertTrue(
+            DictationPersistentInputRefreshPolicy.shouldSchedule(
+                preferenceChanged: true,
+                preferenceEnabled: false,
+                hasRecoveryMarker: false,
+                shouldRecoverInheritedTemporaryOverride: false
+            ),
+            "a preference notification must schedule deferred cleanup even when the new preference is disabled"
+        )
+        assertFalse(
+            DictationPersistentInputRefreshPolicy.shouldSchedule(
+                preferenceChanged: false,
+                preferenceEnabled: false,
+                hasRecoveryMarker: false,
+                shouldRecoverInheritedTemporaryOverride: false
+            ),
+            "unrelated topology noise should remain idle when there is no preference or recovery work"
+        )
+        assertTrue(
+            DictationPersistentInputRefreshPolicy.shouldDefer(isDictationActive: true),
+            "persistent input maintenance must not interrupt a live dictation graph"
+        )
+        assertFalse(
+            DictationPersistentInputRefreshPolicy.shouldDefer(isDictationActive: false),
+            "persistent input maintenance should resume after dictation stops"
+        )
+    }
+
     runSuite("DictationPreferredInputPolicy uses preferred USB then automatic fallback") {
         let bluetooth = DictationAudioDevice(id: 1, name: "AirPods", transport: .bluetooth, inputChannelCount: 1, uid: "airpods")
         let macMic = DictationAudioDevice(id: 2, name: "MacBook Pro Microphone", transport: .builtIn, inputChannelCount: 1, uid: "mac")
@@ -323,6 +352,72 @@ func testDictationInputDeviceSelectionPolicy() {
 
         assertEqual(selection.selectedInput, usbMic, "USB mics should stay selected")
         assertEqual(selection.reason, .defaultIsSafe, "USB mics do not need the Bluetooth fallback")
+    }
+
+    runSuite("DictationVoiceProcessingRoutePolicy avoids VPIO on split Bluetooth output") {
+        let bluetoothOutput = device(1, "Bluetooth Output", .bluetooth, inputChannels: 0)
+        let bluetoothInput = device(2, "Bluetooth Input", .bluetooth)
+        let builtInInput = device(3, "Built-In Microphone", .builtIn)
+        let usbInput = device(4, "USB Microphone", .usb)
+        let builtInOutput = device(5, "Built-In Speakers", .builtIn, inputChannels: 0)
+
+        func selection(
+            input: DictationAudioDevice,
+            output: DictationAudioDevice?
+        ) -> DictationInputDeviceSelection {
+            DictationInputDeviceSelection(
+                defaultInput: input,
+                selectedInput: input,
+                defaultOutput: output,
+                reason: .defaultIsSafe
+            )
+        }
+
+        assertEqual(
+            DictationVoiceProcessingRoutePolicy.decision(
+                requested: true,
+                selection: selection(input: builtInInput, output: bluetoothOutput)
+            ),
+            .deferredForSplitBluetoothOutput,
+            "built-in mic plus Bluetooth output should avoid call-mode route renegotiation"
+        )
+        assertEqual(
+            DictationVoiceProcessingRoutePolicy.decision(
+                requested: true,
+                selection: selection(input: usbInput, output: bluetoothOutput)
+            ),
+            .deferredForSplitBluetoothOutput,
+            "USB mic plus Bluetooth output should also stay on the regular input graph"
+        )
+        assertEqual(
+            DictationVoiceProcessingRoutePolicy.decision(
+                requested: true,
+                selection: selection(input: bluetoothInput, output: bluetoothOutput)
+            ),
+            .enabled,
+            "matched Bluetooth voice routes should preserve the explicit VPIO preference"
+        )
+        assertEqual(
+            DictationVoiceProcessingRoutePolicy.decision(
+                requested: true,
+                selection: selection(input: builtInInput, output: builtInOutput)
+            ),
+            .enabled,
+            "non-Bluetooth routes should preserve the explicit VPIO preference"
+        )
+        assertEqual(
+            DictationVoiceProcessingRoutePolicy.decision(
+                requested: false,
+                selection: selection(input: builtInInput, output: bluetoothOutput)
+            ),
+            .disabledByPreference,
+            "the route policy should never override an explicitly disabled preference"
+        )
+        assertEqual(
+            DictationVoiceProcessingRoutePolicy.decision(requested: true, selection: nil),
+            .enabled,
+            "unknown routes should not silently discard an explicit preference"
+        )
     }
 
     runSuite("DictationInputDeviceSelectionPolicy keeps AirPods when no built-in fallback exists") {

--- a/Tests/ParakeetAudioOwnershipSourceContractTests.swift
+++ b/Tests/ParakeetAudioOwnershipSourceContractTests.swift
@@ -313,7 +313,7 @@ func testParakeetAudioOwnershipSourceContract() {
                 of: "// MARK: - Recorded Audio Buffering",
                 range: stopStart.upperBound..<engineSource.endIndex
               ),
-              let handlerStart = recoverySource.range(of: "private func handleAudioConfigChange() async"),
+              let handlerStart = recoverySource.range(of: "private func handleAudioConfigChange("),
               let handlerEnd = recoverySource.range(
                 of: "private func recordStableRouteChangeAnalytics",
                 range: handlerStart.upperBound..<recoverySource.endIndex
@@ -356,7 +356,7 @@ func testParakeetAudioOwnershipSourceContract() {
                 of: "// MARK: - Recorded Audio Buffering",
                 range: stopStart.upperBound..<engineSource.endIndex
               ),
-              let handlerStart = recoverySource.range(of: "private func handleAudioConfigChange() async"),
+              let handlerStart = recoverySource.range(of: "private func handleAudioConfigChange("),
               let handlerEnd = recoverySource.range(
                 of: "private func recordStableRouteChangeAnalytics",
                 range: handlerStart.upperBound..<recoverySource.endIndex

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -913,7 +913,7 @@ func testParakeetStartRecordingFailurePolicy() {
 
     runSuite("ParakeetEngine config changes invalidate zombie ownership before cancellation can suspend") {
         let source = readParakeetDeviceRecoverySource()
-        guard let handlerStart = source.range(of: "private func handleAudioConfigChange() async"),
+        guard let handlerStart = source.range(of: "private func handleAudioConfigChange("),
               let handlerEnd = source.range(of: "private func recordStableRouteChangeAnalytics", range: handlerStart.upperBound..<source.endIndex) else {
             assertTrue(false, "test should find the audio config-change handler")
             return


### PR DESCRIPTION
## What changed

- stops healthy dictation graphs from being torn down by same-route CoreAudio configuration echoes
- requires the exact selected input/output endpoints plus a fresh post-notification audio sample before reusing a graph
- keeps full recovery for changed, unknown, stalled, stopped, or unready routes
- defers Apple voice processing only for the unstable split route: built-in/USB microphone with Bluetooth output
- defers persistent system-input maintenance, including preference changes, until the active/start-in-progress dictation session ends
- extends active-recording restart recovery for the measured Bluetooth 24/48 kHz settling race
- admits only transient route/format retries, with both an eight-attempt cap and a four-second monotonic admission window
- stops immediately after engine failures/timeouts and avoids the old dead delay after the terminal attempt
- keeps device identity process-local and telemetry categorical; no local-first or privacy boundary changed

## Live failure traced

A later real-hardware run invalidated the earlier clean-route claim. During an active dictation, the split Bluetooth route moved between 24 kHz and 48 kHz. Four starts failed while CoreAudio was still settling, and the old retry budget aborted the recording immediately before the route became usable. The app process stayed alive; the dictation session was interrupted, which made the overlay disappear and felt like a force quit.

The new deterministic regression reproduces that timing boundary: four pre-settle failures still leave a fifth attempt available, the loop remains time/attempt bounded, terminal attempts add no dead sleep, and engine failures/timeouts cannot multiply the outer retry budget.

## Verification

- signed app build, signature verification, launch smoke, and performance budget: PASS
- focused recovery / start-policy / Bluetooth suites: 45/45, 166/166, and 121/121
- isolated full fast suite: 12,644 passed, 0 failed
- full QA bench: PASS, 17 checks, 0 failures (one unrelated non-blocking warning from legacy local capture artifacts)
- synthetic audio reliability matrix: PASS
- GitHub repo hygiene, Swift checks, SPM tests, and app build: PASS
- independent Terra review: GREEN
- Codex review against the real origin/main base: clean, no actionable findings

## Proof boundary

Automated and synthetic proof is green, but it cannot prove real Bluetooth hardware behavior. The replacement signed build still needs the exact output-switch scenario repeated on hardware before this draft becomes ready or merges. Meeting-recorder release proof remains a separate gate for the combined release candidate.