### PR TITLE
Guard system wake for shared meeting mic

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1694,6 +1694,17 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func handleSystemWake() async {
+        // Meeting capture owns the live audio graph while dictation borrows
+        // its PCM. Wake belongs to the meeting recovery path; do not wake or
+        // rebuild the dormant dictation AVAudioEngine. Mirrors the guard in
+        // ParakeetDeviceRecovery.handleAudioConfigChange().
+        if ParakeetSystemWakePolicy.decision(sharedMeetingMicRecording: sharedMeetingMicRecording) == .skipSharedMeetingMic {
+            AppLogger.transcription.info("PARAKEET | system wake detected, dictation borrowing meeting mic, skipping teardown")
+            EventReporter.shared.capture(level: .info, engine: "parakeet", event: "system_wake_shared_meeting_mic_skipped",
+                message: "System woke from sleep while dictation was borrowing the meeting microphone; meeting capture owns wake recovery")
+            return
+        }
+
         AppLogger.transcription.info("PARAKEET | system wake detected, resetting audio engine")
         EventReporter.shared.capture(level: .info, engine: "parakeet", event: "system_wake",
             message: "System woke from sleep, resetting audio engine",

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1711,6 +1711,12 @@ class ParakeetEngine: ObservableObject {
             context: ["was_recording": "\(isRecording)", "was_prewarmed": "\(isEnginePrewarmed)"])
 
         audioGraphGeneration += 1
+        // A wake can interleave with the shared-mic resume transition after
+        // finishSharedMeetingMicRecording() clears the flag but before
+        // finishResume(token:) commits. Invalidate the transition so the
+        // resume path takes its stale-token branch instead of reporting a
+        // successful resume on the graph this teardown is about to stop.
+        sharedMeetingMicTransition.invalidate()
         let wasRecording = isRecording
         cancelAudioWatchdog()
         audioStartAdmission.cancel()

--- a/Sources/Speech/ParakeetSystemWakePolicy.swift
+++ b/Sources/Speech/ParakeetSystemWakePolicy.swift
@@ -1,0 +1,22 @@
+// ParakeetSystemWakePolicy.swift
+// Pure decision for how ParakeetEngine's system-wake handler should react,
+// mirroring the shared-meeting-mic guard already used by
+// ParakeetDeviceRecovery's config-change handler (see handleAudioConfigChange
+// in ParakeetDeviceRecovery.swift). Kept separate and pure so the guard has
+// direct test coverage independent of AVAudioEngine/EventReporter.
+
+enum ParakeetSystemWakeDecision: Equatable {
+    /// Meeting capture owns the live audio graph while dictation borrows its
+    /// PCM. Wake belongs to the meeting recovery path; do not wake or rebuild
+    /// the dormant dictation AVAudioEngine out from under it.
+    case skipSharedMeetingMic
+    /// Dictation owns its own audio graph; tear it down and, if a recording
+    /// was in progress, mark it interrupted.
+    case tearDownAudioGraph
+}
+
+enum ParakeetSystemWakePolicy {
+    static func decision(sharedMeetingMicRecording: Bool) -> ParakeetSystemWakeDecision {
+        sharedMeetingMicRecording ? .skipSharedMeetingMic : .tearDownAudioGraph
+    }
+}

--- a/Tests/ParakeetSystemWakePolicyTests.swift
+++ b/Tests/ParakeetSystemWakePolicyTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+func testParakeetSystemWakePolicy() {
+    runSuite("ParakeetSystemWakePolicy.decision — shared meeting mic recording skips teardown") {
+        assertEqual(
+            ParakeetSystemWakePolicy.decision(sharedMeetingMicRecording: true),
+            .skipSharedMeetingMic,
+            "wake must not tear down the dormant dictation AVAudioEngine while meeting capture owns the live audio graph"
+        )
+    }
+
+    runSuite("ParakeetSystemWakePolicy.decision — regular dictation recovers its own audio graph") {
+        assertEqual(
+            ParakeetSystemWakePolicy.decision(sharedMeetingMicRecording: false),
+            .tearDownAudioGraph,
+            "wake should still reset dictation's own audio graph when it isn't borrowing the meeting mic"
+        )
+    }
+}

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -303,6 +303,7 @@ APP_SOURCES=(
     "Sources/Speech/ParakeetRecoveryState.swift"
     "Sources/Speech/ParakeetStartRecordingFailurePolicy.swift"
     "Sources/Speech/ParakeetShortAudioGate.swift"
+    "Sources/Speech/ParakeetSystemWakePolicy.swift"
     "Sources/Speech/DictationAudioRecovery.swift"
     "Sources/Speech/RecordedAudioTimeline.swift"
     "Sources/Speech/SharedMeetingMicRecorder.swift"


### PR DESCRIPTION
## Bug

`ParakeetEngine.handleSystemWake()` (`Sources/Speech/ParakeetEngine.swift:1696`) tore down the audio engine on every system wake — `removeRecordingTap`, `stopAudioEngine`, `isRecording = false` — with no `sharedMeetingMicRecording` guard.

Its sibling handler `ParakeetDeviceRecovery.handleAudioConfigChange()` (`Sources/Speech/ParakeetDeviceRecovery.swift:100-114`) already guards this: when dictation is borrowing the meeting's mic PCM, meeting capture owns the live audio graph, so the dormant dictation `AVAudioEngine` must not be woken or rebuilt.

Because `handleSystemWake()` lacked the same guard, a sleep/wake during a shared-mic dictation (dictation borrowing meeting capture's mic) tore down dictation state the meeting session owns, killing the dictation while the meeting kept recording uninterrupted.

## Fix

Added a pure `ParakeetSystemWakePolicy` (`Sources/Speech/ParakeetSystemWakePolicy.swift`) mirroring the `handleAudioConfigChange()` guard semantics: `.skipSharedMeetingMic` when `sharedMeetingMicRecording` is true, `.tearDownAudioGraph` otherwise. `handleSystemWake()` now consults it first and, when dictation is borrowing the meeting mic, logs/reports (`system_wake_shared_meeting_mic_skipped`, privacy-safe — no transcript/device/path data) and returns without touching `AVAudioEngine` or `isRecording`, leaving the shared-mic borrow alone so the meeting's own wake handling recovers it.

Also added `Sources/Speech/ParakeetSystemWakePolicy.swift` to `run-tests.sh`'s `APP_SOURCES` (root fast-test runner is a curated list, not a `find` glob) and a root fast test at `Tests/ParakeetSystemWakePolicyTests.swift` (`testParakeetSystemWakePolicy`) covering both branches of the decision.

## Verification

```
bash build.sh --no-open   # Build complete!
bash run-tests.sh         # 12598 tests, 12598 passed, 0 failed
```

(Worktree lacked prebuilt deps; ran `bash build-deps.sh --force` first, which succeeded.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)