### PR TITLE
Keep route warnings from clobbering mic boost

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -1783,6 +1783,11 @@ final class MeetingOverlayController: NSObject {
         // An inactivity prompt owns its stop policy. The route warning is
         // latched on the session and appears as soon as that prompt clears.
         if state == .prompt, promptKind == .audioInactivity { return }
+        // Precedence: never replace an active mic-boost prompt (mirrors
+        // applyMicBoostPrompt above deferring to an active route warning).
+        // The route warning is latched on the session and appears as soon
+        // as the mic-boost prompt clears.
+        if state == .prompt, promptKind == .micBoost { return }
 
         autoHideTask?.cancel()
         promptCountdownTask?.cancel()


### PR DESCRIPTION
## Asymmetry (verified)

`Sources/UI/Overlay/MeetingOverlayController.swift`, the four `apply*` prompt handlers (~lines 1664-1857) hand-duplicate precedence checks between the meeting overlay's warning kinds (`systemAudio`, `audioInactivity`, `micBoost`, `audioRoute`).

`applyMicBoostPrompt` (line 1748-1771, guards at 1754-1758) refuses to replace an active `.systemAudio`, `.audioRoute`, or `.audioInactivity` prompt:

```swift
if state == .prompt, promptKind == .systemAudio { return }
if state == .prompt, promptKind == .audioRoute { return }
if state == .prompt, promptKind == .audioInactivity { return }
```

`applyAudioRouteWarning` (line 1773-1801, guards at 1782-1785, before this change) only guarded `.systemAudio` and `.audioInactivity`:

```swift
if state == .prompt, promptKind == .systemAudio { return }
if state == .prompt, promptKind == .audioInactivity { return }
```

No `.micBoost` guard — so a route warning firing while a mic-boost prompt was on screen would silently clobber it, even though the reverse (mic-boost yielding to an active route warning) was explicitly forbidden one function up.

## Inferred precedence order

From the guard patterns, `MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt` (`Sources/Meeting/MeetingSystemAudioStatusCopy.swift:144-151`, `hasAudioInactivityWarning` param), and the `clear*` fallback chains (which re-present exactly what the guards protect):

1. **`audioInactivity`** — top of the stack. `applyAudioInactivityWarning` has no prompt-kind guard at all (only checks the session is `.recording`); everything else defers to it, including `systemAudio` (via the policy check).
2. **`systemAudio`** — defers only to `audioInactivity`. It is not guarded against by anything else in a way that stops it clobbering `audioRoute`/`micBoost` — `applySystemAudioDegradationWarning` has no `.audioRoute`/`.micBoost` guards, and both `audioRoute` and `micBoost` explicitly defer to `.systemAudio`. So `systemAudio` outranks both.
3. **`audioRoute` and `micBoost`** — same tier, **mutually deferential (sticky)**, not a strict order: whichever is already showing stays showing; the other's handler no-ops until the active one clears (at which point its `clear*` fallback chain re-presents the other if still latched on the session). Before this fix, `micBoost` deferred to `audioRoute` but not vice versa — that broken symmetry is what this PR fixes. This is a "first up wins" relationship, not "A always beats B."

## Fix

Minimal, one guard added to `applyAudioRouteWarning`, mirroring the existing `applyMicBoostPrompt` guard:

```swift
// Precedence: never replace an active mic-boost prompt (mirrors
// applyMicBoostPrompt above deferring to an active route warning).
// The route warning is latched on the session and appears as soon
// as the mic-boost prompt clears.
if state == .prompt, promptKind == .micBoost { return }
```

No other asymmetry of this shape was found. `systemAudio` and `audioInactivity` intentionally don't defer to `audioRoute`/`micBoost` (both of the latter already defer to both of the former in both handlers), and the `clear*` fallback chains for all four kinds were read but are consistent with this order — not touched.

Did not extract a `MeetingPromptGuard.shouldDefer` helper: the three guard lines in each handler carry their own inline rationale comments (e.g. "it can auto-stop the recording", "expiry must never auto-enable VPIO") that are meaningful per-pair, not mechanical — collapsing them into one predicate would either lose that context or require restructuring the handlers, which is explicitly out of scope for this Wave-0 fix. A later PR is expected to replace all four handlers with a single precedence resolver.

## Verification

- `bash build.sh --no-open` — build succeeded, code-signed, launch smoke passed (Launch to interactive: 2051.2ms, budget 3000.0ms)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12596 tests, 12596 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
