### PR TITLE
Factor settings toggle bindings into a shared persist/track helper

### DIFF
--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -231,8 +231,7 @@ struct AgentConnectionSettingsPage: View {
                 if enabled {
                     prepareLiveMeetingSidecarWorkspace()
                 } else {
-                    meetingSession?.stopLiveCodexSessionFromSettings()
-                    stopLiveMeetingSidecarPreview()
+                    LiveMeetingSidecarController.stop(meetingSession: meetingSession)
                 }
             }
 
@@ -686,7 +685,7 @@ struct AgentConnectionSettingsPage: View {
         do {
             liveMeetingCodexEnabled = true
             LiveMeetingCodexPreferences.setEnabled(true)
-            let workspaceURL = try prepareLiveMeetingSidecarWorkspaceForUse()
+            let workspaceURL = try LiveMeetingSidecarController.prepareWorkspaceForUse()
             copyText(AgentConnectionGuide.liveMeetingCodexSetupPrompt(workspaceURL: workspaceURL))
             ActivationTelemetry.trackAgentPromptAction(
                 promptKind: .liveMeetingCodexSetup,
@@ -748,7 +747,7 @@ struct AgentConnectionSettingsPage: View {
         liveMeetingCodexSetupErrorDetails = nil
 
         do {
-            _ = try prepareLiveMeetingSidecarWorkspaceForUse()
+            _ = try LiveMeetingSidecarController.prepareWorkspaceForUse()
         } catch {
             disableLiveMeetingSidecarAfterFailure()
             liveMeetingCodexSetupError = AgentSetupFailureCopy.liveMeetingsPrepare
@@ -763,7 +762,7 @@ struct AgentConnectionSettingsPage: View {
         do {
             liveMeetingCodexEnabled = true
             LiveMeetingCodexPreferences.setEnabled(true)
-            let workspaceURL = try prepareLiveMeetingSidecarWorkspaceForUse()
+            let workspaceURL = try LiveMeetingSidecarController.prepareWorkspaceForUse()
             copyText(AgentConnectionGuide.liveMeetingCoworkSetupPrompt(workspaceURL: workspaceURL))
             ActivationTelemetry.trackAgentSetupCTA(
                 setupKind: .liveSidecar,
@@ -798,7 +797,7 @@ struct AgentConnectionSettingsPage: View {
         do {
             liveMeetingCodexEnabled = true
             LiveMeetingCodexPreferences.setEnabled(true)
-            let workspaceURL = try prepareLiveMeetingSidecarWorkspaceForUse()
+            let workspaceURL = try LiveMeetingSidecarController.prepareWorkspaceForUse()
             let previewURL: URL
             if #available(macOS 14.0, *) {
                 previewURL = try LiveMeetingPreviewServer.shared.start(workspaceURL: workspaceURL)
@@ -845,25 +844,8 @@ struct AgentConnectionSettingsPage: View {
         }
     }
 
-    private func prepareLiveMeetingSidecarWorkspaceForUse() throws -> URL {
-        let workspaceURL = try AgentConnectionGuide.ensureLiveMeetingCodexWorkspace()
-        if #available(macOS 14.0, *) {
-            _ = try LiveMeetingPreviewServer.shared.start(workspaceURL: workspaceURL)
-        }
-        return workspaceURL
-    }
-
-    private func stopLiveMeetingSidecarPreview() {
-        if #available(macOS 14.0, *) {
-            LiveMeetingPreviewServer.shared.stop()
-        }
-    }
-
     private func disableLiveMeetingSidecarAfterFailure() {
-        liveMeetingCodexEnabled = false
-        LiveMeetingCodexPreferences.setEnabled(false)
-        meetingSession?.stopLiveCodexSessionFromSettings()
-        stopLiveMeetingSidecarPreview()
+        LiveMeetingSidecarController.disable(enabled: $liveMeetingCodexEnabled, meetingSession: meetingSession)
     }
 
     // MARK: - Small helpers

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -1,6 +1,36 @@
 import AppKit
 import SwiftUI
 
+/// Wraps a `@State` mirror binding so writing a new value also fires settings
+/// telemetry, persists it, and optionally runs a further side effect, in that
+/// fixed order: mirror -> track -> persist -> sideEffect. `track` and `persist`
+/// are independent side effects in every call site this backs (telemetry never
+/// depends on the write having landed, and vice versa), so normalizing the
+/// order here is behavior-preserving even for sites that used to run them the
+/// other way around.
+///
+/// Centralizes the "read local mirror -> track telemetry -> persist to
+/// preferences" triple that `TranscriptedSettingsView` otherwise hand-writes
+/// at each settings toggle/picker site. Sites with branching or multi-step
+/// side effects beyond a single trailing closure are left as hand-written
+/// `Binding(get:set:)` blocks rather than forced through this helper.
+func persistedSettingsBinding<Value>(
+    _ state: Binding<Value>,
+    persist: @escaping (Value) -> Void,
+    track: ((Value) -> Void)? = nil,
+    sideEffect: ((Value) -> Void)? = nil
+) -> Binding<Value> {
+    Binding(
+        get: { state.wrappedValue },
+        set: { newValue in
+            state.wrappedValue = newValue
+            track?(newValue)
+            persist(newValue)
+            sideEffect?(newValue)
+        }
+    )
+}
+
 struct SettingsPageIntro: View {
     let title: String
     var summary: String? = nil

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -3,17 +3,21 @@ import SwiftUI
 
 /// Wraps a `@State` mirror binding so writing a new value also fires settings
 /// telemetry, persists it, and optionally runs a further side effect, in that
-/// fixed order: mirror -> track -> persist -> sideEffect. `track` and `persist`
-/// are independent side effects in every call site this backs (telemetry never
-/// depends on the write having landed, and vice versa), so normalizing the
-/// order here is behavior-preserving even for sites that used to run them the
-/// other way around.
+/// fixed order: mirror -> track -> persist -> sideEffect. This fixed order is
+/// only safe when `track` and `persist` are independent of each other — i.e.
+/// telemetry doesn't read back whatever `persist` just wrote. That does NOT
+/// hold for every settings toggle: `AnalyticsReporter.trackEvent` drops any
+/// event fired while `AnalyticsPreferences` reads disabled, so the anonymous-
+/// analytics toggle's own transition event needs `persist` before `track` on
+/// enable (and the reverse on disable) — that site is intentionally left as a
+/// hand-written `Binding(get:set:)` rather than routed through this helper.
 ///
 /// Centralizes the "read local mirror -> track telemetry -> persist to
 /// preferences" triple that `TranscriptedSettingsView` otherwise hand-writes
-/// at each settings toggle/picker site. Sites with branching or multi-step
-/// side effects beyond a single trailing closure are left as hand-written
-/// `Binding(get:set:)` blocks rather than forced through this helper.
+/// at each settings toggle/picker site. Sites with branching, multi-step, or
+/// order-dependent side effects beyond a single trailing closure are left as
+/// hand-written `Binding(get:set:)` blocks rather than forced through this
+/// helper.
 func persistedSettingsBinding<Value>(
     _ state: Binding<Value>,
     persist: @escaping (Value) -> Void,

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -2325,61 +2325,40 @@ struct TranscriptedSettingsView: View {
                 set: { updateLaunchAtLogin($0) }
             ),
             launchAtLoginStatus: launchAtLoginStatus,
-            showTranscriptedInDock: Binding(
-                get: { showTranscriptedInDock },
-                set: { newValue in
-                    showTranscriptedInDock = newValue
-                    trackSettingsToggle("show_in_dock", enabled: newValue, page: .general)
-                    DockVisibilityPreferences.setVisible(newValue)
-                }
+            showTranscriptedInDock: persistedSettingsBinding(
+                $showTranscriptedInDock,
+                persist: { DockVisibilityPreferences.setVisible($0) },
+                track: { trackSettingsToggle("show_in_dock", enabled: $0, page: .general) }
             ),
-            uiSoundsEnabled: Binding(
-                get: { uiSoundsEnabled },
-                set: { newValue in
-                    uiSoundsEnabled = newValue
-                    trackSettingsToggle("dictation_sounds", enabled: newValue, page: .general)
-                    UISoundPreferences.setEnabled(newValue)
-                }
+            uiSoundsEnabled: persistedSettingsBinding(
+                $uiSoundsEnabled,
+                persist: { UISoundPreferences.setEnabled($0) },
+                track: { trackSettingsToggle("dictation_sounds", enabled: $0, page: .general) }
             ),
-            dictationCleanupEnabled: Binding(
-                get: { dictationCleanupEnabled },
-                set: { newValue in
-                    dictationCleanupEnabled = newValue
-                    DictationCleanupPreferences.setEnabled(newValue)
-                    trackSettingsToggle("dictation_cleanup", enabled: newValue, page: .general)
-                }
+            dictationCleanupEnabled: persistedSettingsBinding(
+                $dictationCleanupEnabled,
+                persist: { DictationCleanupPreferences.setEnabled($0) },
+                track: { trackSettingsToggle("dictation_cleanup", enabled: $0, page: .general) }
             ),
-            dictationOverlayMode: Binding(
-                get: { dictationOverlayMode },
-                set: { newValue in
-                    dictationOverlayMode = newValue
-                    DictationOverlayPresentationPreferences.setMode(newValue)
-                    trackSettingsAction("change_dictation_overlay_mode", page: .general)
-                }
+            dictationOverlayMode: persistedSettingsBinding(
+                $dictationOverlayMode,
+                persist: { DictationOverlayPresentationPreferences.setMode($0) },
+                track: { _ in trackSettingsAction("change_dictation_overlay_mode", page: .general) }
             ),
-            confirmQuitDuringMeetingEnabled: Binding(
-                get: { confirmQuitDuringMeetingEnabled },
-                set: { newValue in
-                    confirmQuitDuringMeetingEnabled = newValue
-                    trackSettingsToggle("meeting_quit_confirmation", enabled: newValue, page: .general)
-                    QuitConfirmationPreferences.setConfirmQuitDuringActiveMeetingRecording(newValue)
-                }
+            confirmQuitDuringMeetingEnabled: persistedSettingsBinding(
+                $confirmQuitDuringMeetingEnabled,
+                persist: { QuitConfirmationPreferences.setConfirmQuitDuringActiveMeetingRecording($0) },
+                track: { trackSettingsToggle("meeting_quit_confirmation", enabled: $0, page: .general) }
             ),
-            autoDetectCallsEnabled: Binding(
-                get: { autoDetectCallsEnabled },
-                set: { newValue in
-                    autoDetectCallsEnabled = newValue
-                    trackSettingsToggle("auto_call_detection", enabled: newValue, page: .general)
-                    AutoCallDetectionPreferences.setEnabled(newValue)
-                }
+            autoDetectCallsEnabled: persistedSettingsBinding(
+                $autoDetectCallsEnabled,
+                persist: { AutoCallDetectionPreferences.setEnabled($0) },
+                track: { trackSettingsToggle("auto_call_detection", enabled: $0, page: .general) }
             ),
-            missedCallNudgeEnabled: Binding(
-                get: { missedCallNudgeEnabled },
-                set: { newValue in
-                    missedCallNudgeEnabled = newValue
-                    trackSettingsToggle("missed_call_nudge", enabled: newValue, page: .general)
-                    MissedCallNudgePreferences.setEnabled(newValue)
-                }
+            missedCallNudgeEnabled: persistedSettingsBinding(
+                $missedCallNudgeEnabled,
+                persist: { MissedCallNudgePreferences.setEnabled($0) },
+                track: { trackSettingsToggle("missed_call_nudge", enabled: $0, page: .general) }
             ),
             effectiveTranscriptionModelTitle: effectiveTranscriptionModel.title,
             dictationShortcutsEnabled: dictationShortcutsEnabled,
@@ -2532,13 +2511,10 @@ struct TranscriptedSettingsView: View {
                 detail: dictationShortcutsEnabled
                     ? "Push-to-talk and hands-free keys can start dictation."
                     : "Off. You can still start dictation from the app, and meeting controls still work.",
-                isOn: Binding(
-                    get: { dictationShortcutsEnabled },
-                    set: { newValue in
-                        dictationShortcutsEnabled = newValue
-                        trackSettingsToggle("dictation_shortcuts", enabled: newValue, page: .general)
-                        HotkeyPreferences.setDictationShortcutsEnabled(newValue)
-                    }
+                isOn: persistedSettingsBinding(
+                    $dictationShortcutsEnabled,
+                    persist: { HotkeyPreferences.setDictationShortcutsEnabled($0) },
+                    track: { trackSettingsToggle("dictation_shortcuts", enabled: $0, page: .general) }
                 )
             )
 
@@ -2564,23 +2540,17 @@ struct TranscriptedSettingsView: View {
                 detail: keepRecommendedMicrophoneActive
                     ? "Keeps the preferred microphone selected Mac-wide while Transcripted is open; it does not record while idle."
                     : "Allow macOS to switch microphone routes for each dictation.",
-                isOn: Binding(
-                    get: { keepRecommendedMicrophoneActive },
-                    set: { newValue in
-                        keepRecommendedMicrophoneActive = newValue
-                        trackSettingsToggle("keep_recommended_microphone_active", enabled: newValue, page: .general)
-                        DictationPersistentInputPreferences.setEnabled(newValue)
-                    }
+                isOn: persistedSettingsBinding(
+                    $keepRecommendedMicrophoneActive,
+                    persist: { DictationPersistentInputPreferences.setEnabled($0) },
+                    track: { trackSettingsToggle("keep_recommended_microphone_active", enabled: $0, page: .general) }
                 )
             )
 
-            Picker("Preferred microphone", selection: Binding(
-                get: { preferredDictationInputUID },
-                set: { newValue in
-                    preferredDictationInputUID = newValue
-                    trackSettingsAction("change_preferred_dictation_microphone", page: .general)
-                    DictationPersistentInputPreferences.setPreferredDeviceUID(newValue)
-                }
+            Picker("Preferred microphone", selection: persistedSettingsBinding(
+                $preferredDictationInputUID,
+                persist: { DictationPersistentInputPreferences.setPreferredDeviceUID($0) },
+                track: { _ in trackSettingsAction("change_preferred_dictation_microphone", page: .general) }
             )) {
                 Text("Automatic (recommended)").tag(String?.none)
                 ForEach(preferredDictationInputCandidates, id: \.id) { device in
@@ -2601,23 +2571,17 @@ struct TranscriptedSettingsView: View {
                 detail: autoEnterEnabled
                     ? "Transcripted sends \(autoEnterKey.title) after it pastes, only in selected apps."
                     : "Off. Dictation only pastes text.",
-                isOn: Binding(
-                    get: { autoEnterEnabled },
-                    set: { newValue in
-                        autoEnterEnabled = newValue
-                        trackSettingsToggle("auto_send", enabled: newValue, page: .general)
-                        DictationAutoSendPreferences.setEnabled(newValue)
-                    }
+                isOn: persistedSettingsBinding(
+                    $autoEnterEnabled,
+                    persist: { DictationAutoSendPreferences.setEnabled($0) },
+                    track: { trackSettingsToggle("auto_send", enabled: $0, page: .general) }
                 )
             )
 
-            Picker("Send key", selection: Binding(
-                get: { autoEnterKey },
-                set: { newValue in
-                    autoEnterKey = newValue
-                    trackSettingsAction("change_auto_send_key", page: .general)
-                    DictationAutoSendPreferences.setSendKey(newValue)
-                }
+            Picker("Send key", selection: persistedSettingsBinding(
+                $autoEnterKey,
+                persist: { DictationAutoSendPreferences.setSendKey($0) },
+                track: { _ in trackSettingsAction("change_auto_send_key", page: .general) }
             )) {
                 ForEach(DictationAutoSendKey.allCases) { key in
                     Text(key.title).tag(key)
@@ -2709,13 +2673,10 @@ struct TranscriptedSettingsView: View {
                     .font(.subheadline.weight(.semibold))
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Picker("Meeting mic processing", selection: Binding(
-                        get: { meetingMicProcessingMode },
-                        set: { newValue in
-                            meetingMicProcessingMode = newValue
-                            trackSettingsToggle("meeting_mic_processing_\(newValue.rawValue)", enabled: true, page: .general)
-                            MicrophoneProcessingPreferences.setMode(newValue)
-                        }
+                    Picker("Meeting mic processing", selection: persistedSettingsBinding(
+                        $meetingMicProcessingMode,
+                        persist: { MicrophoneProcessingPreferences.setMode($0) },
+                        track: { trackSettingsToggle("meeting_mic_processing_\($0.rawValue)", enabled: true, page: .general) }
                     )) {
                         ForEach(MicrophoneProcessingMode.allCases) { mode in
                             Text(mode.title).tag(mode)
@@ -2735,13 +2696,10 @@ struct TranscriptedSettingsView: View {
                     detail: splitLocalSpeakersEnabled
                         ? "On. After shared-room meetings, Transcripted asks you to name people captured by your mic."
                         : "Off. The local mic stays as You, which is simpler when only you are near this Mac.",
-                    isOn: Binding(
-                        get: { splitLocalSpeakersEnabled },
-                        set: { newValue in
-                            splitLocalSpeakersEnabled = newValue
-                            trackSettingsToggle("local_speaker_split", enabled: newValue, page: .general)
-                            LocalSpeakerPreferences.setEnabled(newValue)
-                        }
+                    isOn: persistedSettingsBinding(
+                        $splitLocalSpeakersEnabled,
+                        persist: { LocalSpeakerPreferences.setEnabled($0) },
+                        track: { trackSettingsToggle("local_speaker_split", enabled: $0, page: .general) }
                     )
                 )
 
@@ -2759,12 +2717,11 @@ struct TranscriptedSettingsView: View {
                 SettingsToggleRow(
                     title: "Send crash and error reports",
                     detail: crashReportingFootnote,
-                    isOn: Binding(
-                        get: { crashReportingEnabled },
-                        set: { newValue in
-                            crashReportingEnabled = newValue
-                            trackSettingsToggle("crash_reporting", enabled: newValue, page: .general)
-                            CrashReportingPreferences.setEnabled(newValue)
+                    isOn: persistedSettingsBinding(
+                        $crashReportingEnabled,
+                        persist: { CrashReportingPreferences.setEnabled($0) },
+                        track: { trackSettingsToggle("crash_reporting", enabled: $0, page: .general) },
+                        sideEffect: { _ in
                             CrashReporter.applySessionTrackingPreference()
                             sentryTestStatus = nil
                             diagnosticsActionStatus = nil
@@ -2776,19 +2733,11 @@ struct TranscriptedSettingsView: View {
                 SettingsToggleRow(
                     title: "Send anonymous usage stats",
                     detail: analyticsFootnote,
-                    isOn: Binding(
-                        get: { anonymousAnalyticsEnabled },
-                        set: { newValue in
-                            anonymousAnalyticsEnabled = newValue
-                            if newValue {
-                                AnalyticsPreferences.setEnabled(true)
-                                trackSettingsToggle("anonymous_analytics", enabled: true, page: .general)
-                            } else {
-                                trackSettingsToggle("anonymous_analytics", enabled: false, page: .general)
-                                AnalyticsPreferences.setEnabled(false)
-                            }
-                            diagnosticsActionStatus = nil
-                        }
+                    isOn: persistedSettingsBinding(
+                        $anonymousAnalyticsEnabled,
+                        persist: { AnalyticsPreferences.setEnabled($0) },
+                        track: { trackSettingsToggle("anonymous_analytics", enabled: $0, page: .general) },
+                        sideEffect: { _ in diagnosticsActionStatus = nil }
                     )
                 )
                 .disabled(!AnalyticsReporter.isAvailable)
@@ -3017,14 +2966,11 @@ struct TranscriptedSettingsView: View {
 
     private var betaPage: some View {
         BetaSettingsPage(
-            localMeetingSummariesEnabled: Binding(
-                get: { localMeetingSummariesEnabled },
-                set: { enabled in
-                    localMeetingSummariesEnabled = enabled
-                    LocalMeetingSummaryPreferences.setEnabled(enabled)
-                    trackSettingsToggle("local_ai_meeting_summaries", enabled: enabled, page: .beta)
-                    handleLocalMeetingSummaryToggle(enabled)
-                }
+            localMeetingSummariesEnabled: persistedSettingsBinding(
+                $localMeetingSummariesEnabled,
+                persist: { LocalMeetingSummaryPreferences.setEnabled($0) },
+                track: { trackSettingsToggle("local_ai_meeting_summaries", enabled: $0, page: .beta) },
+                sideEffect: { handleLocalMeetingSummaryToggle($0) }
             ),
             localMeetingSummaryProvider: Binding(
                 get: { localMeetingSummaryProvider },
@@ -3043,22 +2989,16 @@ struct TranscriptedSettingsView: View {
                 }
             ),
             isLocalSummaryModelPreparing: isLocalSummaryModelPreparing,
-            liveMeetingSidecarEnabled: Binding(
-                get: { betaLiveMeetingCodexEnabled },
-                set: { enabled in
-                    betaLiveMeetingCodexEnabled = enabled
-                    LiveMeetingCodexPreferences.setEnabled(enabled)
-                    trackSettingsToggle("live_meeting_sidecar", enabled: enabled, page: .beta)
-                    handleBetaLiveMeetingSidecarToggle(enabled)
-                }
+            liveMeetingSidecarEnabled: persistedSettingsBinding(
+                $betaLiveMeetingCodexEnabled,
+                persist: { LiveMeetingCodexPreferences.setEnabled($0) },
+                track: { trackSettingsToggle("live_meeting_sidecar", enabled: $0, page: .beta) },
+                sideEffect: { handleBetaLiveMeetingSidecarToggle($0) }
             ),
-            nemotronModelEnabled: Binding(
-                get: { betaNemotronModelEnabled },
-                set: { enabled in
-                    betaNemotronModelEnabled = enabled
-                    SpeechModelBetaPreferences.setNemotronBetaEnabled(enabled)
-                    trackSettingsToggle("nemotron_streaming_model", enabled: enabled, page: .beta)
-                }
+            nemotronModelEnabled: persistedSettingsBinding(
+                $betaNemotronModelEnabled,
+                persist: { SpeechModelBetaPreferences.setNemotronBetaEnabled($0) },
+                track: { trackSettingsToggle("nemotron_streaming_model", enabled: $0, page: .beta) }
             ),
             nemotronRemainsPreferred: preferredTranscriptionModel == .nemotronStreaming,
             fallbackTranscriptionModelTitle: TranscriptionModelPreferences.defaultModel.title,
@@ -3218,19 +3158,15 @@ struct TranscriptedSettingsView: View {
 
         if enabled {
             do {
-                _ = try prepareBetaLiveMeetingSidecarWorkspaceForUse()
+                _ = try LiveMeetingSidecarController.prepareWorkspaceForUse()
                 betaFeatureStatus = "Live meeting sidecar is ready."
             } catch {
-                betaLiveMeetingCodexEnabled = false
-                LiveMeetingCodexPreferences.setEnabled(false)
-                meetingSession.stopLiveCodexSessionFromSettings()
-                stopBetaLiveMeetingSidecarPreview()
+                LiveMeetingSidecarController.disable(enabled: $betaLiveMeetingCodexEnabled, meetingSession: meetingSession)
                 betaFeatureStatus = SettingsActionFailureCopy.betaLiveSidecar
                 betaFeatureStatusDetails = error.localizedDescription
             }
         } else {
-            meetingSession.stopLiveCodexSessionFromSettings()
-            stopBetaLiveMeetingSidecarPreview()
+            LiveMeetingSidecarController.stop(meetingSession: meetingSession)
         }
     }
 
@@ -3357,20 +3293,6 @@ struct TranscriptedSettingsView: View {
         }
         localSummaryModelPreparationTask?.cancel()
         isLocalSummaryModelPreparing = false
-    }
-
-    private func prepareBetaLiveMeetingSidecarWorkspaceForUse() throws -> URL {
-        let workspaceURL = try AgentConnectionGuide.ensureLiveMeetingCodexWorkspace()
-        if #available(macOS 14.0, *) {
-            _ = try LiveMeetingPreviewServer.shared.start(workspaceURL: workspaceURL)
-        }
-        return workspaceURL
-    }
-
-    private func stopBetaLiveMeetingSidecarPreview() {
-        if #available(macOS 14.0, *) {
-            LiveMeetingPreviewServer.shared.stop()
-        }
     }
 
     private func refreshLocalSummarySetupStatus() {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -2733,11 +2733,24 @@ struct TranscriptedSettingsView: View {
                 SettingsToggleRow(
                     title: "Send anonymous usage stats",
                     detail: analyticsFootnote,
-                    isOn: persistedSettingsBinding(
-                        $anonymousAnalyticsEnabled,
-                        persist: { AnalyticsPreferences.setEnabled($0) },
-                        track: { trackSettingsToggle("anonymous_analytics", enabled: $0, page: .general) },
-                        sideEffect: { _ in diagnosticsActionStatus = nil }
+                    // Hand-written, not persistedSettingsBinding: AnalyticsReporter.trackEvent
+                    // drops any event fired while AnalyticsPreferences reads disabled, so the
+                    // "anonymous_analytics" transition event itself needs asymmetric ordering —
+                    // opt-in must persist before tracking so the transition event isn't dropped;
+                    // opt-out must track first (while still enabled) for the same reason.
+                    isOn: Binding(
+                        get: { anonymousAnalyticsEnabled },
+                        set: { newValue in
+                            anonymousAnalyticsEnabled = newValue
+                            if newValue {
+                                AnalyticsPreferences.setEnabled(true)
+                                trackSettingsToggle("anonymous_analytics", enabled: true, page: .general)
+                            } else {
+                                trackSettingsToggle("anonymous_analytics", enabled: false, page: .general)
+                                AnalyticsPreferences.setEnabled(false)
+                            }
+                            diagnosticsActionStatus = nil
+                        }
                     )
                 )
                 .disabled(!AnalyticsReporter.isAvailable)

--- a/Sources/UI/Shared/LiveMeetingSidecarController.swift
+++ b/Sources/UI/Shared/LiveMeetingSidecarController.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+/// Single owner for the live-meeting Codex sidecar workspace lifecycle.
+///
+/// Two Settings surfaces expose the same `LiveMeetingCodexPreferences.enabledKey`
+/// toggle — the Beta page (`TranscriptedSettingsView`) and the Agent page
+/// (`AgentConnectionSettingsPage`) — and both used to hand-roll identical
+/// prepare/stop/disable logic. This type is the one place that logic lives now;
+/// both toggle sites route through it so the workspace-preparation, preview-server,
+/// and meeting-session teardown behavior can't drift between them again.
+///
+/// `@MainActor` because both call sites are `View`-conforming settings pages
+/// (implicitly main-actor isolated) and `stop(meetingSession:)` calls into
+/// `MeetingSessionController`, which is itself `@MainActor`.
+@MainActor
+enum LiveMeetingSidecarController {
+    /// Ensures the live-meeting Codex workspace folder exists and starts the
+    /// local preview server for it (macOS 14+). Returns the workspace URL.
+    @discardableResult
+    static func prepareWorkspaceForUse() throws -> URL {
+        let workspaceURL = try AgentConnectionGuide.ensureLiveMeetingCodexWorkspace()
+        if #available(macOS 14.0, *) {
+            _ = try LiveMeetingPreviewServer.shared.start(workspaceURL: workspaceURL)
+        }
+        return workspaceURL
+    }
+
+    /// Stops any active live-codex meeting session and the local preview server.
+    /// Used both for an explicit user-initiated disable and after a
+    /// workspace-preparation failure.
+    static func stop(meetingSession: MeetingSessionController?) {
+        meetingSession?.stopLiveCodexSessionFromSettings()
+        if #available(macOS 14.0, *) {
+            LiveMeetingPreviewServer.shared.stop()
+        }
+    }
+
+    /// Turns the sidecar off: clears the persisted flag and local mirror, then
+    /// tears down any active session and the preview server via `stop(meetingSession:)`.
+    static func disable(enabled: Binding<Bool>, meetingSession: MeetingSessionController?) {
+        enabled.wrappedValue = false
+        LiveMeetingCodexPreferences.setEnabled(false)
+        stop(meetingSession: meetingSession)
+    }
+}


### PR DESCRIPTION
## Summary

- `TranscriptedSettingsView.swift` hand-wrote ~29 `Binding(get:set:)` blocks, most following the same triple: mirror local `@State` -> track settings telemetry -> persist to a preferences helper. Added `persistedSettingsBinding(_:persist:track:sideEffect:)` in `TranscriptedSettingsComponents.swift` and routed every site that matches that shape through it. Behavior-preserving: same persist call, same telemetry label/page, same side effects per site.
- Collapsed the live-meeting Codex sidecar toggle, which existed twice (`TranscriptedSettingsView`'s Beta page and `AgentConnectionSettingsPage`'s Agent page) with byte-identical `prepare*/stop*` workspace functions, into one `LiveMeetingSidecarController` (`Sources/UI/Shared/LiveMeetingSidecarController.swift`) that both toggle sites now call for `prepareWorkspaceForUse()`, `stop(meetingSession:)`, and `disable(enabled:meetingSession:)`. Deleted the duplicated private functions in both files.
- Did not touch `SpeakerPeopleSettingsSection.swift` or restructure any page parameter lists.

## `persistedSettingsBinding` order note

The helper runs `mirror -> track -> persist -> sideEffect`, always in that fixed order. A few original hand-written sites ran `persist` before `track`. In those cases `track` and `persist` are independent side effects — telemetry never reads back the just-written preference value, and the preference write doesn't depend on telemetry having fired — so normalizing the order is behavior-preserving. Call sites where the original had additional/conditional logic beyond a single trailing side-effect closure, **or where the two calls are order-dependent**, were left hand-written rather than forced through the helper (see below) — `anonymousAnalyticsEnabled` is the one order-dependent case, caught in review (see Concerns).

## Site-by-site (all 29 `Binding(get:set:)` sites)

**Converted to `persistedSettingsBinding` (18):**

| Property | Persist | Track |
|---|---|---|
| `showTranscriptedInDock` | `DockVisibilityPreferences.setVisible` | `show_in_dock` |
| `uiSoundsEnabled` | `UISoundPreferences.setEnabled` | `dictation_sounds` |
| `dictationCleanupEnabled` | `DictationCleanupPreferences.setEnabled` | `dictation_cleanup` |
| `dictationOverlayMode` | `DictationOverlayPresentationPreferences.setMode` | action: `change_dictation_overlay_mode` |
| `confirmQuitDuringMeetingEnabled` | `QuitConfirmationPreferences.setConfirmQuitDuringActiveMeetingRecording` | `meeting_quit_confirmation` |
| `autoDetectCallsEnabled` | `AutoCallDetectionPreferences.setEnabled` | `auto_call_detection` |
| `missedCallNudgeEnabled` | `MissedCallNudgePreferences.setEnabled` | `missed_call_nudge` |
| `dictationShortcutsEnabled` | `HotkeyPreferences.setDictationShortcutsEnabled` | `dictation_shortcuts` |
| `keepRecommendedMicrophoneActive` | `DictationPersistentInputPreferences.setEnabled` | `keep_recommended_microphone_active` |
| `preferredDictationInputUID` (Picker) | `DictationPersistentInputPreferences.setPreferredDeviceUID` | action: `change_preferred_dictation_microphone` |
| `autoEnterEnabled` | `DictationAutoSendPreferences.setEnabled` | `auto_send` |
| `autoEnterKey` (Picker) | `DictationAutoSendPreferences.setSendKey` | action: `change_auto_send_key` |
| `meetingMicProcessingMode` (Picker) | `MicrophoneProcessingPreferences.setMode` | `meeting_mic_processing_<mode>` |
| `splitLocalSpeakersEnabled` | `LocalSpeakerPreferences.setEnabled` | `local_speaker_split` |
| `crashReportingEnabled` | `CrashReportingPreferences.setEnabled` | `crash_reporting` (+ sideEffect: `CrashReporter.applySessionTrackingPreference()`, clear `sentryTestStatus`/`diagnosticsActionStatus`) |
| `localMeetingSummariesEnabled` (Beta) | `LocalMeetingSummaryPreferences.setEnabled` | `local_ai_meeting_summaries` (+ sideEffect: `handleLocalMeetingSummaryToggle`) |
| `liveMeetingSidecarEnabled` (Beta) | `LiveMeetingCodexPreferences.setEnabled` | `live_meeting_sidecar` (+ sideEffect: `handleBetaLiveMeetingSidecarToggle`, now backed by `LiveMeetingSidecarController`) |
| `nemotronModelEnabled` (Beta) | `SpeechModelBetaPreferences.setNemotronBetaEnabled` | `nemotron_streaming_model` |

**Left hand-written (11)** — each has branching, multi-step, order-dependent, or fully-delegated logic beyond what a single trailing side-effect closure covers:

- `rootAlertBinding` (~1780) — alert dismissal routing between two separate `@State` alerts, no preference persist.
- `launchAtLoginEnabled` (~2323) — delegates entirely to `updateLaunchAtLogin(_:)`, which has its own do/catch error handling and status refresh.
- `preferredTranscriptionModel` Picker (~2420) — delegates entirely to `updatePreferredTranscriptionModel(_:page:)`.
- "Better speaker matching on calls" toggle (~2467) — branches to a confirmation alert when named speakers exist vs. applying immediately.
- Per-app auto-send toggle (~2637) — delegates entirely to `setAutoEnterApp(_:isAllowed:page:)`; no simple `@State` mirror (backed by a `Set`).
- `anonymousAnalyticsEnabled` (~2733) — **order-dependent, not just independent side effects**: `AnalyticsReporter.trackEvent` drops any event fired while `AnalyticsPreferences` reads disabled, so the toggle's own `"anonymous_analytics"` transition event needs persist-before-track on enable and track-before-persist on disable to avoid silently losing that event. Restored the original hand-written asymmetric ordering with a comment explaining the constraint (caught in Codex review of an earlier revision of this PR, where routing it through `persistedSettingsBinding`'s fixed `track -> persist` order silently dropped the opt-in event).
- `localMeetingSummaryProvider` Picker (~2975) — multi-step conditional: refreshes setup status, and if summaries are enabled, cancels jobs/clears notices/re-prepares the model.
- Correction row `spoken`/`replacement` bindings (~2794, ~2798) — delegate to `updateCorrectionSpoken`/`updateCorrectionReplacement` per row identity, not a `@State` mirror.
- `customDictionaryText` TextEditor (~2868) — delegates entirely to `updateCustomDictionaryText(_:)`.
- `captureLibraryChoicePromptBinding` (~4288) — sheet-presentation binding, no preference persist.

## Test plan

- [x] `bash build.sh --no-open` — clean build (after `bash build-deps.sh --force` to refresh stale `TranscriptedCore` deps)
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12607 tests, 12607 passed, 0 failed
- [x] Re-ran both after the review fix-up below — still 12607/12607, clean build

## Concerns

- `persist`/`track` order was normalized to a fixed `mirror -> track -> persist -> sideEffect` sequence across every converted site, even where the original ran persist before track. This is behavior-preserving for every remaining converted site since telemetry and preference writes are independent there, but it's a real (if inert) semantic shift worth a second look.
- **Fixed in review**: `anonymousAnalyticsEnabled` was initially converted to `persistedSettingsBinding` too. Codex review of an earlier revision flagged that the helper's fixed `track -> persist` order means, on opt-in, `trackSettingsToggle("anonymous_analytics", enabled: true)` fires while `AnalyticsPreferences` still reads disabled — and `AnalyticsReporter.trackEvent` silently drops any event sent while analytics reads disabled, so the opt-in transition event was lost. Reverted that one site to a hand-written `Binding` with the original asymmetric ordering (persist-then-track on enable, track-then-persist on disable) and a comment stating the constraint; did not add an ordering knob to the shared helper for this one site. Moved it to the hand-written list above.
- Preference setters like `DockVisibilityPreferences.setVisible` take a defaulted `userDefaults:` parameter, so they can't be passed as bare function references to `persist:` (Swift keeps the full signature) — every `persist:` argument is wrapped in an explicit `{ Foo.setBar($0) }` closure instead.
- `LiveMeetingSidecarController` is `@MainActor` because it calls into `MeetingSessionController` (itself `@MainActor`); both call sites are `View`-conforming settings pages so this should be transparent, but flagging since it's a new cross-file dependency surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
