### PR TITLE
Extract meeting overlay's warning-prompt precedence into a pure resolver

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -1375,6 +1375,13 @@ final class MeetingOverlayController: NSObject {
     private var promptKind: PromptKind?
     private var audioRouteWarningOutcome: CaptureRouteStabilizationOutcome?
     private var systemAudioDegradationWarning: MeetingSystemAudioDegradationWarning?
+    // Audio inactivity drives its own per-second countdown Task
+    // (schedulePromptCountdown). The combined warning subscription re-fires
+    // on *any* of the four signals changing, so this mirror lets it tell
+    // "the inactivity warning itself changed" apart from "some unrelated
+    // signal changed while inactivity was already the winning prompt" —
+    // only the former should restart the countdown.
+    private var lastAppliedAudioInactivityWarning: MeetingAudioInactivityWarning?
     private var promptCountdownTask: Task<Void, Never>?
     private var promptSecondsRemaining = 0
 
@@ -1397,15 +1404,12 @@ final class MeetingOverlayController: NSObject {
     private var latestTranscriptPhase: LiveMeetingTranscriptFeedPhase = .idle
     private var transcriptPushPending = false
 
-    private enum PromptKind {
-        case systemAudio
-        case audioInactivity
-        case micBoost
-        case audioRoute
-        // Post-call "that call wasn't recorded" awareness nudge. No candidate,
-        // no detector callbacks — Got It / Don't show again only.
-        case missedCall
-    }
+    // The precedence lattice for these kinds lives in the pure
+    // `MeetingPromptPriority.resolve` — kept in its own Foundation-pure file
+    // (with the shared `MeetingWarningPromptKind` enum) so the root fast-test
+    // runner can exercise it without pulling in this controller's AppKit/
+    // MeetingSessionController dependencies.
+    typealias PromptKind = MeetingWarningPromptKind
 
     // Kept for the countdown-refresh pass, which rebuilds the display each tick.
     private var missedCallPrompt: MeetingPromptUnrecordedCall?
@@ -1586,33 +1590,29 @@ final class MeetingOverlayController: NSObject {
             }
             .store(in: &subscriptions)
 
-        session.$audioInactivityWarning
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] warning in
-                self?.applyAudioInactivityWarning(warning)
-            }
-            .store(in: &subscriptions)
-
-        session.$systemAudioDegradationWarning
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] warning in
-                self?.applySystemAudioDegradationWarning(warning)
-            }
-            .store(in: &subscriptions)
-
-        session.$isMicBoostPromptVisible
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] visible in
-                self?.applyMicBoostPrompt(visible)
-            }
-            .store(in: &subscriptions)
-
-        session.$audioRouteWarning
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] outcome in
-                self?.applyAudioRouteWarning(outcome)
-            }
-            .store(in: &subscriptions)
+        // The four warning-driven prompts are read together and resolved as
+        // one unit: their precedence lattice (audioInactivity > systemAudio >
+        // {audioRoute, micBoost}, the latter pair mutually sticky) needs to
+        // see all four latest values at once to pick a winner — the old
+        // per-signal .sink handlers re-derived that ordering by hand across
+        // four apply*/clear* pairs, which is exactly what
+        // MeetingPromptPriority.resolve now encodes in one place.
+        Publishers.CombineLatest4(
+            session.$audioInactivityWarning,
+            session.$systemAudioDegradationWarning,
+            session.$isMicBoostPromptVisible,
+            session.$audioRouteWarning
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] inactivity, systemAudio, micBoostVisible, route in
+            self?.applyWarningPrompt(
+                inactivity: inactivity,
+                systemAudio: systemAudio,
+                micBoostVisible: micBoostVisible,
+                route: route
+            )
+        }
+        .store(in: &subscriptions)
 
         let feed = session.liveTranscriptFeed
         feed.$finalEntries
@@ -1661,203 +1661,175 @@ final class MeetingOverlayController: NSObject {
         pushTranscriptToView()
     }
 
-    private func applySystemAudioDegradationWarning(
-        _ warning: MeetingSystemAudioDegradationWarning?
+    /// Single entry point for all four warning-driven prompts. Fires whenever
+    /// any of them changes (see the CombineLatest4 subscription in
+    /// `wireSubscriptions`), recomputes the winning kind via
+    /// `MeetingPromptPriority.resolve`, and renders it — replacing the old
+    /// four apply*/clear* method pairs that re-derived the same precedence
+    /// by hand.
+    private func applyWarningPrompt(
+        inactivity: MeetingAudioInactivityWarning?,
+        systemAudio: MeetingSystemAudioDegradationWarning?,
+        micBoostVisible: Bool,
+        route: CaptureRouteStabilizationOutcome?
     ) {
-        systemAudioDegradationWarning = warning
-        if warning != nil {
+        systemAudioDegradationWarning = systemAudio
+        audioRouteWarningOutcome = route
+
+        // A live system-audio warning keeps the pill fully expanded even
+        // while a higher-priority prompt (audio inactivity) is the one
+        // actually shown — isVisuallyCondensed/scheduleRestIfNeeded key off
+        // this raw signal, not the resolved prompt kind.
+        if systemAudio != nil {
             bloomFromRest()
         }
-        guard MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt(
-            warning: warning,
-            hasAudioInactivityWarning: meetingSession?.audioInactivityWarning != nil
-        ), let warning else {
-            clearSystemAudioPrompt()
-            pushToView()
-            return
-        }
-        guard meetingSession?.state == .recording else {
-            pushToView()
-            return
-        }
 
-        autoHideTask?.cancel()
-        promptCountdownTask?.cancel()
-        promptKind = .systemAudio
-        promptSecondsRemaining = 0
-        currentPrompt = systemAudioWarningPromptDisplay(warning: warning)
-        bloomFromRest()
-        state = .prompt
-        showPanel()
-        pushToView()
-    }
-
-    private func clearSystemAudioPrompt() {
-        guard promptKind == .systemAudio else { return }
-
-        promptCountdownTask?.cancel()
-        promptKind = nil
-        currentPrompt = nil
-
-        if meetingSession?.state == .recording {
-            if let inactivityWarning = meetingSession?.audioInactivityWarning {
-                applyAudioInactivityWarning(inactivityWarning)
-            } else if let routeWarning = meetingSession?.audioRouteWarning {
-                applyAudioRouteWarning(routeWarning)
-            } else if meetingSession?.isMicBoostPromptVisible == true {
-                applyMicBoostPrompt(true)
-            } else {
-                state = .recording
-                showPanel()
-                pushToView()
-                flushPendingTranscriptIfNeeded()
-                scheduleRestIfNeeded()
-            }
-        } else {
-            state = .idle
-            hidePanel()
-        }
-    }
-
-    private func applyAudioInactivityWarning(_ warning: MeetingAudioInactivityWarning?) {
-        guard let warning else {
-            clearAudioInactivityPrompt()
-            return
-        }
-
-        guard meetingSession?.state == .recording else { return }
-
-        autoHideTask?.cancel()
-        promptCountdownTask?.cancel()
-
-        promptKind = .audioInactivity
-        promptSecondsRemaining = warning.automaticStopAllowed ? max(1, warning.countdownSeconds) : 0
-        currentPrompt = audioInactivityPromptDisplay(
-            warning: warning,
-            countdownSeconds: promptSecondsRemaining
+        let resolvedKind = MeetingPromptPriority.resolve(
+            inactivity: inactivity,
+            systemAudio: systemAudio,
+            routeActive: route != nil,
+            micBoostVisible: micBoostVisible,
+            current: promptKind,
+            isRecording: meetingSession?.state == .recording
         )
+
+        guard let resolvedKind else {
+            lastAppliedAudioInactivityWarning = nil
+            if isWarningDrivenPromptKind(promptKind) {
+                clearWarningPrompt()
+            }
+            return
+        }
+
+        if resolvedKind == .audioInactivity, promptKind == .audioInactivity,
+           inactivity == lastAppliedAudioInactivityWarning {
+            // Already showing this exact inactivity warning and some
+            // unrelated signal is what changed. Its per-second countdown
+            // Task is still ticking down — don't restart it under a fresh
+            // value.
+            return
+        }
+
+        guard let display = promptDisplay(
+            for: resolvedKind,
+            inactivity: inactivity,
+            systemAudio: systemAudio,
+            route: route
+        ) else {
+            // Resolver and display builder disagreed about which raw signal
+            // backs `resolvedKind` — shouldn't happen; leave the previous
+            // prompt state untouched rather than show a blank prompt.
+            return
+        }
+
+        autoHideTask?.cancel()
+        promptCountdownTask?.cancel()
+        promptKind = resolvedKind
+        promptSecondsRemaining = display.countdownSeconds
+        currentPrompt = display.prompt
+        if resolvedKind == .audioInactivity {
+            lastAppliedAudioInactivityWarning = inactivity
+        }
         bloomFromRest()
-        state = .prompt
+        state = presentationState(session: meetingSession?.state ?? .idle, prompt: promptKind)
         showPanel()
         pushToView()
-        if warning.automaticStopAllowed {
+        if display.schedulesCountdown {
             schedulePromptCountdown()
         }
     }
 
-    private func applyMicBoostPrompt(_ visible: Bool) {
-        guard visible else {
-            clearMicBoostPrompt()
-            return
+    /// Builds the display copy for the resolved warning-prompt kind, plus
+    /// whether it starts a countdown (only audio inactivity does — its
+    /// countdown can auto-stop the recording; the others never expire on
+    /// their own).
+    private func promptDisplay(
+        for kind: PromptKind,
+        inactivity: MeetingAudioInactivityWarning?,
+        systemAudio: MeetingSystemAudioDegradationWarning?,
+        route: CaptureRouteStabilizationOutcome?
+    ) -> (prompt: PromptDisplay, countdownSeconds: Int, schedulesCountdown: Bool)? {
+        switch kind {
+        case .systemAudio:
+            guard let systemAudio else { return nil }
+            return (systemAudioWarningPromptDisplay(warning: systemAudio), 0, false)
+        case .audioInactivity:
+            guard let inactivity else { return nil }
+            let seconds = inactivity.automaticStopAllowed ? max(1, inactivity.countdownSeconds) : 0
+            return (
+                audioInactivityPromptDisplay(warning: inactivity, countdownSeconds: seconds),
+                seconds,
+                inactivity.automaticStopAllowed
+            )
+        case .audioRoute:
+            guard let route else { return nil }
+            return (audioRouteWarningPromptDisplay(outcome: route), 0, false)
+        case .micBoost:
+            // No schedulePromptCountdown(): expiry must never auto-enable VPIO.
+            return (micBoostPromptDisplay(), 0, false)
+        case .missedCall:
+            return nil
         }
-        guard meetingSession?.state == .recording else { return }
-        if state == .prompt, promptKind == .systemAudio { return }
-        if state == .prompt, promptKind == .audioRoute { return }
-        // Precedence: never replace an active audio-inactivity prompt (it can
-        // auto-stop the recording). The post-meeting Home hint is the backstop.
-        if state == .prompt, promptKind == .audioInactivity { return }
-
-        autoHideTask?.cancel()
-        promptCountdownTask?.cancel()
-
-        promptKind = .micBoost
-        promptSecondsRemaining = 0
-        currentPrompt = micBoostPromptDisplay()
-        bloomFromRest()
-        state = .prompt
-        showPanel()
-        pushToView()
-        // No schedulePromptCountdown(): expiry must never auto-enable VPIO.
     }
 
-    private func applyAudioRouteWarning(
-        _ outcome: CaptureRouteStabilizationOutcome?
-    ) {
-        audioRouteWarningOutcome = outcome
-        guard let outcome else {
-            clearAudioRoutePrompt()
-            return
+    private func isWarningDrivenPromptKind(_ kind: PromptKind?) -> Bool {
+        switch kind {
+        case .systemAudio, .audioInactivity, .audioRoute, .micBoost:
+            return true
+        case .missedCall, .none:
+            return false
         }
-        guard meetingSession?.state == .recording else { return }
-        if state == .prompt, promptKind == .systemAudio { return }
-        // An inactivity prompt owns its stop policy. The route warning is
-        // latched on the session and appears as soon as that prompt clears.
-        if state == .prompt, promptKind == .audioInactivity { return }
-        // Precedence: never replace an active mic-boost prompt (mirrors
-        // applyMicBoostPrompt above deferring to an active route warning).
-        // The route warning is latched on the session and appears as soon
-        // as the mic-boost prompt clears.
-        if state == .prompt, promptKind == .micBoost { return }
-
-        autoHideTask?.cancel()
-        promptCountdownTask?.cancel()
-        promptKind = .audioRoute
-        promptSecondsRemaining = 0
-        currentPrompt = audioRouteWarningPromptDisplay(outcome: outcome)
-        bloomFromRest()
-        state = .prompt
-        showPanel()
-        pushToView()
     }
 
-    private func clearAudioRoutePrompt() {
-        guard promptKind == .audioRoute else { return }
-
+    /// Common "nothing left to show" path once the resolver returns nil for
+    /// a previously-active warning prompt.
+    private func clearWarningPrompt() {
         promptCountdownTask?.cancel()
         promptKind = nil
         currentPrompt = nil
 
         if meetingSession?.state == .recording {
-            if let inactivityWarning = meetingSession?.audioInactivityWarning {
-                applyAudioInactivityWarning(inactivityWarning)
-            } else if let warning = systemAudioDegradationWarning, warning.shouldPresentPrompt {
-                applySystemAudioDegradationWarning(warning)
-            } else if meetingSession?.isMicBoostPromptVisible == true {
-                applyMicBoostPrompt(true)
-            } else {
-                state = .recording
-                showPanel()
-                pushToView()
-                flushPendingTranscriptIfNeeded()
-                scheduleRestIfNeeded()
-            }
-        } else {
-            state = .idle
-            hidePanel()
-        }
-    }
-
-    private func clearMicBoostPrompt() {
-        guard promptKind == .micBoost else { return }
-
-        promptCountdownTask?.cancel()
-        promptKind = nil
-        currentPrompt = nil
-
-        if meetingSession?.state == .recording {
-            if let inactivityWarning = meetingSession?.audioInactivityWarning {
-                applyAudioInactivityWarning(inactivityWarning)
-                return
-            }
-            if let warning = systemAudioDegradationWarning, warning.shouldPresentPrompt {
-                applySystemAudioDegradationWarning(warning)
-                return
-            }
-            if let routeWarning = meetingSession?.audioRouteWarning {
-                applyAudioRouteWarning(routeWarning)
-                return
-            }
-            state = .recording
+            state = presentationState(session: .recording, prompt: nil)
             showPanel()
             pushToView()
-            // Transcript updates that arrived while the prompt was up were
-            // deferred (the drawer only renders in .recording); flush them
-            // now instead of waiting for the next ASR update.
             flushPendingTranscriptIfNeeded()
             scheduleRestIfNeeded()
         } else {
             state = .idle
             hidePanel()
+        }
+    }
+
+    /// Pure derivation of the overlay's presentation state from the session
+    /// state plus the currently-resolved prompt kind (whichever of the four
+    /// warning prompts `MeetingPromptPriority` resolved to, or the
+    /// missed-call nudge — both funnel through `promptKind`).
+    ///
+    /// Not total, though: `.saved` is a transient display (session `.ready`
+    /// right after `.transcribing`, shown for `scheduleAutoHide`'s 1.5s
+    /// before falling back to idle) that depends on the *previous* overlay
+    /// state, not just the current session state — genuinely not derivable
+    /// from `(session, prompt)` alone. `applySessionState` below keeps that
+    /// one case as an explicit imperative branch instead of forcing it
+    /// through this function.
+    private func presentationState(
+        session: MeetingSessionController.State,
+        prompt: PromptKind?
+    ) -> OverlayState {
+        if prompt != nil {
+            return .prompt
+        }
+        switch session {
+        case .idle, .ready:
+            return .idle
+        case .loadingModels:
+            return .preparing
+        case .recording:
+            return .recording
+        case .transcribing:
+            return .transcribing
+        case .error(let message):
+            return .error(message)
         }
     }
 
@@ -1871,15 +1843,15 @@ final class MeetingOverlayController: NSObject {
                 break
             }
             promptKind = nil
-            state = .idle
+            state = presentationState(session: sessionState, prompt: promptKind)
             hidePanel()
         case .loadingModels:
             cancelRest()
             isTranscriptExpanded = false
-            state = .preparing
             currentPrompt = nil
             promptKind = nil
             promptCountdownTask?.cancel()
+            state = presentationState(session: sessionState, prompt: promptKind)
             showPanel()
         case .ready:
             cancelRest()
@@ -1890,6 +1862,10 @@ final class MeetingOverlayController: NSObject {
             }
             // Ready but not recording — hide unless we're already showing a
             // terminal state (saved/error); the auto-hide task handles those.
+            // `.saved` can't be derived from (session, prompt) alone — it
+            // only exists because the *previous* overlay state was
+            // `.transcribing` — so it stays an explicit branch here instead
+            // of going through `presentationState`.
             if case .transcribing = state {
                 state = .saved
                 showPanel()
@@ -1898,7 +1874,7 @@ final class MeetingOverlayController: NSObject {
             }
             if case .saved = state { break }
             if case .error = state { break }
-            state = .idle
+            state = presentationState(session: sessionState, prompt: promptKind)
             hidePanel()
         case .recording:
             if state != .recording {
@@ -1910,30 +1886,30 @@ final class MeetingOverlayController: NSObject {
                 isPanelHovered = false
             }
             isRestingCondensed = false
-            state = .recording
             currentPrompt = nil
             promptKind = nil
             promptCountdownTask?.cancel()
             autoHideTask?.cancel()
+            state = presentationState(session: sessionState, prompt: promptKind)
             showPanel()
             flushPendingTranscriptIfNeeded()
             scheduleRestIfNeeded()
         case .transcribing:
             cancelRest()
             isTranscriptExpanded = false
-            state = .transcribing
             currentPrompt = nil
             promptKind = nil
             promptCountdownTask?.cancel()
+            state = presentationState(session: sessionState, prompt: promptKind)
             showPanel()
-        case .error(let message):
+        case .error:
             cancelRest()
             isTranscriptExpanded = false
-            state = .error(message)
             currentPrompt = nil
             promptKind = nil
             promptCountdownTask?.cancel()
             autoHideTask?.cancel()
+            state = presentationState(session: sessionState, prompt: promptKind)
             showPanel()
         }
         pushToView()
@@ -2126,8 +2102,9 @@ final class MeetingOverlayController: NSObject {
                 await session.stopRecording(reason: .audioRouteWarning)
             }
         case .micBoost:
-            // Session clears the published flag, which routes back through
-            // applyMicBoostPrompt(false) -> clearMicBoostPrompt -> .recording.
+            // Session clears the published flag, which the combined warning
+            // subscription picks up and resolves back down to .recording (or
+            // to whichever prompt was suppressed behind this one).
             meetingSession?.acceptMicBoostPrompt()
         case .missedCall:
             onMissedCallNudgeResolved?(.acknowledged)
@@ -2500,44 +2477,6 @@ final class MeetingOverlayController: NSObject {
         currentPrompt = nil
         state = .idle
         hidePanel()
-    }
-
-    private func clearAudioInactivityPrompt() {
-        guard promptKind == .audioInactivity else { return }
-
-        promptCountdownTask?.cancel()
-        promptKind = nil
-        currentPrompt = nil
-
-        if meetingSession?.state == .recording {
-            if let warning = systemAudioDegradationWarning, warning.shouldPresentPrompt {
-                applySystemAudioDegradationWarning(warning)
-                return
-            }
-            state = .recording
-            showPanel()
-            pushToView()
-            // The silence that raised this prompt can hold it up for minutes;
-            // flush transcript updates deferred behind it instead of waiting
-            // for the next ASR update.
-            flushPendingTranscriptIfNeeded()
-            scheduleRestIfNeeded()
-            if let routeWarning = meetingSession?.audioRouteWarning {
-                applyAudioRouteWarning(routeWarning)
-                return
-            }
-            // A mic-boost prompt may have fired while the inactivity prompt
-            // was up (suppressed by precedence) or been replaced by it. The
-            // session still latches it visible — and already recorded its
-            // outcome as "shown" — so re-present instead of silently losing
-            // the one-shot in-meeting offer.
-            if meetingSession?.isMicBoostPromptVisible == true {
-                applyMicBoostPrompt(true)
-            }
-        } else {
-            state = .idle
-            hidePanel()
-        }
     }
 
     private func schedulePromptCountdown() {

--- a/Sources/UI/Overlay/MeetingPromptPriority.swift
+++ b/Sources/UI/Overlay/MeetingPromptPriority.swift
@@ -1,0 +1,92 @@
+// MeetingPromptPriority.swift
+// Pure precedence lattice for the meeting overlay's four warning-driven
+// prompts (audio inactivity, system-audio degradation, audio route
+// instability, mic boost). Extracted from MeetingOverlayController so the
+// rule is encoded once instead of being re-derived by hand across four
+// apply*/clear* method pairs.
+//
+// Deliberately Foundation-pure and independent of both
+// MeetingOverlayController and MeetingSessionController: those pull in
+// AppKit/TranscriptedCore-heavy dependencies that the root fast-test runner
+// (run-tests.sh) does not compile. Callers translate their own richer types
+// (CaptureRouteStabilizationOutcome, MeetingSessionController.State, ...)
+// down to the primitives this file needs.
+
+import Foundation
+
+/// Which of the meeting overlay's prompt kinds is currently in play.
+/// Shared between the pure resolver below and `MeetingOverlayController`
+/// (which typealiases its own `PromptKind` to this).
+enum MeetingWarningPromptKind: Equatable {
+    case systemAudio
+    case audioInactivity
+    case micBoost
+    case audioRoute
+    // Post-call "that call wasn't recorded" awareness nudge. Not one of the
+    // four warning-driven kinds below — MeetingOverlayController presents it
+    // outside this resolver (it can only appear while not recording, so it
+    // never competes with the warning lattice) — see
+    // `MeetingPromptPresentationGate.allowsDetectedMeetingPrompt`.
+    case missedCall
+}
+
+enum MeetingPromptPriority {
+    /// Resolves which of the four warning-driven prompts (if any) the
+    /// meeting overlay should currently show, given the latest value of each
+    /// signal.
+    ///
+    /// Precedence: `audioInactivity` > `systemAudio` > `{audioRoute, micBoost}`.
+    ///
+    /// - `audioInactivity` always wins: it can auto-stop the recording, so
+    ///   its countdown must stay visible over anything else.
+    /// - `systemAudio` is gated by `MeetingSystemAudioPromptPolicy`, which
+    ///   already folds in "never fight an active inactivity prompt" — this
+    ///   branch is only reached once `inactivity` is nil, so that policy
+    ///   check is passed `hasAudioInactivityWarning: false`.
+    /// - `audioRoute` and `micBoost` are mutually sticky: whichever one is
+    ///   already the active prompt (`current`) stays active even if the
+    ///   other's condition also becomes true, so (say) a route hiccup can't
+    ///   get silently swapped out from under the user by a mic-boost offer,
+    ///   or vice versa. When neither is currently active, `audioRoute` wins
+    ///   the tie — this matches every clear*-fallback chain in the
+    ///   pre-resolver code, which always re-checked `audioRoute` before
+    ///   `micBoost` once a higher-priority prompt cleared.
+    static func resolve(
+        inactivity: MeetingAudioInactivityWarning?,
+        systemAudio: MeetingSystemAudioDegradationWarning?,
+        routeActive: Bool,
+        micBoostVisible: Bool,
+        current: MeetingWarningPromptKind?,
+        isRecording: Bool
+    ) -> MeetingWarningPromptKind? {
+        // All four warnings are recording-only: MeetingSessionController only
+        // latches them while actively recording, and the overlay must never
+        // keep showing a stale warning prompt once recording stops.
+        guard isRecording else { return nil }
+
+        if inactivity != nil {
+            return .audioInactivity
+        }
+
+        if MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt(
+            warning: systemAudio,
+            hasAudioInactivityWarning: false
+        ) {
+            return .systemAudio
+        }
+
+        if current == .audioRoute, routeActive {
+            return .audioRoute
+        }
+        if current == .micBoost, micBoostVisible {
+            return .micBoost
+        }
+        if routeActive {
+            return .audioRoute
+        }
+        if micBoostVisible {
+            return .micBoost
+        }
+        return nil
+    }
+}

--- a/Tests/MeetingPromptPriorityTests.swift
+++ b/Tests/MeetingPromptPriorityTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+func testMeetingPromptPriority() {
+    let interruption = MeetingSystemAudioDegradationWarning(
+        cause: .interruption,
+        phase: .recovering,
+        isPromptDismissed: false
+    )
+    let dismissedSystemAudio = MeetingSystemAudioDegradationWarning(
+        cause: .interruption,
+        phase: .recovering,
+        isPromptDismissed: true
+    )
+    let inactivity = MeetingAudioInactivityWarning(
+        inactiveDuration: 5 * 60,
+        countdownSeconds: 30
+    )
+
+    runSuite("MeetingPromptPriority — not recording never shows a warning prompt") {
+        assertNil(
+            MeetingPromptPriority.resolve(
+                inactivity: inactivity,
+                systemAudio: interruption,
+                routeActive: true,
+                micBoostVisible: true,
+                current: nil,
+                isRecording: false
+            ),
+            "every signal can be hot, but the overlay must never show a stale warning prompt once recording stops"
+        )
+    }
+
+    runSuite("MeetingPromptPriority — full precedence lattice: inactivity > systemAudio > {route, micBoost}") {
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: inactivity,
+                systemAudio: interruption,
+                routeActive: true,
+                micBoostVisible: true,
+                current: nil,
+                isRecording: true
+            ),
+            .audioInactivity,
+            "audio inactivity always wins — it can auto-stop the recording"
+        )
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: interruption,
+                routeActive: true,
+                micBoostVisible: true,
+                current: nil,
+                isRecording: true
+            ),
+            .systemAudio,
+            "system audio outranks route and mic boost once inactivity is clear"
+        )
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: true,
+                micBoostVisible: false,
+                current: nil,
+                isRecording: true
+            ),
+            .audioRoute,
+            "route shows on its own once nothing above it is active"
+        )
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: false,
+                micBoostVisible: true,
+                current: nil,
+                isRecording: true
+            ),
+            .micBoost,
+            "mic boost shows on its own once nothing above it is active"
+        )
+        assertNil(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: false,
+                micBoostVisible: false,
+                current: nil,
+                isRecording: true
+            ),
+            "no signal, no prompt"
+        )
+        assertNil(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: dismissedSystemAudio,
+                routeActive: false,
+                micBoostVisible: false,
+                current: .systemAudio,
+                isRecording: true
+            ),
+            "a dismissed system-audio warning must not keep re-presenting"
+        )
+    }
+
+    runSuite("MeetingPromptPriority — route and mic boost are mutually sticky") {
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: true,
+                micBoostVisible: true,
+                current: nil,
+                isRecording: true
+            ),
+            .audioRoute,
+            "when neither is currently shown and both fire together, route wins the tie — matching every " +
+                "clear*-fallback chain in the pre-resolver code, which always re-checked route before mic boost"
+        )
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: true,
+                micBoostVisible: true,
+                current: .micBoost,
+                isRecording: true
+            ),
+            .micBoost,
+            "mic boost stays up even though route also became active — a route hiccup must not steal the " +
+                "prompt out from under an already-showing mic-boost offer"
+        )
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: true,
+                micBoostVisible: true,
+                current: .audioRoute,
+                isRecording: true
+            ),
+            .audioRoute,
+            "route stays up even though mic boost also became active — the reverse direction of stickiness"
+        )
+    }
+
+    runSuite("MeetingPromptPriority — the suppressed sibling re-applies once the sticky one clears") {
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: true,
+                micBoostVisible: false,
+                current: .micBoost,
+                isRecording: true
+            ),
+            .audioRoute,
+            "mic boost's own condition cleared while route's stayed hot — route takes over, the exact " +
+                "scenario the clear*-fallback chains handled by hand before this resolver existed"
+        )
+        assertEqual(
+            MeetingPromptPriority.resolve(
+                inactivity: nil,
+                systemAudio: nil,
+                routeActive: false,
+                micBoostVisible: true,
+                current: .audioRoute,
+                isRecording: true
+            ),
+            .micBoost,
+            "route's own condition cleared while mic boost's stayed hot — mic boost takes over"
+        )
+    }
+
+    runSuite("MeetingPromptPriority — recording stop clears everything, even a sticky prompt") {
+        assertNil(
+            MeetingPromptPriority.resolve(
+                inactivity: inactivity,
+                systemAudio: interruption,
+                routeActive: true,
+                micBoostVisible: true,
+                current: .micBoost,
+                isRecording: false
+            ),
+            "every signal still hot and a prompt still marked current, but recording stopped — nothing shows"
+        )
+    }
+}

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -392,6 +392,7 @@ APP_SOURCES=(
     "Sources/UI/Overlay/DictationMeterPolicy.swift"
     "Sources/UI/Overlay/MeetingLiveViewAffordancePolicy.swift"
     "Sources/UI/Overlay/MeetingPillRestPolicy.swift"
+    "Sources/UI/Overlay/MeetingPromptPriority.swift"
     "Sources/Support/MeetingOverlayPillPreferences.swift"
     "Sources/UI/Overlay/DictationCancelHintPolicy.swift"
     "Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift"


### PR DESCRIPTION
## Summary

Subsumes PR #1621's route→micBoost precedence guard into a single pure
resolver covering all four of the meeting overlay's warning-driven prompts,
per findings #8 and #19 of the recent UI hotspot audit.

**Before:** `MeetingOverlayController` had four independent `.sink`
subscriptions (one per `MeetingSessionController` warning publisher), each
driving its own `apply*`/`clear*` method pair (8 methods total, ~200 lines).
Precedence between the four prompts — audio inactivity, system-audio
degradation, audio route instability, mic boost — was re-derived by hand in
every pair via ad-hoc `if state == .prompt, promptKind == .x { return }`
guards and multi-branch fallback chains in each `clear*` method.

**After:**

1. **`Sources/UI/Overlay/MeetingPromptPriority.swift`** (new) — a pure,
   Foundation-only `MeetingPromptPriority.resolve(...)` function encoding the
   lattice once: `audioInactivity > systemAudio > {audioRoute, micBoost}`,
   with the last two mutually sticky (whichever is currently shown stays
   shown even if the other's condition also becomes true; tie-break to
   `audioRoute` when neither is current — matching every fallback chain in
   the old code, which always checked route before mic boost). Reuses
   `MeetingSystemAudioPromptPolicy.shouldPresentSystemAudioPrompt` rather
   than re-deriving that gate. Deliberately independent of
   `MeetingOverlayController`/`MeetingSessionController` (both too
   AppKit/TranscriptedCore-heavy for the root fast-test runner) — it takes
   primitive types (`routeActive: Bool`, `isRecording: Bool`) instead of
   `CaptureRouteStabilizationOutcome`/`MeetingSessionController.State`
   directly. `MeetingOverlayController.PromptKind` is now a `typealias` to
   this file's `MeetingWarningPromptKind`.

2. **One combined subscription** (`Publishers.CombineLatest4` over the four
   session warning publishers) replaces the four separate `.sink` closures
   and eight `apply*`/`clear*` methods with `applyWarningPrompt(...)` +
   `clearWarningPrompt()` + a small `promptDisplay(for:...)` builder. The
   presented prompt is now a pure function of the four signals, the
   currently-active prompt kind, and session state — recomputed fresh on
   every emission instead of hand-chained through per-signal fallbacks.
   (Audio inactivity keeps a small mirror, `lastAppliedAudioInactivityWarning`,
   so its own per-second countdown `Task` only restarts when the inactivity
   warning itself changes, not when an unrelated signal in the CombineLatest4
   tuple changes.)

3. **`presentationState(session:prompt:) -> OverlayState`** replaces the
   direct `state = .prompt` / `.recording` / etc. assignments scattered
   across the prompt handlers and `applySessionState`.

## What stayed imperative, and why

- **`OverlayState.saved`** is a transient display (`session == .ready` right
  after the overlay was `.transcribing`, shown for 1.5s via `scheduleAutoHide`
  before falling back to idle). It depends on the *previous* overlay state,
  not just `(session, prompt)`, so it can't be pure — `applySessionState`
  keeps it as an explicit branch, documented inline.
- **The missed-call nudge** (`PromptKind.missedCall`) never enters
  `MeetingPromptPriority.resolve` — it can only appear while *not* recording
  (`MeetingPromptPresentationGate.allowsDetectedMeetingPrompt` disallows it
  during `.recording`), so it never competes with the four warning prompts.
  It's still driven by `presentMissedCallNudge`/`dismissPrompt`/
  `handlePromptCountdownExpired`, unchanged.
- **`systemAudioDegradationWarning`/`audioRouteWarningOutcome` mirrors** stay
  on the controller (needed for `isVisuallyCondensed`/`scheduleRestIfNeeded`,
  which key off the raw signal even when a higher-priority prompt suppresses
  its display — e.g. a live system-audio warning keeps the pill expanded even
  while audio-inactivity owns the visible prompt).

Net: -60 lines in `MeetingOverlayController.swift` despite the new pure file
and its test.

## Test plan

- [x] `bash build-deps.sh --force` (deps were stale) then `bash build.sh --no-open` — clean build, only two pre-existing unrelated warnings (`MeetingSessionController.swift:2712`, `DictationSessionController.swift:1010`)
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12620/12620 passed, including the new `Tests/MeetingPromptPriorityTests.swift` (`testMeetingPromptPriority`) covering the full precedence lattice, mutual stickiness in both directions, the suppressed-sibling-reapplies-on-clear scenario, and recording-stop clearing everything
- [x] `Sources/UI/Overlay/MeetingPromptPriority.swift` added to `run-tests.sh`'s `APP_SOURCES` manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)