### PR TITLE
Add typed PipelineErrorKind to stop failure classification drift

### DIFF
--- a/Sources/Meeting/FailedMeetingPresentation.swift
+++ b/Sources/Meeting/FailedMeetingPresentation.swift
@@ -6,7 +6,7 @@ enum FailedMeetingPresentation {
         from failed: FailedTranscription,
         isRetrying: Bool
     ) -> MeetingSessionController.FailedMeetingItem {
-        let failureKind = MeetingFailureKind.classify(message: failed.errorMessage)
+        let failureKind = MeetingFailureKind.classify(errorKind: failed.errorKind, message: failed.errorMessage)
         let availableAudioURLs = audioURLs(for: failed)
         let hasRetryableAudioFiles = failed.audioFilesExist()
         let copy = MeetingFailureCopy.make(

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 enum MeetingFailureKind: String {
     case systemAudioPermission = "system_audio_permission"
@@ -36,6 +39,53 @@ enum MeetingFailureKind: String {
         }
     }
 
+    /// Maps a typed Core pipeline failure onto this taxonomy. `PipelineErrorKind`
+    /// only covers failures that flow through `TranscriptionTaskManager`'s typed
+    /// error surface, so this is a total, non-failable mapping over that subset —
+    /// it never produces `.unexpectedError`. Meeting-only categories (permission
+    /// gates, import preparation, stop timeouts, speaker-name finalization, ...)
+    /// have no `PipelineErrorKind` counterpart and stay on the legacy string path.
+    init(errorKind: PipelineErrorKind) {
+        switch errorKind {
+        case .transcriptionAlreadyInProgress:
+            self = .pipelineBusy
+        case .missingSystemAudio:
+            self = .systemAudioPermission
+        case .recordingTooShort:
+            self = .recordingTooShort
+        case .emptyAudioFile:
+            self = .emptyAudio
+        case .noSpeechDetected:
+            self = .noSpeechDetected
+        case .invalidAudioFormat:
+            self = .invalidAudioFormat
+        case .microphoneAudioUnusable:
+            self = .microphoneAudioUnusable
+        case .saveFailed:
+            self = .saveFailed
+        case .modelNotLoaded:
+            self = .modelNotLoaded
+        case .diarizationFailed:
+            self = .diarizationFailed
+        case .transcriptionInferenceFailed:
+            self = .transcriptionInferenceFailed
+        case .pipelineFailed:
+            self = .pipelineFailed
+        }
+    }
+
+    /// Preferred entry point once a typed `errorKind` is available (e.g. from
+    /// `FailedTranscription.errorKind`). Falls back to legacy string matching
+    /// via `classify(message:)` only when `errorKind` is nil — persisted
+    /// entries from before typed errors existed, or failures that never had
+    /// a `PipelineError` in the first place.
+    static func classify(errorKind: PipelineErrorKind?, message: String) -> MeetingFailureKind {
+        if let errorKind {
+            return MeetingFailureKind(errorKind: errorKind)
+        }
+        return classify(message: message)
+    }
+
     static func isRecordingTooShortMessage(_ message: String) -> Bool {
         let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let mentionsAudioMinimum = (
@@ -57,6 +107,11 @@ enum MeetingFailureKind: String {
             || mentionsAudioMinimum
     }
 
+    /// Legacy fallback: classifies by keyword matching over a free-form message.
+    /// Prefer `classify(errorKind:message:)` when a typed `PipelineErrorKind` is
+    /// available. This stays byte-equivalent to the pre-typed-error behavior so
+    /// old persisted `FailedTranscription` rows (with `errorKind == nil`) keep
+    /// classifying the same way.
     static func classify(message: String) -> MeetingFailureKind {
         let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2751,7 +2751,11 @@ final class MeetingSessionController: ObservableObject {
             activeStoppedAudioRecovery = nil
             let transcriptionTrigger = activeTranscriptionTrigger
             let diagnosticMessage = taskManager.lastFailureDiagnosticMessage ?? message
-            let failureKind = MeetingFailureKind.classify(message: diagnosticMessage)
+            // Only trust the typed kind when it was captured alongside the diagnostic
+            // message actually being classified below — not when this fell back to
+            // the raw overlay `message`, which never had a typed kind computed for it.
+            let errorKind = taskManager.lastFailureDiagnosticMessage != nil ? taskManager.lastFailureErrorKind : nil
+            let failureKind = MeetingFailureKind.classify(errorKind: errorKind, message: diagnosticMessage)
             if failureKind.shouldReportAsSkippedTranscript {
                 finishLiveCodexSessionForCurrentTranscriptionFailureIfNeeded(
                     failedJobID: activeQueuedTranscriptionJobID

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -1,5 +1,49 @@
 import Foundation
 
+/// Stable, persistable classification of a pipeline failure.
+///
+/// This is the single source of truth for "what kind of failure was this"
+/// once a typed `PipelineError` (or an error `TranscriptionTaskManager` can
+/// otherwise classify) is in hand. It replaces re-deriving the same meaning
+/// from `errorMessage` strings in multiple independent places.
+///
+/// Cases mirror the buckets `TranscriptionTaskManager.safeFailureDiagnosticMessage`
+/// already distinguishes (see its switch over `PipelineError` plus its text
+/// fallback), because that is the one place a typed Swift `Error` is still in
+/// hand when a failure is classified. Downstream consumers such as
+/// `MeetingFailureKind` fold these into their own broader taxonomy — which
+/// also covers failure sources (permission gates, import preparation, stop
+/// timeouts, ...) that never produce a `PipelineError` and so never populate
+/// this field; those stay on the legacy string-matching fallback.
+///
+/// Raw values are persisted (`FailedTranscription.errorKind`) and must stay
+/// stable — do not rename or reuse a raw value for a different meaning.
+public enum PipelineErrorKind: String, Codable, Equatable, Hashable, CaseIterable, Sendable {
+    case transcriptionAlreadyInProgress = "transcription_already_in_progress"
+    case missingSystemAudio = "missing_system_audio"
+    case recordingTooShort = "recording_too_short"
+    case emptyAudioFile = "empty_audio_file"
+    case noSpeechDetected = "no_speech_detected"
+    case invalidAudioFormat = "invalid_audio_format"
+    case microphoneAudioUnusable = "microphone_audio_unusable"
+    case saveFailed = "save_failed"
+    case modelNotLoaded = "model_not_loaded"
+    case diarizationFailed = "diarization_failed"
+    case transcriptionInferenceFailed = "transcription_inference_failed"
+    case pipelineFailed = "pipeline_failed"
+
+    /// Whether this failure could succeed if retried, independent of
+    /// message text. Mirrors `PipelineError.isRetryable`.
+    public var isRetryable: Bool {
+        switch self {
+        case .emptyAudioFile, .microphoneAudioUnusable, .noSpeechDetected, .recordingTooShort, .invalidAudioFormat, .missingSystemAudio:
+            return false
+        case .transcriptionAlreadyInProgress, .modelNotLoaded, .diarizationFailed, .transcriptionInferenceFailed, .saveFailed, .pipelineFailed:
+            return true
+        }
+    }
+}
+
 /// Represents a transcription that failed and can be retried
 public struct FailedTranscription: Identifiable, Codable, Equatable {
     public let id: UUID
@@ -11,6 +55,11 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     public let meetingTitle: String?
     public var retryCount: Int
     public var lastRetryDate: Date?
+    /// Typed classification captured at the point the original error was thrown.
+    /// `nil` for entries persisted before this field existed, or for failures
+    /// that never carried a typed `PipelineError` (e.g. permission/import
+    /// failures) — those keep classifying through the legacy string fallback.
+    public var errorKind: PipelineErrorKind?
 
     public init(
         id: UUID = UUID(),
@@ -21,7 +70,8 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         errorMessage: String,
         meetingTitle: String? = nil,
         retryCount: Int = 0,
-        lastRetryDate: Date? = nil
+        lastRetryDate: Date? = nil,
+        errorKind: PipelineErrorKind? = nil
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -32,6 +82,7 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         self.meetingTitle = meetingTitle
         self.retryCount = retryCount
         self.lastRetryDate = lastRetryDate
+        self.errorKind = errorKind
     }
 
     /// Returns a user-friendly formatted timestamp
@@ -52,16 +103,27 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     }
 
     /// Whether this failure could succeed if retried.
-    /// Uses PipelineError classification when available, falls back to keyword matching
-    /// for entries persisted before typed errors were introduced.
+    /// Uses the typed `errorKind` when available (captured at throw time).
+    /// Legacy fallback: keyword matching for entries persisted before typed
+    /// errors were introduced, used only when `errorKind` is nil.
     public var isRetryable: Bool {
-        if let typed = pipelineError {
+        if let errorKind {
+            if errorKind == .missingSystemAudio, systemAudioURL == nil {
+                return true
+            }
+            return errorKind.isRetryable
+        }
+        return legacyIsRetryable
+    }
+
+    /// Legacy fallback: keyword matching for pre-typed-error entries.
+    private var legacyIsRetryable: Bool {
+        if let typed = legacyPipelineError {
             if case .missingSystemAudio = typed, systemAudioURL == nil {
                 return true
             }
             return typed.isRetryable
         }
-        // Legacy fallback: keyword matching for pre-typed-error entries
         let permanent = [
             "Empty audio file",
             "no samples recorded",
@@ -76,9 +138,10 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         return !permanent.contains(where: { errorMessage.localizedCaseInsensitiveContains($0) })
     }
 
-    /// Attempt to reconstruct the typed PipelineError from the stored message.
-    /// Returns nil for legacy entries that don't match any known pattern.
-    private var pipelineError: PipelineError? {
+    /// Legacy fallback: attempt to reconstruct a typed PipelineError from the
+    /// stored message via keyword matching. Returns nil for legacy entries
+    /// that don't match any known pattern. Used only when `errorKind` is nil.
+    private var legacyPipelineError: PipelineError? {
         let normalized = errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
         if normalized.contains("no samples recorded") || normalized.contains("empty audio file") {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -585,16 +585,70 @@ public class TranscriptionTaskManager: ObservableObject {
         failureClassification(for: error).message
     }
 
-    /// Typed counterpart to `safeFailureDiagnosticMessage(for:)`, computed from
-    /// the same classification pass so the two can never drift. This is the
-    /// one place a typed Swift `Error` is still in hand when a pipeline
-    /// failure is classified — callers should capture this alongside the
-    /// diagnostic message and thread it through to `FailedTranscription.errorKind`
-    /// rather than re-deriving meaning from the message string later.
-    public static func failureKind(for error: Error) -> PipelineErrorKind {
-        failureClassification(for: error).kind
+    /// Typed classification to PERSIST as `FailedTranscription.errorKind` —
+    /// deliberately narrower than `safeFailureDiagnosticMessage(for:)`.
+    ///
+    /// This only returns non-nil when `error` is a genuine `PipelineError`
+    /// case with the typed error actually in hand (excluding `.unknown`,
+    /// which just wraps free text). Every other error — including any
+    /// `PipelineError.unknown` — returns nil here, even though
+    /// `safeFailureDiagnosticMessage` classifies a much broader set of
+    /// free-form `NSError`/`localizedDescription` text for the *display*
+    /// message. That broad text net must never leak into what gets
+    /// persisted as `errorKind`: `FailedTranscription.isRetryable` and
+    /// `MeetingFailureKind` trust `errorKind` over the legacy string
+    /// fallback, and the legacy fallback's keyword net (in
+    /// `FailedTranscription.legacyPipelineError` / `MeetingFailureKind
+    /// .classify(message:)`) is intentionally much narrower than the
+    /// display-message net — e.g. a raw CoreAudio `-50` NSError's
+    /// description contains "avfaudio"/"coreaudio", which the display-message
+    /// fallback recognizes as invalid-audio-format, but which the legacy
+    /// retry-classification net does not, so on `main` that failure stayed
+    /// retryable and bucketed as unexpected rather than becoming permanently
+    /// non-retryable. Returning nil here for text-routed errors preserves
+    /// that behavior: the caller keeps using the (unchanged) legacy fallback
+    /// for anything that didn't arrive as a typed `PipelineError`.
+    public static func failureKind(for error: Error) -> PipelineErrorKind? {
+        guard let pipelineError = error as? PipelineError else { return nil }
+        switch pipelineError {
+        case .emptyAudioFile:
+            return .emptyAudioFile
+        case .microphoneAudioUnusable:
+            return .microphoneAudioUnusable
+        case .noSpeechDetected:
+            return .noSpeechDetected
+        case .recordingTooShort:
+            return .recordingTooShort
+        case .invalidAudioFormat:
+            return .invalidAudioFormat
+        case .missingSystemAudio:
+            return .missingSystemAudio
+        case .modelNotLoaded:
+            return .modelNotLoaded
+        case .modelInferenceFailed:
+            // NOTE: legacy text classification would bucket an underlying
+            // message naming a diarization model (e.g. "PyAnnote") as
+            // `.diarizationFailed` instead. No current throw site passes a
+            // diarization model name through `.modelInferenceFailed` — every
+            // call site here is a transcription-model failure — so this is a
+            // latent divergence, not an active one. If a diarization engine
+            // ever starts throwing `.modelInferenceFailed`, this should
+            // switch on the model name the same way the legacy text path
+            // does, rather than assuming transcription.
+            return .transcriptionInferenceFailed
+        case .saveFailed:
+            return .saveFailed
+        case .unknown:
+            // Free text wrapped in a PipelineError case, not a real typed
+            // classification — treat it like any other untyped error.
+            return nil
+        }
     }
 
+    /// Backs `safeFailureDiagnosticMessage(for:)` only. Its `kind` half is an
+    /// implementation detail of picking the right `message` string — it is
+    /// deliberately NOT the source of `failureKind(for:)` above, which uses
+    /// its own narrower, typed-only switch instead of this text-inclusive one.
     private static func failureClassification(for error: Error) -> (kind: PipelineErrorKind, message: String) {
         if let pipelineError = error as? PipelineError {
             switch pipelineError {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -27,6 +27,7 @@ public class TranscriptionTaskManager: ObservableObject {
     @Published public var lastSavedDuration: String? = nil
     @Published public var lastSavedSpeakerCount: Int? = nil
     @Published public private(set) var lastFailureDiagnosticMessage: String? = nil
+    @Published public private(set) var lastFailureErrorKind: PipelineErrorKind? = nil
 
     var lastSavedTranscriptId: UUID?
     private var savedTranscriptTaskIdsByTranscriptId: [UUID: UUID] = [:]
@@ -236,6 +237,11 @@ public class TranscriptionTaskManager: ObservableObject {
             } catch {
                 AppLogger.pipeline.error("Transcription task failed", ["taskId": "\(task.id)", "error": "\(error.localizedDescription)"])
 
+                // Computed once, here, while the typed error is still in hand — threaded
+                // through to both the live display state and the persisted failed-queue
+                // row so downstream classifiers don't have to re-derive it from strings.
+                let errorKind = Self.failureKind(for: error)
+
                 let shouldPreserveFailedAudio = await MainActor.run { () -> Bool in
                     if self.preservedTaskIdsForShutdown.remove(task.id) != nil {
                         self.handleTaskCompletion(taskId: task.id)
@@ -245,7 +251,8 @@ public class TranscriptionTaskManager: ObservableObject {
 
                     self.publishFailure(
                         displayMessage: "Transcription failed",
-                        diagnosticMessage: Self.safeFailureDiagnosticMessage(for: error)
+                        diagnosticMessage: Self.safeFailureDiagnosticMessage(for: error),
+                        errorKind: errorKind
                     )
                     return true
                 }
@@ -258,7 +265,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     errorMessage: error.localizedDescription,
                     taskId: task.id,
                     meetingTitle: task.meetingTitle,
-                    recordingDate: task.recordingDate
+                    recordingDate: task.recordingDate,
+                    errorKind: errorKind
                 )
 
                 await MainActor.run {
@@ -283,7 +291,8 @@ public class TranscriptionTaskManager: ObservableObject {
         taskId: UUID = UUID(),
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
-        archiveAudio: Bool = true
+        archiveAudio: Bool = true,
+        errorKind: PipelineErrorKind? = nil
     ) async -> Bool {
         guard micAudioURL != nil || systemAudioURL != nil else {
             AppLogger.pipeline.error("No audio files available to retain for failed transcription", [
@@ -318,7 +327,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     errorMessage: errorMessage,
                     meetingTitle: meetingTitle,
                     recordingDate: recordingDate,
-                    removeOriginalsAfterArchive: true
+                    removeOriginalsAfterArchive: true,
+                    errorKind: errorKind
                 )
             }
         }
@@ -330,7 +340,8 @@ public class TranscriptionTaskManager: ObservableObject {
             taskId: taskId,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
-            archiveAudio: archiveAudio
+            archiveAudio: archiveAudio,
+            errorKind: errorKind
         )
     }
 
@@ -450,7 +461,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     let diagnosticMessage = Self.safeFailureDiagnosticMessage(for: error)
                     self.publishFailure(
                         displayMessage: Self.importedAudioFailureDisplayMessage(forDiagnosticMessage: diagnosticMessage),
-                        diagnosticMessage: diagnosticMessage
+                        diagnosticMessage: diagnosticMessage,
+                        errorKind: Self.failureKind(for: error)
                     )
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: taskId)
@@ -556,7 +568,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     let diagnosticMessage = Self.safeFailureDiagnosticMessage(for: error)
                     self.publishFailure(
                         displayMessage: Self.savedAudioRetranscriptionFailureDisplayMessage(forDiagnosticMessage: diagnosticMessage),
-                        diagnosticMessage: diagnosticMessage
+                        diagnosticMessage: diagnosticMessage,
+                        errorKind: Self.failureKind(for: error)
                     )
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: taskId)
@@ -569,39 +582,53 @@ public class TranscriptionTaskManager: ObservableObject {
     }
 
     public static func safeFailureDiagnosticMessage(for error: Error) -> String {
+        failureClassification(for: error).message
+    }
+
+    /// Typed counterpart to `safeFailureDiagnosticMessage(for:)`, computed from
+    /// the same classification pass so the two can never drift. This is the
+    /// one place a typed Swift `Error` is still in hand when a pipeline
+    /// failure is classified — callers should capture this alongside the
+    /// diagnostic message and thread it through to `FailedTranscription.errorKind`
+    /// rather than re-deriving meaning from the message string later.
+    public static func failureKind(for error: Error) -> PipelineErrorKind {
+        failureClassification(for: error).kind
+    }
+
+    private static func failureClassification(for error: Error) -> (kind: PipelineErrorKind, message: String) {
         if let pipelineError = error as? PipelineError {
             switch pipelineError {
             case .emptyAudioFile:
-                return "Empty audio file"
+                return (.emptyAudioFile, "Empty audio file")
             case .microphoneAudioUnusable:
-                return "Microphone audio was not usable"
+                return (.microphoneAudioUnusable, "Microphone audio was not usable")
             case .noSpeechDetected:
-                return "No speech detected"
+                return (.noSpeechDetected, "No speech detected")
             case .recordingTooShort:
-                return "Recording too short"
+                return (.recordingTooShort, "Recording too short")
             case .invalidAudioFormat:
-                return "Invalid audio format"
+                return (.invalidAudioFormat, "Invalid audio format")
             case .missingSystemAudio:
-                return PipelineError.missingSystemAudio.localizedDescription
+                return (.missingSystemAudio, PipelineError.missingSystemAudio.localizedDescription)
             case .modelNotLoaded(let model):
-                return "\(model) model not loaded"
+                return (.modelNotLoaded, "\(model) model not loaded")
             case .modelInferenceFailed(let model, _):
-                return "\(model) inference failed"
+                return (.transcriptionInferenceFailed, "\(model) inference failed")
             case .saveFailed:
-                return "Failed to save transcript"
+                return (.saveFailed, "Failed to save transcript")
             case .unknown(let underlying):
-                return safeFailureDiagnosticMessage(forText: underlying)
+                return failureClassification(forText: underlying)
             }
         }
 
-        return safeFailureDiagnosticMessage(forText: error.localizedDescription)
+        return failureClassification(forText: error.localizedDescription)
     }
 
-    private static func safeFailureDiagnosticMessage(forText message: String) -> String {
+    private static func failureClassification(forText message: String) -> (kind: PipelineErrorKind, message: String) {
         let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
         if normalized.contains("transcription already in progress") {
-            return "Transcription already in progress"
+            return (.transcriptionAlreadyInProgress, "Transcription already in progress")
         }
 
         if normalized.contains(anyOf: [
@@ -609,7 +636,7 @@ public class TranscriptionTaskManager: ObservableObject {
             "system audio recording",
             "screen recording",
         ]) {
-            return PipelineError.missingSystemAudio.localizedDescription
+            return (.missingSystemAudio, PipelineError.missingSystemAudio.localizedDescription)
         }
 
         if normalized.contains(anyOf: [
@@ -624,7 +651,7 @@ public class TranscriptionTaskManager: ObservableObject {
             "at least one second",
             "at least two seconds",
         ]) && (normalized.contains("audio") || normalized.contains("recording")) {
-            return "Recording too short"
+            return (.recordingTooShort, "Recording too short")
         }
 
         if normalized.contains(anyOf: [
@@ -632,14 +659,14 @@ public class TranscriptionTaskManager: ObservableObject {
             "empty audio file",
             "no samples recorded",
         ]) {
-            return "Empty audio file"
+            return (.emptyAudioFile, "Empty audio file")
         }
 
         if normalized.contains(anyOf: [
             "no speech detected",
             "no speech was found",
         ]) {
-            return "No speech detected"
+            return (.noSpeechDetected, "No speech detected")
         }
 
         if normalized.contains(anyOf: [
@@ -653,7 +680,7 @@ public class TranscriptionTaskManager: ObservableObject {
             "coreaudio error",
             "failed to create avaudioconverter",
         ]) {
-            return "Invalid audio format"
+            return (.invalidAudioFormat, "Invalid audio format")
         }
 
         if normalized.contains(anyOf: [
@@ -661,7 +688,7 @@ public class TranscriptionTaskManager: ObservableObject {
             "could not write transcript",
             "permission denied",
         ]) {
-            return "Failed to save transcript"
+            return (.saveFailed, "Failed to save transcript")
         }
 
         if normalized.contains(anyOf: [
@@ -670,7 +697,7 @@ public class TranscriptionTaskManager: ObservableObject {
             "model failed to load",
             "speech model failed to load",
         ]) {
-            return "Model not loaded"
+            return (.modelNotLoaded, "Model not loaded")
         }
 
         if normalized.contains(anyOf: [
@@ -679,7 +706,7 @@ public class TranscriptionTaskManager: ObservableObject {
             "wespeaker",
             "diarization",
         ]) {
-            return "Diarization failed"
+            return (.diarizationFailed, "Diarization failed")
         }
 
         if normalized.contains(anyOf: [
@@ -697,10 +724,10 @@ public class TranscriptionTaskManager: ObservableObject {
             "transcription failed",
             "whisper",
         ]) {
-            return "Transcription inference failed"
+            return (.transcriptionInferenceFailed, "Transcription inference failed")
         }
 
-        return "Pipeline failed"
+        return (.pipelineFailed, "Pipeline failed")
     }
 
     private static func importedAudioFailureDisplayMessage(forDiagnosticMessage message: String) -> String {
@@ -771,13 +798,15 @@ public class TranscriptionTaskManager: ObservableObject {
         return "Transcripted couldn't re-transcribe that saved audio. Try again, or start a new recording if the retained audio is damaged."
     }
 
-    private func publishFailure(displayMessage: String, diagnosticMessage: String) {
+    private func publishFailure(displayMessage: String, diagnosticMessage: String, errorKind: PipelineErrorKind? = nil) {
         lastFailureDiagnosticMessage = diagnosticMessage
+        lastFailureErrorKind = errorKind
         displayStatus = .failed(message: displayMessage)
     }
 
     private func publishNonFailureStatus(_ status: DisplayStatus) {
         lastFailureDiagnosticMessage = nil
+        lastFailureErrorKind = nil
         displayStatus = status
     }
 
@@ -794,7 +823,8 @@ public class TranscriptionTaskManager: ObservableObject {
         taskId: UUID = UUID(),
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
-        archiveAudio: Bool = true
+        archiveAudio: Bool = true,
+        errorKind: PipelineErrorKind? = nil
     ) {
         _ = addFailedTranscriptionRetainingAvailableAudio(
             micAudioURL: micAudioURL,
@@ -803,7 +833,8 @@ public class TranscriptionTaskManager: ObservableObject {
             taskId: taskId,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
-            archiveAudio: archiveAudio
+            archiveAudio: archiveAudio,
+            errorKind: errorKind
         )
     }
 
@@ -895,7 +926,8 @@ public class TranscriptionTaskManager: ObservableObject {
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
         archiveAudio: Bool = true,
-        clearRecordingJournalAfterPersistence: Bool = true
+        clearRecordingJournalAfterPersistence: Bool = true,
+        errorKind: PipelineErrorKind? = nil
     ) -> Bool {
         guard micAudioURL != nil || systemAudioURL != nil else {
             AppLogger.pipeline.error("No audio files available to retain for failed transcription", [
@@ -913,7 +945,8 @@ public class TranscriptionTaskManager: ObservableObject {
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
             removeOriginalsAfterArchive: false,
-            clearRecordingJournalAfterPersistence: clearRecordingJournalAfterPersistence
+            clearRecordingJournalAfterPersistence: clearRecordingJournalAfterPersistence,
+            errorKind: errorKind
         )
         if didPersist, archiveAudio {
             scheduleFailedRecordingAudioArchive(
@@ -938,7 +971,8 @@ public class TranscriptionTaskManager: ObservableObject {
         meetingTitle: String?,
         recordingDate: Date?,
         removeOriginalsAfterArchive: Bool,
-        clearRecordingJournalAfterPersistence: Bool = true
+        clearRecordingJournalAfterPersistence: Bool = true,
+        errorKind: PipelineErrorKind? = nil
     ) -> Bool {
         let failedSystemURL = retainedAudio?.systemURL ?? originalSystemURL
         let placeholderMicURL = makeSilentMicPlaceholderIfNeeded(
@@ -958,7 +992,8 @@ public class TranscriptionTaskManager: ObservableObject {
             systemAudioURL: failedSystemURL,
             errorMessage: errorMessage,
             meetingTitle: meetingTitle,
-            recordingDate: recordingDate
+            recordingDate: recordingDate,
+            errorKind: errorKind
         )
         guard didPersist else {
             if let retainedAudio {
@@ -1571,6 +1606,7 @@ public class TranscriptionTaskManager: ObservableObject {
 
         } catch {
             AppLogger.pipeline.error("Retry failed", ["error": "\(error.localizedDescription)"])
+            let errorKind = Self.failureKind(for: error)
             let diagnosticMessage = "Retry failed: \(Self.safeFailureDiagnosticMessage(for: error))"
             await MainActor.run {
                 guard !self.finishCancelledTaskIfNeeded(taskId: failedId, error: error) else { return }
@@ -1580,7 +1616,8 @@ public class TranscriptionTaskManager: ObservableObject {
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
                 failedTranscriptionManager.updateFailedTranscriptionError(
                     id: failedId,
-                    errorMessage: diagnosticMessage
+                    errorMessage: diagnosticMessage,
+                    errorKind: errorKind
                 )
                 self.removeSupersededRetrySourceAudioIfNeeded(
                     failedId: failedId,
@@ -1589,7 +1626,8 @@ public class TranscriptionTaskManager: ObservableObject {
                 )
                 self.publishFailure(
                     displayMessage: "Retry failed",
-                    diagnosticMessage: diagnosticMessage
+                    diagnosticMessage: diagnosticMessage,
+                    errorKind: errorKind
                 )
                 self.scheduleStatusReset(delay: 8)
             }

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -220,7 +220,8 @@ public class FailedTranscriptionManager: ObservableObject {
                 errorMessage: entry.errorMessage,
                 meetingTitle: entry.meetingTitle,
                 retryCount: entry.retryCount,
-                lastRetryDate: entry.lastRetryDate
+                lastRetryDate: entry.lastRetryDate,
+                errorKind: entry.errorKind
             ), true, true)
         }
 
@@ -259,7 +260,8 @@ public class FailedTranscriptionManager: ObservableObject {
             errorMessage: entry.errorMessage,
             meetingTitle: entry.meetingTitle,
             retryCount: entry.retryCount,
-            lastRetryDate: entry.lastRetryDate
+            lastRetryDate: entry.lastRetryDate,
+            errorKind: entry.errorKind
         ), true, false)
     }
 
@@ -298,7 +300,8 @@ public class FailedTranscriptionManager: ObservableObject {
             errorMessage: entry.errorMessage,
             meetingTitle: entry.meetingTitle,
             retryCount: entry.retryCount,
-            lastRetryDate: entry.lastRetryDate
+            lastRetryDate: entry.lastRetryDate,
+            errorKind: entry.errorKind
         ), true)
     }
 
@@ -465,7 +468,8 @@ public class FailedTranscriptionManager: ObservableObject {
         systemAudioURL: URL?,
         errorMessage: String,
         meetingTitle: String? = nil,
-        recordingDate: Date? = nil
+        recordingDate: Date? = nil,
+        errorKind: PipelineErrorKind? = nil
     ) -> Bool {
         // Security: validate incoming audio URLs before they ever reach the queue.
         // The on-disk load path already re-checks sandboxing, but without this guard an
@@ -485,7 +489,8 @@ public class FailedTranscriptionManager: ObservableObject {
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
             errorMessage: errorMessage,
-            meetingTitle: meetingTitle
+            meetingTitle: meetingTitle,
+            errorKind: errorKind
         )
 
         failedTranscriptions.append(failed)
@@ -539,7 +544,8 @@ public class FailedTranscriptionManager: ObservableObject {
             errorMessage: existing.errorMessage,
             meetingTitle: existing.meetingTitle,
             retryCount: existing.retryCount,
-            lastRetryDate: existing.lastRetryDate
+            lastRetryDate: existing.lastRetryDate,
+            errorKind: existing.errorKind
         )
 
         let didPersist = saveFailedTranscriptions()
@@ -620,7 +626,11 @@ public class FailedTranscriptionManager: ObservableObject {
     }
 
     @discardableResult
-    public func updateFailedTranscriptionError(id: UUID, errorMessage: String) -> Bool {
+    public func updateFailedTranscriptionError(
+        id: UUID,
+        errorMessage: String,
+        errorKind: PipelineErrorKind? = nil
+    ) -> Bool {
         guard let index = failedTranscriptions.firstIndex(where: { $0.id == id }) else {
             return false
         }
@@ -635,7 +645,8 @@ public class FailedTranscriptionManager: ObservableObject {
             errorMessage: errorMessage,
             meetingTitle: existing.meetingTitle,
             retryCount: existing.retryCount,
-            lastRetryDate: existing.lastRetryDate
+            lastRetryDate: existing.lastRetryDate,
+            errorKind: errorKind
         )
 
         let didPersist = saveFailedTranscriptions()

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -255,4 +255,33 @@ func testMeetingFailureKind() {
 
         assertEqual(kind, .unexpectedError, "unknown failures should avoid the vague 'other' label")
     }
+
+    runSuite("MeetingFailureKind prefers a typed errorKind over message text") {
+        // The message alone would legacy-match .recordingTooShort — the typed
+        // kind must win so a stale/generic message can't override it.
+        let kind = MeetingFailureKind.classify(errorKind: .saveFailed, message: "Recording too short")
+
+        assertEqual(kind, .saveFailed, "a typed errorKind should override legacy message matching")
+    }
+
+    runSuite("MeetingFailureKind falls back to message matching when errorKind is nil") {
+        let kind = MeetingFailureKind.classify(errorKind: nil, message: "Recording too short")
+
+        assertEqual(kind, .recordingTooShort, "nil errorKind should defer to the legacy string classifier")
+    }
+
+    runSuite("MeetingFailureKind maps PipelineErrorKind naming differences correctly") {
+        // These two rename across the Core/Meeting boundary — pin the mapping
+        // explicitly so a future rename on either side is caught here.
+        assertEqual(
+            MeetingFailureKind(errorKind: .transcriptionAlreadyInProgress),
+            .pipelineBusy,
+            "PipelineErrorKind.transcriptionAlreadyInProgress should map to MeetingFailureKind.pipelineBusy"
+        )
+        assertEqual(
+            MeetingFailureKind(errorKind: .missingSystemAudio),
+            .systemAudioPermission,
+            "PipelineErrorKind.missingSystemAudio should map to MeetingFailureKind.systemAudioPermission"
+        )
+    }
 }

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -284,4 +284,41 @@ func testMeetingFailureKind() {
             "PipelineErrorKind.missingSystemAudio should map to MeetingFailureKind.systemAudioPermission"
         )
     }
+
+    // MARK: - Codex review regression: text-routed errors keep classifying
+    // exactly as they did on main once TranscriptionTaskManager.failureKind(for:)
+    // stopped persisting a kind for non-typed errors. classify(errorKind: nil,
+    // message:) always defers to classify(message:), so these pin the same
+    // three example messages the Core-side regression tests use to their
+    // (unchanged) legacy bucket.
+
+    runSuite("MeetingFailureKind classifies the CoreAudio -50 regression message as unexpected") {
+        let message = "The operation couldn't be completed. (com.apple.coreaudio.avfaudio error -50.)"
+
+        assertEqual(
+            MeetingFailureKind.classify(errorKind: nil, message: message),
+            .unexpectedError,
+            "a raw CoreAudio device error with no typed kind should stay in the generic bucket, not a specific one it never earned"
+        )
+    }
+
+    runSuite("MeetingFailureKind classifies the broad empty-audio regression message") {
+        let message = "Empty audio was captured from the input device"
+
+        assertEqual(
+            MeetingFailureKind.classify(errorKind: nil, message: message),
+            .emptyAudio,
+            "classify(message:) is unchanged by the errorKind fix — this message already matched its own 'empty audio' keyword on main"
+        )
+    }
+
+    runSuite("MeetingFailureKind classifies the screen-recording regression message") {
+        let message = "Recording stopped because Screen Recording access was revoked mid-capture"
+
+        assertEqual(
+            MeetingFailureKind.classify(errorKind: nil, message: message),
+            .systemAudioPermission,
+            "classify(message:) is unchanged by the errorKind fix — this message already matched its own 'screen recording' keyword on main"
+        )
+    }
 }

--- a/Tests/PipelineErrorKindContractTests.swift
+++ b/Tests/PipelineErrorKindContractTests.swift
@@ -1,0 +1,72 @@
+// PipelineErrorKindContractTests.swift
+// Pins the typed `PipelineErrorKind` classification path against the legacy
+// string-matching fallback so they cannot silently drift apart while the
+// fallback still exists for pre-typed-error `FailedTranscription` entries.
+//
+// The canonical messages below are the exact strings
+// `TranscriptionTaskManager.safeFailureDiagnosticMessage` produces for each
+// `PipelineErrorKind` case (pinned independently by
+// `TranscriptionPipelineErrorPolicyTests` in the TranscriptedCore SPM test
+// target — that file and this one together cover the full typed-error ->
+// canonical-message -> MeetingFailureKind chain, since `TranscriptionTaskManager`
+// itself is not part of this fast-test runner's flat compile).
+
+import Foundation
+
+private let pipelineErrorKindCanonicalMessages: [(kind: PipelineErrorKind, message: String)] = [
+    (.transcriptionAlreadyInProgress, "Transcription already in progress"),
+    (.missingSystemAudio, "System audio is required. Please grant System Audio Recording permission in System Settings."),
+    (.recordingTooShort, "Recording too short"),
+    (.emptyAudioFile, "Empty audio file"),
+    (.noSpeechDetected, "No speech detected"),
+    (.invalidAudioFormat, "Invalid audio format"),
+    (.microphoneAudioUnusable, "Microphone audio was not usable"),
+    (.saveFailed, "Failed to save transcript"),
+    (.modelNotLoaded, "Model not loaded"),
+    (.diarizationFailed, "Diarization failed"),
+    (.transcriptionInferenceFailed, "Transcription inference failed"),
+    (.pipelineFailed, "Pipeline failed"),
+]
+
+private func makeFailedTranscription(errorMessage: String, errorKind: PipelineErrorKind?) -> FailedTranscription {
+    FailedTranscription(
+        micAudioURL: URL(fileURLWithPath: "/tmp/pipeline-error-kind-contract-mic.wav"),
+        systemAudioURL: URL(fileURLWithPath: "/tmp/pipeline-error-kind-contract-system.wav"),
+        errorMessage: errorMessage,
+        errorKind: errorKind
+    )
+}
+
+func testPipelineErrorKindContract() {
+    runSuite("PipelineErrorKind covers every canonical safeFailureDiagnosticMessage bucket") {
+        assertEqual(
+            Set(pipelineErrorKindCanonicalMessages.map(\.kind)),
+            Set(PipelineErrorKind.allCases),
+            "every PipelineErrorKind case needs a canonical message fixture here, or the contract below silently skips it"
+        )
+    }
+
+    for fixture in pipelineErrorKindCanonicalMessages {
+        runSuite("PipelineErrorKind.\(fixture.kind.rawValue) — typed and legacy paths agree on MeetingFailureKind") {
+            let typedResult = MeetingFailureKind.classify(errorKind: fixture.kind, message: fixture.message)
+            let legacyResult = MeetingFailureKind.classify(errorKind: nil, message: fixture.message)
+
+            assertEqual(
+                typedResult,
+                legacyResult,
+                "typed kind \(fixture.kind.rawValue) classified as \(typedResult.rawValue) but legacy string matching on its canonical message classified as \(legacyResult.rawValue)"
+            )
+        }
+
+        runSuite("PipelineErrorKind.\(fixture.kind.rawValue) — typed and legacy isRetryable agree") {
+            let typedEntry = makeFailedTranscription(errorMessage: fixture.message, errorKind: fixture.kind)
+            let legacyEntry = makeFailedTranscription(errorMessage: fixture.message, errorKind: nil)
+
+            assertEqual(
+                typedEntry.isRetryable,
+                legacyEntry.isRetryable,
+                "typed kind \(fixture.kind.rawValue) disagreed with legacy string matching on isRetryable for its canonical message"
+            )
+        }
+    }
+}

--- a/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
@@ -427,6 +427,92 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertFalse(failure.isRetryable)
     }
 
+    func testFailedTranscriptionErrorKindTakesPrecedenceOverLegacyMessageMatching() {
+        // The message text alone would legacy-match "recording too short" (permanent),
+        // but a typed errorKind of .saveFailed (retryable) must win — proving the
+        // typed field is actually consulted first, not just carried as inert metadata.
+        let typed = FailedTranscription(
+            micAudioURL: testRoot.appendingPathComponent("mic.wav"),
+            systemAudioURL: testRoot.appendingPathComponent("system.wav"),
+            errorMessage: "Recording too short",
+            errorKind: .saveFailed
+        )
+        XCTAssertTrue(typed.isRetryable, "typed errorKind should take precedence over legacy message matching")
+
+        let legacy = FailedTranscription(
+            micAudioURL: testRoot.appendingPathComponent("mic.wav"),
+            systemAudioURL: testRoot.appendingPathComponent("system.wav"),
+            errorMessage: "Recording too short",
+            errorKind: nil
+        )
+        XCTAssertFalse(legacy.isRetryable, "without a typed kind, the same message should still fall back to legacy matching")
+    }
+
+    func testFailedTranscriptionDecodesLegacyJSONMissingErrorKindField() throws {
+        // Simulates a `FailedTranscription` persisted before `errorKind` existed:
+        // encode a current entry, then strip the "errorKind" key entirely (not just
+        // null it out) before decoding, matching what's actually on disk for old rows.
+        let modern = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: testRoot.appendingPathComponent("mic.wav"),
+            systemAudioURL: testRoot.appendingPathComponent("system.wav"),
+            errorMessage: "No speech detected",
+            errorKind: .noSpeechDetected
+        )
+        let encoded = try JSONEncoder.iso8601.encode(modern)
+        guard var object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
+            XCTFail("expected a JSON object")
+            return
+        }
+        XCTAssertNotNil(object["errorKind"], "precondition: the modern encoding should include errorKind")
+        object.removeValue(forKey: "errorKind")
+
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder.iso8601.decode(FailedTranscription.self, from: legacyData)
+
+        XCTAssertNil(decoded.errorKind, "legacy rows without the errorKind key must decode to nil, not fail or default")
+        XCTAssertEqual(decoded.errorMessage, "No speech detected")
+        XCTAssertFalse(decoded.isRetryable, "decoded legacy entry should still classify via the string fallback")
+    }
+
+    func testFailedTranscriptionManagerLoadsLegacyQueueFileWithoutErrorKind() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let micURL = paths.audioCaptures.appendingPathComponent("legacy-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 5_000),
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Empty audio file",
+            errorKind: .emptyAudioFile
+        )
+        let encoded = try JSONEncoder.iso8601.encode([entry])
+        guard var array = try JSONSerialization.jsonObject(with: encoded) as? [[String: Any]] else {
+            XCTFail("expected a JSON array")
+            return
+        }
+        array[0].removeValue(forKey: "errorKind")
+        let legacyQueueData = try JSONSerialization.data(withJSONObject: array)
+
+        try FileManager.default.createDirectory(
+            at: paths.failedQueue.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try legacyQueueData.write(to: paths.failedQueue, options: .atomic)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions.count, 1)
+        XCTAssertNil(manager.failedTranscriptions.first?.errorKind)
+        XCTAssertEqual(manager.failedTranscriptions.first?.errorMessage, "Empty audio file")
+        XCTAssertFalse(manager.failedTranscriptions.first?.isRetryable ?? true)
+    }
+
     func testLoadHealsMissingMicAudioToMergedSibling() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
@@ -231,12 +231,15 @@ final class TranscriptionPipelineErrorPolicyTests: XCTestCase {
         )
     }
 
-    // MARK: - failureKind(for:) — computed alongside safeFailureDiagnosticMessage
+    // MARK: - failureKind(for:) — narrower than safeFailureDiagnosticMessage
     //
-    // `failureKind(for:)` and `safeFailureDiagnosticMessage(for:)` share one
-    // internal classification pass (`failureClassification(for:)`), so these
-    // pin kind and message together for every error this function can see.
-    // A future edit that changes one without the other breaks here first.
+    // `failureKind(for:)` only returns non-nil for a genuine typed
+    // `PipelineError` (excluding `.unknown`, which just wraps free text).
+    // It is deliberately NOT sourced from the same broad text-fallback net
+    // `safeFailureDiagnosticMessage` uses for display messages — see the
+    // "text-routed" tests below for why leaking that broad net into the
+    // persisted `errorKind` would regress retryability/bucketing for
+    // failures that never carried a typed `PipelineError`.
 
     func testFailureKindRoutesTypedAudioErrors() {
         XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.emptyAudioFile), .emptyAudioFile)
@@ -256,83 +259,73 @@ final class TranscriptionPipelineErrorPolicyTests: XCTestCase {
         XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.saveFailed(detail: "disk full")), .saveFailed)
     }
 
-    func testFailureKindDelegatesUnknownPipelineErrorToTextClassifier() {
-        XCTAssertEqual(
+    func testFailureKindReturnsNilForUnknownPipelineError() {
+        // .unknown(underlying:) just wraps free text in a PipelineError case —
+        // it is not a genuine typed classification, so it must not persist a kind.
+        XCTAssertNil(
             TranscriptionTaskManager.failureKind(
                 for: PipelineError.unknown(underlying: "Transcription already in progress, please wait")
-            ),
-            .transcriptionAlreadyInProgress
+            )
         )
     }
 
-    func testFailureKindClassifiesTextRoutedErrorsConsistentlyWithTheirMessage() {
-        // Table of (error, expected kind, expected message) — every entry here
-        // exercises the same classification pass safeFailureDiagnosticMessage
-        // uses, so kind and message can never silently disagree.
-        let cases: [(error: Error, kind: PipelineErrorKind, message: String)] = [
+    func testFailureKindReturnsNilForNonPipelineErrors() {
+        // Table of (error, expected message) — safeFailureDiagnosticMessage still
+        // classifies these broadly for display purposes, but none of them carry a
+        // typed PipelineError, so failureKind(for:) must return nil for every one.
+        let cases: [(error: Error, message: String)] = [
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "TRANSCRIPTION ALREADY IN PROGRESS"]),
-                .transcriptionAlreadyInProgress,
                 "Transcription already in progress"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "System audio recording permission is required"]),
-                .missingSystemAudio,
                 PipelineError.missingSystemAudio.localizedDescription
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Audio recording was too short — at least 2 seconds required"]),
-                .recordingTooShort,
                 "Recording too short"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "No samples recorded"]),
-                .emptyAudioFile,
                 "Empty audio file"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "No speech detected in the recording"]),
-                .noSpeechDetected,
                 "No speech detected"
             ),
             (
                 NSError(domain: "com.apple.coreaudio.avfaudio", code: -50, userInfo: [NSLocalizedDescriptionKey: "avfaudio error -50"]),
-                .invalidAudioFormat,
                 "Invalid audio format"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to save the transcript to disk"]),
-                .saveFailed,
                 "Failed to save transcript"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Speech model failed to load"]),
-                .modelNotLoaded,
                 "Model not loaded"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "pyannote raised an internal error"]),
-                .diarizationFailed,
                 "Diarization failed"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Parakeet prediction failed at step 42"]),
-                .transcriptionInferenceFailed,
                 "Transcription inference failed"
             ),
             (
                 NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Something opaque happened in an unrelated subsystem"]),
-                .pipelineFailed,
                 "Pipeline failed"
             ),
         ]
 
         for testCase in cases {
-            XCTAssertEqual(
+            XCTAssertNil(
                 TranscriptionTaskManager.failureKind(for: testCase.error),
-                testCase.kind,
-                "kind mismatch for message: \(testCase.message)"
+                "expected nil errorKind for a non-PipelineError, got a kind for message: \(testCase.message)"
             )
+            // The display message classifier is unaffected by this change.
             XCTAssertEqual(
                 TranscriptionTaskManager.safeFailureDiagnosticMessage(for: testCase.error),
                 testCase.message
@@ -340,29 +333,76 @@ final class TranscriptionPipelineErrorPolicyTests: XCTestCase {
         }
     }
 
-    func testFailureKindCoversEveryPipelineErrorKindCase() {
-        // Every PipelineErrorKind case must be reachable from this classifier —
-        // an unreachable case would be dead weight nothing could ever set.
-        let reachableKinds = Set(
-            TranscriptionPipelineErrorPolicyTests_allCanonicalErrors.map {
-                TranscriptionTaskManager.failureKind(for: $0)
-            }
+    // MARK: - Codex review regression: text-routed errors must not become
+    // permanently non-retryable / misclassified via a persisted errorKind.
+    //
+    // Concrete regression this guards against: a raw CoreAudio NSError whose
+    // description happens to contain "avfaudio"/"coreaudio" would, before this
+    // fix, get classified by the broad display-message net as `.invalidAudioFormat`
+    // and PERSISTED as `errorKind`, making `FailedTranscription.isRetryable` false
+    // (Try Again hidden) for what was — on `main`, before typed errorKind existed —
+    // a transient, retryable CoreAudio device error bucketed as `unexpected_error`.
+
+    func testFailureKindIsNilForCoreAudioDeviceErrorText() {
+        // Exact fixture already pinned by
+        // testSafeFailureDiagnosticMessageClassifiesAvfaudioStringAsInvalidFormat.
+        let error = NSError(
+            domain: "com.apple.coreaudio.avfaudio",
+            code: -50,
+            userInfo: [NSLocalizedDescriptionKey: "The operation couldn't be completed. (com.apple.coreaudio.avfaudio error -50.)"]
         )
-        XCTAssertEqual(reachableKinds, Set(PipelineErrorKind.allCases))
+
+        XCTAssertNil(TranscriptionTaskManager.failureKind(for: error))
+
+        let failed = FailedTranscription(
+            micAudioURL: URL(fileURLWithPath: "/tmp/pipeline-error-kind-regression-mic.wav"),
+            systemAudioURL: nil,
+            errorMessage: error.localizedDescription,
+            errorKind: TranscriptionTaskManager.failureKind(for: error)
+        )
+        XCTAssertTrue(failed.isRetryable, "a transient CoreAudio device error should stay retryable, matching main")
+    }
+
+    func testFailureKindIsNilForBroadEmptyAudioVariantText() {
+        // Broader than "empty audio file" / "no samples recorded" — matches the
+        // display-message net's "empty audio" fragment but not the legacy
+        // row-level parser's narrower "empty audio file" / "no samples recorded".
+        let error = NSError(
+            domain: "Test",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "Empty audio was captured from the input device"]
+        )
+
+        XCTAssertNil(TranscriptionTaskManager.failureKind(for: error))
+
+        let failed = FailedTranscription(
+            micAudioURL: URL(fileURLWithPath: "/tmp/pipeline-error-kind-regression-mic.wav"),
+            systemAudioURL: nil,
+            errorMessage: error.localizedDescription,
+            errorKind: TranscriptionTaskManager.failureKind(for: error)
+        )
+        XCTAssertTrue(failed.isRetryable, "a broad 'empty audio' variant not matching the legacy permanent list should stay retryable")
+    }
+
+    func testFailureKindIsNilForScreenRecordingVariantText() {
+        // Matches the display-message net's "screen recording" fragment (used to
+        // pick the missingSystemAudio display message) but not the legacy
+        // row-level parser's permanent-failure keyword list, which only checks
+        // "System audio is required" / "System Audio Recording" verbatim.
+        let error = NSError(
+            domain: "Test",
+            code: 0,
+            userInfo: [NSLocalizedDescriptionKey: "Recording stopped because Screen Recording access was revoked mid-capture"]
+        )
+
+        XCTAssertNil(TranscriptionTaskManager.failureKind(for: error))
+
+        let failed = FailedTranscription(
+            micAudioURL: URL(fileURLWithPath: "/tmp/pipeline-error-kind-regression-mic.wav"),
+            systemAudioURL: URL(fileURLWithPath: "/tmp/pipeline-error-kind-regression-system.wav"),
+            errorMessage: error.localizedDescription,
+            errorKind: TranscriptionTaskManager.failureKind(for: error)
+        )
+        XCTAssertTrue(failed.isRetryable, "a 'screen recording' variant not matching the legacy permanent list should stay retryable")
     }
 }
-
-private let TranscriptionPipelineErrorPolicyTests_allCanonicalErrors: [Error] = [
-    PipelineError.emptyAudioFile,
-    PipelineError.microphoneAudioUnusable,
-    PipelineError.noSpeechDetected,
-    PipelineError.recordingTooShort(duration: 0.5),
-    PipelineError.invalidAudioFormat(detail: "bad"),
-    PipelineError.missingSystemAudio,
-    PipelineError.modelNotLoaded(model: "Parakeet"),
-    PipelineError.saveFailed(detail: "disk full"),
-    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "TRANSCRIPTION ALREADY IN PROGRESS"]),
-    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "pyannote raised an internal error"]),
-    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Parakeet prediction failed at step 42"]),
-    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Something opaque happened in an unrelated subsystem"]),
-]

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
@@ -230,4 +230,139 @@ final class TranscriptionPipelineErrorPolicyTests: XCTestCase {
             actual
         )
     }
+
+    // MARK: - failureKind(for:) — computed alongside safeFailureDiagnosticMessage
+    //
+    // `failureKind(for:)` and `safeFailureDiagnosticMessage(for:)` share one
+    // internal classification pass (`failureClassification(for:)`), so these
+    // pin kind and message together for every error this function can see.
+    // A future edit that changes one without the other breaks here first.
+
+    func testFailureKindRoutesTypedAudioErrors() {
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.emptyAudioFile), .emptyAudioFile)
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.noSpeechDetected), .noSpeechDetected)
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.recordingTooShort(duration: 0.5)), .recordingTooShort)
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.invalidAudioFormat(detail: "bad")), .invalidAudioFormat)
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.microphoneAudioUnusable), .microphoneAudioUnusable)
+    }
+
+    func testFailureKindRoutesTypedSystemAndModelErrors() {
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.missingSystemAudio), .missingSystemAudio)
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.modelNotLoaded(model: "Parakeet")), .modelNotLoaded)
+        XCTAssertEqual(
+            TranscriptionTaskManager.failureKind(for: PipelineError.modelInferenceFailed(model: "Parakeet", underlying: "boom")),
+            .transcriptionInferenceFailed
+        )
+        XCTAssertEqual(TranscriptionTaskManager.failureKind(for: PipelineError.saveFailed(detail: "disk full")), .saveFailed)
+    }
+
+    func testFailureKindDelegatesUnknownPipelineErrorToTextClassifier() {
+        XCTAssertEqual(
+            TranscriptionTaskManager.failureKind(
+                for: PipelineError.unknown(underlying: "Transcription already in progress, please wait")
+            ),
+            .transcriptionAlreadyInProgress
+        )
+    }
+
+    func testFailureKindClassifiesTextRoutedErrorsConsistentlyWithTheirMessage() {
+        // Table of (error, expected kind, expected message) — every entry here
+        // exercises the same classification pass safeFailureDiagnosticMessage
+        // uses, so kind and message can never silently disagree.
+        let cases: [(error: Error, kind: PipelineErrorKind, message: String)] = [
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "TRANSCRIPTION ALREADY IN PROGRESS"]),
+                .transcriptionAlreadyInProgress,
+                "Transcription already in progress"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "System audio recording permission is required"]),
+                .missingSystemAudio,
+                PipelineError.missingSystemAudio.localizedDescription
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Audio recording was too short — at least 2 seconds required"]),
+                .recordingTooShort,
+                "Recording too short"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "No samples recorded"]),
+                .emptyAudioFile,
+                "Empty audio file"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "No speech detected in the recording"]),
+                .noSpeechDetected,
+                "No speech detected"
+            ),
+            (
+                NSError(domain: "com.apple.coreaudio.avfaudio", code: -50, userInfo: [NSLocalizedDescriptionKey: "avfaudio error -50"]),
+                .invalidAudioFormat,
+                "Invalid audio format"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Failed to save the transcript to disk"]),
+                .saveFailed,
+                "Failed to save transcript"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Speech model failed to load"]),
+                .modelNotLoaded,
+                "Model not loaded"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "pyannote raised an internal error"]),
+                .diarizationFailed,
+                "Diarization failed"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Parakeet prediction failed at step 42"]),
+                .transcriptionInferenceFailed,
+                "Transcription inference failed"
+            ),
+            (
+                NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Something opaque happened in an unrelated subsystem"]),
+                .pipelineFailed,
+                "Pipeline failed"
+            ),
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(
+                TranscriptionTaskManager.failureKind(for: testCase.error),
+                testCase.kind,
+                "kind mismatch for message: \(testCase.message)"
+            )
+            XCTAssertEqual(
+                TranscriptionTaskManager.safeFailureDiagnosticMessage(for: testCase.error),
+                testCase.message
+            )
+        }
+    }
+
+    func testFailureKindCoversEveryPipelineErrorKindCase() {
+        // Every PipelineErrorKind case must be reachable from this classifier —
+        // an unreachable case would be dead weight nothing could ever set.
+        let reachableKinds = Set(
+            TranscriptionPipelineErrorPolicyTests_allCanonicalErrors.map {
+                TranscriptionTaskManager.failureKind(for: $0)
+            }
+        )
+        XCTAssertEqual(reachableKinds, Set(PipelineErrorKind.allCases))
+    }
 }
+
+private let TranscriptionPipelineErrorPolicyTests_allCanonicalErrors: [Error] = [
+    PipelineError.emptyAudioFile,
+    PipelineError.microphoneAudioUnusable,
+    PipelineError.noSpeechDetected,
+    PipelineError.recordingTooShort(duration: 0.5),
+    PipelineError.invalidAudioFormat(detail: "bad"),
+    PipelineError.missingSystemAudio,
+    PipelineError.modelNotLoaded(model: "Parakeet"),
+    PipelineError.saveFailed(detail: "disk full"),
+    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "TRANSCRIPTION ALREADY IN PROGRESS"]),
+    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "pyannote raised an internal error"]),
+    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Parakeet prediction failed at step 42"]),
+    NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Something opaque happened in an unrelated subsystem"]),
+]

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -359,6 +359,7 @@ APP_SOURCES=(
     "Sources/Observability/UnrecognizedSelectorReason.swift"
     "Sources/Reliability/WakeRecoveryCoordinator.swift"
     "Sources/TranscriptedCore/Models/SpeakerMapping.swift"
+    "Sources/TranscriptedCore/Models/FailedTranscription.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerMatchOutcome.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerPeopleReviewPolicy.swift"


### PR DESCRIPTION
## Summary

Failure meaning for the transcription pipeline was re-derived from human-readable `errorMessage` strings by **five independent `.contains(...)` keyword parsers**, even though `TranscriptionTaskManager` has the typed Swift `Error` in hand at the moment a failure occurs. These parsers had already drifted apart once in production (commit `7c70a0c1`, "fix: align pipelineBusy classifier with actual TranscriptionTaskManager error message").

This PR adds a stable, `Codable` `PipelineErrorKind` enum, computes it **once** where the typed error still exists, threads it through `FailedTranscription` as an optional field, and converts the downstream classifiers to prefer it — keeping the existing keyword matching only as an explicit legacy fallback for entries with no typed kind.

## The five parsers (audit)

1. `TranscriptionTaskManager.safeFailureDiagnosticMessage` (Core) — typed `PipelineError` switch + `.contains(...)` text fallback → canonical display string. **Has the typed error, throws the type info away.**
2. `importedAudioFailureDisplayMessage` / `savedAudioRetranscriptionFailureDisplayMessage` (Core) — re-parses the canonical string from #1 via more `.contains(...)` chains into user-facing copy.
3. `FailedTranscription.pipelineError` + `isRetryable` (Core) — re-parses the persisted `errorMessage` back into a `PipelineError` via its own keyword chain + a separate "permanent" keyword list.
4. `MeetingFailureKind.classify(message:)` (Meeting) — a third independent keyword pass, with a much broader taxonomy (permission gates, import prep, stop timeout, speaker-name finalization, ...) since it also classifies failures that never flow through Core's typed `PipelineError` at all.
5. `MeetingFailureExplanation` retryability derivation (Meeting) — on inspection this one **already switches on the typed `MeetingFailureKind` enum**, not raw strings, so nothing needed to change there directly; it benefits automatically once #4 gets typed-aware.

## Bucket enumeration

`PipelineErrorKind` covers the buckets reachable from `TranscriptionTaskManager`'s own classification (its typed `PipelineError` switch, unioned with its `.contains(...)` text fallback — since `FailedTranscription.errorMessage` is often the raw, non-canonicalized `error.localizedDescription`, not the canonical string, so the fallback matters):

| `PipelineErrorKind` | Canonical message | `isRetryable` | Maps to `MeetingFailureKind` |
|---|---|---|---|
| `transcriptionAlreadyInProgress` | "Transcription already in progress" | true | `.pipelineBusy` |
| `missingSystemAudio` | `PipelineError.missingSystemAudio.localizedDescription` | false* | `.systemAudioPermission` |
| `recordingTooShort` | "Recording too short" | false | `.recordingTooShort` |
| `emptyAudioFile` | "Empty audio file" | false | `.emptyAudio` |
| `noSpeechDetected` | "No speech detected" | false | `.noSpeechDetected` |
| `invalidAudioFormat` | "Invalid audio format" | false | `.invalidAudioFormat` |
| `microphoneAudioUnusable` | "Microphone audio was not usable" | false | `.microphoneAudioUnusable` |
| `saveFailed` | "Failed to save transcript" | true | `.saveFailed` |
| `modelNotLoaded` | "Model not loaded" / "\<model\> model not loaded" | true | `.modelNotLoaded` |
| `diarizationFailed` | "Diarization failed" | true | `.diarizationFailed` |
| `transcriptionInferenceFailed` | "Transcription inference failed" / "\<model\> inference failed" | true | `.transcriptionInferenceFailed` |
| `pipelineFailed` | "Pipeline failed" (default fallback) | true | `.pipelineFailed` |

\* `missingSystemAudio` is forced retryable when `systemAudioURL == nil` (mic-only capture can still retry once permission is granted) — preserved from the existing logic on both the typed and legacy paths.

`MeetingFailureKind`'s remaining buckets (`microphonePermission`, `microphoneMissing`, `audioDeviceUnavailable`, `speakerNameFinalizationFailed`, `speakerFinalizationFailed`, `modelDownloadFailed`, `importFileMissing`, `importFileUnreadable`, `importUnsupportedFile`, `importCopyFailed`, `savedBeforeQuit`, `stopTimeout`, `unexpectedError`) come from failure sources that never carry a typed Core `PipelineError` — permission gates, import preparation, stop-timeout bookkeeping, speaker-name finalization. Those stay on the legacy string-matching fallback, since there is no typed error to compute a kind from in the first place; giving `PipelineErrorKind` cases for them would be untestable dead weight (nothing could ever set them, and the contract test below requires every case to have a real canonical message).

## Where it's threaded

- Computed once in `TranscriptionTaskManager`'s primary transcription-failure catch block, the retry-failure catch block, the imported-audio failure path, and the saved-audio-retranscription failure path — everywhere the typed `Error` is directly in hand.
- `TranscriptionTaskManager` gained `lastFailureErrorKind` (published, alongside the existing `lastFailureDiagnosticMessage`) for the live/in-session failure surface.
- `FailedTranscriptionManager.addFailedTranscription` / `updateFailedTranscriptionError` / all internal reconciliation rewrites now carry `errorKind` through persistence instead of dropping it.
- `FailedTranscription.isRetryable` checks `errorKind` first (including the mic-only `missingSystemAudio` special case), falling back to the renamed `legacyIsRetryable` / `legacyPipelineError` only when `errorKind == nil`.
- `MeetingFailureKind` gained `classify(errorKind:message:)` (typed-first, falls back to the pre-existing `classify(message:)` when `errorKind` is nil) and `init(errorKind:)` (the total, non-failable Core→Meeting mapping). `FailedMeetingPresentation` and `MeetingSessionController`'s terminal-failure handling now pass `errorKind` through.
- Import-preparation, permission-gate, and other non-Core failure sources are untouched — they never had a typed kind and still don't.

## Compatibility proof (old persisted `FailedTranscription` rows)

`errorKind` is a new optional `var` on a `Codable` struct with synthesized `Codable` conformance, so old on-disk rows missing the key decode to `errorKind == nil` for free. Proven directly rather than just asserted:

- `testFailedTranscriptionDecodesLegacyJSONMissingErrorKindField` (`Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift`) — encodes a modern entry, **strips the `errorKind` key entirely** (not just nulls it — matching what's actually on disk for pre-existing rows) via `JSONSerialization`, decodes it back, and asserts `errorKind == nil` plus that `isRetryable` still falls back correctly.
- `testFailedTranscriptionManagerLoadsLegacyQueueFileWithoutErrorKind` — same strip-the-key trick but through the full `FailedTranscriptionManager(paths:)` on-disk load path (the actual persisted-queue-file format), confirming the manager loads legacy rows without failing or defaulting oddly.
- `testFailedTranscriptionErrorKindTakesPrecedenceOverLegacyMessageMatching` — same message text, one entry typed and one not, proving the typed field is actually consulted first rather than just carried as inert metadata.

## Contract test (pins typed vs. legacy so they can't drift again)

`Tests/PipelineErrorKindContractTests.swift` (fast-test runner) asserts, for every `PipelineErrorKind` case, that classifying via the typed path (`MeetingFailureKind.classify(errorKind:message:)`) and via the legacy string path (`classify(message:)` on that kind's canonical message) yield the **same `MeetingFailureKind`** and the **same `isRetryable`**. It also asserts every `PipelineErrorKind` case has a canonical-message fixture, so a new case can't silently skip the contract.

`TranscriptionPipelineErrorPolicyTests.swift` (Core SPM target) complements this with `failureKind(for:)`/`safeFailureDiagnosticMessage(for:)` pinning: both are computed from one shared internal pass (`failureClassification(for:)`), so kind and message literally cannot drift from each other at the source.

(These live in two files because `Sources/Meeting/*` and `Sources/TranscriptedCore/*` are different compilation boundaries — the fast-test runner is a hand-curated flat `swiftc` compile with no module linking, while `TranscriptionTaskManager` is only reachable from the SPM package's `swift test`. `MeetingFailureKind.swift`'s `import TranscriptedCore` is now guarded behind `#if canImport(TranscriptedCore)`, matching the existing pattern used elsewhere in `Sources/Meeting`/`Sources/UI`, and `Sources/TranscriptedCore/Models/FailedTranscription.swift` was added to `run-tests.sh`'s flat source list so `PipelineErrorKind` is visible there too.)

## Verification

All run against a clean `build-deps.sh --force` in this worktree (Core sources changed):

- `bash build-deps.sh --force` — clean
- `bash build.sh --no-open` — clean (two pre-existing, unrelated `[#no-usage]` warnings in `MeetingSessionController.swift`/`DictationSessionController.swift`, not touched by this change)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12636 tests, 12636 passed, 0 failed
- `bash run-integration-smoke.sh` — core smoke + wake-recovery smoke + recovery-merge package tests all pass
- `swift test` — 884 tests, 13 skipped, 0 failures (includes the new contract + legacy-decode tests above)

## Concerns / follow-ups

- The synthetic hardcoded-string early-return paths in `TranscriptionTaskManager` (e.g. rejecting a second concurrent transcription, or a too-short recording caught before the pipeline even starts) still don't set `errorKind` — they're known-constant strings rather than typed errors, so they keep relying on the (unchanged, still-tested) legacy string fallback. Threading explicit kinds through those too would be a reasonable, low-risk follow-up but was left out to keep this diff focused on the actual typed-error path.
- `MeetingFailureExplanation` needed no code changes — it already switched on the typed `MeetingFailureKind` enum rather than parsing strings, so it inherits the fix once its callers pass a typed-aware `MeetingFailureKind` in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
