### PR TITLE
Make imported-audio recovery decide from the journal alone

### DIFF
--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -258,17 +258,61 @@ enum ImportedTranscriptionQueueJournal {
             || existingAudioURLs.contains(audioURL.standardizedFileURL)
     }
 
+    /// Resolves recovery from the journal's `phase` alone. This is the primary,
+    /// durable decision: `claim()` and the transcript-save completion path
+    /// (`TranscriptionTaskManager.markTaskTranscriptCommitted` →
+    /// `transcriptCommitConfirmed()`) both write `phase` as part of a single
+    /// atomic (temp-file + rename) journal write, so once a journal reports
+    /// `.transcriptCommitted` or `.scratchCleanupPending` that fact is
+    /// authoritative on its own — no other signal needs reconciling.
     static func recoveryAction(
+        phase: ImportedTranscriptionQueueJournalPhase
+    ) -> ImportedTranscriptionQueueJournalRecoveryAction {
+        switch phase {
+        case .scratchCleanupPending:
+            return .cleanScratch
+        case .transcriptCommitted:
+            return .handOffScratch
+        case .queued, .active:
+            return .replayTranscription
+        }
+    }
+
+    /// Legacy/crash-window migration fallback — the one remaining place
+    /// recovery still consults live filesystem state instead of the journal
+    /// alone.
+    ///
+    /// `recoveryAction(phase:)` is authoritative whenever the journal already
+    /// claims an outcome. This function only runs when it does not (`.queued`
+    /// or `.active`, i.e. no commit marker yet), which happens for two
+    /// distinct reasons:
+    ///
+    /// 1. A journal written by an app version that predates the
+    ///    transcript-commit phase transition. `ImportedTranscriptionQueueJournalRecord`
+    ///    decodes a missing `phase` key as `.queued`, so an old in-flight
+    ///    journal always looks unstarted even when its transcript was already
+    ///    saved before the app updated.
+    /// 2. The crash window between the transcript Markdown file being durably
+    ///    written and the `.transcriptCommitted` journal write that follows it
+    ///    immediately after. Those are two different files on two different
+    ///    fsync/rename operations, so no single atomic write can cover both —
+    ///    a crash in that exact window is a real possibility on every launch,
+    ///    not just a migration concern for old installs.
+    ///
+    /// In both cases the filesystem is searched once, at startup recovery, for
+    /// a transcript stamped with the journal's job id
+    /// (`TranscriptSaver.existingTranscriptURLs`). Finding one hands the
+    /// scratch audio off (recorded work is not lost) and the caller durably
+    /// upgrades the journal to `.transcriptCommitted` via
+    /// `transcriptCommitConfirmed()`, so the *next* recovery pass for the same
+    /// journal never needs this fallback again — the migration self-heals.
+    static func legacyRecoveryAction(
         phase: ImportedTranscriptionQueueJournalPhase,
         stableTranscriptExists: Bool
     ) -> ImportedTranscriptionQueueJournalRecoveryAction {
-        if phase == .scratchCleanupPending {
-            return .cleanScratch
-        }
-        if phase == .transcriptCommitted || stableTranscriptExists {
-            return .handOffScratch
-        }
-        return .replayTranscription
+        let journalOnlyAction = recoveryAction(phase: phase)
+        guard journalOnlyAction == .replayTranscription else { return journalOnlyAction }
+        return stableTranscriptExists ? .handOffScratch : .replayTranscription
     }
 
     private static func journalURL(for id: UUID, in directory: URL) -> URL {

--- a/Sources/Meeting/TranscriptionQueueCoordinator.swift
+++ b/Sources/Meeting/TranscriptionQueueCoordinator.swift
@@ -506,12 +506,24 @@ final class TranscriptionQueueCoordinator {
             }
             return (record, recoverySession)
         }
-        // Scan only after every available lease is held. A prior owner can no
-        // longer publish a stable transcript after this snapshot and leave us
-        // with stale evidence that would replay the same job.
+        // The journal alone decides recovery for phases that already record a
+        // definitive outcome (`ImportedTranscriptionQueueJournal.recoveryAction`).
+        // The filesystem is only ever consulted through the legacy/crash-window
+        // fallback (`legacyRecoveryAction`), and only for the subset of claimed
+        // records whose phase does not yet claim a committed transcript — so a
+        // normal relaunch, where every in-flight journal already reflects its
+        // outcome, does no directory scan at all. Scan only after every
+        // available lease is held: a prior owner can no longer publish a
+        // stable transcript after this snapshot and leave us with stale
+        // evidence that would replay the same job.
+        let ambiguousRecordIDs = Set(
+            claimedRecords
+                .filter { ImportedTranscriptionQueueJournal.recoveryAction(phase: $0.1.phase) == .replayTranscription }
+                .map { $0.0.id }
+        )
         let existingTranscriptsByID = TranscriptSaver.existingTranscriptURLs(
             in: MeetingStoragePaths.transcriptsFolder,
-            transcriptIds: Set(claimedRecords.map { $0.0.id })
+            transcriptIds: ambiguousRecordIDs
         )
         var recoveredJobIDs = Set(queuedTranscriptionJobs.map(\.id))
         var recoveredAudioURLs = Set(
@@ -563,11 +575,19 @@ final class TranscriptionQueueCoordinator {
                 continue
             }
 
-            let stableTranscriptExists = existingTranscriptsByID[record.id] != nil
-            switch ImportedTranscriptionQueueJournal.recoveryAction(
-                phase: recoverySession.phase,
-                stableTranscriptExists: stableTranscriptExists
-            ) {
+            let baseAction = ImportedTranscriptionQueueJournal.recoveryAction(phase: recoverySession.phase)
+            // Only ambiguous journals (no commit marker yet) consult the
+            // legacy/crash-window filesystem fallback; a journal that already
+            // claims an outcome never touches `existingTranscriptsByID`.
+            let stableTranscriptExists = baseAction == .replayTranscription
+                && existingTranscriptsByID[record.id] != nil
+            let action = baseAction == .replayTranscription
+                ? ImportedTranscriptionQueueJournal.legacyRecoveryAction(
+                    phase: recoverySession.phase,
+                    stableTranscriptExists: stableTranscriptExists
+                )
+                : baseAction
+            switch action {
             case .replayTranscription:
                 break
             case .cleanScratch:

--- a/Tests/MeetingImportedAudioPreparerTests.swift
+++ b/Tests/MeetingImportedAudioPreparerTests.swift
@@ -686,8 +686,7 @@ func testMeetingImportedAudioPreparer() async {
         assertEqual(cleanupOwner?.phase, .transcriptCommitted, "relaunch should preserve the committed cleanup phase")
         assertEqual(
             ImportedTranscriptionQueueJournal.recoveryAction(
-                phase: cleanupOwner?.phase ?? .active,
-                stableTranscriptExists: false
+                phase: cleanupOwner?.phase ?? .active
             ),
             .handOffScratch,
             "transcript commit alone must hand off audio intentionally retained after an archive failure"
@@ -719,38 +718,102 @@ func testMeetingImportedAudioPreparer() async {
         )
     }
 
-    runSuite("Imported transcription recovery resolves both transcript crash boundaries") {
+    runSuite("Imported transcription recovery decides from the journal phase alone") {
         assertEqual(
-            ImportedTranscriptionQueueJournal.recoveryAction(
-                phase: .active,
-                stableTranscriptExists: true
-            ),
-            .handOffScratch,
-            "a stable transcript identity must hand off uncertain scratch after the Markdown write but before the phase marker"
-        )
-        assertEqual(
-            ImportedTranscriptionQueueJournal.recoveryAction(
-                phase: .transcriptCommitted,
-                stableTranscriptExists: false
-            ),
-            .handOffScratch,
-            "a committed record without cleanup authorization must receive durable visible ownership"
-        )
-        assertEqual(
-            ImportedTranscriptionQueueJournal.recoveryAction(
-                phase: .active,
-                stableTranscriptExists: false
-            ),
+            ImportedTranscriptionQueueJournal.recoveryAction(phase: .queued),
             .replayTranscription,
-            "recovery should replay only when neither commit proof exists"
+            "an untouched journal has no commit proof, so recovery must replay it"
         )
         assertEqual(
-            ImportedTranscriptionQueueJournal.recoveryAction(
-                phase: .scratchCleanupPending,
-                stableTranscriptExists: false
-            ),
+            ImportedTranscriptionQueueJournal.recoveryAction(phase: .active),
+            .replayTranscription,
+            "recovery should replay only when the journal itself has no commit marker"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.recoveryAction(phase: .transcriptCommitted),
+            .handOffScratch,
+            "a committed record without cleanup authorization must receive durable visible ownership from the journal alone"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.recoveryAction(phase: .scratchCleanupPending),
             .cleanScratch,
-            "recovery should finish an authorized cleanup idempotently"
+            "recovery should finish an authorized cleanup idempotently from the journal alone"
+        )
+    }
+
+    runSuite("Imported transcription recovery falls back to the legacy filesystem check only when the journal is ambiguous") {
+        assertEqual(
+            ImportedTranscriptionQueueJournal.legacyRecoveryAction(phase: .active, stableTranscriptExists: true),
+            .handOffScratch,
+            "a stable transcript identity must hand off uncertain scratch after the Markdown write but before the phase marker — the inherent crash-between-transcript-write-and-journal-update window no single atomic write can close"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.legacyRecoveryAction(phase: .queued, stableTranscriptExists: true),
+            .handOffScratch,
+            "a journal written before the phase field existed decodes as .queued; the legacy fallback must still recognize its already-committed transcript"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.legacyRecoveryAction(phase: .active, stableTranscriptExists: false),
+            .replayTranscription,
+            "recovery should replay when neither the journal nor the legacy filesystem check shows commit proof"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.legacyRecoveryAction(phase: .transcriptCommitted, stableTranscriptExists: false),
+            .handOffScratch,
+            "the legacy fallback must defer entirely to the journal once it already claims commitment, never downgrading a committed phase"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.legacyRecoveryAction(phase: .scratchCleanupPending, stableTranscriptExists: false),
+            .cleanScratch,
+            "the legacy fallback must defer entirely to the journal for an authorized cleanup phase too"
+        )
+    }
+
+    runSuite("Imported transcription queue record decodes a pre-phase-field journal and recovers it via the legacy fallback") {
+        // Fixture: the on-disk shape written by an app version before `phase`
+        // and `owner` existed on the journal record. Decoding must still
+        // succeed (`phase` defaults to `.queued`), and because the journal
+        // alone cannot prove the transcript was already committed, recovery
+        // must fall through to the one legacy filesystem check to close the
+        // gap rather than silently losing or replaying already-finished work.
+        let id = UUID()
+        let recordingDate = Date(timeIntervalSince1970: 1_704_067_200)
+        let enqueuedAt = recordingDate.addingTimeInterval(5)
+        let legacyJSON = """
+        {
+            "id": "\(id.uuidString)",
+            "audioFilename": "imported-legacy.wav",
+            "recordingDate": \(recordingDate.timeIntervalSinceReferenceDate),
+            "enqueuedAt": \(enqueuedAt.timeIntervalSinceReferenceDate),
+            "sttModelRawValue": "parakeet"
+        }
+        """
+        let decoded = try! JSONDecoder().decode(
+            ImportedTranscriptionQueueJournalRecord.self,
+            from: Data(legacyJSON.utf8)
+        )
+        assertEqual(decoded.id, id, "a pre-phase-field journal should still decode its job identity")
+        assertEqual(
+            decoded.phase,
+            .queued,
+            "a journal predating the phase field must default to queued instead of failing to decode or dropping the record"
+        )
+        assertNil(decoded.owner, "a pre-owner-field journal should decode with no live lease owner")
+
+        assertEqual(
+            ImportedTranscriptionQueueJournal.recoveryAction(phase: decoded.phase),
+            .replayTranscription,
+            "the journal alone cannot prove a pre-phase-field record's transcript was already committed"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.legacyRecoveryAction(phase: decoded.phase, stableTranscriptExists: true),
+            .handOffScratch,
+            "the legacy filesystem fallback must still recover a pre-phase-field journal whose transcript already exists on disk"
+        )
+        assertEqual(
+            ImportedTranscriptionQueueJournal.legacyRecoveryAction(phase: decoded.phase, stableTranscriptExists: false),
+            .replayTranscription,
+            "a pre-phase-field journal with no transcript on disk should replay, the same as any unstarted job"
         )
     }
 


### PR DESCRIPTION
## Problem

`Sources/Meeting/MeetingImportedAudioPreparer.swift`'s
`ImportedTranscriptionQueueJournal.recoveryAction(phase:stableTranscriptExists:)`
reconciled two signals at decision time on every recovery pass: the
journal's `phase`, and a fresh filesystem lookup (`stableTranscriptExists`)
via `TranscriptSaver.existingTranscriptURLs`. It OR'd them unconditionally —
even for journals whose `phase` already recorded a definitive outcome
(`.transcriptCommitted`, `.scratchCleanupPending`). Nine narrow commits in
the recent window (`a5fca146`, `d8be6138`, `750e57ea`, `b84a7810`,
`9334dd82`, `c8443e1f`, …) each patched one interleaving of this
reconciliation; a live-filesystem signal layered on top of a durable
journal is exactly the shape that keeps producing new races to find.

## What was already true on `main`

Reading the file and its git history first turned up that two of the three
pieces of the requested design were **already implemented** by the prior
race-fix commits, so this PR does not re-do them:

1. **Single atomic journal write.** `ImportedTranscriptionQueueJournalRecord`
   already carries `phase` and `owner` as fields on one struct, and
   `claim()` already sets both in one in-memory update followed by exactly
   one `write()` call. `write()` was already atomic-rename (temp file +
   `fsync` + `rename` + directory `fsync`) — no separately-settable
   phase/owner fields, no non-atomic multi-step journal writes.
2. **Transcript-commit recorded into the journal at save time.**
   `TranscriptionPipelineRunner.commitSavedTranscriptSideEffectsUnlessCancelled`
   already calls `markTaskTranscriptCommitted(taskId:)` right after the
   transcript save commits, which already calls
   `importedRecoverySession?.transcriptCommitConfirmed()` — writing
   `.transcriptCommitted` into the journal atomically, in-process, using the
   same session/lock held since the job started.

## What this PR actually changes

The one gap: `recoveryAction` still took the live filesystem signal as a
required, always-consulted input, so *every* recovery pass re-derived
`stableTranscriptExists` for *every* claimed journal regardless of whether
the journal already answered the question. This PR splits the function:

- **`recoveryAction(phase:)`** — the sole, journal-only decision.
  `.scratchCleanupPending` → `cleanScratch`; `.transcriptCommitted` →
  `handOffScratch`; `.queued`/`.active` → `replayTranscription`. No
  filesystem access.
- **`legacyRecoveryAction(phase:stableTranscriptExists:)`** — the one
  remaining filesystem fallback, used *only* when `recoveryAction(phase:)`
  returns `.replayTranscription` (the journal has no commit marker yet).
  This covers two distinct cases with the same shape:
  1. A journal written by an app version predating the `phase` field — the
     decoder defaults a missing `phase` key to `.queued`, so an old
     in-flight journal looks unstarted even if its transcript was already
     saved.
  2. The crash window between the transcript Markdown file being durably
     written and the `.transcriptCommitted` journal write that follows it.
     Those are two different files with two different `fsync`/`rename`
     operations; no single atomic write can cover both, so this window is
     inherent on every launch, not just a migration concern for old
     installs. Documented inline on `legacyRecoveryAction`.

  When the fallback finds a stable transcript, the caller (unchanged) still
  calls `transcriptCommitConfirmed()`, durably upgrading the journal to
  `.transcriptCommitted` — so the *next* recovery pass for that same job
  never needs the fallback again.

`TranscriptionQueueCoordinator.recoverImportedAudioJobs()` now computes
`recoveryAction(phase:)` per claimed record *before* touching the
filesystem, and only includes the ambiguous subset's ids in the
`TranscriptSaver.existingTranscriptURLs` scan. A normal relaunch — where
every in-flight journal already reflects its outcome — does no directory
scan at all.

## Backward compatibility

- Round-trip test ("Imported transcription committed phase survives a crash
  until scratch cleanup") persists/claims/commits a journal exactly as
  today's app writes it (full schema, phase + owner) and proves it still
  recovers correctly.
- New fixture test ("...decodes a pre-phase-field journal and recovers it
  via the legacy fallback") hand-writes JSON missing the `phase`/`owner`
  keys entirely (the truly old on-disk shape), proves it still decodes
  (`phase` defaults to `.queued`), and proves `legacyRecoveryAction` is what
  recovers it.

## New/updated test coverage (`Tests/MeetingImportedAudioPreparerTests.swift`)

- `recoveryAction(phase:)` for all four phases (journal-only decisions).
- `legacyRecoveryAction(phase:stableTranscriptExists:)` for the crash-window
  case (`.active`, transcript exists on disk), the legacy-schema case
  (`.queued`, transcript exists), the no-proof case (replay), and proof that
  it never downgrades an already-committed/cleanup-pending phase.
- The pre-phase-field decode + recovery fixture above.

## Verification

- `bash build-deps.sh --force` (stamp mismatch on first run) — clean
- `bash build.sh --no-open` — clean (pre-existing unrelated `#no-usage`
  warnings in `MeetingSessionController.swift` / `DictationSessionController.swift`)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12618 tests, 0
  failed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh` — clean
  (app/core linkage, `MicRecordingFileMergerTests`, wake recovery)

## Deviations from the original ask

- No change was needed to make journal writes atomic-rename or to make
  phase/owner a single struct/write — both were already true. Said so above
  rather than re-implementing.
- The "transcript-save completion path records commit into the journal"
  wiring already existed (`markTaskTranscriptCommitted` →
  `transcriptCommitConfirmed()`); this PR did not touch that call site,
  only the decision function it feeds into during recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)