### PR TITLE
Replace pipeline cancellation param-threading with a rollback registry

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -737,10 +737,15 @@ extension TranscriptionTaskManager {
                     }
                 ))
             }
-            rollback.register { [weak self] in
-                await MainActor.run {
-                    self?.cancelSpeakerNamingRequest(transcriptId: transcriptId)
-                }
+            // Snapshot a strong local before the actor hop instead of capturing `[weak self]`
+            // into this closure: `self` isn't Sendable, so a weak capture that then crosses into
+            // a nested `@Sendable` MainActor closure warns today and is a hard error under
+            // Swift 6. The registry only ever lives for the duration of this call, so there is no
+            // retain-cycle risk in capturing strongly here — unlike `onComplete` above, which is
+            // handed off to a request object that can outlive this function.
+            let manager = self
+            rollback.register {
+                await manager.cancelSpeakerNamingRequest(transcriptId: transcriptId)
                 AppLogger.pipeline.info("Rollback: cancelled queued speaker naming request", [
                     "transcriptId": transcriptId.uuidString
                 ])
@@ -956,7 +961,11 @@ extension TranscriptionTaskManager {
         (statsStore ?? StatsDatabase.shared).recordSession(metadata)
     }
 
-    private func commitSavedTranscriptSideEffectsUnlessCancelled(
+    /// Not `private`: the "superseded task" branch below (`canCommitTaskSideEffects` returning
+    /// false without any `Task.checkCancellation()` throw) is exercised directly by
+    /// `PipelineRollbackRegistryManagerTests` so that scenario is tested against the real
+    /// method instead of only inferred from `PipelineRollbackRegistry`'s generic behavior.
+    func commitSavedTranscriptSideEffectsUnlessCancelled(
         taskId: UUID,
         savedURL: URL,
         result: TranscriptionResult,

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -197,25 +197,25 @@ extension TranscriptionTaskManager {
         ) else {
             throw PipelineError.saveFailed(detail: "Could not write mic-only transcript to \(outputFolder.lastPathComponent)")
         }
-        let deleteSavedTranscriptOnCancellation = replacementTranscriptRollback == nil
-        try await checkCancellationAfterTranscriptSideEffects(
+        let rollback = PipelineRollbackRegistry()
+        Self.registerSavedTranscriptRollback(
             savedURL: savedURL,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-            replacementTranscriptRollback: replacementTranscriptRollback
+            replacementTranscriptRollback: replacementTranscriptRollback,
+            into: rollback
         )
+        try await rollback.checkCancellation()
 
         let archiveOutcome = await archiveRecordingAudioIfConfigured(
             micURL: micURL,
             systemURL: nil,
             savedURL: savedURL
         )
-        try await checkCancellationAfterTranscriptSideEffects(
-            savedURL: savedURL,
-            retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-            replacementTranscriptRollback: replacementTranscriptRollback
+        Self.registerRetainedAudioRollback(
+            directory: archiveOutcome.retainedAudioDirectory,
+            urls: archiveOutcome.retainedAudioURLs,
+            into: rollback
         )
+        try await rollback.checkCancellation()
 
         try await commitSavedTranscriptSideEffectsUnlessCancelled(
             taskId: taskId,
@@ -225,10 +225,7 @@ extension TranscriptionTaskManager {
             meetingTitle: meetingTitle,
             transcriptDate: transcriptDate,
             notifier: notifier,
-            retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-            replacementTranscriptRollback: replacementTranscriptRollback
+            rollback: rollback
         )
 
         if archiveOutcome.didArchiveRecordingAudio && removeSourceAudioAfterArchive && sourceFailedTranscriptionId == nil {
@@ -548,12 +545,13 @@ extension TranscriptionTaskManager {
         ) else {
             throw PipelineError.saveFailed(detail: "Could not write transcript to \(outputFolder.lastPathComponent)")
         }
-        let deleteSavedTranscriptOnCancellation = replacementTranscriptRollback == nil
-        try await checkCancellationAfterTranscriptSideEffects(
+        let rollback = PipelineRollbackRegistry()
+        Self.registerSavedTranscriptRollback(
             savedURL: savedURL,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-            replacementTranscriptRollback: replacementTranscriptRollback
+            replacementTranscriptRollback: replacementTranscriptRollback,
+            into: rollback
         )
+        try await rollback.checkCancellation()
 
         AppLogger.pipeline.info("Phase 2 complete: Transcript saved", ["file": savedURL.lastPathComponent])
 
@@ -588,13 +586,12 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: nil,
                 retainedAudioURLs: []
             )
-        try await checkCancellationAfterTranscriptSideEffects(
-            savedURL: savedURL,
-            retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-            replacementTranscriptRollback: replacementTranscriptRollback
+        Self.registerRetainedAudioRollback(
+            directory: archiveOutcome.retainedAudioDirectory,
+            urls: archiveOutcome.retainedAudioURLs,
+            into: rollback
         )
+        try await rollback.checkCancellation()
         let shouldRemoveScratchAudio = archiveOutcome.didArchiveRecordingAudio && removeSourceAudioAfterArchive
 
         // Phase 3: Speaker naming — for system speakers that need action, plus any mic
@@ -632,17 +629,11 @@ extension TranscriptionTaskManager {
                         matchedProfileSnapshot: context?.matchedProfileSnapshot
                     ))
                 }
+                Self.registerSpeakerClipsRollback(clips.map(\.clipURL), channel: "system", into: rollback)
             } catch {
                 AppLogger.pipeline.warning("System clip extraction failed, skipping system naming", ["error": error.localizedDescription])
             }
-            try await checkCancellationAfterTranscriptSideEffects(
-                savedURL: savedURL,
-                retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-                retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: namingEntries.map(\.clipURL),
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-                replacementTranscriptRollback: replacementTranscriptRollback
-            )
+            try await rollback.checkCancellation()
         }
 
         // Mic-channel naming — surface every mic speaker with a persistent profile so the
@@ -679,17 +670,11 @@ extension TranscriptionTaskManager {
                         matchedProfileSnapshot: context?.matchedProfileSnapshot
                     ))
                 }
+                Self.registerSpeakerClipsRollback(micClips.map(\.clipURL), channel: "mic", into: rollback)
             } catch {
                 AppLogger.pipeline.warning("Mic clip extraction failed, skipping mic naming", ["error": error.localizedDescription])
             }
-            try await checkCancellationAfterTranscriptSideEffects(
-                savedURL: savedURL,
-                retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-                retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: namingEntries.map(\.clipURL),
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-                replacementTranscriptRollback: replacementTranscriptRollback
-            )
+            try await rollback.checkCancellation()
         }
 
         if !namingEntries.isEmpty {
@@ -720,14 +705,7 @@ extension TranscriptionTaskManager {
             }.count
 
             let capturedEntries = namingEntries
-            try await checkCancellationAfterTranscriptSideEffects(
-                savedURL: savedURL,
-                retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-                retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: capturedEntries.map(\.clipURL),
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-                replacementTranscriptRollback: replacementTranscriptRollback
-            )
+            try await rollback.checkCancellation()
             await MainActor.run {
                 let importedRecoverySession = self.importedRecoverySession(
                     taskId: taskId
@@ -759,15 +737,15 @@ extension TranscriptionTaskManager {
                     }
                 ))
             }
-            try await checkCancellationAfterTranscriptSideEffects(
-                savedURL: savedURL,
-                retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-                retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: capturedEntries.map(\.clipURL),
-                queuedSpeakerRequestTranscriptId: transcriptId,
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-                replacementTranscriptRollback: replacementTranscriptRollback
-            )
+            rollback.register { [weak self] in
+                await MainActor.run {
+                    self?.cancelSpeakerNamingRequest(transcriptId: transcriptId)
+                }
+                AppLogger.pipeline.info("Rollback: cancelled queued speaker naming request", [
+                    "transcriptId": transcriptId.uuidString
+                ])
+            }
+            try await rollback.checkCancellation()
             try await commitSavedTranscriptSideEffectsUnlessCancelled(
                 taskId: taskId,
                 savedURL: savedURL,
@@ -776,12 +754,7 @@ extension TranscriptionTaskManager {
                 meetingTitle: meetingTitle,
                 transcriptDate: transcriptDate,
                 notifier: notifier,
-                retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-                retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: capturedEntries.map(\.clipURL),
-                queuedSpeakerRequestTranscriptId: transcriptId,
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-                replacementTranscriptRollback: replacementTranscriptRollback
+                rollback: rollback
             )
             recordPendingAutoAcceptOutcomes()
 
@@ -801,10 +774,7 @@ extension TranscriptionTaskManager {
             meetingTitle: meetingTitle,
             transcriptDate: transcriptDate,
             notifier: notifier,
-            retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-            replacementTranscriptRollback: replacementTranscriptRollback
+            rollback: rollback
         )
         recordPendingAutoAcceptOutcomes()
 
@@ -835,7 +805,11 @@ extension TranscriptionTaskManager {
         let retainedAudioURLs: [URL]
     }
 
-    private struct ReplacementTranscriptRollback: Sendable {
+    /// Not `private`: exercised directly (via `@testable import`) by pipeline-rollback tests
+    /// that drive `registerSavedTranscriptRollback` through both its delete and restore branches
+    /// without re-running the whole async pipeline. Still internal-only — outside the module
+    /// boundary this stays invisible, same as before.
+    struct ReplacementTranscriptRollback: Sendable {
         let url: URL
         let originalData: Data
         private let originalFileDates: OriginalFileDates?
@@ -990,30 +964,15 @@ extension TranscriptionTaskManager {
         meetingTitle: String?,
         transcriptDate: Date,
         notifier: TranscriptNotifier?,
-        retainedAudioDirectory: URL? = nil,
-        retainedAudioURLs: [URL] = [],
-        speakerClipURLs: [URL] = [],
-        queuedSpeakerRequestTranscriptId: UUID? = nil,
-        deleteSavedTranscriptOnCancellation: Bool = true,
-        replacementTranscriptRollback: ReplacementTranscriptRollback? = nil
+        rollback: PipelineRollbackRegistry
     ) async throws {
-        try await checkCancellationAfterTranscriptSideEffects(
-            savedURL: savedURL,
-            retainedAudioDirectory: retainedAudioDirectory,
-            retainedAudioURLs: retainedAudioURLs,
-            speakerClipURLs: speakerClipURLs,
-            queuedSpeakerRequestTranscriptId: queuedSpeakerRequestTranscriptId,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
-            replacementTranscriptRollback: replacementTranscriptRollback
-        )
+        try await rollback.checkCancellation()
 
+        // Not a Task-cancellation rollback — a separate "did something else already claim this
+        // task's side effects" check (e.g. superseded by a retry). Still routes through the same
+        // registry so it undoes exactly what checkCancellation() would have.
         let didCommit = await MainActor.run {
-            guard canCommitTaskSideEffects(taskId: taskId) else {
-                if let queuedSpeakerRequestTranscriptId {
-                    cancelSpeakerNamingRequest(transcriptId: queuedSpeakerRequestTranscriptId)
-                }
-                return false
-            }
+            guard canCommitTaskSideEffects(taskId: taskId) else { return false }
 
             commitSavedTranscriptSideEffects(
                 savedURL: savedURL,
@@ -1028,84 +987,124 @@ extension TranscriptionTaskManager {
         }
 
         guard didCommit else {
-            cleanupCancelledTranscriptSideEffects(
-                savedURL: savedURL,
-                retainedAudioDirectory: retainedAudioDirectory,
-                retainedAudioURLs: retainedAudioURLs,
-                speakerClipURLs: speakerClipURLs,
-                deleteSavedTranscript: deleteSavedTranscriptOnCancellation,
-                replacementTranscriptRollback: replacementTranscriptRollback
-            )
+            await rollback.rollbackAll()
             throw CancellationError()
         }
     }
 
-    private func checkCancellationAfterTranscriptSideEffects(
+    /// Registers the saved-transcript rollback: restore the pre-existing file when this
+    /// run replaced one in place, otherwise delete the newly saved file. The two were
+    /// always tied together 1:1 at every previous call site (`deleteSavedTranscriptOnCancellation
+    /// = (replacementTranscriptRollback == nil)`), so that derivation is folded directly into
+    /// the branch here instead of being re-computed and re-threaded by each caller.
+    nonisolated static func registerSavedTranscriptRollback(
         savedURL: URL,
-        retainedAudioDirectory: URL? = nil,
-        retainedAudioURLs: [URL] = [],
-        speakerClipURLs: [URL] = [],
-        queuedSpeakerRequestTranscriptId: UUID? = nil,
-        deleteSavedTranscriptOnCancellation: Bool = true,
-        replacementTranscriptRollback: ReplacementTranscriptRollback? = nil
-    ) async throws {
+        replacementTranscriptRollback: ReplacementTranscriptRollback?,
+        into rollback: PipelineRollbackRegistry
+    ) {
+        if let replacementTranscriptRollback {
+            rollback.register {
+                replacementTranscriptRollback.restore()
+            }
+        } else {
+            rollback.register {
+                try? FileManager.default.removeItem(at: savedURL)
+                AppLogger.pipeline.info("Rollback: deleted saved transcript", ["file": savedURL.lastPathComponent])
+            }
+        }
+    }
+
+    /// Registers the retained-audio rollback: remove the archived audio files, then remove
+    /// the archive directory if that leaves it empty. No-op when nothing was archived.
+    nonisolated static func registerRetainedAudioRollback(
+        directory: URL?,
+        urls: [URL],
+        into rollback: PipelineRollbackRegistry
+    ) {
+        guard directory != nil || !urls.isEmpty else { return }
+        rollback.register {
+            for url in urls {
+                try? FileManager.default.removeItem(at: url)
+            }
+            if let directory {
+                let remaining = (try? FileManager.default.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: nil
+                )) ?? []
+                if remaining.isEmpty {
+                    try? FileManager.default.removeItem(at: directory)
+                }
+            }
+            AppLogger.pipeline.info("Rollback: removed retained meeting audio", [
+                "files": "\(urls.count)",
+                "directoryRemoved": "\(directory != nil)"
+            ])
+        }
+    }
+
+    /// Registers the rollback for one channel's freshly extracted speaker clips. No-op when
+    /// extraction produced nothing (matches today's behavior of only ever removing clips that
+    /// actually exist).
+    nonisolated static func registerSpeakerClipsRollback(
+        _ urls: [URL],
+        channel: String,
+        into rollback: PipelineRollbackRegistry
+    ) {
+        guard !urls.isEmpty else { return }
+        rollback.register {
+            for url in urls {
+                try? FileManager.default.removeItem(at: url)
+            }
+            AppLogger.pipeline.info("Rollback: removed extracted speaker clips", [
+                "channel": channel,
+                "count": "\(urls.count)"
+            ])
+        }
+    }
+
+}
+
+/// Accumulates undo closures for side effects performed while one transcription pipeline run
+/// (`transcribeMultichannelPipeline` / `transcribeMicrophoneOnlyPipeline`) progresses, so a late
+/// cancellation rolls back exactly what has happened without every checkpoint re-stating a
+/// growing "what to clean up if cancelled" parameter list. Each side effect registers its own
+/// undo as it happens; `checkCancellation()` runs them (most-recently-registered first) only if
+/// the run is actually cancelled at that point.
+///
+/// Created fresh per pipeline run and only ever driven by that run's single sequential `async`
+/// call chain — never handed to a concurrent Task or shared across runs. `@unchecked Sendable`
+/// here just satisfies the compiler for the awaited hops between the pipeline's `nonisolated`
+/// code and its `@MainActor` helpers; it is not asserting safety under real concurrent access.
+final class PipelineRollbackRegistry: @unchecked Sendable {
+    private var undos: [() async -> Void] = []
+
+    /// Register an undo for a side effect that just happened. Undos run in LIFO order — most
+    /// recently registered first — mirroring "last thing done, first thing undone".
+    func register(_ undo: @escaping () async -> Void) {
+        undos.append(undo)
+    }
+
+    /// Checks for cancellation. If cancelled, rolls back every registered undo and rethrows.
+    func checkCancellation() async throws {
         do {
             try Task.checkCancellation()
         } catch {
-            if let queuedSpeakerRequestTranscriptId {
-                await MainActor.run {
-                    cancelSpeakerNamingRequest(transcriptId: queuedSpeakerRequestTranscriptId)
-                }
-            }
-            cleanupCancelledTranscriptSideEffects(
-                savedURL: savedURL,
-                retainedAudioDirectory: retainedAudioDirectory,
-                retainedAudioURLs: retainedAudioURLs,
-                speakerClipURLs: speakerClipURLs,
-                deleteSavedTranscript: deleteSavedTranscriptOnCancellation,
-                replacementTranscriptRollback: replacementTranscriptRollback
-            )
+            await rollbackAll()
             throw error
         }
     }
 
-    nonisolated private func cleanupCancelledTranscriptSideEffects(
-        savedURL: URL,
-        retainedAudioDirectory: URL?,
-        retainedAudioURLs: [URL],
-        speakerClipURLs: [URL],
-        deleteSavedTranscript: Bool,
-        replacementTranscriptRollback: ReplacementTranscriptRollback?
-    ) {
-        if let replacementTranscriptRollback {
-            replacementTranscriptRollback.restore()
-        } else if deleteSavedTranscript {
-            try? FileManager.default.removeItem(at: savedURL)
+    /// Runs every registered undo (most-recently-registered first), then clears the registry.
+    /// Idempotent: undos are consumed as they run, so a second call is a no-op.
+    func rollbackAll() async {
+        guard !undos.isEmpty else { return }
+        let pending = Array(undos.reversed())
+        undos.removeAll()
+        AppLogger.pipeline.info("Rolling back pipeline side effects", ["steps": "\(pending.count)"])
+        for undo in pending {
+            await undo()
         }
-        for retainedAudioURL in retainedAudioURLs {
-            try? FileManager.default.removeItem(at: retainedAudioURL)
-        }
-        if let retainedAudioDirectory {
-            let remaining = (try? FileManager.default.contentsOfDirectory(
-                at: retainedAudioDirectory,
-                includingPropertiesForKeys: nil
-            )) ?? []
-            if remaining.isEmpty {
-                try? FileManager.default.removeItem(at: retainedAudioDirectory)
-            }
-        }
-        for clipURL in speakerClipURLs {
-            try? FileManager.default.removeItem(at: clipURL)
-        }
-        AppLogger.pipeline.info("Cleaned cancelled transcription side effects", [
-            "transcript": savedURL.lastPathComponent,
-            "transcriptRemoved": "\(deleteSavedTranscript)",
-            "clips": "\(speakerClipURLs.count)",
-            "retainedAudioFiles": "\(retainedAudioURLs.count)",
-            "retainedAudio": retainedAudioDirectory == nil ? "false" : "true"
-        ])
     }
-
 }
 
 @available(macOS 14.0, *)

--- a/Tests/TranscriptedCoreTests/PipelineTests/PipelineRollbackRegistryManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/PipelineRollbackRegistryManagerTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Companion to `PipelineRollbackRegistryTests.swift`. That file drives the register* helpers
+/// directly against fixture files — real production code, but no real `TranscriptionTaskManager`
+/// behind it. This file covers the two scenarios that genuinely need one:
+///
+///  - Checkpoint 6 (dequeuing a just-queued speaker naming request) mutates manager-owned queue
+///    state and triggers `cancelSpeakerNamingRequest`'s own clip cleanup — a recorder stand-in
+///    can't catch a regression in that wiring, only a real `enqueueSpeakerNamingRequest` /
+///    `cancelSpeakerNamingRequest` round trip can.
+///  - The "superseded task" rollback branch inside `commitSavedTranscriptSideEffectsUnlessCancelled`
+///    triggers on `canCommitTaskSideEffects(taskId:)` returning false, which is not a
+///    `Task.checkCancellation()` throw — a separate trigger path worth proving separately from
+///    the Task-cancellation path already covered generically.
+///
+/// Declared as an extension on `TranscriptionTaskManagerMetadataTests` (matching
+/// `TranscriptionTaskManagerImportedAudioTests.swift`) to reuse its `makeManager()` fixture and
+/// `tempDirectory` instead of re-implementing manager construction here.
+@available(macOS 14.0, *)
+@MainActor
+extension TranscriptionTaskManagerMetadataTests {
+
+    /// Mirrors the real `transcribeMultichannelPipeline` registration for checkpoint 6 exactly:
+    /// a strong `manager` local captured (not `[weak self]`) into `rollback.register { await
+    /// manager.cancelSpeakerNamingRequest(transcriptId:) }`. Asserts the queued request is
+    /// genuinely dequeued (not just that some closure ran) and that `cancelSpeakerNamingRequest`'s
+    /// own clip cleanup fires as a side effect, exactly as it would after a real cancellation.
+    func testRealDequeueRollbackCancelsQueuedSpeakerNamingRequestAndItsOwnClipCleanup() async throws {
+        let manager = makeManager()
+        let transcriptId = UUID()
+        let savedURL = tempDirectory.appendingPathComponent("transcripts").appendingPathComponent("Dequeue_Call.md")
+        try Data("transcript".utf8).write(to: savedURL)
+
+        // cancelSpeakerNamingRequest's own cleanup only deletes files under a managed cleanup
+        // directory (a safety guard against deleting arbitrary paths) — the same directory real
+        // clip extraction always writes to — so this clip must live there for that assertion to
+        // mean anything.
+        let clipURL = manager.transcription.speakerClipsDirectory.appendingPathComponent("system_speaker_0.caf")
+        try Data("clip".utf8).write(to: clipURL)
+
+        let entry = SpeakerNamingEntry(
+            id: UUID(),
+            diarizerSpeakerId: "0",
+            channel: .system,
+            clipURL: clipURL,
+            sampleText: "hello there",
+            currentName: nil,
+            matchSimilarity: nil,
+            needsNaming: true,
+            needsConfirmation: false
+        )
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [entry],
+            transcriptURL: savedURL,
+            transcriptId: transcriptId,
+            systemAudioURL: tempDirectory.appendingPathComponent("system.wav"),
+            micAudioURL: nil,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        ))
+        XCTAssertNotNil(manager.speakerNamingRequest, "request should be queued before rollback runs")
+
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerSavedTranscriptRollback(savedURL: savedURL, replacementTranscriptRollback: nil, into: rollback)
+        // The exact production pattern from transcribeMultichannelPipeline: snapshot a strong
+        // local before the actor hop, not [weak self].
+        rollback.register {
+            await manager.cancelSpeakerNamingRequest(transcriptId: transcriptId)
+        }
+
+        await rollback.rollbackAll()
+
+        XCTAssertNil(manager.speakerNamingRequest, "rollback should dequeue the request via the real coordinator method")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: savedURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path), "cancelSpeakerNamingRequest's own cleanupSpeakerClips should remove the clip")
+    }
+
+    /// Full six-checkpoint shape against a real manager and real files: transcript, retained
+    /// audio, both channels' clips, and a queued naming request that gets dequeued. Complements
+    /// the file-only checkpoints 1-4 covered in `PipelineRollbackRegistryTests.swift` by proving
+    /// the whole chain converges to a clean final state when a live manager is involved too.
+    func testRealCheckpointSixSequenceCleansEveryArtifactAndDequeuesTheRequest() async throws {
+        let manager = makeManager()
+        let transcriptId = UUID()
+
+        let savedURL = tempDirectory.appendingPathComponent("transcripts").appendingPathComponent("Full_Sequence.md")
+        try Data("transcript".utf8).write(to: savedURL)
+
+        let audioDirectory = tempDirectory.appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Full_Sequence_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        let micAudioURL = audioDirectory.appendingPathComponent("microphone.wav")
+        let systemAudioURL = audioDirectory.appendingPathComponent("system_audio.wav")
+        try Data("mic".utf8).write(to: micAudioURL)
+        try Data("system".utf8).write(to: systemAudioURL)
+
+        let clipsDirectory = manager.transcription.speakerClipsDirectory
+        let systemClipURL = clipsDirectory.appendingPathComponent("full_system_speaker_0.caf")
+        let micClipURL = clipsDirectory.appendingPathComponent("full_mic_speaker_0.caf")
+        try Data("system clip".utf8).write(to: systemClipURL)
+        try Data("mic clip".utf8).write(to: micClipURL)
+
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerSavedTranscriptRollback(savedURL: savedURL, replacementTranscriptRollback: nil, into: rollback)
+        TranscriptionTaskManager.registerRetainedAudioRollback(directory: audioDirectory, urls: [micAudioURL, systemAudioURL], into: rollback)
+        TranscriptionTaskManager.registerSpeakerClipsRollback([systemClipURL], channel: "system", into: rollback)
+        TranscriptionTaskManager.registerSpeakerClipsRollback([micClipURL], channel: "mic", into: rollback)
+
+        let entry = SpeakerNamingEntry(
+            id: UUID(),
+            diarizerSpeakerId: "0",
+            channel: .system,
+            clipURL: systemClipURL,
+            sampleText: "hello there",
+            currentName: nil,
+            matchSimilarity: nil,
+            needsNaming: true,
+            needsConfirmation: false
+        )
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [entry],
+            transcriptURL: savedURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemAudioURL,
+            micAudioURL: micAudioURL,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        ))
+        rollback.register {
+            await manager.cancelSpeakerNamingRequest(transcriptId: transcriptId)
+        }
+        XCTAssertNotNil(manager.speakerNamingRequest)
+
+        await rollback.rollbackAll()
+
+        XCTAssertNil(manager.speakerNamingRequest)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: savedURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micAudioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemClipURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micClipURL.path))
+    }
+
+    /// `canCommitTaskSideEffects(taskId:)` returning false — because `taskId` was never (or is no
+    /// longer) in `activeTasks` — is a distinct trigger from `Task.checkCancellation()` throwing,
+    /// but `commitSavedTranscriptSideEffectsUnlessCancelled` routes both through the same
+    /// `rollback.rollbackAll()`. Prove the superseded path for real: the ambient Task here is
+    /// never cancelled, only `taskId` is deliberately kept out of `activeTasks`.
+    func testSupersededTaskRollsBackThroughRealCommitSavedTranscriptSideEffectsUnlessCancelled() async throws {
+        let manager = makeManager()
+        let taskId = UUID()
+        let transcriptId = UUID()
+
+        let savedURL = tempDirectory.appendingPathComponent("transcripts").appendingPathComponent("Superseded_Call.md")
+        try Data("transcript".utf8).write(to: savedURL)
+        let audioDirectory = tempDirectory.appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Superseded_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        let micAudioURL = audioDirectory.appendingPathComponent("microphone.wav")
+        try Data("mic".utf8).write(to: micAudioURL)
+
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerSavedTranscriptRollback(savedURL: savedURL, replacementTranscriptRollback: nil, into: rollback)
+        TranscriptionTaskManager.registerRetainedAudioRollback(directory: audioDirectory, urls: [micAudioURL], into: rollback)
+
+        XCTAssertFalse(Task.isCancelled, "this scenario must be distinguishable from the Task-cancellation path")
+        XCTAssertNil(manager.activeTasks[taskId], "taskId is deliberately absent — this is what makes canCommitTaskSideEffects return false")
+
+        do {
+            try await manager.commitSavedTranscriptSideEffectsUnlessCancelled(
+                taskId: taskId,
+                savedURL: savedURL,
+                result: TranscriptionResult(micUtterances: [], systemUtterances: [], duration: 1, processingTime: 0.1),
+                transcriptId: transcriptId,
+                meetingTitle: nil,
+                transcriptDate: Date(),
+                notifier: nil,
+                rollback: rollback
+            )
+            XCTFail("Expected the superseded branch to throw CancellationError")
+        } catch is CancellationError {
+            // Expected — this helper has always thrown here, cancelled Task or not.
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: savedURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micAudioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioDirectory.path))
+    }
+}

--- a/Tests/TranscriptedCoreTests/PipelineTests/PipelineRollbackRegistryTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/PipelineRollbackRegistryTests.swift
@@ -111,6 +111,31 @@ final class PipelineRollbackRegistryTests: XCTestCase {
         XCTAssertEqual(order, ["undo"], "a second rollbackAll() must be a no-op — undos are consumed as they run")
     }
 
+    /// `rollbackAll()`'s undo loop never calls `Task.checkCancellation()` itself — it must not,
+    /// or a cleanup started because the task was cancelled would abort partway through and leak
+    /// whatever hadn't run yet. Prove every registered undo still executes even while the ambient
+    /// task is (already, genuinely) cancelled throughout the entire call.
+    func testRollbackAllRunsEveryUndoEvenWhileTheAmbientTaskIsAlreadyCancelled() async throws {
+        let rollback = PipelineRollbackRegistry()
+        let recorder = CallRecorder()
+        rollback.register { await recorder.record("first") }
+        rollback.register { await recorder.record("second") }
+        rollback.register { await recorder.record("third") }
+
+        let gate = CancellationGate()
+        let task = Task {
+            await gate.waitUntilOpened()
+            XCTAssertTrue(Task.isCancelled, "the task must genuinely be cancelled going into rollbackAll()")
+            await rollback.rollbackAll()
+        }
+        task.cancel()
+        await gate.open()
+        await task.value
+
+        let order = await recorder.order
+        XCTAssertEqual(order, ["third", "second", "first"], "cleanup mid-cancellation must still run to completion, LIFO")
+    }
+
     // MARK: - registerSavedTranscriptRollback
 
     func testRegisterSavedTranscriptRollbackDeletesSavedFileWhenNoReplacement() async throws {
@@ -245,36 +270,68 @@ final class PipelineRollbackRegistryTests: XCTestCase {
         XCTAssertEqual(order, ["sentinel"], "extraction that produced zero clips should register no undo")
     }
 
-    // MARK: - Full checkpoint sequence
+    // MARK: - Mic-only pipeline shape
 
-    /// Builds the artifacts a real `transcribeMultichannelPipeline` run would have produced by
-    /// each of its six cancellation checkpoints, registering rollback exactly as production code
-    /// does at each stage reached, then simulates cancellation landing at `stage`. Verifies only
-    /// the artifacts registered through that stage are cleaned, and — critically — that
-    /// artifacts belonging to stages the run never reached are untouched (because, matching
-    /// production, this helper never even creates them past `stage`).
-    private struct StageArtifacts {
-        let savedURL: URL
-        let retainedAudioDirectory: URL?
-        let retainedAudioURLs: [URL]
-        let systemClipURLs: [URL]
-        let micClipURLs: [URL]
-        let dequeueCalled: Bool
+    /// `transcribeMicrophoneOnlyPipeline` only ever has two cancellation checkpoints — save,
+    /// then archive — with no speaker clips and no naming request, unlike the six-checkpoint
+    /// multichannel shape covered below. Drives the same two production helpers in the same
+    /// order that function uses, so a regression that (for example) started registering a third
+    /// category for the mic-only path would show up here.
+    func testMicOnlyPipelineShapeOnlyEverRegistersTranscriptAndRetainedAudio() async throws {
+        let root = tempRoot.appendingPathComponent("mic-only", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let savedURL = root.appendingPathComponent("Call.md")
+        try Data("mic-only transcript".utf8).write(to: savedURL)
+        let audioDirectory = root.appendingPathComponent("Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        let micAudioURL = audioDirectory.appendingPathComponent("microphone.wav")
+        try Data("mic".utf8).write(to: micAudioURL)
+
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerSavedTranscriptRollback(savedURL: savedURL, replacementTranscriptRollback: nil, into: rollback)
+        TranscriptionTaskManager.registerRetainedAudioRollback(directory: audioDirectory, urls: [micAudioURL], into: rollback)
+
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: savedURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micAudioURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioDirectory.path))
     }
 
-    @discardableResult
-    private func runCheckpointSequence(upTo stage: Int, in root: URL) async throws -> (rollback: PipelineRollbackRegistry, artifacts: StageArtifacts, recorder: CallRecorder) {
+    // MARK: - Full checkpoint sequence (multichannel pipeline, checkpoints 1-4)
+
+    /// Builds the artifacts a real `transcribeMultichannelPipeline` run would have produced by
+    /// cancellation checkpoints 1-4, registering rollback with the exact production helpers at
+    /// each stage reached, then simulates cancellation landing at `stage`. Artifact creation
+    /// itself is gated by `stage`, not just registration — a "cancelled at checkpoint N" case
+    /// must not have later-stage files on disk at all, matching a real run that never got that
+    /// far, so a truncated run genuinely proves its stated boundary instead of merely leaving an
+    /// unregistered-but-present file untouched.
+    ///
+    /// Checkpoints 5 and 6 (the bare recheck before enqueuing, and dequeuing the just-queued
+    /// speaker naming request) need a real `TranscriptionTaskManager` to exercise for real —
+    /// `cancelSpeakerNamingRequest` mutates manager-owned queue state and its own clip cleanup —
+    /// so those are covered separately in `PipelineRollbackRegistryManagerTests.swift` against
+    /// production `enqueueSpeakerNamingRequest`/`cancelSpeakerNamingRequest`, not a stand-in here.
+    private struct StageArtifacts {
+        var savedURL: URL
+        var retainedAudioDirectory: URL?
+        var retainedAudioURLs: [URL] = []
+        var systemClipURLs: [URL] = []
+        var micClipURLs: [URL] = []
+    }
+
+    private func runCheckpointSequence(upTo stage: Int, in root: URL) throws -> (rollback: PipelineRollbackRegistry, artifacts: StageArtifacts) {
+        precondition((1...4).contains(stage), "this harness only models checkpoints 1-4; see the doc comment above")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let rollback = PipelineRollbackRegistry()
-        let recorder = CallRecorder()
 
         // Checkpoint 1: transcript saved.
         let savedURL = root.appendingPathComponent("Call.md")
         try Data("transcript".utf8).write(to: savedURL)
         TranscriptionTaskManager.registerSavedTranscriptRollback(savedURL: savedURL, replacementTranscriptRollback: nil, into: rollback)
-        guard stage >= 1 else {
-            return (rollback, StageArtifacts(savedURL: savedURL, retainedAudioDirectory: nil, retainedAudioURLs: [], systemClipURLs: [], micClipURLs: [], dequeueCalled: false), recorder)
-        }
+        var artifacts = StageArtifacts(savedURL: savedURL)
+        guard stage >= 2 else { return (rollback, artifacts) }
 
         // Checkpoint 2: recording audio archived.
         let audioDirectory = root.appendingPathComponent("Call_audio", isDirectory: true)
@@ -283,67 +340,49 @@ final class PipelineRollbackRegistryTests: XCTestCase {
         let systemAudioURL = audioDirectory.appendingPathComponent("system_audio.wav")
         try Data("mic".utf8).write(to: micAudioURL)
         try Data("system".utf8).write(to: systemAudioURL)
-        var retainedAudioURLs: [URL] = []
-        var retainedAudioDirectory: URL?
-        if stage >= 2 {
-            retainedAudioURLs = [micAudioURL, systemAudioURL]
-            retainedAudioDirectory = audioDirectory
-            TranscriptionTaskManager.registerRetainedAudioRollback(directory: audioDirectory, urls: retainedAudioURLs, into: rollback)
-        }
+        TranscriptionTaskManager.registerRetainedAudioRollback(directory: audioDirectory, urls: [micAudioURL, systemAudioURL], into: rollback)
+        artifacts.retainedAudioDirectory = audioDirectory
+        artifacts.retainedAudioURLs = [micAudioURL, systemAudioURL]
+        guard stage >= 3 else { return (rollback, artifacts) }
 
         // Checkpoint 3: system speaker clips extracted.
         let clipsDirectory = root.appendingPathComponent("clips", isDirectory: true)
         try FileManager.default.createDirectory(at: clipsDirectory, withIntermediateDirectories: true)
         let systemClipURL = clipsDirectory.appendingPathComponent("system_speaker_0.caf")
         try Data("system clip".utf8).write(to: systemClipURL)
-        var systemClipURLs: [URL] = []
-        if stage >= 3 {
-            systemClipURLs = [systemClipURL]
-            TranscriptionTaskManager.registerSpeakerClipsRollback(systemClipURLs, channel: "system", into: rollback)
-        }
+        TranscriptionTaskManager.registerSpeakerClipsRollback([systemClipURL], channel: "system", into: rollback)
+        artifacts.systemClipURLs = [systemClipURL]
+        guard stage >= 4 else { return (rollback, artifacts) }
 
         // Checkpoint 4: mic speaker clips extracted.
         let micClipURL = clipsDirectory.appendingPathComponent("mic_speaker_0.caf")
         try Data("mic clip".utf8).write(to: micClipURL)
-        var micClipURLs: [URL] = []
-        if stage >= 4 {
-            micClipURLs = [micClipURL]
-            TranscriptionTaskManager.registerSpeakerClipsRollback(micClipURLs, channel: "mic", into: rollback)
-        }
+        TranscriptionTaskManager.registerSpeakerClipsRollback([micClipURL], channel: "mic", into: rollback)
+        artifacts.micClipURLs = [micClipURL]
 
-        // Checkpoint 5 registers nothing new (a bare recheck before the MainActor enqueue hop).
-
-        // Checkpoint 6: speaker naming request enqueued — registers the dequeue undo.
-        if stage >= 6 {
-            rollback.register { await recorder.record("dequeue") }
-        }
-
-        return (
-            rollback,
-            StageArtifacts(
-                savedURL: savedURL,
-                retainedAudioDirectory: retainedAudioDirectory,
-                retainedAudioURLs: retainedAudioURLs,
-                systemClipURLs: systemClipURLs,
-                micClipURLs: micClipURLs,
-                dequeueCalled: false
-            ),
-            recorder
-        )
+        return (rollback, artifacts)
     }
 
-    func testCancellationAtSaveCheckpointOnlyRemovesTranscript() async throws {
+    func testCancellationAtSaveCheckpointOnlyEverCreatesAndRemovesTranscript() async throws {
         let root = tempRoot.appendingPathComponent("stage1", isDirectory: true)
-        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 1, in: root)
+        let (rollback, artifacts) = try runCheckpointSequence(upTo: 1, in: root)
+
+        // Prove the boundary, not just the cleanup: a run cancelled this early never even
+        // creates the later-stage directories, exactly like a real pipeline that never reached
+        // archiving or clip extraction.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("Call_audio").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("clips").path))
 
         await rollback.rollbackAll()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: artifacts.savedURL.path))
     }
 
-    func testCancellationAfterArchiveCheckpointRemovesTranscriptAndRetainedAudio() async throws {
+    func testCancellationAfterArchiveCheckpointRemovesTranscriptAndRetainedAudioButNeverCreatedClips() async throws {
         let root = tempRoot.appendingPathComponent("stage2", isDirectory: true)
-        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 2, in: root)
+        let (rollback, artifacts) = try runCheckpointSequence(upTo: 2, in: root)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("clips").path), "a run cancelled before clip extraction never creates the clips directory")
 
         await rollback.rollbackAll()
 
@@ -356,12 +395,14 @@ final class PipelineRollbackRegistryTests: XCTestCase {
         }
     }
 
-    func testCancellationAfterSystemClipsCheckpointAlsoRemovesSystemClipsButNotUnextractedMicClip() async throws {
+    func testCancellationAfterSystemClipsCheckpointAlsoRemovesSystemClipsButNeverCreatedMicClip() async throws {
         let root = tempRoot.appendingPathComponent("stage3", isDirectory: true)
-        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 3, in: root)
-        // Mic clip file exists on disk (created by the helper for the next stage) but was never
-        // registered, exactly like a real run that hasn't reached mic extraction yet.
+        let (rollback, artifacts) = try runCheckpointSequence(upTo: 3, in: root)
+        // The mic clip's checkpoint (4) was never reached, so — unlike the isolated
+        // registerSpeakerClipsRollback unit test above, which deliberately creates both clips to
+        // prove channel scoping — this file genuinely does not exist yet.
         let micClipURL = root.appendingPathComponent("clips", isDirectory: true).appendingPathComponent("mic_speaker_0.caf")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micClipURL.path), "a run cancelled before mic extraction never creates the mic clip")
 
         await rollback.rollbackAll()
 
@@ -369,23 +410,11 @@ final class PipelineRollbackRegistryTests: XCTestCase {
         for url in artifacts.systemClipURLs {
             XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
         }
-        XCTAssertTrue(FileManager.default.fileExists(atPath: micClipURL.path), "a clip from a checkpoint never reached must not be touched")
     }
 
     func testCancellationAfterMicClipsCheckpointRemovesBothChannelsClips() async throws {
         let root = tempRoot.appendingPathComponent("stage4", isDirectory: true)
-        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 4, in: root)
-
-        await rollback.rollbackAll()
-
-        for url in artifacts.systemClipURLs + artifacts.micClipURLs {
-            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
-        }
-    }
-
-    func testCancellationAfterQueuingNamingRequestDequeuesFirstThenCleansFilesLastRegisteredFirst() async throws {
-        let root = tempRoot.appendingPathComponent("stage6", isDirectory: true)
-        let (rollback, artifacts, recorder) = try await runCheckpointSequence(upTo: 6, in: root)
+        let (rollback, artifacts) = try runCheckpointSequence(upTo: 4, in: root)
 
         await rollback.rollbackAll()
 
@@ -393,7 +422,5 @@ final class PipelineRollbackRegistryTests: XCTestCase {
         for url in artifacts.retainedAudioURLs + artifacts.systemClipURLs + artifacts.micClipURLs {
             XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
         }
-        let order = await recorder.order
-        XCTAssertEqual(order, ["dequeue"], "the queued speaker-naming request should be dequeued as part of rollback")
     }
 }

--- a/Tests/TranscriptedCoreTests/PipelineTests/PipelineRollbackRegistryTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/PipelineRollbackRegistryTests.swift
@@ -1,0 +1,399 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Coordinates a Task-cancellation test so the cancellation is guaranteed to be visible
+/// *before* the task under test ever calls `Task.checkCancellation()`. `Task.cancel()` is
+/// synchronous, but a bare `Task { ... }` may start running on another thread before the
+/// caller gets around to cancelling it — gating the task body behind this continuation
+/// removes that race instead of relying on a sleep-then-cancel timing guess.
+private actor CancellationGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func waitUntilOpened() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor CallRecorder {
+    private(set) var order: [String] = []
+
+    func record(_ label: String) {
+        order.append(label)
+    }
+}
+
+/// Covers `PipelineRollbackRegistry`, the accumulator `transcribeMultichannelPipeline` /
+/// `transcribeMicrophoneOnlyPipeline` use so a late cancellation rolls back exactly the side
+/// effects that happened by that point, without every checkpoint re-stating a growing
+/// "what to clean up" parameter list (see `Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift`).
+///
+/// Two layers:
+///  - Generic registry mechanics (order, idempotency, non-cancelled no-op).
+///  - The three real `TranscriptionTaskManager.register*Rollback` helpers the pipeline calls at
+///    each checkpoint, driven directly against real temp-file artifacts standing in for a saved
+///    transcript, retained audio, and extracted speaker clips — so "cancelled at checkpoint N"
+///    is simulated by registering exactly the helpers a real run would have called by stage N
+///    and nothing more, then asserting only those artifacts get cleaned.
+@available(macOS 14.0, *)
+final class PipelineRollbackRegistryTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PipelineRollbackRegistryTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        super.tearDown()
+    }
+
+    // MARK: - Generic registry mechanics
+
+    func testCheckCancellationDoesNothingWhenNotCancelled() async throws {
+        let rollback = PipelineRollbackRegistry()
+        let recorder = CallRecorder()
+        rollback.register { await recorder.record("undo") }
+
+        try await rollback.checkCancellation()
+
+        let order = await recorder.order
+        XCTAssertTrue(order.isEmpty, "a non-cancelled checkpoint must not run any registered undo")
+    }
+
+    func testCheckCancellationRunsRegisteredUndosMostRecentlyRegisteredFirstThenRethrows() async throws {
+        let rollback = PipelineRollbackRegistry()
+        let recorder = CallRecorder()
+        rollback.register { await recorder.record("first") }
+        rollback.register { await recorder.record("second") }
+        rollback.register { await recorder.record("third") }
+
+        let gate = CancellationGate()
+        let task = Task {
+            await gate.waitUntilOpened()
+            try await rollback.checkCancellation()
+        }
+        task.cancel()
+        await gate.open()
+
+        do {
+            try await task.value
+            XCTFail("Expected cancellation to propagate")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        let order = await recorder.order
+        XCTAssertEqual(order, ["third", "second", "first"], "undos run LIFO: most-recently-registered first")
+    }
+
+    func testRollbackAllIsIdempotent() async {
+        let rollback = PipelineRollbackRegistry()
+        let recorder = CallRecorder()
+        rollback.register { await recorder.record("undo") }
+
+        await rollback.rollbackAll()
+        await rollback.rollbackAll()
+
+        let order = await recorder.order
+        XCTAssertEqual(order, ["undo"], "a second rollbackAll() must be a no-op — undos are consumed as they run")
+    }
+
+    // MARK: - registerSavedTranscriptRollback
+
+    func testRegisterSavedTranscriptRollbackDeletesSavedFileWhenNoReplacement() async throws {
+        let savedURL = tempRoot.appendingPathComponent("Call_2026-08-03.md")
+        try Data("saved transcript".utf8).write(to: savedURL)
+        let rollback = PipelineRollbackRegistry()
+
+        TranscriptionTaskManager.registerSavedTranscriptRollback(
+            savedURL: savedURL,
+            replacementTranscriptRollback: nil,
+            into: rollback
+        )
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: savedURL.path), "a fresh save with no replacement target should be deleted on rollback")
+    }
+
+    func testRegisterSavedTranscriptRollbackRestoresOriginalFileWhenReplacing() async throws {
+        let targetURL = tempRoot.appendingPathComponent("Reviewed_Call.md")
+        let originalContents = "original reviewed transcript"
+        try Data(originalContents.utf8).write(to: targetURL)
+        let replacementRollback = try XCTUnwrap(
+            try TranscriptionTaskManager.ReplacementTranscriptRollback.capture(for: targetURL),
+            "capture() should snapshot an existing target file"
+        )
+
+        // Simulate the pipeline overwriting the file in place with new content.
+        try Data("replacement transcript".utf8).write(to: targetURL)
+
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerSavedTranscriptRollback(
+            savedURL: targetURL,
+            replacementTranscriptRollback: replacementRollback,
+            into: rollback
+        )
+        await rollback.rollbackAll()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: targetURL.path), "a replacement rollback restores, never deletes, the target file")
+        let restored = try String(contentsOf: targetURL, encoding: .utf8)
+        XCTAssertEqual(restored, originalContents)
+    }
+
+    // MARK: - registerRetainedAudioRollback
+
+    func testRegisterRetainedAudioRollbackRemovesFilesAndEmptyDirectory() async throws {
+        let audioDirectory = tempRoot.appendingPathComponent("Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        let micURL = audioDirectory.appendingPathComponent("microphone.wav")
+        let systemURL = audioDirectory.appendingPathComponent("system_audio.wav")
+        try Data("mic".utf8).write(to: micURL)
+        try Data("system".utf8).write(to: systemURL)
+
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerRetainedAudioRollback(
+            directory: audioDirectory,
+            urls: [micURL, systemURL],
+            into: rollback
+        )
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: audioDirectory.path), "an emptied archive directory should be removed too")
+    }
+
+    func testRegisterRetainedAudioRollbackKeepsDirectoryWhenNotEmpty() async throws {
+        let audioDirectory = tempRoot.appendingPathComponent("Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        let micURL = audioDirectory.appendingPathComponent("microphone.wav")
+        let unrelatedURL = audioDirectory.appendingPathComponent("unrelated.txt")
+        try Data("mic".utf8).write(to: micURL)
+        try Data("leave me".utf8).write(to: unrelatedURL)
+
+        let rollback = PipelineRollbackRegistry()
+        // Only the mic URL was ever archived by this run — mirrors a run that only ever got as
+        // far as retaining one file before something else (out of scope here) wrote a neighbor.
+        TranscriptionTaskManager.registerRetainedAudioRollback(
+            directory: audioDirectory,
+            urls: [micURL],
+            into: rollback
+        )
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioDirectory.path), "a non-empty directory must survive rollback")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unrelatedURL.path))
+    }
+
+    func testRegisterRetainedAudioRollbackNoOpWhenNothingArchived() async {
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerRetainedAudioRollback(directory: nil, urls: [], into: rollback)
+
+        let recorder = CallRecorder()
+        // No undo should have been registered at all — prove it by registering a sentinel
+        // afterwards and checking rollbackAll() only ever ran the sentinel.
+        rollback.register { await recorder.record("sentinel") }
+        await rollback.rollbackAll()
+
+        let order = await recorder.order
+        XCTAssertEqual(order, ["sentinel"], "an archive outcome with nothing retained should register no undo")
+    }
+
+    // MARK: - registerSpeakerClipsRollback
+
+    func testRegisterSpeakerClipsRollbackOnlyRemovesRegisteredChannelClips() async throws {
+        let clipsDirectory = tempRoot.appendingPathComponent("clips", isDirectory: true)
+        try FileManager.default.createDirectory(at: clipsDirectory, withIntermediateDirectories: true)
+        let systemClipURL = clipsDirectory.appendingPathComponent("system_speaker_0.caf")
+        let micClipURL = clipsDirectory.appendingPathComponent("mic_speaker_0.caf")
+        try Data("system clip".utf8).write(to: systemClipURL)
+        try Data("mic clip".utf8).write(to: micClipURL)
+
+        // Cancellation at the "system clips extracted, mic clips not reached yet" checkpoint:
+        // only the system-channel helper has been called so far.
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerSpeakerClipsRollback([systemClipURL], channel: "system", into: rollback)
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemClipURL.path), "the registered channel's clip should be removed")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micClipURL.path), "a clip from a channel not yet registered must survive")
+    }
+
+    func testRegisterSpeakerClipsRollbackNoOpWhenNoClipsExtracted() async {
+        let rollback = PipelineRollbackRegistry()
+        TranscriptionTaskManager.registerSpeakerClipsRollback([], channel: "system", into: rollback)
+
+        let recorder = CallRecorder()
+        rollback.register { await recorder.record("sentinel") }
+        await rollback.rollbackAll()
+
+        let order = await recorder.order
+        XCTAssertEqual(order, ["sentinel"], "extraction that produced zero clips should register no undo")
+    }
+
+    // MARK: - Full checkpoint sequence
+
+    /// Builds the artifacts a real `transcribeMultichannelPipeline` run would have produced by
+    /// each of its six cancellation checkpoints, registering rollback exactly as production code
+    /// does at each stage reached, then simulates cancellation landing at `stage`. Verifies only
+    /// the artifacts registered through that stage are cleaned, and — critically — that
+    /// artifacts belonging to stages the run never reached are untouched (because, matching
+    /// production, this helper never even creates them past `stage`).
+    private struct StageArtifacts {
+        let savedURL: URL
+        let retainedAudioDirectory: URL?
+        let retainedAudioURLs: [URL]
+        let systemClipURLs: [URL]
+        let micClipURLs: [URL]
+        let dequeueCalled: Bool
+    }
+
+    @discardableResult
+    private func runCheckpointSequence(upTo stage: Int, in root: URL) async throws -> (rollback: PipelineRollbackRegistry, artifacts: StageArtifacts, recorder: CallRecorder) {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let rollback = PipelineRollbackRegistry()
+        let recorder = CallRecorder()
+
+        // Checkpoint 1: transcript saved.
+        let savedURL = root.appendingPathComponent("Call.md")
+        try Data("transcript".utf8).write(to: savedURL)
+        TranscriptionTaskManager.registerSavedTranscriptRollback(savedURL: savedURL, replacementTranscriptRollback: nil, into: rollback)
+        guard stage >= 1 else {
+            return (rollback, StageArtifacts(savedURL: savedURL, retainedAudioDirectory: nil, retainedAudioURLs: [], systemClipURLs: [], micClipURLs: [], dequeueCalled: false), recorder)
+        }
+
+        // Checkpoint 2: recording audio archived.
+        let audioDirectory = root.appendingPathComponent("Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+        let micAudioURL = audioDirectory.appendingPathComponent("microphone.wav")
+        let systemAudioURL = audioDirectory.appendingPathComponent("system_audio.wav")
+        try Data("mic".utf8).write(to: micAudioURL)
+        try Data("system".utf8).write(to: systemAudioURL)
+        var retainedAudioURLs: [URL] = []
+        var retainedAudioDirectory: URL?
+        if stage >= 2 {
+            retainedAudioURLs = [micAudioURL, systemAudioURL]
+            retainedAudioDirectory = audioDirectory
+            TranscriptionTaskManager.registerRetainedAudioRollback(directory: audioDirectory, urls: retainedAudioURLs, into: rollback)
+        }
+
+        // Checkpoint 3: system speaker clips extracted.
+        let clipsDirectory = root.appendingPathComponent("clips", isDirectory: true)
+        try FileManager.default.createDirectory(at: clipsDirectory, withIntermediateDirectories: true)
+        let systemClipURL = clipsDirectory.appendingPathComponent("system_speaker_0.caf")
+        try Data("system clip".utf8).write(to: systemClipURL)
+        var systemClipURLs: [URL] = []
+        if stage >= 3 {
+            systemClipURLs = [systemClipURL]
+            TranscriptionTaskManager.registerSpeakerClipsRollback(systemClipURLs, channel: "system", into: rollback)
+        }
+
+        // Checkpoint 4: mic speaker clips extracted.
+        let micClipURL = clipsDirectory.appendingPathComponent("mic_speaker_0.caf")
+        try Data("mic clip".utf8).write(to: micClipURL)
+        var micClipURLs: [URL] = []
+        if stage >= 4 {
+            micClipURLs = [micClipURL]
+            TranscriptionTaskManager.registerSpeakerClipsRollback(micClipURLs, channel: "mic", into: rollback)
+        }
+
+        // Checkpoint 5 registers nothing new (a bare recheck before the MainActor enqueue hop).
+
+        // Checkpoint 6: speaker naming request enqueued — registers the dequeue undo.
+        if stage >= 6 {
+            rollback.register { await recorder.record("dequeue") }
+        }
+
+        return (
+            rollback,
+            StageArtifacts(
+                savedURL: savedURL,
+                retainedAudioDirectory: retainedAudioDirectory,
+                retainedAudioURLs: retainedAudioURLs,
+                systemClipURLs: systemClipURLs,
+                micClipURLs: micClipURLs,
+                dequeueCalled: false
+            ),
+            recorder
+        )
+    }
+
+    func testCancellationAtSaveCheckpointOnlyRemovesTranscript() async throws {
+        let root = tempRoot.appendingPathComponent("stage1", isDirectory: true)
+        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 1, in: root)
+
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: artifacts.savedURL.path))
+    }
+
+    func testCancellationAfterArchiveCheckpointRemovesTranscriptAndRetainedAudio() async throws {
+        let root = tempRoot.appendingPathComponent("stage2", isDirectory: true)
+        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 2, in: root)
+
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: artifacts.savedURL.path))
+        for url in artifacts.retainedAudioURLs {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+        }
+        if let directory = artifacts.retainedAudioDirectory {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        }
+    }
+
+    func testCancellationAfterSystemClipsCheckpointAlsoRemovesSystemClipsButNotUnextractedMicClip() async throws {
+        let root = tempRoot.appendingPathComponent("stage3", isDirectory: true)
+        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 3, in: root)
+        // Mic clip file exists on disk (created by the helper for the next stage) but was never
+        // registered, exactly like a real run that hasn't reached mic extraction yet.
+        let micClipURL = root.appendingPathComponent("clips", isDirectory: true).appendingPathComponent("mic_speaker_0.caf")
+
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: artifacts.savedURL.path))
+        for url in artifacts.systemClipURLs {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micClipURL.path), "a clip from a checkpoint never reached must not be touched")
+    }
+
+    func testCancellationAfterMicClipsCheckpointRemovesBothChannelsClips() async throws {
+        let root = tempRoot.appendingPathComponent("stage4", isDirectory: true)
+        let (rollback, artifacts, _) = try await runCheckpointSequence(upTo: 4, in: root)
+
+        await rollback.rollbackAll()
+
+        for url in artifacts.systemClipURLs + artifacts.micClipURLs {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+        }
+    }
+
+    func testCancellationAfterQueuingNamingRequestDequeuesFirstThenCleansFilesLastRegisteredFirst() async throws {
+        let root = tempRoot.appendingPathComponent("stage6", isDirectory: true)
+        let (rollback, artifacts, recorder) = try await runCheckpointSequence(upTo: 6, in: root)
+
+        await rollback.rollbackAll()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: artifacts.savedURL.path))
+        for url in artifacts.retainedAudioURLs + artifacts.systemClipURLs + artifacts.micClipURLs {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+        }
+        let order = await recorder.order
+        XCTAssertEqual(order, ["dequeue"], "the queued speaker-naming request should be dequeued as part of rollback")
+    }
+}


### PR DESCRIPTION
## Summary

`transcribeMultichannelPipeline` (`Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift`) called `checkCancellationAfterTranscriptSideEffects(...)` at six checkpoints as the pipeline progressed, re-passing a growing hand-assembled "what to roll back" parameter list at each one (`savedURL`, `retainedAudioDirectory`, `retainedAudioURLs`, `speakerClipURLs`, `queuedSpeakerRequestTranscriptId`, `deleteSavedTranscriptOnCancellation`, `replacementTranscriptRollback`). Every new side effect had to be manually added to every subsequent call site, or a late cancellation would leak that artifact.

This replaces the threaded-parameter approach with `PipelineRollbackRegistry`, a small local accumulator (final class, `@unchecked Sendable` only to satisfy the compiler across the pipeline's `nonisolated` ⇄ `@MainActor` hops — never shared across concurrent tasks). Each side effect registers its own undo closure the moment it happens; every checkpoint collapses to `try await rollback.checkCancellation()`, which runs registered undos **in reverse (LIFO) order** and rethrows exactly as before.

Same fix applied to `transcribeMicrophoneOnlyPipeline`, which shared the same `checkCancellationAfterTranscriptSideEffects` / `cleanupCancelledTranscriptSideEffects` / `commitSavedTranscriptSideEffectsUnlessCancelled` helpers (that's why it wasn't split off — the plumbing is genuinely shared).

## Parameter → registration mapping

| Old parameter | New registration point |
|---|---|
| `savedURL` + `deleteSavedTranscriptOnCancellation` + `replacementTranscriptRollback` | `TranscriptionTaskManager.registerSavedTranscriptRollback(savedURL:replacementTranscriptRollback:into:)`, called once right after `TranscriptSaver.saveTranscript` succeeds. `deleteSavedTranscriptOnCancellation` was always derived as `replacementTranscriptRollback == nil` at every call site, so that derivation is now folded directly into the branch instead of being recomputed and re-threaded everywhere. |
| `retainedAudioDirectory` + `retainedAudioURLs` | `registerRetainedAudioRollback(directory:urls:into:)`, called once right after `archiveRecordingAudioIfConfigured` returns. Bundles "remove files, then remove the directory if that leaves it empty" into one closure, preserving the one real ordering dependency in the original cleanup. |
| `speakerClipURLs` (system) | `registerSpeakerClipsRollback(_:channel:"system",into:)`, called right after system-speaker clip extraction, scoped to only the clips just extracted (not the whole growing `namingEntries` list the old code re-passed). |
| `speakerClipURLs` (mic) | `registerSpeakerClipsRollback(_:channel:"mic",into:)`, called right after mic-speaker clip extraction, same scoping. |
| `queuedSpeakerRequestTranscriptId` | An inline `rollback.register { … cancelSpeakerNamingRequest(transcriptId:) … }` closure registered immediately after `enqueueSpeakerNamingRequest` succeeds. |

`commitSavedTranscriptSideEffectsUnlessCancelled`'s non-cancellation "was this task's side effects superseded?" branch (`canCommitTaskSideEffects` returning false) now also routes through `rollback.rollbackAll()` instead of a parallel hand-rolled cleanup call — same set of undos, same effect, one code path instead of two.

## Behavior notes / things I checked

- **Conditional rollback (the old `deleteSavedTranscriptOnCancellation` flag):** always tied 1:1 to `replacementTranscriptRollback == nil` at every original call site, so folding it into `registerSavedTranscriptRollback`'s branch is behavior-preserving, not just a simplification.
- **Ordering:** the original cleanup ran in a fixed order (transcript → retained-audio-files → retained-audio-dir → clips) regardless of when cancellation was detected. The new registry runs undos LIFO (most-recently-registered first), so the *order* of independent cleanup categories now differs from before. This is safe because all of them operate on disjoint filesystem paths with only one real dependency — retained-audio files must be removed before checking whether the directory is empty — which is preserved by keeping that as one atomic closure. The one *behaviorally* order-sensitive part (dequeue the speaker-naming request before other cleanup) is preserved too: the dequeue closure is registered last (after enqueue), so LIFO naturally runs it first, exactly matching the original code's explicit "dequeue first, then cleanup" sequencing.
- **Non-cancellation reuse:** `checkCancellationAfterTranscriptSideEffects`/`cleanupCancelledTranscriptSideEffects` were also invoked from the "superseded task" branch inside `commitSavedTranscriptSideEffectsUnlessCancelled` (not a `Task.checkCancellation()` throw). That path now calls `rollback.rollbackAll()` directly — same registry, same undos, explicitly documented in a code comment at that call site.
- Exposed `TranscriptionTaskManager.ReplacementTranscriptRollback` and the three `register*Rollback` static helpers as internal (dropped `private`) so the new test can drive them directly against real temp-file artifacts instead of re-implementing their logic — still invisible outside the module.

## Test plan

- [x] Added `Tests/TranscriptedCoreTests/PipelineTests/PipelineRollbackRegistryTests.swift`: generic registry mechanics (LIFO order, non-cancelled no-op, `rollbackAll()` idempotency), each `register*Rollback` helper exercised individually against real files/directories, and a composed "checkpoint sequence" simulation that registers exactly what a real run would have registered by cancellation stages 1/2/3/4/6 and asserts only those artifacts are cleaned (and that artifacts from stages never reached are left untouched).
- [x] `bash build-deps.sh --force`
- [x] `bash build.sh --no-open`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12607 tests, 0 failed
- [x] `bash run-integration-smoke.sh`
- [x] `swift test` — 891 tests (13 pre-existing skips), 0 failures

## Concerns

- No existing tests exercised this rollback path before this PR (confirmed via grep for the old helper names in `Tests/`), so there's no way to diff against a "before" baseline test run — correctness rests on the parameter-mapping table above plus the new tests.
- The rollback-ordering change (fixed-forward → LIFO-by-registration) is a real, deliberate behavior change from the literal old code, though not from its *effective* filesystem outcome for the reasons above. Flagging it explicitly in case reviewers want the exact original ordering preserved instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
