### PR TITLE
Introduce SupersessionEpoch and migrate first counter cohort

### DIFF
--- a/Sources/Speech/NemotronEngine.swift
+++ b/Sources/Speech/NemotronEngine.swift
@@ -21,7 +21,7 @@ final class NemotronEngine: ObservableObject {
 
     private var manager: (any StreamingAsrManager)?
     private var initializationTask: Task<Void, Never>?
-    private var initializationGeneration: UInt64 = 0
+    private var initializationGeneration = SupersessionEpoch()
     // Serializes transcribeSamples calls: the streaming manager is stateful
     // (appendAudio → processBufferedAudio → finish → reset), so overlapping
     // segments must never interleave on the same manager.
@@ -41,15 +41,14 @@ final class NemotronEngine: ObservableObject {
             return
         }
 
-        initializationGeneration &+= 1
-        let generation = initializationGeneration
+        let generation = initializationGeneration.begin()
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.load(generation: generation)
         }
         initializationTask = task
         await task.value
-        if initializationGeneration == generation, initializationTask == task {
+        if initializationGeneration.finishIfCurrent(generation), initializationTask == task {
             initializationTask = nil
         }
     }
@@ -77,7 +76,7 @@ final class NemotronEngine: ObservableObject {
     }
 
     func cleanup() {
-        initializationGeneration &+= 1
+        initializationGeneration.invalidate()
         initializationTask?.cancel()
         initializationTask = nil
         inFlightTranscription?.cancel()
@@ -188,8 +187,8 @@ final class NemotronEngine: ObservableObject {
         }
     }
 
-    private func load(generation: UInt64) async {
-        guard generation == initializationGeneration, !Task.isCancelled else { return }
+    private func load(generation: SupersessionEpoch.Token) async {
+        guard initializationGeneration.isCurrent(generation), !Task.isCancelled else { return }
         let loadingManager = Self.variant.createManager()
 
         // loadModels() downloads from HuggingFace into FluidAudio's model
@@ -201,7 +200,7 @@ final class NemotronEngine: ObservableObject {
         do {
             try await loadingManager.loadModels()
 
-            guard generation == initializationGeneration, !Task.isCancelled else {
+            guard initializationGeneration.isCurrent(generation), !Task.isCancelled else {
                 await loadingManager.cleanup()
                 return
             }
@@ -216,7 +215,7 @@ final class NemotronEngine: ObservableObject {
             )
         } catch {
             await loadingManager.cleanup()
-            guard generation == initializationGeneration, !Task.isCancelled else { return }
+            guard initializationGeneration.isCurrent(generation), !Task.isCancelled else { return }
             let friendlyMessage = "Couldn't load \(Self.model.title): \(error.localizedDescription)"
             AppLogger.transcription.error("NEMOTRON | \(friendlyMessage)")
             modelDownloadState = .failed(friendlyMessage)

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -4,6 +4,7 @@
 import Combine
 import FluidAudio
 import Foundation
+import TranscriptedCore
 
 @MainActor
 class STTRouter: ObservableObject {
@@ -25,7 +26,7 @@ class STTRouter: ObservableObject {
     private var recordingModelOwnership = TranscriptionRecordingModelOwnership()
     private var warmupOwnership = TranscriptionModelWarmupOwnership()
     private var backgroundWarmupTask: Task<Void, Never>?
-    private var backgroundWarmupGeneration: UInt64 = 0
+    private var backgroundWarmupGeneration = SupersessionEpoch()
     private var isShuttingDown = false
 
     private var activeRecordingModel: TranscriptionModelChoice? {
@@ -266,13 +267,12 @@ class STTRouter: ObservableObject {
 
     private func scheduleSelectedModelWarmup() {
         guard !isShuttingDown else { return }
-        backgroundWarmupGeneration &+= 1
-        let generation = backgroundWarmupGeneration
+        let generation = backgroundWarmupGeneration.begin()
         backgroundWarmupTask?.cancel()
         backgroundWarmupTask = Task { @MainActor [weak self] in
             guard let self, !Task.isCancelled, !self.isShuttingDown else { return }
             await self.initializeSelectedModelInBackground()
-            guard generation == self.backgroundWarmupGeneration else { return }
+            guard self.backgroundWarmupGeneration.finishIfCurrent(generation) else { return }
             self.backgroundWarmupTask = nil
         }
     }
@@ -497,7 +497,7 @@ class STTRouter: ObservableObject {
 
     func cleanup() {
         isShuttingDown = true
-        backgroundWarmupGeneration &+= 1
+        backgroundWarmupGeneration.invalidate()
         backgroundWarmupTask?.cancel()
         backgroundWarmupTask = nil
         warmupOwnership.reset()

--- a/Sources/Speech/TranscriptionModelWarmupOwnership.swift
+++ b/Sources/Speech/TranscriptionModelWarmupOwnership.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 enum TranscriptionModelRuntime: Hashable {
     case parakeet
@@ -110,16 +113,24 @@ struct TranscriptionPendingModelOwnership {
     }
 }
 
+/// Generation-gated guard for in-flight model preparation. Reimplemented on top
+/// of `SupersessionEpoch` so its begin/invalidate/isCurrent semantics are
+/// anchored to the shared primitive; the `UInt64`-based public surface is kept
+/// unchanged so `MeetingSTTAdapter` (its only caller) and its tests do not need
+/// to change.
 struct TranscriptionModelPreparationGeneration {
-    private(set) var current: UInt64 = 0
+    private var epoch = SupersessionEpoch()
+
+    var current: UInt64 {
+        epoch.current.rawValue
+    }
 
     mutating func begin() -> UInt64 {
-        current &+= 1
-        return current
+        epoch.begin().rawValue
     }
 
     mutating func invalidate() {
-        current &+= 1
+        epoch.invalidate()
     }
 
     func isCurrent(_ generation: UInt64) -> Bool {

--- a/Sources/Speech/WhisperEngine.swift
+++ b/Sources/Speech/WhisperEngine.swift
@@ -15,7 +15,7 @@ final class WhisperEngine: ObservableObject {
     private var loadedModel: TranscriptionModelChoice?
     private var initializingModel: TranscriptionModelChoice?
     private var initializationTask: Task<Void, Never>?
-    private var initializationGeneration: UInt64 = 0
+    private var initializationGeneration = SupersessionEpoch()
 
     var activeModel: TranscriptionModelChoice? {
         loadedModel
@@ -38,8 +38,7 @@ final class WhisperEngine: ObservableObject {
         }
 
         initializationTask?.cancel()
-        initializationGeneration &+= 1
-        let generation = initializationGeneration
+        let generation = initializationGeneration.begin()
         initializingModel = model
 
         let task = Task { @MainActor [weak self] in
@@ -49,7 +48,7 @@ final class WhisperEngine: ObservableObject {
         initializationTask = task
         await task.value
 
-        if initializationGeneration == generation {
+        if initializationGeneration.finishIfCurrent(generation) {
             initializationTask = nil
             initializingModel = nil
         }
@@ -165,7 +164,7 @@ final class WhisperEngine: ObservableObject {
     }
 
     func cleanup() {
-        initializationGeneration &+= 1
+        initializationGeneration.invalidate()
         initializationTask?.cancel()
         initializationTask = nil
         initializingModel = nil
@@ -178,16 +177,16 @@ final class WhisperEngine: ObservableObject {
         }
     }
 
-    private func load(model: TranscriptionModelChoice, generation: UInt64) async {
+    private func load(model: TranscriptionModelChoice, generation: SupersessionEpoch.Token) async {
         guard let variant = model.whisperKitModelName else { return }
-        guard generation == initializationGeneration, !Task.isCancelled else { return }
+        guard initializationGeneration.isCurrent(generation), !Task.isCancelled else { return }
 
         if loadedModel != model {
             let existing = whisperKit
             whisperKit = nil
             loadedModel = nil
             await existing?.unloadModels()
-            guard generation == initializationGeneration, !Task.isCancelled else { return }
+            guard initializationGeneration.isCurrent(generation), !Task.isCancelled else { return }
         }
 
         modelDownloadState = .downloading(progress: 0)
@@ -204,14 +203,14 @@ final class WhisperEngine: ObservableObject {
                 Task { @MainActor in
                     guard
                         let self,
-                        self.initializationGeneration == generation,
+                        self.initializationGeneration.isCurrent(generation),
                         self.initializingModel == model
                     else { return }
                     self.modelDownloadState = .downloading(progress: progress.fractionCompleted)
                 }
             }
 
-            guard generation == initializationGeneration, !Task.isCancelled else { return }
+            guard initializationGeneration.isCurrent(generation), !Task.isCancelled else { return }
             modelDownloadState = .loading
             AppLogger.transcription.info("WHISPER | loading \(model.title) from \(modelFolder.path)")
 
@@ -229,7 +228,7 @@ final class WhisperEngine: ObservableObject {
             )
             let pipe = try await WhisperKit(config)
 
-            guard generation == initializationGeneration, !Task.isCancelled else {
+            guard initializationGeneration.isCurrent(generation), !Task.isCancelled else {
                 await pipe.unloadModels()
                 return
             }
@@ -250,7 +249,7 @@ final class WhisperEngine: ObservableObject {
                 ]
             )
         } catch {
-            guard generation == initializationGeneration, !Task.isCancelled else { return }
+            guard initializationGeneration.isCurrent(generation), !Task.isCancelled else { return }
             let friendlyMessage = "Couldn't load \(model.title): \(error.localizedDescription)"
             AppLogger.transcription.error("WHISPER | \(friendlyMessage)")
             modelDownloadState = .failed(friendlyMessage)

--- a/Sources/TranscriptedCore/Utilities/SupersessionEpoch.swift
+++ b/Sources/TranscriptedCore/Utilities/SupersessionEpoch.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+/// A pure, allocation-free "is this async completion still current, or has it been
+/// superseded" counter.
+///
+/// The tree re-implements this exact question — "did something newer start before
+/// my async work finished?" — roughly three dozen times as raw `Int`/`UInt64`
+/// fields with hand-placed `guard x == y` checks (e.g. `FloatingOverlayController
+/// .hideGeneration`, `HomeViewModel.refreshGeneration`, `STTRouter
+/// .backgroundWarmupGeneration`, `WhisperEngine.initializationGeneration`). Every
+/// one of those sites hand-rolls the same three moves — bump, capture, compare —
+/// with subtly different semantics at the edges (does a bump also fence out
+/// current holders? does a successful comparison consume anything?). This type
+/// names those moves once so a reader only has to learn the vocabulary a single
+/// time.
+///
+/// `SupersessionEpoch` intentionally carries **no isolation opinion** — no lock,
+/// no `@MainActor`. Every migrated call site so far is a `@MainActor`-hosted
+/// field (mirroring `ParakeetRecoveryState`, which is a plain `Equatable` struct
+/// mutated only under its host's own confinement). The host is responsible for
+/// serializing access, exactly as it already does for the raw counter it
+/// replaces.
+///
+/// ### Vocabulary
+///
+/// - `begin()` — "I am starting a new unit of work; give me a token that proves
+///   I am the current owner." Mirrors the bump-then-capture pairs at
+///   `HomeViewModel.loadCurrentLimits` (`refreshGeneration += 1; let generation =
+///   refreshGeneration`), `SpeakerPeopleSettingsViewModel.refresh`,
+///   `TranscriptedSettingsView.refreshHomeDashboard`, `STTRouter
+///   .scheduleSelectedModelWarmup`, `WhisperEngine.initialize`, and
+///   `NemotronEngine.initialize`.
+/// - `snapshot()` — "let me read the current token without claiming ownership of
+///   anything." Mirrors `FloatingOverlayController.hideWithConfirmAnimation` /
+///   `hideWithCancelAnimation`, which capture `let gen = hideGeneration` before
+///   kicking off an animation, purely to compare against later — the capture
+///   site never "began" a unit of work via a bump of its own.
+/// - `isCurrent(_:)` — a pure, repeatable "is this token still the live one?"
+///   check. Mirrors the several independent guard checks scattered through
+///   `WhisperEngine.load(model:generation:)` and `NemotronEngine.load
+///   (generation:)`, each of which re-checks the same captured generation at a
+///   different suspension point without consuming anything.
+/// - `invalidate()` — "something reset or is starting over, and nobody in
+///   particular owns the new epoch." Mirrors the bare `hideGeneration &+= 1` in
+///   `FloatingOverlayController.showPanel()` / `cancelPendingHideForActiveDictation
+///   ()`, and the `cleanup()`/`cancel()` bumps in `STTRouter`, `WhisperEngine`,
+///   `NemotronEngine`, and `HomeViewModel` that exist purely to fence out
+///   whatever async work was previously in flight.
+/// - `finishIfCurrent(_:)` — "my owned unit of work reached its terminal
+///   outcome; tell me whether I am still allowed to publish it." Does **not**
+///   bump — the epoch stays open for whatever comes next. Mirrors the
+///   `generation == self.refreshGeneration` / `generation == self
+///   .backgroundWarmupGeneration` checks that gate applying a `Task`'s result in
+///   `HomeViewModel`, `SpeakerPeopleSettingsViewModel`, `TranscriptedSettingsView
+///   .refreshHomeDashboard`, and `STTRouter.scheduleSelectedModelWarmup`, and the
+///   `initializationGeneration == generation` check at the very end of
+///   `WhisperEngine.initialize` / `NemotronEngine.initialize` that decides
+///   whether the caller still owns clearing its own tracking fields.
+/// - `supersedeIfCurrent(_:)` — a terminal outcome that must also fence out every
+///   other holder of the current token, e.g. a timeout that "wins" the race and
+///   needs to make sure the original attempt can no longer publish anything late.
+///   Mirrors `ParakeetRecoveryState.timeoutRecovery(generation:)`, which compares
+///   against the current generation and then bumps it in the same operation
+///   (`guard generation == self.generation, isRecovering else { return false };
+///   self.generation &+= 1; ...; return true`).
+/// - `predictedNext()` — names the "predict the generation a stop is about to
+///   mint" pattern used at `MeetingCaptureBridge.stopAndAwaitFiles`, which reads
+///   `audio.currentRecordingSessionGeneration &+ 1` to pre-register the
+///   generation a synchronous `audio.stop()` call is about to produce, before
+///   that call actually bumps it. **Hazard:** the prediction is only valid if
+///   nothing else can bump the epoch between the call to `predictedNext()` and
+///   the actual `begin()`/bump that is expected to produce the predicted value
+///   — exactly as `MeetingCaptureBridge` relies on `audio.stop()` being the very
+///   next synchronous statement after computing `stopGeneration`. Do not cache a
+///   `predictedNext()` result across a suspension point or any code that could
+///   itself call `begin()`/`invalidate()`/`supersedeIfCurrent(_:)`.
+///
+/// All arithmetic uses `&+` — this is a long-running counter for in-process
+/// liveness checks, not an identity that must never repeat, so overflow wrapping
+/// (once every ~584 billion years at 1 bump/ns) is an accepted, deliberate
+/// behavior rather than a bug to guard against.
+public struct SupersessionEpoch: Equatable, Sendable {
+    /// An opaque, comparable point-in-time reading of a `SupersessionEpoch`.
+    ///
+    /// Tokens can only be produced by their owning `SupersessionEpoch` (via
+    /// `begin()`, `snapshot()`, or `predictedNext()`), which keeps arbitrary code
+    /// from constructing a token that happens to compare equal by accident.
+    ///
+    /// `rawValue` is exposed read-only for logging/telemetry interop — several
+    /// existing call sites already thread a raw `UInt64` generation number
+    /// through structured log context (e.g. `MeetingCaptureBridge`'s
+    /// `"stopGeneration"` / `"currentGeneration"` log fields, and
+    /// `ParakeetZombieRecoveryTerminal.generation`). Migrated call sites that
+    /// need to log a generation number can read `token.rawValue` instead of
+    /// reintroducing a parallel raw counter just for logging.
+    public struct Token: Equatable, Sendable {
+        public let rawValue: UInt64
+
+        fileprivate init(rawValue: UInt64) {
+            self.rawValue = rawValue
+        }
+    }
+
+    /// The epoch's current token. Starts at the zero generation, matching every
+    /// migrated raw-counter field's `= 0` initial value.
+    public private(set) var current: Token
+
+    public init() {
+        current = Token(rawValue: 0)
+    }
+
+    /// Test-only escape hatch for constructing an epoch already positioned at an
+    /// arbitrary raw generation, so wraparound behavior can be exercised without
+    /// looping `begin()` `UInt64.max` times. Not public — reachable only from
+    /// within this module, e.g. via `@testable import`.
+    init(testRawValue: UInt64) {
+        current = Token(rawValue: testRawValue)
+    }
+
+    /// Starts a new epoch that the caller now owns, and returns the token that
+    /// proves ownership. Use this at the top of an operation that is about to
+    /// kick off async work whose eventual completion must be checked against
+    /// staleness (the bump-then-capture half of the `begin`/`finishIfCurrent`
+    /// pair).
+    @discardableResult
+    public mutating func begin() -> Token {
+        current = Token(rawValue: current.rawValue &+ 1)
+        return current
+    }
+
+    /// Reads the current token without claiming ownership of a new epoch. Use
+    /// this to capture "the epoch as of right now" purely for a later
+    /// comparison, when the capturing call site did not itself start a new unit
+    /// of work (the observe-then-verify half of the `snapshot`/`isCurrent` pair).
+    public func snapshot() -> Token {
+        current
+    }
+
+    /// Pure, repeatable check: is `t` still the live token? Never mutates, and
+    /// may be called any number of times against the same captured token across
+    /// several suspension points within one logical unit of work.
+    public func isCurrent(_ t: Token) -> Bool {
+        t == current
+    }
+
+    /// Bumps the epoch with no particular new owner — the "something reset, or
+    /// is starting fresh, and every previously-issued token is now stale" move.
+    /// Use this for cleanup/cancel/reset paths that exist purely to fence out
+    /// whatever was previously in flight, not to hand out a new token to
+    /// anything in particular.
+    public mutating func invalidate() {
+        current = Token(rawValue: current.rawValue &+ 1)
+    }
+
+    /// Compares `t` against the current token **without bumping**. Returns
+    /// `true` when the caller's owned unit of work (previously started with
+    /// `begin()`) is still current and is therefore allowed to publish its
+    /// result. The epoch stays open afterward — this is a terminal check for
+    /// the caller's own attempt, not a reset for everyone else.
+    @discardableResult
+    public mutating func finishIfCurrent(_ t: Token) -> Bool {
+        t == current
+    }
+
+    /// Compares `t` against the current token **and bumps it** when they match.
+    /// Use this for a terminal outcome that must also fence out every other
+    /// holder of the current token — e.g. a timeout that "wins" a race and needs
+    /// to guarantee the original attempt can no longer publish a late result.
+    /// Returns `false` (without bumping) when `t` is already stale.
+    @discardableResult
+    public mutating func supersedeIfCurrent(_ t: Token) -> Bool {
+        guard t == current else { return false }
+        current = Token(rawValue: current.rawValue &+ 1)
+        return true
+    }
+
+    /// Predicts the token a future `begin()` (or equivalent bump) is about to
+    /// mint, **without** bumping the epoch now. Exists for call sites that must
+    /// pre-register the generation an imminent synchronous operation is about to
+    /// produce, before that operation itself performs the bump (see
+    /// `MeetingCaptureBridge.stopAndAwaitFiles`, which is not migrated onto this
+    /// type but is the pattern this operation names).
+    ///
+    /// - Warning: The prediction is only valid until the next call that mutates
+    ///   this epoch. Do not hold a `predictedNext()` result across a suspension
+    ///   point, or across any code that might itself call `begin()`,
+    ///   `invalidate()`, or `supersedeIfCurrent(_:)` — doing so silently
+    ///   invalidates the prediction and reintroduces the exact staleness bug
+    ///   this type exists to prevent.
+    public func predictedNext() -> Token {
+        Token(rawValue: current.rawValue &+ 1)
+    }
+}
+
+/// A single-slot claim check keyed by a `SupersessionEpoch.Token`.
+///
+/// Pairs naturally with `SupersessionEpoch` for the common "stash a payload that
+/// only the owner of a given generation may later retrieve" shape — e.g. a
+/// pending continuation, a callback, or a piece of async-attempt state that must
+/// not be handed to a caller holding a stale token.
+public struct ClaimSlot<Payload> {
+    private var entry: (token: SupersessionEpoch.Token, payload: Payload)?
+
+    public init() {}
+
+    /// Installs `payload` under `token`, unconditionally displacing whatever was
+    /// previously stored (regardless of which token owned it). Returns the
+    /// displaced payload, if any, so the caller can decide how to handle it
+    /// (e.g. resume a displaced continuation with a cancellation error).
+    @discardableResult
+    public mutating func install(_ payload: Payload, ownedBy token: SupersessionEpoch.Token) -> Payload? {
+        let displaced = entry?.payload
+        entry = (token, payload)
+        return displaced
+    }
+
+    /// Removes and returns the stored payload only if it is currently owned by
+    /// `token`; leaves the slot untouched and returns `nil` otherwise. The
+    /// compare-and-consume operation — call this from the one place that is
+    /// allowed to claim the payload for `token`.
+    public mutating func takeIfOwned(by token: SupersessionEpoch.Token) -> Payload? {
+        guard let entry, entry.token == token else { return nil }
+        self.entry = nil
+        return entry.payload
+    }
+
+    /// Reads the stored payload without removing it, only if it is currently
+    /// owned by `token`.
+    public func peekIfOwned(by token: SupersessionEpoch.Token) -> Payload? {
+        guard let entry, entry.token == token else { return nil }
+        return entry.payload
+    }
+
+    /// Removes and returns whatever is stored, regardless of which token owns
+    /// it. Use for unconditional teardown paths (e.g. host shutdown) that must
+    /// clear the slot no matter what.
+    @discardableResult
+    public mutating func clear() -> Payload? {
+        defer { entry = nil }
+        return entry?.payload
+    }
+
+    /// Clears the slot only if it is currently owned by `token`. Returns
+    /// whether anything was cleared.
+    @discardableResult
+    public mutating func clearIfOwned(by token: SupersessionEpoch.Token) -> Bool {
+        guard let entry, entry.token == token else { return false }
+        self.entry = nil
+        return true
+    }
+}
+
+extension ClaimSlot: Sendable where Payload: Sendable {}

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -4,6 +4,7 @@
 
 import AppKit
 import Combine
+import TranscriptedCore
 
 @MainActor
 class FloatingOverlayController {
@@ -113,8 +114,8 @@ class FloatingOverlayController {
     private static let cursorFollowSmoothing: CGFloat = 0.32
     private static let miniLoadingRevealDelayNanoseconds: UInt64 = 700_000_000
 
-    /// Generation counter — incremented on every showPanel(), checked in async _performHide()
-    private var hideGeneration: UInt64 = 0
+    /// Epoch — invalidated on every showPanel(), checked in async _performHide()
+    private var hideGeneration = SupersessionEpoch()
 
     /// Combine subscriptions for engine state → view updates
     private var subscriptions = Set<AnyCancellable>()
@@ -258,7 +259,7 @@ class FloatingOverlayController {
         guard let panel = panel else { return }
 
         // Invalidate any pending async _performHide() from a previous session's animation
-        hideGeneration &+= 1
+        hideGeneration.invalidate()
 
         // Cancel stale timers from a previous session
         errorDismissTask?.cancel()
@@ -399,7 +400,7 @@ class FloatingOverlayController {
     }
 
     private func cancelPendingHideForActiveDictation() {
-        hideGeneration &+= 1
+        hideGeneration.invalidate()
         successDismissTask?.cancel()
         successDismissTask = nil
 
@@ -435,7 +436,7 @@ class FloatingOverlayController {
 
     func hideWithConfirmAnimation(completion: (() -> Void)? = nil) {
         guard let panel = panel else { completion?(); _performHide(); return }
-        let gen = hideGeneration
+        let gen = hideGeneration.snapshot()
         panel.ignoresMouseEvents = true
 
         // Make sure the overlay cannot intercept the follow-up paste.
@@ -449,7 +450,7 @@ class FloatingOverlayController {
         }, completionHandler: { [weak self] in
             completion?()
             Task { @MainActor [weak self] in
-                guard let self = self, self.hideGeneration == gen else { return }
+                guard let self = self, self.hideGeneration.isCurrent(gen) else { return }
                 self._performHide()
             }
         })
@@ -466,7 +467,7 @@ class FloatingOverlayController {
 
     func hideWithCancelAnimation() {
         guard let panel = panel else { _performHide(); return }
-        let gen = hideGeneration
+        let gen = hideGeneration.snapshot()
         panel.ignoresMouseEvents = true
 
         let baseX = panel.frame.origin.x
@@ -486,7 +487,7 @@ class FloatingOverlayController {
         DispatchQueue.main.asyncAfter(deadline: .now() + stepDuration * Double(offsets.count)) { [weak self, weak panel] in
             guard let panel = panel else {
                 Task { @MainActor [weak self] in
-                    guard let self = self, self.hideGeneration == gen else { return }
+                    guard let self = self, self.hideGeneration.isCurrent(gen) else { return }
                     self._performHide()
                 }
                 return
@@ -497,7 +498,7 @@ class FloatingOverlayController {
                 panel.animator().alphaValue = 0
             }, completionHandler: { [weak self] in
                 Task { @MainActor [weak self] in
-                    guard let self = self, self.hideGeneration == gen else { return }
+                    guard let self = self, self.hideGeneration.isCurrent(gen) else { return }
                     self._performHide()
                 }
             })

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -28,7 +28,7 @@ final class HomeViewModel: ObservableObject {
     private var scanWarningDismissed = false
 
     private var refreshTask: Task<Void, Never>?
-    private var refreshGeneration = 0
+    private var refreshGeneration = SupersessionEpoch()
     private var dictationLimit = 10
     private var meetingLimit = 10
     private var didTrackActivationReturnProxy = false
@@ -125,10 +125,9 @@ final class HomeViewModel: ObservableObject {
 
     private func loadCurrentLimits(isInitialLoad: Bool, isSilent: Bool = false) {
         refreshTask?.cancel()
-        refreshGeneration += 1
+        let generation = refreshGeneration.begin()
         isLoading = isInitialLoad && !isSilent
         isLoadingMore = !isInitialLoad && !isSilent
-        let generation = refreshGeneration
         let requestedDictationLimit = dictationLimit
         let requestedMeetingLimit = meetingLimit
         refreshTask = Task { @MainActor in
@@ -140,7 +139,7 @@ final class HomeViewModel: ObservableObject {
             let diagnosis = await Task.detached(priority: .utility) {
                 RecentMeetingsScanner.diagnose()
             }.value
-            guard !Task.isCancelled, generation == self.refreshGeneration else {
+            guard !Task.isCancelled, self.refreshGeneration.finishIfCurrent(generation) else {
                 return
             }
             self.scanWarning = self.scanWarningDismissed
@@ -171,7 +170,7 @@ final class HomeViewModel: ObservableObject {
     func cancel() {
         refreshTask?.cancel()
         refreshTask = nil
-        refreshGeneration += 1
+        refreshGeneration.invalidate()
         isLoading = false
         isLoadingMore = false
     }

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -137,7 +137,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     private var mergeTargetsByProfileID: [UUID: [SpeakerProfile]] = [:]
     private var clipURLsByProfileID: [UUID: URL] = [:]
     private var undoableMergesByTargetID: [UUID: SpeakerMergeRecord] = [:]
-    private var refreshGeneration = 0
+    private var refreshGeneration = SupersessionEpoch()
 
     private struct Snapshot {
         let profiles: [SpeakerProfile]
@@ -189,8 +189,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     }
 
     func refresh() {
-        refreshGeneration += 1
-        let generation = refreshGeneration
+        let generation = refreshGeneration.begin()
         let speakerDatabase = self.speakerDatabase
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
@@ -201,7 +200,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
                 legacyClipsDirectory: legacyClipsDirectory
             )
             DispatchQueue.main.async {
-                guard let self, self.refreshGeneration == generation else { return }
+                guard let self, self.refreshGeneration.finishIfCurrent(generation) else { return }
                 self.applySnapshot(snapshot)
             }
         }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -59,7 +59,7 @@ struct TranscriptedSettingsView: View {
     @State private var captureLibraryMigrationStatus: String?
     @State private var homeDashboardRefreshTask: Task<Void, Never>?
     @State private var homeDashboardRefreshInFlight = false
-    @State private var homeDashboardRefreshGeneration = 0
+    @State private var homeDashboardRefreshGeneration = SupersessionEpoch()
     @State private var lastHomeDashboardRefreshStartedAt: Date?
     @State private var modelCacheSnapshot: ModelCacheSnapshot?
     @State private var modelCacheLoading = false
@@ -4124,15 +4124,14 @@ struct TranscriptedSettingsView: View {
         }
 
         homeDashboardRefreshTask?.cancel()
-        homeDashboardRefreshGeneration += 1
-        let generation = homeDashboardRefreshGeneration
+        let generation = homeDashboardRefreshGeneration.begin()
         lastHomeDashboardRefreshStartedAt = now
         homeDashboardRefreshInFlight = true
         homeViewModel.refresh()
 
         homeDashboardRefreshTask = Task { @MainActor in
             await statsService.refreshStats()
-            guard !Task.isCancelled, generation == homeDashboardRefreshGeneration else { return }
+            guard !Task.isCancelled, homeDashboardRefreshGeneration.finishIfCurrent(generation) else { return }
             homeDashboardRefreshInFlight = false
             homeDashboardRefreshTask = nil
         }

--- a/Tests/TranscriptedCoreTests/UtilitiesTests/SupersessionEpochTests.swift
+++ b/Tests/TranscriptedCoreTests/UtilitiesTests/SupersessionEpochTests.swift
@@ -1,0 +1,309 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Coverage for `SupersessionEpoch` and `ClaimSlot`, including wraparound and the
+/// `predictedNext()` prediction-then-begin handshake. See doc comments on
+/// `Sources/TranscriptedCore/Utilities/SupersessionEpoch.swift` for the tree
+/// patterns each operation's semantics are anchored to.
+final class SupersessionEpochTests: XCTestCase {
+
+    // MARK: - begin()
+
+    func testBeginStartsAtGenerationOneFromZeroInitialState() {
+        var epoch = SupersessionEpoch()
+        XCTAssertEqual(epoch.current.rawValue, 0)
+        let token = epoch.begin()
+        XCTAssertEqual(token.rawValue, 1)
+        XCTAssertEqual(epoch.current, token)
+    }
+
+    func testBeginProducesDistinctTokensEachCall() {
+        var epoch = SupersessionEpoch()
+        let first = epoch.begin()
+        let second = epoch.begin()
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(epoch.isCurrent(second))
+        XCTAssertFalse(epoch.isCurrent(first))
+    }
+
+    // MARK: - snapshot()
+
+    func testSnapshotReadsCurrentWithoutBumping() {
+        var epoch = SupersessionEpoch()
+        let started = epoch.begin()
+        let snapshot = epoch.snapshot()
+        XCTAssertEqual(snapshot, started)
+        // Snapshotting must not itself advance the epoch.
+        XCTAssertEqual(epoch.snapshot(), started)
+        XCTAssertTrue(epoch.isCurrent(started))
+    }
+
+    func testSnapshotBeforeAnyBeginReadsZeroGeneration() {
+        let epoch = SupersessionEpoch()
+        XCTAssertEqual(epoch.snapshot().rawValue, 0)
+    }
+
+    // MARK: - isCurrent(_:)
+
+    func testIsCurrentIsPureAndRepeatable() {
+        var epoch = SupersessionEpoch()
+        let token = epoch.begin()
+        // Calling isCurrent repeatedly must never consume or mutate anything —
+        // mirrors WhisperEngine.load(model:generation:)'s several independent
+        // guard checks against one captured generation.
+        for _ in 0..<5 {
+            XCTAssertTrue(epoch.isCurrent(token))
+        }
+    }
+
+    func testIsCurrentFalseAfterSupersession() {
+        var epoch = SupersessionEpoch()
+        let first = epoch.begin()
+        _ = epoch.begin()
+        XCTAssertFalse(epoch.isCurrent(first))
+    }
+
+    // MARK: - invalidate()
+
+    func testInvalidateBumpsAndFencesOutPreviousToken() {
+        var epoch = SupersessionEpoch()
+        let token = epoch.begin()
+        XCTAssertTrue(epoch.isCurrent(token))
+        epoch.invalidate()
+        XCTAssertFalse(epoch.isCurrent(token))
+    }
+
+    func testInvalidateWithNoPriorBeginStillAdvancesFromZero() {
+        var epoch = SupersessionEpoch()
+        XCTAssertEqual(epoch.current.rawValue, 0)
+        epoch.invalidate()
+        XCTAssertEqual(epoch.current.rawValue, 1)
+    }
+
+    func testDoubleInvalidateFencesOutAnyPreviouslyCapturedToken() {
+        var epoch = SupersessionEpoch()
+        let token = epoch.begin()
+        epoch.invalidate()
+        epoch.invalidate()
+        XCTAssertFalse(epoch.isCurrent(token))
+    }
+
+    // MARK: - finishIfCurrent(_:)
+
+    func testFinishIfCurrentReturnsTrueAndLeavesEpochOpenForNewWork() {
+        var epoch = SupersessionEpoch()
+        let token = epoch.begin()
+        XCTAssertTrue(epoch.finishIfCurrent(token))
+        // The epoch must stay open — a stale-completion guard, not a reset.
+        XCTAssertEqual(epoch.current, token)
+        XCTAssertTrue(epoch.isCurrent(token))
+    }
+
+    func testFinishIfCurrentReturnsFalseWithoutBumpingWhenStale() {
+        var epoch = SupersessionEpoch()
+        let first = epoch.begin()
+        let second = epoch.begin()
+        XCTAssertFalse(epoch.finishIfCurrent(first))
+        // A failed finish must not mutate the epoch at all.
+        XCTAssertEqual(epoch.current, second)
+        XCTAssertTrue(epoch.isCurrent(second))
+    }
+
+    func testFinishIfCurrentCanBeCalledAgainAfterSuccessSinceItDidNotConsume() {
+        var epoch = SupersessionEpoch()
+        let token = epoch.begin()
+        XCTAssertTrue(epoch.finishIfCurrent(token))
+        XCTAssertTrue(epoch.finishIfCurrent(token))
+    }
+
+    // MARK: - supersedeIfCurrent(_:)
+
+    func testSupersedeIfCurrentBumpsAndFencesOutTheWinningTokenItself() {
+        var epoch = SupersessionEpoch()
+        let token = epoch.begin()
+        XCTAssertTrue(epoch.supersedeIfCurrent(token))
+        // Unlike finishIfCurrent, the winning token itself is now stale — the
+        // bump moved the epoch past it, matching
+        // ParakeetRecoveryState.timeoutRecovery(generation:).
+        XCTAssertFalse(epoch.isCurrent(token))
+    }
+
+    func testSupersedeIfCurrentReturnsFalseWithoutBumpingWhenAlreadyStale() {
+        var epoch = SupersessionEpoch()
+        let first = epoch.begin()
+        let second = epoch.begin()
+        XCTAssertFalse(epoch.supersedeIfCurrent(first))
+        XCTAssertEqual(epoch.current, second)
+        XCTAssertTrue(epoch.isCurrent(second))
+    }
+
+    func testSupersedeIfCurrentThenAnyOtherHolderOfThatTokenIsAlsoFencedOut() {
+        var epoch = SupersessionEpoch()
+        let token = epoch.begin()
+        let concurrentHolder = epoch.snapshot()
+        XCTAssertTrue(epoch.supersedeIfCurrent(token))
+        XCTAssertFalse(epoch.isCurrent(concurrentHolder))
+        XCTAssertFalse(epoch.finishIfCurrent(concurrentHolder))
+    }
+
+    // MARK: - predictedNext()
+
+    func testPredictedNextMatchesTheTokenAnImmediatelyFollowingBeginProduces() {
+        var epoch = SupersessionEpoch()
+        _ = epoch.begin()
+        let predicted = epoch.predictedNext()
+        let actual = epoch.begin()
+        XCTAssertEqual(predicted, actual)
+    }
+
+    func testPredictedNextDoesNotItselfMutateTheEpoch() {
+        var epoch = SupersessionEpoch()
+        let before = epoch.snapshot()
+        _ = epoch.predictedNext()
+        XCTAssertEqual(epoch.snapshot(), before)
+    }
+
+    func testPredictedNextBecomesStaleIfSomethingElseBumpsFirst() {
+        // Names the hazard called out in the doc comment: a prediction is only
+        // valid until the next mutating call. If something else invalidates the
+        // epoch between the prediction and the expected mint, the prediction no
+        // longer matches.
+        var epoch = SupersessionEpoch()
+        let predicted = epoch.predictedNext()
+        epoch.invalidate()
+        let actual = epoch.begin()
+        XCTAssertNotEqual(predicted, actual)
+    }
+
+    // MARK: - wraparound
+
+    func testBeginWrapsAroundAtUInt64MaxUsingOverflowSafeArithmetic() {
+        var epoch = SupersessionEpoch()
+        epoch.forceCurrent(rawValue: .max)
+        let wrapped = epoch.begin()
+        XCTAssertEqual(wrapped.rawValue, 0)
+        XCTAssertTrue(epoch.isCurrent(wrapped))
+    }
+
+    func testInvalidateWrapsAroundAtUInt64Max() {
+        var epoch = SupersessionEpoch()
+        epoch.forceCurrent(rawValue: .max)
+        epoch.invalidate()
+        XCTAssertEqual(epoch.current.rawValue, 0)
+    }
+
+    func testSupersedeIfCurrentWrapsAroundAtUInt64Max() {
+        var epoch = SupersessionEpoch()
+        epoch.forceCurrent(rawValue: .max)
+        let token = epoch.current
+        XCTAssertTrue(epoch.supersedeIfCurrent(token))
+        XCTAssertEqual(epoch.current.rawValue, 0)
+    }
+
+    func testPredictedNextWrapsAroundAtUInt64Max() {
+        var epoch = SupersessionEpoch()
+        epoch.forceCurrent(rawValue: .max)
+        XCTAssertEqual(epoch.predictedNext().rawValue, 0)
+    }
+
+    // MARK: - Equatable
+
+    func testSupersessionEpochEqualityIsByCurrentToken() {
+        var lhs = SupersessionEpoch()
+        var rhs = SupersessionEpoch()
+        XCTAssertEqual(lhs, rhs)
+        _ = lhs.begin()
+        XCTAssertNotEqual(lhs, rhs)
+        _ = rhs.begin()
+        XCTAssertEqual(lhs, rhs)
+    }
+}
+
+// MARK: - ClaimSlot
+
+final class ClaimSlotTests: XCTestCase {
+
+    func testInstallStoresPayloadRetrievableByItsOwningToken() {
+        var epoch = SupersessionEpoch()
+        var slot = ClaimSlot<String>()
+        let token = epoch.begin()
+        XCTAssertNil(slot.install("first", ownedBy: token))
+        XCTAssertEqual(slot.peekIfOwned(by: token), "first")
+    }
+
+    func testInstallReturnsDisplacedPayloadRegardlessOfPriorOwner() {
+        var epoch = SupersessionEpoch()
+        var slot = ClaimSlot<String>()
+        let first = epoch.begin()
+        _ = slot.install("first", ownedBy: first)
+        let second = epoch.begin()
+        let displaced = slot.install("second", ownedBy: second)
+        XCTAssertEqual(displaced, "first")
+        XCTAssertEqual(slot.peekIfOwned(by: second), "second")
+        XCTAssertNil(slot.peekIfOwned(by: first))
+    }
+
+    func testTakeIfOwnedConsumesOnlyOnMatchingToken() {
+        var epoch = SupersessionEpoch()
+        var slot = ClaimSlot<Int>()
+        let stale = epoch.begin()
+        let current = epoch.begin()
+        _ = slot.install(42, ownedBy: current)
+
+        XCTAssertNil(slot.takeIfOwned(by: stale))
+        // A failed take must not disturb the stored payload.
+        XCTAssertEqual(slot.peekIfOwned(by: current), 42)
+
+        XCTAssertEqual(slot.takeIfOwned(by: current), 42)
+        // A successful take empties the slot.
+        XCTAssertNil(slot.peekIfOwned(by: current))
+    }
+
+    func testPeekIfOwnedDoesNotConsume() {
+        var epoch = SupersessionEpoch()
+        var slot = ClaimSlot<Int>()
+        let token = epoch.begin()
+        _ = slot.install(7, ownedBy: token)
+        XCTAssertEqual(slot.peekIfOwned(by: token), 7)
+        XCTAssertEqual(slot.peekIfOwned(by: token), 7)
+    }
+
+    func testClearReturnsAndRemovesRegardlessOfOwner() {
+        var epoch = SupersessionEpoch()
+        var slot = ClaimSlot<Int>()
+        let token = epoch.begin()
+        _ = slot.install(99, ownedBy: token)
+        XCTAssertEqual(slot.clear(), 99)
+        XCTAssertNil(slot.clear())
+        XCTAssertNil(slot.peekIfOwned(by: token))
+    }
+
+    func testClearIfOwnedOnlyClearsOnMatchingToken() {
+        var epoch = SupersessionEpoch()
+        var slot = ClaimSlot<Int>()
+        let stale = epoch.begin()
+        let current = epoch.begin()
+        _ = slot.install(1, ownedBy: current)
+
+        XCTAssertFalse(slot.clearIfOwned(by: stale))
+        XCTAssertEqual(slot.peekIfOwned(by: current), 1)
+
+        XCTAssertTrue(slot.clearIfOwned(by: current))
+        XCTAssertNil(slot.peekIfOwned(by: current))
+    }
+
+    func testClearIfOwnedOnEmptySlotReturnsFalse() {
+        let epoch = SupersessionEpoch()
+        var slot = ClaimSlot<Int>()
+        XCTAssertFalse(slot.clearIfOwned(by: epoch.snapshot()))
+    }
+}
+
+extension SupersessionEpoch {
+    /// Test-only backdoor for exercising wraparound behavior without looping
+    /// `begin()` `UInt64.max` times. Delegates to the module-internal
+    /// `init(testRawValue:)`, reachable here via `@testable import`.
+    fileprivate mutating func forceCurrent(rawValue: UInt64) {
+        self = SupersessionEpoch(testRawValue: rawValue)
+    }
+}

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -303,6 +303,7 @@ APP_SOURCES=(
     "Sources/Speech/RecordedAudioTimeline.swift"
     "Sources/Speech/SharedMeetingMicRecorder.swift"
     "Sources/Speech/DictationAudioLevelMeter.swift"
+    "Sources/TranscriptedCore/Utilities/SupersessionEpoch.swift"
     "Sources/Speech/TranscriptionModelWarmupOwnership.swift"
     "Sources/Meeting/MeetingRecordingStartGate.swift"
     "Sources/Meeting/MeetingCaptureSupport.swift"


### PR DESCRIPTION
## Summary

Introduces one pure primitive pair for the "is this async completion still current, or has it been superseded?" check the tree hand-rolls ~19 times as raw `Int`/`UInt64` counters, and migrates the lowest-risk cohort onto it (all `@MainActor`-hosted raw counters). Design was specified by the coordinating session; this PR implements it as specified.

### Part 1 — the primitives

New file: `Sources/TranscriptedCore/Utilities/SupersessionEpoch.swift`

- `SupersessionEpoch` / `SupersessionEpoch.Token` — pure value types, **no isolation opinion** (no lock, no `@MainActor`), mirroring how `ParakeetRecoveryState` is a plain `Equatable` struct mutated only under its host's own confinement.
- `ClaimSlot<Payload>` — a single-slot claim check keyed by a token, `Sendable` when `Payload` is.
- Every operation's doc comment cites the exact tree pattern its semantics are anchored to (see the file for the full citations).
- Full coverage in `Tests/TranscriptedCoreTests/UtilitiesTests/SupersessionEpochTests.swift` (30 tests): every operation, wraparound at `UInt64.max`, and the `predictedNext()` prediction-then-`begin()` handshake.

### Part 2 — migration table

| Site | Old bump/compare | New operation | Why |
|---|---|---|---|
| `FloatingOverlayController.hideGeneration` | `hideGeneration &+= 1` (showPanel/cancelPendingHideForActiveDictation) | `.invalidate()` | Nobody in particular "owns" the bump — it's a cancel-all fence for whatever hide animation was pending |
| | `let gen = hideGeneration` (before kicking off an animation) | `.snapshot()` | The capturing site never `begin()`'d a unit of work of its own — it's a pure observe-then-verify capture |
| | `self.hideGeneration == gen` (animation completion) | `.isCurrent(gen)` | Pure repeatable read; two exclusive branches in `hideWithCancelAnimation` both check the same snapshotted token |
| `HomeViewModel.refreshGeneration` | `refreshGeneration += 1; let generation = refreshGeneration` | `.begin()` | Starts an owned async refresh |
| | `generation == self.refreshGeneration` (Task completion) | `.finishIfCurrent(generation)` | Terminal check gating whether this owned attempt may publish its result |
| | `refreshGeneration += 1` (`cancel()`) | `.invalidate()` | Cancel-all fence, no new owner |
| `SpeakerPeopleSettingsViewModel.refreshGeneration` | same shape as `HomeViewModel` | `.begin()` / `.finishIfCurrent(generation)` | Same reasoning |
| `TranscriptedSettingsView.homeDashboardRefreshGeneration` | same shape | `.begin()` / `.finishIfCurrent(generation)` | Same reasoning |
| `STTRouter.backgroundWarmupGeneration` | `&+= 1; let generation = ...` (scheduleSelectedModelWarmup) | `.begin()` | Starts owned background warmup |
| | `generation == self.backgroundWarmupGeneration` (Task completion) | `.finishIfCurrent(generation)` | Terminal check before clearing `backgroundWarmupTask` |
| | `&+= 1` (`cleanup()`) | `.invalidate()` | Cancel-all fence |
| `WhisperEngine.initializationGeneration` | `&+= 1; let generation = ...` (`initialize`) | `.begin()` | Starts owned model-load task |
| | `initializationGeneration == generation` (end of `initialize`, decides whether to clear tracking) | `.finishIfCurrent(generation)` | Terminal check for the owned attempt |
| | 5 intermediate guards inside `load(model:generation:)` and its progress closure | `.isCurrent(generation)` | Repeatable pure reads at several suspension points within the same logical unit of work, none of which "finish" anything |
| | `&+= 1` (`cleanup()`) | `.invalidate()` | Cancel-all fence |
| `NemotronEngine.initializationGeneration` | same shape as `WhisperEngine` | `.begin()` / `.finishIfCurrent(generation)` / `.isCurrent(generation)` (×3) / `.invalidate()` | Same reasoning |
| `TranscriptionModelPreparationGeneration` | hand-rolled `begin()`/`invalidate()`/`isCurrent()` over a raw `UInt64` | Reimplemented on top of `SupersessionEpoch`, `UInt64` public API unchanged | Anchors its semantics to the shared primitive without touching its only caller (`MeetingSTTAdapter`) or its tests |

**Not touched** (later cohorts, per scope): `recordingSessionGeneration`, `audioGraphGeneration`, any Parakeet ownership token, SCK/SystemAudioCapture counters, `pasteGeneration`, anything NSLock-hosted. All 8 assigned sites migrated — none resisted.

### Build-harness wrinkle

`Sources/Speech/TranscriptionModelWarmupOwnership.swift` is compiled twice: once as a real `TranscriptedCore`-module app-target file (`build.sh`, via the prebuilt archive) and once as a flat raw source alongside hand-picked `Sources/Support`/`Sources/Speech` files in `run-tests.sh`'s fast-test compile (no module search path there at all — confirmed by grep, no `-I`/`-L`/`-F` flags exist in that script). A bare `import TranscriptedCore` in that file broke `run-tests.sh`'s flat compile with "no such module". Fixed by gating the import behind `#if canImport(TranscriptedCore)` — the exact idiom already used by ~15 other dual-compiled files in the tree (`HomeMeetingDeletion.swift`, `MeetingFailureKind.swift`, etc.) — and adding `Sources/TranscriptedCore/Utilities/SupersessionEpoch.swift` directly to `run-tests.sh`'s `APP_SOURCES` list so the flat compile still sees the type.

## Verification (all foreground, in order, all green)

1. `bash build-deps.sh --force` — OK
2. `bash build.sh --no-open` — OK (proves the app target links the new Core type through the prebuilt archive)
3. `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12661 tests, 12661 passed, 0 failed
4. `bash run-integration-smoke.sh` — core smoke + wake smoke + `MicRecordingFileMergerTests` (7/7) all OK
5. `swift test` — 946 tests, 0 failures, 13 skipped (pre-existing), includes new `SupersessionEpochTests` (23) and `ClaimSlotTests` (7)

One transient failure during verification: an isolated `swift test --filter MicRecordingFileMergerTests` run hit a stale `@rpath/ESpeakNG.framework` dlopen error from a `.build` cache still referencing a framework `build-deps.sh --force` had legitimately stopped bundling (FluidAudio ≥ 0.15 no longer needs ESpeakNG). Confirmed via `git stash` that this reproduces identically on unmodified `origin/main` sources with the same `.build` cache, and that rerunning `build-deps.sh --force` (refreshing the deps stamp) makes it disappear — pre-existing environmental flakiness, unrelated to this change, not present in the final green run reported above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
