### PR TITLE
Make meeting capture attempt bookkeeping and local summary telemetry compiler-checked MainActor

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -76,7 +76,17 @@ final class MeetingCaptureBridge: ObservableObject {
         wireSubscriptions()
     }
 
-    deinit {
+    // `isolated deinit` (available on this toolchain without any extra
+    // language-mode flag — verified with `swiftc -typecheck` against a
+    // standalone repro) keeps this teardown compiler-checked on MainActor
+    // instead of relying on every release site happening to run there.
+    // `MeetingCaptureAttempt` is itself @MainActor now, so a plain
+    // (nonisolated) deinit could no longer touch `startAttempt`/
+    // `completionAttempt` at all; isolating the whole deinit is simpler than
+    // splitting teardown into an explicit `invalidate()`/`shutdown()` call
+    // for a bridge whose only owner (`MeetingSessionController`) doesn't
+    // need bespoke teardown sequencing before releasing it.
+    isolated deinit {
         timedOutStopCompletionExpiryTasks.values.forEach { $0.cancel() }
         startAttempt.reset()?.resume(returning: false)
         completionAttempt.reset()?.resume(returning: CaptureStopResult(
@@ -159,6 +169,16 @@ final class MeetingCaptureBridge: ObservableObject {
         guard audio.isRecording else {
             return currentStopResult()
         }
+        // A second overlapping stop call (e.g. two callers racing to stop the
+        // same recording before Core's completion callback fires) must not
+        // silently displace a still-pending completion's continuation —
+        // `MeetingCaptureAttempt.begin()` overwrites unconditionally, so the
+        // caller is responsible for resolving any outstanding attempt first.
+        // `startRecording()` already does the equivalent reset for a stale
+        // completion attempt left over from a previous recording; mirror it
+        // here so a concurrent stop can't leak a continuation and hang its
+        // caller forever.
+        completionAttempt.reset()?.resume(returning: currentStopResult())
         let stopTimeout = TranscriptedConstants.meetingStopTimeout(
             forRecordingDuration: max(recordingDuration, audio.recordingDuration)
         )

--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -88,12 +88,17 @@ final class MeetingCaptureBridge: ObservableObject {
     // need bespoke teardown sequencing before releasing it.
     isolated deinit {
         timedOutStopCompletionExpiryTasks.values.forEach { $0.cancel() }
-        startAttempt.reset()?.resume(returning: false)
-        completionAttempt.reset()?.resume(returning: CaptureStopResult(
+        for continuation in startAttempt.reset() {
+            continuation.resume(returning: false)
+        }
+        let stopResult = CaptureStopResult(
             micURL: audio.micAudioFileURL,
             systemURL: audio.systemAudioFileURL,
             didTimeOut: false
-        ))
+        )
+        for continuation in completionAttempt.reset() {
+            continuation.resume(returning: stopResult)
+        }
         // Combine cancellables auto-release. Audio's own deinit tears down CoreAudio.
     }
 
@@ -103,7 +108,10 @@ final class MeetingCaptureBridge: ObservableObject {
     /// active until `stopAndAwaitFiles()` is called.
     func startRecording() async -> Bool {
         expectedStopGeneration = nil
-        completionAttempt.reset()?.resume(returning: currentStopResult())
+        let staleStopResult = currentStopResult()
+        for continuation in completionAttempt.reset() {
+            continuation.resume(returning: staleStopResult)
+        }
         if audio.isRecording { return true }
 
         // Keep the immediately preceding timed-out stop across this start so
@@ -136,22 +144,27 @@ final class MeetingCaptureBridge: ObservableObject {
         audio.enableSoftwareAGC = micProcessingMode.allowsSoftwareAutogainFallback
 
         return await withCheckedContinuation { continuation in
-            startAttempt.reset()?.resume(returning: false)
+            for pending in startAttempt.reset() {
+                pending.resume(returning: false)
+            }
             let attemptID = startAttempt.begin(continuation)
 
             audio.start()
 
             startAttempt.setTimeoutTask(Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: TranscriptedConstants.meetingStartTimeout)
-                guard let self,
-                      let continuation = self.startAttempt.resetIfCurrent(attemptID) else { return }
+                guard let self else { return }
+                let waiters = self.startAttempt.resetIfCurrent(attemptID)
+                guard !waiters.isEmpty else { return }
                 self.errorMessage = AudioCaptureStartState.timeoutFailureMessage(
                     existingErrorMessage: self.errorMessage,
                     micAudioStreaming: self.audio.micAudioStreaming,
                     systemAudioStreaming: self.audio.systemAudioStreaming
                 )
                 self.audio.stop()
-                continuation.resume(returning: false)
+                for continuation in waiters {
+                    continuation.resume(returning: false)
+                }
             })
         }
     }
@@ -162,28 +175,57 @@ final class MeetingCaptureBridge: ObservableObject {
     /// expiry (`didTimeOut == true`). On timeout the WAV header may not be
     /// fully patched, so the caller should treat the audio as failed-but-
     /// recoverable rather than enqueuing it for transcription directly.
+    ///
+    /// If a stop is already in flight, this call joins it instead of issuing
+    /// its own `audio.stop()` — every joined caller gets the exact same
+    /// result. In that case `timedOutOwner`/`onTimedOutCompletion` are
+    /// ignored: only the first (attempt-owning) caller's values govern the
+    /// shared attempt, since there is only one real completion event to
+    /// route. Today's only concurrent caller of this method is
+    /// `stopAndDiscardFiles()`, and `MeetingSessionController`'s state
+    /// machine does not issue two overlapping stops in practice — this join
+    /// path exists to make that guarantee compiler/type-level instead of
+    /// convention-level.
     func stopAndAwaitFiles(
         timedOutOwner: TimedOutStopCompletionOwner? = nil,
         onTimedOutCompletion: ((CaptureStopResult) -> Void)? = nil
     ) async -> CaptureStopResult {
-        guard audio.isRecording else {
-            return currentStopResult()
-        }
-        // A second overlapping stop call (e.g. two callers racing to stop the
-        // same recording before Core's completion callback fires) must not
-        // silently displace a still-pending completion's continuation —
-        // `MeetingCaptureAttempt.begin()` overwrites unconditionally, so the
-        // caller is responsible for resolving any outstanding attempt first.
-        // `startRecording()` already does the equivalent reset for a stale
-        // completion attempt left over from a previous recording; mirror it
-        // here so a concurrent stop can't leak a continuation and hang its
-        // caller forever.
-        completionAttempt.reset()?.resume(returning: currentStopResult())
-        let stopTimeout = TranscriptedConstants.meetingStopTimeout(
-            forRecordingDuration: max(recordingDuration, audio.recordingDuration)
-        )
-
         return await withCheckedContinuation { continuation in
+            // A second overlapping stop call (e.g. two callers racing to stop
+            // the same recording before Core's completion callback fires)
+            // must NOT start its own attempt: that would call `audio.stop()`
+            // again, mint a fresh completionAttempt token, and displace the
+            // first attempt's continuation with a fabricated "complete"
+            // result while the WAV writers may still be closing — and once
+            // displaced, the *real* completion (when it lands) would resolve
+            // whichever continuation happens to be stored, not the one that
+            // actually asked for it. Instead, join the attempt already in
+            // flight and wait for the exact same eventual result — there is
+            // only one underlying `audio.stop()` call and one real
+            // completion event to own, so every caller must observe it.
+            //
+            // This check must run *before* consulting `audio.isRecording`:
+            // Core's `Audio.stop()` flips `isRecording` false from a
+            // `DispatchQueue.main.async` block queued before the slow
+            // CoreAudio teardown / WAV finalization even starts (see
+            // `Audio.stop()`'s "unfreeze the UI immediately" comment), so a
+            // second call landing in that window would already see
+            // `audio.isRecording == false` despite the real completion still
+            // being outstanding. `completionAttempt`'s own active/inactive
+            // state — not `audio.isRecording` — is the source of truth for
+            // whether a stop is already in flight.
+            if completionAttempt.joinIfActive(continuation) {
+                return
+            }
+
+            guard audio.isRecording else {
+                continuation.resume(returning: currentStopResult())
+                return
+            }
+
+            let stopTimeout = TranscriptedConstants.meetingStopTimeout(
+                forRecordingDuration: max(recordingDuration, audio.recordingDuration)
+            )
             let stopGeneration = audio.currentRecordingSessionGeneration &+ 1
             expectedStopGeneration = stopGeneration
             let attemptID = completionAttempt.begin(continuation)
@@ -191,8 +233,9 @@ final class MeetingCaptureBridge: ObservableObject {
 
             completionAttempt.setTimeoutTask(Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: stopTimeout)
-                guard let self,
-                      let continuation = self.completionAttempt.resetIfCurrent(attemptID) else { return }
+                guard let self else { return }
+                let waiters = self.completionAttempt.resetIfCurrent(attemptID)
+                guard !waiters.isEmpty else { return }
 
                 EventReporter.shared.capture(
                     level: .error,
@@ -215,7 +258,10 @@ final class MeetingCaptureBridge: ObservableObject {
                     handler: onTimedOutCompletion
                 )
                 self.scheduleTimedOutStopCompletionExpiry(generation: stopGeneration)
-                continuation.resume(returning: self.currentStopResult(didTimeOut: true))
+                let timedOutResult = self.currentStopResult(didTimeOut: true)
+                for continuation in waiters {
+                    continuation.resume(returning: timedOutResult)
+                }
             })
         }
     }
@@ -270,14 +316,19 @@ final class MeetingCaptureBridge: ObservableObject {
         case .waiting:
             return
         case .ready:
-            startAttempt.reset()?.resume(returning: true)
+            for continuation in startAttempt.reset() {
+                continuation.resume(returning: true)
+            }
         case .failed(let message):
-            guard let continuation = startAttempt.reset() else { return }
+            let waiters = startAttempt.reset()
+            guard !waiters.isEmpty else { return }
             errorMessage = message
             if audio.isRecording {
                 audio.stop()
             }
-            continuation.resume(returning: false)
+            for continuation in waiters {
+                continuation.resume(returning: false)
+            }
         }
     }
 
@@ -326,9 +377,12 @@ final class MeetingCaptureBridge: ObservableObject {
                     currentAudioGeneration: self.audio.currentRecordingSessionGeneration
                 ) {
                 case .expectedStop:
-                    guard let continuation = self.completionAttempt.reset() else { return }
+                    let waiters = self.completionAttempt.reset()
+                    guard !waiters.isEmpty else { return }
                     self.expectedStopGeneration = nil
-                    continuation.resume(returning: result)
+                    for continuation in waiters {
+                        continuation.resume(returning: result)
+                    }
                 case .unexpectedCurrentStop:
                     self.onUnexpectedRecordingComplete?(result)
                 case .stale:

--- a/Sources/Meeting/MeetingCaptureSupport.swift
+++ b/Sources/Meeting/MeetingCaptureSupport.swift
@@ -352,10 +352,22 @@ struct TimedOutStopCompletionRegistry {
 // so the UUID's global uniqueness was never actually load-bearing — a
 // per-instance monotonic token is observationally identical for every real
 // comparison this type performs.
+//
+// `reset()`/`resetIfCurrent(_:)` return an *array* rather than a single
+// optional continuation because a caller can `joinIfActive(_:)` an
+// already-in-flight attempt instead of starting its own: two overlapping
+// `MeetingCaptureBridge.stopAndAwaitFiles()` calls must resolve to the exact
+// same `CaptureStopResult`, not each mint their own `begin()`/token and race
+// Core's real completion callback against each other. Every element of the
+// returned array must be resumed with the *same* value by the caller, so
+// every waiter observes the one true outcome of the one underlying
+// operation (`audio.stop()` is only ever called once per attempt).
 @MainActor
 final class MeetingCaptureAttempt<Output> {
     private var epoch = SupersessionEpoch()
     private var slot = ClaimSlot<CheckedContinuation<Output, Never>>()
+    private var waiters: [CheckedContinuation<Output, Never>] = []
+    private var isActive = false
     private var timeoutTask: Task<Void, Never>?
 
     deinit {
@@ -366,9 +378,23 @@ final class MeetingCaptureAttempt<Output> {
         let token = epoch.begin()
         // Matches the previous behavior exactly: silently displaces whatever
         // was stashed before. Callers remain responsible for resolving any
-        // outstanding attempt (via `reset()`) before starting a new one.
+        // outstanding attempt (via `reset()`) — or joining it (via
+        // `joinIfActive(_:)`) — before starting a new one.
         slot.install(continuation, ownedBy: token)
+        waiters.removeAll()
+        isActive = true
         return token
+    }
+
+    /// Appends `continuation` as an additional waiter on the attempt already
+    /// in flight, returning `true` if there was one to join. Returns `false`
+    /// (and leaves `continuation` untouched, for the caller to `begin()` its
+    /// own attempt) when nothing is active.
+    @discardableResult
+    func joinIfActive(_ continuation: CheckedContinuation<Output, Never>) -> Bool {
+        guard isActive else { return false }
+        waiters.append(continuation)
+        return true
     }
 
     func setTimeoutTask(_ task: Task<Void, Never>) {
@@ -376,14 +402,24 @@ final class MeetingCaptureAttempt<Output> {
         timeoutTask = task
     }
 
-    func reset() -> CheckedContinuation<Output, Never>? {
+    /// Unconditionally clears the pending attempt — primary continuation and
+    /// every joined waiter alike — and returns every continuation that must
+    /// now be resumed with the same value, exactly once each.
+    func reset() -> [CheckedContinuation<Output, Never>] {
         timeoutTask?.cancel()
         timeoutTask = nil
-        return slot.clear()
+        isActive = false
+        var resolved: [CheckedContinuation<Output, Never>] = []
+        if let primary = slot.clear() {
+            resolved.append(primary)
+        }
+        resolved.append(contentsOf: waiters)
+        waiters.removeAll()
+        return resolved
     }
 
-    func resetIfCurrent(_ token: SupersessionEpoch.Token) -> CheckedContinuation<Output, Never>? {
-        guard epoch.isCurrent(token) else { return nil }
+    func resetIfCurrent(_ token: SupersessionEpoch.Token) -> [CheckedContinuation<Output, Never>] {
+        guard epoch.isCurrent(token) else { return [] }
         return reset()
     }
 }

--- a/Sources/Meeting/MeetingCaptureSupport.swift
+++ b/Sources/Meeting/MeetingCaptureSupport.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 /// Result of a stop request. `didTimeOut == true` means we did not receive
 /// `Audio.onRecordingComplete` within `meetingStopTimeout`, so the WAV files
@@ -332,20 +335,40 @@ struct TimedOutStopCompletionRegistry {
     }
 }
 
+// @MainActor because every real usage lives inside MeetingCaptureBridge
+// (@MainActor), including its deinit. Without this annotation the type was
+// safe only by convention: nothing stopped a future caller from touching it
+// off-main, and a dropped-without-resume CheckedContinuation is a runtime
+// trap hazard. Marking the class @MainActor makes that confinement
+// compiler-checked instead of relying on every call site staying disciplined.
+//
+// The token/payload shape below is a direct re-expression of the previous
+// `attemptID: UUID?` + `continuation: CheckedContinuation<Output, Never>?`
+// pair using `SupersessionEpoch` + `ClaimSlot` (Sources/TranscriptedCore/
+// Utilities/SupersessionEpoch.swift). This is a safe drop-in, not a
+// behavior change: `attemptID` was only ever minted by `begin()` and
+// compared against `self.attemptID` on the *same* `MeetingCaptureAttempt`
+// instance (never logged, persisted, or compared across bridge instances),
+// so the UUID's global uniqueness was never actually load-bearing — a
+// per-instance monotonic token is observationally identical for every real
+// comparison this type performs.
+@MainActor
 final class MeetingCaptureAttempt<Output> {
-    private var continuation: CheckedContinuation<Output, Never>?
-    private var attemptID: UUID?
+    private var epoch = SupersessionEpoch()
+    private var slot = ClaimSlot<CheckedContinuation<Output, Never>>()
     private var timeoutTask: Task<Void, Never>?
 
     deinit {
         timeoutTask?.cancel()
     }
 
-    func begin(_ continuation: CheckedContinuation<Output, Never>) -> UUID {
-        let attemptID = UUID()
-        self.continuation = continuation
-        self.attemptID = attemptID
-        return attemptID
+    func begin(_ continuation: CheckedContinuation<Output, Never>) -> SupersessionEpoch.Token {
+        let token = epoch.begin()
+        // Matches the previous behavior exactly: silently displaces whatever
+        // was stashed before. Callers remain responsible for resolving any
+        // outstanding attempt (via `reset()`) before starting a new one.
+        slot.install(continuation, ownedBy: token)
+        return token
     }
 
     func setTimeoutTask(_ task: Task<Void, Never>) {
@@ -354,16 +377,13 @@ final class MeetingCaptureAttempt<Output> {
     }
 
     func reset() -> CheckedContinuation<Output, Never>? {
-        let continuation = continuation
         timeoutTask?.cancel()
         timeoutTask = nil
-        self.continuation = nil
-        attemptID = nil
-        return continuation
+        return slot.clear()
     }
 
-    func resetIfCurrent(_ attemptID: UUID) -> CheckedContinuation<Output, Never>? {
-        guard self.attemptID == attemptID else { return nil }
+    func resetIfCurrent(_ token: SupersessionEpoch.Token) -> CheckedContinuation<Output, Never>? {
+        guard epoch.isCurrent(token) else { return nil }
         return reset()
     }
 }

--- a/Sources/UI/Settings/LocalSummaryAttemptTelemetry.swift
+++ b/Sources/UI/Settings/LocalSummaryAttemptTelemetry.swift
@@ -47,6 +47,18 @@ enum LocalSummaryTelemetryErrorClassification: Equatable {
     case failure(kind: LocalSummaryTelemetryFailureKind, stage: LocalSummaryTelemetryStage)
 }
 
+// @MainActor: every real usage site (Sources/UI/Settings/TranscriptedSettingsView.swift,
+// generateLocalSummary(...)) constructs this on the settings view's implicit
+// MainActor isolation, calls `intent(...)` synchronously right after, and
+// calls `terminal(...)` only from inside a `Task { @MainActor in ... }`
+// block — the heavy summarizer work itself runs on a `Task.detached` that
+// only touches the NSLock-protected `LocalSummaryTerminalOutcomeArbiter`,
+// never this type. Annotating it @MainActor makes that existing confinement
+// compiler-checked instead of relying on convention, matching its sibling
+// arbiter's compiler/runtime-checked safety story (NSLock there vs. actor
+// isolation here, since the arbiter's whole point is being touched from the
+// detached task too).
+@MainActor
 final class LocalSummaryAttemptTelemetry {
     enum SummaryAction: String {
         case generate

--- a/Tests/LocalSummaryAttemptTelemetryTests.swift
+++ b/Tests/LocalSummaryAttemptTelemetryTests.swift
@@ -206,6 +206,12 @@ final class CyclicNSError: NSError {
     }
 }
 
+// LocalSummaryAttemptTelemetry is @MainActor (all real usage is confined to
+// the settings view's MainActor isolation). Only the `main()` entry point of
+// an executable gets implicit MainActor isolation; the private static
+// helpers below need the annotation explicitly to keep calling it
+// synchronously without threading `await` through this whole harness.
+@MainActor
 @main
 struct Harness {
     static func main() {

--- a/Tests/MeetingCaptureAttemptTests.swift
+++ b/Tests/MeetingCaptureAttemptTests.swift
@@ -9,10 +9,11 @@ func testMeetingCaptureAttempt() async {
         let attempt = MeetingCaptureAttempt<Int>()
         let result = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
             let token = attempt.begin(continuation)
-            guard let resolved = attempt.resetIfCurrent(token) else {
-                fatalError("expected the just-begun token to still be current")
+            let resolved = attempt.resetIfCurrent(token)
+            guard resolved.count == 1 else {
+                fatalError("expected the just-begun token to still be current with exactly one waiter")
             }
-            resolved.resume(returning: 42)
+            resolved[0].resume(returning: 42)
         }
         assertEqual(
             result, 42,
@@ -24,10 +25,11 @@ func testMeetingCaptureAttempt() async {
         let attempt = MeetingCaptureAttempt<Bool>()
         let result = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             _ = attempt.begin(continuation)
-            guard let resolved = attempt.reset() else {
-                fatalError("expected reset() to return the pending continuation")
+            let resolved = attempt.reset()
+            guard resolved.count == 1 else {
+                fatalError("expected reset() to return exactly the one pending continuation")
             }
-            resolved.resume(returning: true)
+            resolved[0].resume(returning: true)
         }
         assertTrue(
             result,
@@ -37,7 +39,10 @@ func testMeetingCaptureAttempt() async {
 
     runSuite("MeetingCaptureAttempt.reset is a no-op when nothing is pending") {
         let attempt = MeetingCaptureAttempt<Bool>()
-        assertNil(attempt.reset(), "reset() on a fresh (or already-drained) attempt must return nil, not trap")
+        assertTrue(
+            attempt.reset().isEmpty,
+            "reset() on a fresh (or already-drained) attempt must return no continuations, not trap"
+        )
     }
 
     await runSuite("MeetingCaptureAttempt.resetIfCurrent rejects a token from a previous attempt") {
@@ -46,10 +51,13 @@ func testMeetingCaptureAttempt() async {
             let firstToken = attempt.begin(continuation)
             // A caller must resolve any outstanding attempt before starting a
             // new one (MeetingCaptureBridge.startRecording() and, after this
-            // change, stopAndAwaitFiles() both do this). Simulate that here.
-            attempt.reset()?.resume(returning: 1)
-            assertNil(
-                attempt.resetIfCurrent(firstToken),
+            // change, stopAndAwaitFiles() both do this — or join it via
+            // joinIfActive). Simulate a resolve-then-supersede here.
+            for pending in attempt.reset() {
+                pending.resume(returning: 1)
+            }
+            assertTrue(
+                attempt.resetIfCurrent(firstToken).isEmpty,
                 "a token from an already-resolved attempt must never resolve again"
             )
         }
@@ -57,7 +65,9 @@ func testMeetingCaptureAttempt() async {
 
         let secondResult = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
             _ = attempt.begin(continuation)
-            attempt.reset()?.resume(returning: 2)
+            for pending in attempt.reset() {
+                pending.resume(returning: 2)
+            }
         }
         assertEqual(
             secondResult, 2,
@@ -67,12 +77,15 @@ func testMeetingCaptureAttempt() async {
 
     await runSuite("MeetingCaptureAttempt.begin() silently displaces an unresolved prior attempt") {
         // This documents the exact hazard MeetingCaptureBridge.stopAndAwaitFiles
-        // now guards against: begin() does not protect a caller who forgets to
-        // reset() first. The type intentionally mirrors its previous
-        // UUID-based behavior here (an unconditional overwrite) rather than
-        // silently fixing the symptom at this layer, because MeetingCaptureBridge
-        // is the one place that knows whether an in-flight attempt should be
-        // resumed with a real result or is safe to discard.
+        // now avoids entirely by joining an active attempt (via joinIfActive)
+        // instead of ever calling begin() while one is already in flight:
+        // begin() itself still does not protect a caller who calls it anyway
+        // without resetting (or joining) first. The type intentionally
+        // mirrors its previous UUID-based behavior here (an unconditional
+        // overwrite) rather than silently fixing the symptom at this layer,
+        // because the caller is the one that knows whether an in-flight
+        // attempt should be resumed with a real result, joined, or is safe
+        // to discard.
         let attempt = MeetingCaptureAttempt<Int>()
         let firstBegan = ParakeetAsyncInterleavingGate()
         var firstToken: SupersessionEpoch.Token!
@@ -90,11 +103,13 @@ func testMeetingCaptureAttempt() async {
 
         let secondResult = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
             _ = attempt.begin(continuation)
-            assertNil(
-                attempt.resetIfCurrent(firstToken),
+            assertTrue(
+                attempt.resetIfCurrent(firstToken).isEmpty,
                 "the first attempt's token must be stale once a second begin() has superseded it"
             )
-            attempt.reset()?.resume(returning: 2)
+            for pending in attempt.reset() {
+                pending.resume(returning: 2)
+            }
         }
         assertEqual(secondResult, 2, "reset() resolves whichever attempt is currently stored (the second one)")
 
@@ -108,6 +123,135 @@ func testMeetingCaptureAttempt() async {
             firstResult, 1,
             "the displaced continuation is still resumable directly; only the attempt's own bookkeeping lost it"
         )
+    }
+
+    await runSuite("MeetingCaptureAttempt.joinIfActive returns false when nothing is in flight") {
+        let attempt = MeetingCaptureAttempt<Int>()
+        let result = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
+            let joined = attempt.joinIfActive(continuation)
+            assertFalse(joined, "joinIfActive must report false so the caller knows to begin() its own attempt")
+            // Per contract, a failed join leaves `continuation` untouched —
+            // the caller (MeetingCaptureBridge.stopAndAwaitFiles) is expected
+            // to begin() with it instead. Do that here to resolve cleanly.
+            let token = attempt.begin(continuation)
+            for pending in attempt.resetIfCurrent(token) {
+                pending.resume(returning: 7)
+            }
+        }
+        assertEqual(result, 7)
+    }
+
+    await runSuite("MeetingCaptureAttempt.joinIfActive coalesces overlapping callers onto the same result via resetIfCurrent") {
+        // Mirrors the bug MeetingCaptureBridge.stopAndAwaitFiles used to have:
+        // two overlapping callers must observe the exact same eventual
+        // result instead of the second one displacing (and never resuming)
+        // the first, or minting its own token that makes the real completion
+        // look stale. This suite exercises the "natural completion" path
+        // (resetIfCurrent, matching the token from begin()) — the same
+        // mechanism the bridge's real audio-completion callback uses.
+        let attempt = MeetingCaptureAttempt<Int>()
+        let firstBegan = ParakeetAsyncInterleavingGate()
+        let secondJoined = ParakeetAsyncInterleavingGate()
+        var firstToken: SupersessionEpoch.Token!
+
+        let firstTask = Task { @MainActor () -> Int in
+            await withCheckedContinuation { continuation in
+                firstToken = attempt.begin(continuation)
+                Task { await firstBegan.open() }
+            }
+        }
+        await firstBegan.wait()
+
+        let secondTask = Task { @MainActor () -> Int in
+            await withCheckedContinuation { continuation in
+                let joined = attempt.joinIfActive(continuation)
+                assertTrue(joined, "a second caller must join the in-flight attempt instead of starting its own")
+                Task { await secondJoined.open() }
+            }
+        }
+        await secondJoined.wait()
+
+        let waiters = attempt.resetIfCurrent(firstToken)
+        assertEqual(
+            waiters.count, 2,
+            "resetIfCurrent must return the primary continuation plus every joined waiter"
+        )
+        for continuation in waiters {
+            continuation.resume(returning: 99)
+        }
+
+        let firstResult = await firstTask.value
+        let secondResult = await secondTask.value
+        assertEqual(firstResult, 99, "the attempt-owning caller must see the shared result")
+        assertEqual(secondResult, 99, "the joined caller must see the exact same shared result")
+    }
+
+    await runSuite("MeetingCaptureAttempt.joinIfActive coalesces overlapping callers onto the same result via reset") {
+        // Same coalescing contract as above, but exercised through the
+        // unconditional reset() path — this is what every teardown path
+        // (deinit, a stale-attempt reset, and a timeout task's
+        // resetIfCurrent-then-resume) relies on to resume every joined
+        // waiter, not just the primary one.
+        let attempt = MeetingCaptureAttempt<Bool>()
+        let firstBegan = ParakeetAsyncInterleavingGate()
+        let secondJoined = ParakeetAsyncInterleavingGate()
+
+        let firstTask = Task { @MainActor () -> Bool in
+            await withCheckedContinuation { continuation in
+                _ = attempt.begin(continuation)
+                Task { await firstBegan.open() }
+            }
+        }
+        await firstBegan.wait()
+
+        let secondTask = Task { @MainActor () -> Bool in
+            await withCheckedContinuation { continuation in
+                assertTrue(attempt.joinIfActive(continuation), "second caller should join")
+                Task { await secondJoined.open() }
+            }
+        }
+        await secondJoined.wait()
+
+        let waiters = attempt.reset()
+        assertEqual(waiters.count, 2, "reset() must drain the primary continuation plus every joined waiter")
+        for continuation in waiters {
+            continuation.resume(returning: false)
+        }
+
+        let firstResult = await firstTask.value
+        let secondResult = await secondTask.value
+        assertFalse(firstResult, "teardown must resume the attempt-owning caller")
+        assertFalse(secondResult, "teardown must resume the joined caller with the same value")
+    }
+
+    await runSuite("MeetingCaptureAttempt.begin() clears any stale joined waiters from a prior attempt") {
+        // Defensive: begin() always starts from a clean waiters list, even
+        // though in practice a caller should only ever begin() when nothing
+        // is active (joinIfActive covers the "already active" case).
+        let attempt = MeetingCaptureAttempt<Int>()
+        let firstBegan = ParakeetAsyncInterleavingGate()
+
+        let firstTask = Task { @MainActor () -> Int in
+            await withCheckedContinuation { continuation in
+                _ = attempt.begin(continuation)
+                Task { await firstBegan.open() }
+            }
+        }
+        await firstBegan.wait()
+        for pending in attempt.reset() {
+            pending.resume(returning: 1)
+        }
+        _ = await firstTask.value
+
+        let secondResult = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
+            let token = attempt.begin(continuation)
+            let waiters = attempt.resetIfCurrent(token)
+            assertEqual(waiters.count, 1, "a freshly begun attempt must carry no leftover waiters")
+            for pending in waiters {
+                pending.resume(returning: 2)
+            }
+        }
+        assertEqual(secondResult, 2)
     }
 
     await runSuite("MeetingCaptureAttempt.reset cancels its outstanding timeout task") {
@@ -125,7 +269,9 @@ func testMeetingCaptureAttempt() async {
                 guard !Task.isCancelled else { return }
                 timeoutRan.mark()
             })
-            attempt.reset()?.resume(returning: false)
+            for pending in attempt.reset() {
+                pending.resume(returning: false)
+            }
         }
         assertFalse(result, "reset() should have resumed with the caller-provided value")
         try? await Task.sleep(nanoseconds: 120_000_000)

--- a/Tests/MeetingCaptureAttemptTests.swift
+++ b/Tests/MeetingCaptureAttemptTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+// MeetingCaptureAttempt is @MainActor (Sources/Meeting/MeetingCaptureSupport.swift),
+// so this whole entry function runs isolated to MainActor — matching how its
+// only real caller, MeetingCaptureBridge, is itself @MainActor.
+@MainActor
+func testMeetingCaptureAttempt() async {
+    await runSuite("MeetingCaptureAttempt.resetIfCurrent resolves the current attempt") {
+        let attempt = MeetingCaptureAttempt<Int>()
+        let result = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
+            let token = attempt.begin(continuation)
+            guard let resolved = attempt.resetIfCurrent(token) else {
+                fatalError("expected the just-begun token to still be current")
+            }
+            resolved.resume(returning: 42)
+        }
+        assertEqual(
+            result, 42,
+            "resetIfCurrent should hand back the current attempt's continuation for the caller to resume"
+        )
+    }
+
+    await runSuite("MeetingCaptureAttempt.reset unconditionally resolves the pending attempt") {
+        let attempt = MeetingCaptureAttempt<Bool>()
+        let result = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            _ = attempt.begin(continuation)
+            guard let resolved = attempt.reset() else {
+                fatalError("expected reset() to return the pending continuation")
+            }
+            resolved.resume(returning: true)
+        }
+        assertTrue(
+            result,
+            "reset() must let a teardown path resume the continuation regardless of which token owns it"
+        )
+    }
+
+    runSuite("MeetingCaptureAttempt.reset is a no-op when nothing is pending") {
+        let attempt = MeetingCaptureAttempt<Bool>()
+        assertNil(attempt.reset(), "reset() on a fresh (or already-drained) attempt must return nil, not trap")
+    }
+
+    await runSuite("MeetingCaptureAttempt.resetIfCurrent rejects a token from a previous attempt") {
+        let attempt = MeetingCaptureAttempt<Int>()
+        let firstResult = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
+            let firstToken = attempt.begin(continuation)
+            // A caller must resolve any outstanding attempt before starting a
+            // new one (MeetingCaptureBridge.startRecording() and, after this
+            // change, stopAndAwaitFiles() both do this). Simulate that here.
+            attempt.reset()?.resume(returning: 1)
+            assertNil(
+                attempt.resetIfCurrent(firstToken),
+                "a token from an already-resolved attempt must never resolve again"
+            )
+        }
+        assertEqual(firstResult, 1)
+
+        let secondResult = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
+            _ = attempt.begin(continuation)
+            attempt.reset()?.resume(returning: 2)
+        }
+        assertEqual(
+            secondResult, 2,
+            "a fresh begin() after a resolved attempt should mint an independently resolvable token"
+        )
+    }
+
+    await runSuite("MeetingCaptureAttempt.begin() silently displaces an unresolved prior attempt") {
+        // This documents the exact hazard MeetingCaptureBridge.stopAndAwaitFiles
+        // now guards against: begin() does not protect a caller who forgets to
+        // reset() first. The type intentionally mirrors its previous
+        // UUID-based behavior here (an unconditional overwrite) rather than
+        // silently fixing the symptom at this layer, because MeetingCaptureBridge
+        // is the one place that knows whether an in-flight attempt should be
+        // resumed with a real result or is safe to discard.
+        let attempt = MeetingCaptureAttempt<Int>()
+        let firstBegan = ParakeetAsyncInterleavingGate()
+        var firstToken: SupersessionEpoch.Token!
+        var capturedFirstContinuation: CheckedContinuation<Int, Never>!
+
+        let firstTask = Task { @MainActor () -> Int in
+            await withCheckedContinuation { continuation in
+                capturedFirstContinuation = continuation
+                firstToken = attempt.begin(continuation)
+                Task { await firstBegan.open() }
+            }
+        }
+
+        await firstBegan.wait()
+
+        let secondResult = await withCheckedContinuation { (continuation: CheckedContinuation<Int, Never>) in
+            _ = attempt.begin(continuation)
+            assertNil(
+                attempt.resetIfCurrent(firstToken),
+                "the first attempt's token must be stale once a second begin() has superseded it"
+            )
+            attempt.reset()?.resume(returning: 2)
+        }
+        assertEqual(secondResult, 2, "reset() resolves whichever attempt is currently stored (the second one)")
+
+        // The attempt itself has now lost track of the first continuation —
+        // resume it directly (bypassing the attempt) so this test doesn't
+        // leak an unresumed CheckedContinuation, then prove it really was the
+        // original, still-live continuation and not a trap.
+        capturedFirstContinuation.resume(returning: 1)
+        let firstResult = await firstTask.value
+        assertEqual(
+            firstResult, 1,
+            "the displaced continuation is still resumable directly; only the attempt's own bookkeeping lost it"
+        )
+    }
+
+    await runSuite("MeetingCaptureAttempt.reset cancels its outstanding timeout task") {
+        let attempt = MeetingCaptureAttempt<Bool>()
+        let timeoutRan = TimeoutRanBox()
+        let result = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            _ = attempt.begin(continuation)
+            attempt.setTimeoutTask(Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 40_000_000)
+                // `try?` swallows Task.sleep's CancellationError, so a
+                // cancelled task must check `isCancelled` explicitly before
+                // acting — exactly like every real timeout task in
+                // MeetingCaptureBridge guards itself via resetIfCurrent's
+                // token check, not by relying on the sleep throw alone.
+                guard !Task.isCancelled else { return }
+                timeoutRan.mark()
+            })
+            attempt.reset()?.resume(returning: false)
+        }
+        assertFalse(result, "reset() should have resumed with the caller-provided value")
+        try? await Task.sleep(nanoseconds: 120_000_000)
+        assertFalse(timeoutRan.value, "reset() must cancel the outstanding timeout task so it never fires")
+    }
+}
+
+@MainActor
+private final class TimeoutRanBox {
+    private(set) var value = false
+    func mark() { value = true }
+}


### PR DESCRIPTION
## Summary

Two guard types were safe only by convention (no lock, no actor annotation). This makes both compiler-checked.

### 1. `MeetingCaptureAttempt<Output>` (Sources/Meeting/MeetingCaptureSupport.swift)

Marked `@MainActor`. Every real caller is `MeetingCaptureBridge` (`@MainActor`), including its `deinit`, which was **not** MainActor-isolated before this change — a latent hazard if the bridge ever deinited off-main.

**Waiter coalescing** (updated after review — see PR comment for the full story): `MeetingCaptureAttempt` now supports multiple waiters on one in-flight attempt via `joinIfActive(_ continuation:) -> Bool`. `reset()`/`resetIfCurrent(_:)` return `[CheckedContinuation<Output, Never>]` (every continuation that must resolve to the *same* value) instead of a single optional. The start path's `begin()`/`reset()` single-waiter semantics are untouched; only `completionAttempt`'s stop path ever calls `joinIfActive`.

**Teardown paths and their continuation guarantees** (both `startAttempt` and `completionAttempt` are `MeetingCaptureAttempt` instances; every path below now resumes *every* returned continuation, not just a primary one):

- `MeetingCaptureBridge.deinit` (now `isolated deinit`) — unconditionally resumes every pending `startAttempt` continuation (`false`) and every pending `completionAttempt` continuation (best-effort `CaptureStopResult`), cancels any outstanding timed-out-stop expiry tasks. `isolated deinit` (Swift 6.1+, available on this toolchain — `swiftc --version` shows Swift 6.3.3 — without any extra language-mode flag; verified with a standalone `swiftc -typecheck` repro before adopting it) keeps this on MainActor instead of relying on every release site happening to run there.
- `startRecording()` — resets a stale `completionAttempt` left over from a previous session at the top; installs a fresh `startAttempt` guarded by a MainActor timeout `Task` that resumes+resets via `resetIfCurrent` (token-guarded, so it can't double-resume if `finishPendingStartAttemptIfPossible()` already won the race).
- `finishPendingStartAttemptIfPossible()` (driven by Combine subscriptions on `audio.$isRecording`/`$error`/etc.) — resumes+resets `startAttempt` on ready/failed.
- `stopAndAwaitFiles()` — if a stop is already in flight, **joins** it via `joinIfActive(_:)` instead of starting a new one (no new `begin()`, no new `audio.stop()`, no new token/generation). Otherwise installs `completionAttempt`, guarded by a MainActor timeout `Task` (`resetIfCurrent`-guarded, resumes every waiter with the same timed-out result) and by `wireCallbacks()`'s `onRecordingCompleteWithGeneration` handler (resumes every waiter with the same real result on `.expectedStop` disposition). The join check runs *before* consulting `audio.isRecording`, because `Audio.stop()` flips `isRecording` false from a `DispatchQueue.main.async` block queued before WAV finalization even starts — `completionAttempt`'s own active/inactive state, not `audio.isRecording`, is the source of truth for "is a stop already outstanding."
- **Original P1 (fixed)**: a first pass at this fix resumed a displaced `completionAttempt` continuation with a fabricated `currentStopResult()`, which could report still-finalizing audio as complete and cause the real completion to be misrouted once a second `begin()` advanced the attempt's own token. Replaced with waiter coalescing so two overlapping stop callers always observe the one true result of the one underlying `audio.stop()` call. `Tests/MeetingCaptureAttemptTests.swift` covers coalescing via both `resetIfCurrent` (real-completion path) and `reset()` (every teardown/timeout path), plus a regression test documenting that `begin()` itself still silently displaces if a caller calls it without checking `joinIfActive` first (by design — `joinIfActive` is the guard, not `begin()`).

**Primitive adoption**: re-expressed `MeetingCaptureAttempt`'s `attemptID: UUID?` + `continuation` pair using `SupersessionEpoch` + `ClaimSlot` from PR #1631 (`Sources/TranscriptedCore/Utilities/SupersessionEpoch.swift`). Verified this is a clean drop-in, not a semantic change: `attemptID` was only ever minted by `begin()` and compared against `self.attemptID` on the *same* instance — never logged, persisted, or compared across bridge instances — so the UUID's global uniqueness was never load-bearing.

### 2. `LocalSummaryAttemptTelemetry` (Sources/UI/Settings/LocalSummaryAttemptTelemetry.swift)

Verified every real usage site first (grep): only `TranscriptedSettingsView.generateLocalSummary(...)`. It's constructed synchronously, `.intent()` is called synchronously right after, and every `.terminal()` call is inside `Task { @MainActor in ... }` — the `Task.detached` background work only touches the already-NSLock-protected sibling `LocalSummaryTerminalOutcomeArbiter`, never this type. All MainActor — annotated `@MainActor` to match, giving it the same compiler-checked safety story as its sibling's NSLock (different mechanism, same guarantee, since the sibling actually is touched from the detached task).

This broke the standalone subprocess test harness in `Tests/LocalSummaryAttemptTelemetryTests.swift`, whose `private static` helper functions (called from `Harness.main()`, not inlined into it) lost the implicit MainActor isolation `main()` itself gets. Fixed by marking the harness `struct Harness` `@MainActor`.

## Test plan

- [x] `bash build-deps.sh --force` (stamp mismatch on fresh worktree)
- [x] `bash build.sh --no-open` — clean build, no new warnings
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12684 tests, 0 failed
- [x] `bash run-integration-smoke.sh` — pass
- [x] `swift test` — 946 tests, 13 skipped, 0 failures
- [x] `Tests/MeetingCaptureAttemptTests.swift` covers begin/reset/resetIfCurrent semantics, cross-token rejection, timeout-task cancellation on reset, `joinIfActive` coalescing (both the resetIfCurrent and reset() paths), the false-when-inactive contract, and the begin()-without-reset displacement hazard

Not merging per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
