### PR TITLE
Migrate SystemAudioCapture/SCKAudioCapture generation counters onto SupersessionEpoch

### DIFF
--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -180,7 +180,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     private var _audioFormat: AVAudioFormat?
     private var _isCapturing = false
     private var bufferCallback: ((AVAudioPCMBuffer) -> Void)?
-    private var _generation: UInt64 = 0
+    private var _generationEpoch = SupersessionEpoch()
     private var streamGeneration: UInt64?
     private var streamPhase: StreamPhase = .idle
     private var isWaitingForTimedOutStopCallback = false
@@ -510,17 +510,22 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         }
     }
 
+    // Keep returning raw UInt64 here so the many `generation: UInt64` call
+    // sites below (streamGeneration comparisons, StopTransition, etc. — out of
+    // scope for this migration, see the file-level note near `streamGeneration`)
+    // don't need to change. `.rawValue` is the primitive's documented interop
+    // accessor for exactly this "raw counter threaded through logging/params"
+    // shape.
     private func incrementGeneration() -> UInt64 {
         captureStateLock.lock()
         defer { captureStateLock.unlock() }
-        _generation &+= 1
-        return _generation
+        return _generationEpoch.begin().rawValue
     }
 
     private func currentGeneration() -> UInt64 {
         captureStateLock.lock()
         defer { captureStateLock.unlock() }
-        return _generation
+        return _generationEpoch.snapshot().rawValue
     }
 
     private func currentStreamState() -> CurrentStreamState {
@@ -571,7 +576,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         if let recoveryToken, !recoveryEpochState.isCurrent(recoveryToken) {
             return false
         }
-        guard _generation == generation,
+        guard _generationEpoch.snapshot().rawValue == generation,
               stream == nil,
               !isWaitingForTimedOutStopCallback else {
             return false
@@ -640,7 +645,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         if recoveryEpochState.cancel(preserving: recoveryToken) {
             isRecovering = false
         }
-        _generation &+= 1
+        _generationEpoch.invalidate()
 
         guard let stream, let generation = streamGeneration else {
             _isCapturing = false
@@ -812,7 +817,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
            stream?.captureIdentity == expectedStream.captureIdentity {
             switch streamPhase {
             case .starting, .capturing:
-                _generation &+= 1
+                _generationEpoch.invalidate()
                 _isCapturing = false
                 streamPhase = .stopping
                 shouldRequestStop = true
@@ -1138,8 +1143,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     @discardableResult
     func replacePreparedStreamForTesting(_ preparedStream: any SCKStreamControlling) -> UInt64 {
         captureStateLock.lock()
-        _generation &+= 1
-        let generation = _generation
+        let generation = _generationEpoch.begin().rawValue
         stream = preparedStream
         streamOutput = nil
         bufferCallback = nil

--- a/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
@@ -85,10 +85,10 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
     let deviceChangeDebounce: TimeInterval = 0.3  // 300ms debounce - device changes fire multiple times
 
     // MARK: - Generation Counter (prevents stale delayed cleanup from destroying new sessions)
-    // Incremented each time prepare() creates a new tap session.
-    // The delayed cleanup in stop() captures the generation at schedule time and skips
+    // Bumped each time prepare() creates a new tap session (SupersessionEpoch.begin()).
+    // The delayed cleanup in stop() snapshots the token at schedule time and skips
     // if it no longer matches — meaning a new session has started in the interim.
-    private var _generation: UInt64 = 0
+    private var _generationEpoch = SupersessionEpoch()
     private let generationLock = NSLock()
 
     // MARK: - Recovery Guard (prevents concurrent recovery attempts)
@@ -168,10 +168,10 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
             stopDeviceChangeListener()
         }
 
-        // Increment generation — any pending delayed cleanup from a prior stop()
-        // will see a stale generation and skip itself
+        // Begin a new generation — any pending delayed cleanup from a prior stop()
+        // will see a stale token and skip itself
         generationLock.lock()
-        _generation &+= 1
+        _generationEpoch.begin()
         generationLock.unlock()
 
         AppLogger.audioSystem.info("Setting up system audio tap")
@@ -238,9 +238,9 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
             self?.stopWatchdog()
         }
 
-        // Capture current generation before scheduling delayed cleanup
+        // Snapshot the current generation token before scheduling delayed cleanup
         generationLock.lock()
-        let capturedGeneration = _generation
+        let capturedGeneration = _generationEpoch.snapshot()
         generationLock.unlock()
 
         // Move delay + cleanup to background queue to avoid blocking main thread
@@ -251,11 +251,12 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
 
             // Check if a new session started while we were waiting
             self.generationLock.lock()
-            let currentGeneration = self._generation
+            let isCurrent = self._generationEpoch.isCurrent(capturedGeneration)
+            let currentGeneration = self._generationEpoch.snapshot()
             self.generationLock.unlock()
 
-            if capturedGeneration != currentGeneration {
-                AppLogger.audioSystem.info("Skipping delayed cleanup — new session started (generation \(capturedGeneration) → \(currentGeneration))")
+            if !isCurrent {
+                AppLogger.audioSystem.info("Skipping delayed cleanup — new session started (generation \(capturedGeneration.rawValue) → \(currentGeneration.rawValue))")
                 return
             }
 


### PR DESCRIPTION
## Summary

Continues the `SupersessionEpoch` migration started in #1631/#1632 by moving two more NSLock-hosted raw `UInt64` generation counters onto the primitive. Both hosts keep their existing locks — only the bump/compare arithmetic inside the existing lock scopes changed.

## Per-site migration table

| Site | Field | Change |
|---|---|---|
| `SystemAudioCapture` (`Sources/TranscriptedCore/Audio/SystemAudioCapture.swift`) | `_generation: UInt64` → `_generationEpoch: SupersessionEpoch` | `prepare()` calls `.begin()` where it used to `&+= 1`. `stop()`'s delayed-cleanup settle check (0.5s `Thread.sleep` on a background queue) snapshots a token before scheduling and calls `.isCurrent(_:)` after the sleep instead of comparing two raw `UInt64`s. The skip-log line keeps logging both generation numbers via `.rawValue` for interop — same log text, same information. |
| `SCKAudioCapture` (`Sources/TranscriptedCore/Audio/SCKAudioCapture.swift`) | `_generation: UInt64` → `_generationEpoch: SupersessionEpoch` | Migrated **inside** the existing `incrementGeneration()`/`currentGeneration()` helpers, which still return raw `UInt64` via `.rawValue` — this keeps every downstream `generation: UInt64` call site (there are ~30, all tied to the separate, out-of-scope `streamGeneration`/`StopTransition`/etc. plumbing) unchanged. The direct raw touches outside those helpers moved too: the compare in `installPreparedStreamIfCurrent` (`_generation == generation` → `_generationEpoch.snapshot().rawValue == generation`), the two fence-out bumps in `transitionToStopped` and `stopStreamAndCleanupAfterFailedStartIfOwned` (`_generation &+= 1` → `_generationEpoch.invalidate()`, matching `invalidate()`'s "something reset, no particular new owner" semantics), and the test-only `replacePreparedStreamForTesting`'s own bump-then-capture (→ `_generationEpoch.begin().rawValue`, matching `begin()`). **Not touched**, per the task's explicit carve-out: `streamGeneration` and `SCKRecoveryEpochState` — they're fused with stream identity and have their own epoch-token semantics; later work. |
| `Audio.micRecoverySessionGeneration` (`Sources/TranscriptedCore/Audio/Audio.swift:485`) | **left as `UInt64?`, not migrated** | See "Item 3 decision" below. |

## Item 3 decision: why `micRecoverySessionGeneration` stays a raw `UInt64?`

I traced every call site of `beginMicRecovery(for:)`/`endMicRecovery(for:)` (all in `AudioDeviceRecovery.swift`) and confirmed the `sessionGeneration: UInt64` value they're called with is *not* minted by this admission latch — it's always the caller's already-known `recordingSessionGeneration` (a separate, much larger raw `UInt64` counter threaded through dozens of sites across `AudioDeviceRecovery.swift` and `AudioFileManager.swift`: `micAudioFileOwnership.takeWriterOwned(by:)`, `installRecoveryWriter(_:generation:)`, the watchdog, etc. — well outside this PR's three-item cohort, and itself a "later work" migration on the scale of item 2's `streamGeneration` carve-out).

That rules out both options the task suggested:

- **`ClaimSlot<Payload>`** needs a `SupersessionEpoch.Token` as its ownership key, but there's no `SupersessionEpoch` instance here that mints one — the "token" is really `recordingSessionGeneration`'s raw value, owned by a different, unmigrated counter.
- **Retyping the optional as `SupersessionEpoch.Token?`** hits the same wall: `Token`'s initializer is `fileprivate init(rawValue:)`, deliberately restricted to `SupersessionEpoch.swift` so arbitrary code can't fabricate a token that happens to compare equal by accident (see the doc comment on `Token`). Wrapping an externally-supplied raw `UInt64` from `recordingSessionGeneration` into a `Token` isn't possible without either poking a hole in that anti-forgery guarantee or migrating `recordingSessionGeneration` itself in the same change — which is a much larger, separate blast radius (dozens of sites in two files), not something this PR's scope covers.

`Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift::testMicRecoveryOwnershipRemainsWithTheActiveSession` also calls `beginMicRecovery`/`endMicRecovery` directly with literal `UInt64`s (11, 12) unrelated to any real session — reinforcing that this API's `UInt64` surface is load-bearing today and not something to change without a wider migration.

So `_micRecoverySessionGeneration: UInt64?` is left exactly as-is — behavior-identical, and honestly not migrated rather than forcing a type that would either be dishonest about where its value comes from or require silently expanding scope.

## Verification (all foreground, in order)

1. `bash build-deps.sh --force` — clean
2. `bash build.sh --no-open` — clean
3. `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12684 tests, 12684 passed
4. `bash run-integration-smoke.sh` — OK (core-linkage smoke, wake smoke, recovery merge package tests)
5. `swift test` — 946 tests, 13 skipped, 0 failures (includes `SupersessionEpochTests`/`ClaimSlotTests`, unchanged, still green)

## Test coverage note

Per the task brief: `SystemAudioCapture` and `SCKAudioCapture` are hard to instantiate headlessly (they wrap real `AVAudioEngine`/`SCStream` capture state), so I didn't add new host-level tests. Coverage is the primitive's own existing `SupersessionEpochTests`/`ClaimSlotTests` (untouched, still passing) plus compile proof through the full app build + `swift test` — consistent with what the task anticipated as an acceptable fallback.

## Concerns

None outstanding. Behavior preservation is strict throughout: same bump timing, same comparison outcomes, same lock scopes, same log content (via `.rawValue` interop where a raw counter value was logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
