### PR TITLE
Small findings-tail: dedup permission revalidation, pin Audio.swift metering

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -191,6 +191,23 @@ public class Audio: ObservableObject, @unchecked Sendable {
     @Published public var systemAudioStatus: SystemAudioStatus = .unknown
 
     // Silence detection for "Still Recording?" prompt
+    //
+    // Pinned, not unified: mic and system audio each track "how quiet is it"
+    // as parallel state (this block + `systemAudioSilenceStart`/
+    // `systemAudioStatus`/`systemAudioSilenceThreshold` further down, plus
+    // the mirrored `calculateLevel`/`calculateSystemLevel` and
+    // `updateSilenceTracking`/`updateSystemAudioSilenceTracking` pairs in
+    // AudioLevelMonitor.swift). They read genuinely different signals
+    // (normalized RMS vs. linear peak), use different thresholds and output
+    // shapes (continuous Bool+TimeInterval here vs. a hysteresis-gated
+    // `SystemAudioStatus` enum for system), and the mic path runs
+    // synchronously on the AVAudioEngine tap callback thread under
+    // `micLevelPublishLock`/`systemLevelLock` — see the threading note above
+    // `levelPublishInterval`. Collapsing both into one generic track-state
+    // type would mean generalizing over that metric/threshold/output
+    // divergence inside RT-adjacent, lock-guarded code, which is exactly the
+    // "touches RT code non-trivially" case call out for this cleanup pass —
+    // left alone rather than risking a behavior change here.
     @Published public var silenceDuration: TimeInterval = 0.0  // How long we've been in silence
     @Published public var isSilent: Bool = false  // True when audio below threshold
     let silenceThreshold: Float = 0.02  // Audio level below this = silence
@@ -671,6 +688,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     // Write error tracking — stop writing after repeated failures
     // Thread-safe: accessed from audio file queues (background) and reset from start() (main thread)
+    // Pinned alongside the level/silence duplication noted above `silenceDuration`:
+    // mic and system counters are parallel state with parallel
+    // recordMicWriteFailure/recordSystemWriteFailure handlers in
+    // AudioFileManager.swift, differing only in messaging and which stop
+    // path they call. Left as-is for the same reason (RT-adjacent surface,
+    // deferred rather than forced for this pass).
     private var _consecutiveMicWriteErrors: Int = 0
     private var _consecutiveSystemWriteErrors: Int = 0
     private let writeErrorLock = NSLock()

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -642,12 +642,10 @@ struct PermissionsOnboardingView: View {
     }
 
     private func revalidateSystemAudioPermissionForStatusSurfaces() {
-        guard permissionRevalidationTask == nil else { return }
-        guard TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown else { return }
-        permissionRevalidationTask = Task { @MainActor in
-            _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
+        SystemAudioPermissionRevalidator.revalidateForStatusSurfaces(
+            task: $permissionRevalidationTask
+        ) {
             systemAudioGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
-            permissionRevalidationTask = nil
         }
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -3965,12 +3965,10 @@ struct TranscriptedSettingsView: View {
     }
 
     private func revalidateSystemAudioPermissionForStatusSurfaces() {
-        guard permissionRevalidationTask == nil else { return }
-        guard TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown else { return }
-        permissionRevalidationTask = Task { @MainActor in
-            _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
+        SystemAudioPermissionRevalidator.revalidateForStatusSurfaces(
+            task: $permissionRevalidationTask
+        ) {
             permissionStates = PermissionSnapshot.current()
-            permissionRevalidationTask = nil
         }
     }
 

--- a/Sources/UI/Shared/SystemAudioPermissionRevalidator.swift
+++ b/Sources/UI/Shared/SystemAudioPermissionRevalidator.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Single owner for the "revalidate System Audio Recording permission for
+/// status surfaces" pattern.
+///
+/// Two Settings surfaces need to re-check the live System Audio Recording
+/// permission state whenever their view becomes active or polls — the
+/// Settings shell (`TranscriptedSettingsView`) and onboarding
+/// (`PermissionsOnboardingView`) — and both used to hand-roll identical
+/// guard/task/completion logic. This is the one place that logic lives now;
+/// both call sites route through it so the in-flight-task guard and the
+/// "skip when status is already known-unknown" check can't drift apart.
+///
+/// `@MainActor` because both call sites are `View`-conforming SwiftUI types
+/// (implicitly main-actor isolated).
+@MainActor
+enum SystemAudioPermissionRevalidator {
+    /// Revalidates System Audio Recording permission if a revalidation isn't
+    /// already in flight for this call site.
+    ///
+    /// - Parameters:
+    ///   - task: the call site's own `@State` task slot. Used both to
+    ///     prevent overlapping revalidation runs and so the caller can cancel
+    ///     it directly (e.g. on `onDisappear`).
+    ///   - onUpdated: runs on the main actor after revalidation completes, so
+    ///     the caller can refresh its own permission-state mirror.
+    static func revalidateForStatusSurfaces(
+        task: Binding<Task<Void, Never>?>,
+        onUpdated: @escaping () -> Void
+    ) {
+        guard task.wrappedValue == nil else { return }
+        guard TranscriptedPermissionAccess.systemAudioRecordingStatus() != .unknown else { return }
+        task.wrappedValue = Task { @MainActor in
+            _ = await TranscriptedPermissionAccess.revalidateSystemAudioRecordingStatus()
+            onUpdated()
+            task.wrappedValue = nil
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Three small audit findings, verified against current `main` and closed out in one PR.

**1. Per-field Combine mirroring (TranscriptionTaskManager metadata → MeetingSessionController)** — **already fixed on main.**
PR #1634 already collapsed this: `MeetingSessionController.updateDisplayStatus(_:source:)` is now the single writer for `displayStatus`, and there's exactly one subscription (`taskManager.$displayStatus.sink { ... updateDisplayStatus(status, source: .taskManagerMirror) }`) mirroring it in from `TranscriptionTaskManager`. No per-field sinks remain for this. No change made.

**2. Duplicated system-audio permission revalidation — fixed.**
`revalidateSystemAudioPermissionForStatusSurfaces()` was duplicated near-verbatim in `Sources/UI/Settings/TranscriptedSettingsView.swift` and `Sources/UI/Settings/PermissionsOnboardingView.swift` (same in-flight-task guard, same `.unknown`-status skip, same revalidate-then-refresh shape). Extracted the shared logic into a new `SystemAudioPermissionRevalidator` (`Sources/UI/Shared/SystemAudioPermissionRevalidator.swift`), following the placement convention set by `LiveMeetingSidecarController` (PR #1625) for cross-surface Settings/onboarding helpers. Each call site keeps its own `@State` task slot and passes its own post-revalidation update as a closure (Settings refreshes `permissionStates`; onboarding refreshes `systemAudioGranted`), so behavior is unchanged.

**3. Duplicated audio level metering (mic vs. system) in `Sources/TranscriptedCore/Audio/` — pinned, not forced.**
Still duplicated as parallel state (`Audio.swift` + `AudioLevelMonitor.swift`): mic and system each have their own level/history/publish-lock, their own silence-tracking state, and their own consecutive-write-error counters + handlers. On inspection, though, the two sides aren't just copy-pasted — they read different signals (normalized RMS for mic vs. linear peak for system), use different thresholds, and produce different output shapes (continuous `Bool`+`TimeInterval` for mic vs. a hysteresis-gated `SystemAudioStatus` enum for system). The mic level path also runs synchronously on the AVAudioEngine tap callback thread under existing locks. Generalizing both into one track-state type would mean threading that divergence through RT-adjacent, lock-guarded code — exactly the case called out to pin instead of force. Left the duplication in place and added comments at the three duplication sites (`Audio.swift`'s silence-detection block, its write-error-tracking block, and pointing at the mirrored `calculateLevel`/`calculateSystemLevel` pair in `AudioLevelMonitor.swift`) explaining why, so a future pass has the context.

## Test plan

- [x] `bash build-deps.sh --force` (Core touched)
- [x] `bash build.sh --no-open`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12735 tests, 0 failed
- [x] `bash run-integration-smoke.sh` — passed
- [x] `swift test` — 946 tests, 13 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)