### PR TITLE
Bring system-audio (SCK) recovery to parity with the mic path

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -356,6 +356,31 @@ public class Audio: ObservableObject, @unchecked Sendable {
         _recordingGaps.append(gap)
     }
 
+    /// Records a system-audio-side bounded-recovery attempt (SCK restarting
+    /// its ScreenCaptureKit stream after a buffer stall or stream stop) into
+    /// the SAME counter mic-path device switches use, so system-audio
+    /// dropouts count toward `RecordingHealthInfo.captureQuality` instead of
+    /// being invisible to it. Wired from `wireSystemAudioStatusPublisher`'s
+    /// `recoveryEventPublisher` subscription, which already runs on main.
+    func recordSystemAudioDeviceSwitch() {
+        guard isRecording else { return }
+        deviceSwitchCount += 1
+    }
+
+    /// Records a system-audio recovery gap (bounded SCK recovery succeeded
+    /// after `duration` seconds of stalled/stopped capture), mirroring the
+    /// mic path's `AudioGap` entries into the SAME `recordingGaps` array so
+    /// system-audio interruptions show up in saved transcript health
+    /// metadata the same way mic-side gaps already do.
+    func recordSystemAudioGap(duration: TimeInterval) {
+        guard isRecording else { return }
+        appendRecordingGap(AudioGap(
+            start: Date(timeIntervalSinceNow: -duration),
+            duration: duration,
+            reason: "System audio reconnect"
+        ))
+    }
+
     /// Commit recovery artifacts only while the recovery still owns the
     /// current recording generation. The generation lock also blocks a
     /// concurrent stop/start from advancing the session between the check and
@@ -639,8 +664,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
             _recordingSessionGeneration = newValue
         }
     }
-    let maxRecoveryAttempts = 5
-    let recoveryCooldown: TimeInterval = 5.0  // Min seconds between recovery attempts
+    let maxRecoveryAttempts = AudioRecoveryTuning.Mic.maxRecoveryAttempts
+    let recoveryCooldown: TimeInterval = AudioRecoveryTuning.Mic.recoveryCooldownSeconds  // Min seconds between recovery attempts
 
     func withAudioGraphLock<T>(_ body: () throws -> T) rethrows -> T {
         audioGraphLock.lock()
@@ -931,6 +956,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     // System audio status observation
     private var systemAudioCancellable: AnyCancellable?
+    // Recovery/health event observation (device-switch + gap parity with the
+    // mic path). Separate from `systemAudioCancellable` so re-wiring one
+    // subscription on a new capture attempt doesn't need to touch the other.
+    private var systemAudioRecoveryEventCancellable: AnyCancellable?
     // Protected by systemSilenceLock — written from callback thread, reset on main thread
     private var _systemAudioSilenceStart: Date?
     private let systemSilenceLock = NSLock()
@@ -1105,6 +1134,17 @@ public class Audio: ObservableObject, @unchecked Sendable {
             .sink { [weak self] errorMessage in
                 self?.updateSystemAudioStatus(fromError: errorMessage)
             }
+        systemAudioRecoveryEventCancellable = capture.recoveryEventPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                guard let self else { return }
+                switch event {
+                case .deviceSwitch:
+                    self.recordSystemAudioDeviceSwitch()
+                case .gap(let duration):
+                    self.recordSystemAudioGap(duration: duration)
+                }
+            }
     }
 
     func installWorkspaceSleepWakeObservers() {
@@ -1150,6 +1190,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1.0) { [weak self] in
                     guard let self = self, self.isRecording else { return }
                     self.recoverFromDeviceChange(sessionGeneration: sessionGeneration)
+
+                    // Give system audio the same proactive post-wake recovery
+                    // opportunity as the mic path, instead of only relying on
+                    // SCK's own buffer-stall watchdog (which can take up to
+                    // `AudioRecoveryTuning.SystemAudio.stallTimeoutSeconds`
+                    // to notice). No-ops for backends without bounded
+                    // recovery (see `SystemAudioCaptureEngine`'s default).
+                    self.systemAudioCapture?.recoverAfterSystemWake()
                 }
             }
         }
@@ -2069,6 +2117,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         timer?.invalidate()
         watchdogTimer?.invalidate()
         systemAudioCancellable?.cancel()
+        systemAudioRecoveryEventCancellable?.cancel()
         replaceSystemAudioMonitoringAttempt(with: nil)?.cancel()
         systemAudioCapture?.stopSync()
 

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -364,7 +364,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// `recoveryEventPublisher` subscription, which already runs on main.
     func recordSystemAudioDeviceSwitch() {
         guard isRecording else { return }
-        deviceSwitchCount += 1
+        incrementDeviceSwitchCount()
     }
 
     /// Records a system-audio recovery gap (bounded SCK recovery succeeded
@@ -404,12 +404,32 @@ public class Audio: ObservableObject, @unchecked Sendable {
     }
 
     /// Count of device switches during this recording
-    /// Thread-safe: reset on main thread, incremented on background recovery thread
+    /// Thread-safe: reset on main thread; incremented from BOTH the mic-path
+    /// background recovery queue and the SCK recovery-event subscription on
+    /// main. The get/set pair above is only safe for whole-value resets
+    /// (`deviceSwitchCount = 0`) — a `+=`-style increment through it does a
+    /// get and a set as two separate lock acquisitions, so two concurrent
+    /// incrementers can race and drop an update. `incrementDeviceSwitchCount()`
+    /// does the read-modify-write inside ONE lock acquisition; every
+    /// increment site must go through it instead of `deviceSwitchCount += 1`.
     private var _deviceSwitchCount: Int = 0
     private let deviceSwitchCountLock = NSLock()
     var deviceSwitchCount: Int {
         get { deviceSwitchCountLock.lock(); defer { deviceSwitchCountLock.unlock() }; return _deviceSwitchCount }
         set { deviceSwitchCountLock.lock(); defer { deviceSwitchCountLock.unlock() }; _deviceSwitchCount = newValue }
+    }
+
+    /// Atomically increments and returns the new `deviceSwitchCount`. Use
+    /// this instead of `deviceSwitchCount += 1` at every increment site —
+    /// the mic path's `recoverFromDeviceChange` and the SCK-path
+    /// `recordSystemAudioDeviceSwitch()` below can run concurrently on
+    /// different queues.
+    @discardableResult
+    func incrementDeviceSwitchCount() -> Int {
+        deviceSwitchCountLock.lock()
+        defer { deviceSwitchCountLock.unlock() }
+        _deviceSwitchCount += 1
+        return _deviceSwitchCount
     }
 
     /// Timestamp when system started sleeping (for gap calculation)

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -231,7 +231,12 @@ extension Audio {
         let switchStart = Date()
         let lastMicBufferTime = lastBufferTime
         if reason == .deviceChange {
-            deviceSwitchCount += 1
+            // Atomic read-modify-write: the SCK-path recovery-event
+            // subscription can increment this same counter concurrently on
+            // main (see `Audio.incrementDeviceSwitchCount()`), so a plain
+            // `deviceSwitchCount += 1` here (get + separately-locked set)
+            // could race and drop an increment from either side.
+            incrementDeviceSwitchCount()
         }
         recoveryAttemptCount += 1
         AppLogger.audioMic.debug("Recovering from device change", ["switchNumber": "\(deviceSwitchCount)", "maxAttempts": "\(maxRecoveryAttempts)"])

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -3,6 +3,44 @@ import Foundation
 import CoreAudio
 import QuartzCore
 
+// MARK: - Recovery Tuning
+
+/// Single named surface for the mic-path and system-audio-path bounded
+/// recovery tuning constants. Before this type existed the two paths carried
+/// separate, unlinked numbers — `Audio.maxRecoveryAttempts` /
+/// `Audio.recoveryCooldown` here, `SCKAudioCapture.maxRecoveryAttempts` /
+/// `SCKAudioCapture.bufferStallTimeoutSeconds` in `SCKAudioCapture.swift` —
+/// with nothing showing they tune the same kind of problem. Consolidating
+/// them here makes the relationship (and the current asymmetry) visible.
+///
+/// Every value below is unchanged from before this type existed — this is a
+/// mechanism unification, not a tuning change. `SystemAudio.maxRecoveryAttempts`
+/// staying at 1 instead of matching `Mic.maxRecoveryAttempts` is a deliberate
+/// gap: SCK's bounded recovery restarts an entire ScreenCaptureKit stream
+/// (heavier than reinstalling a mic tap), so raising it is a follow-up
+/// decision, not part of this parity pass.
+enum AudioRecoveryTuning {
+    /// Tuning for `Audio`'s mic-path watchdog + `recoverFromDeviceChange`.
+    enum Mic {
+        /// Matches the watchdog's give-up threshold in `Audio.startWatchdog()`.
+        static let maxRecoveryAttempts = 5
+        /// Matches the watchdog's `timeSinceLastBuffer` stall check in `Audio.startWatchdog()`.
+        static let stallTimeoutSeconds: TimeInterval = 3.0
+        /// Matches `Audio.recoveryCooldown` — minimum seconds between recovery attempts.
+        static let recoveryCooldownSeconds: TimeInterval = 5.0
+    }
+
+    /// Tuning for `SCKAudioCapture`'s bounded mid-recording stream recovery.
+    enum SystemAudio {
+        /// Matches `SCKAudioCapture.maxRecoveryAttempts`.
+        static let maxRecoveryAttempts = 1
+        /// Matches `SCKAudioCapture.bufferStallTimeoutSeconds` — how long the
+        /// buffer watchdog waits with no buffers before treating the stream
+        /// as stalled.
+        static let stallTimeoutSeconds: CFTimeInterval = 5
+    }
+}
+
 // MARK: - Device Recovery & Watchdog
 
 /// Why the mic capture engine is being restarted mid-recording. A consented
@@ -117,7 +155,7 @@ extension Audio {
 
             let timeSinceLastBuffer = CACurrentMediaTime() - self.lastBufferTime
 
-            if timeSinceLastBuffer > 3.0 {
+            if timeSinceLastBuffer > AudioRecoveryTuning.Mic.stallTimeoutSeconds {
                 // Enforce cooldown — don't attempt recovery more often than every 5s
                 if let lastRecovery = self.lastRecoveryTime,
                    Date().timeIntervalSince(lastRecovery) < self.recoveryCooldown {

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -883,6 +883,19 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         captureStateLock.unlock()
     }
 
+    /// Restores the recovery-attempt budget after a confirmed successful
+    /// recovery, mirroring `Audio.finalizeMicRecoveryArtifacts` resetting
+    /// `recoveryAttemptCount = 0` on the mic path. Without this, `attempts`
+    /// only resets on a brand-new (non-recovery) `start()` — a proactive
+    /// post-wake kick that succeeds would otherwise permanently spend this
+    /// capture's one-attempt budget for the rest of the recording even
+    /// though nothing was actually broken.
+    private func resetRecoveryAttemptsAfterSuccess() {
+        captureStateLock.lock()
+        recoveryAttempts = 0
+        captureStateLock.unlock()
+    }
+
     @discardableResult
     private func stopStreamSynchronously(
         _ stream: any SCKStreamControlling,
@@ -1046,6 +1059,17 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         watchdogLock.unlock()
     }
 
+    /// The monotonic time of the last real audio buffer this capture
+    /// delivered — the same value the buffer-stall watchdog compares
+    /// against. Used to measure recovery-gap duration from when audio
+    /// actually stopped flowing, not from whenever the watchdog/error
+    /// callback happened to notice.
+    private func lastKnownBufferTime() -> CFTimeInterval {
+        watchdogLock.lock()
+        defer { watchdogLock.unlock() }
+        return _lastBufferTime
+    }
+
     private func startWatchdog(generation: UInt64) {
         stopWatchdog()
         let timer = DispatchSource.makeTimerSource(queue: watchdogQueue)
@@ -1091,7 +1115,15 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         generation: UInt64,
         attemptRestart: Bool
     ) {
-        let failureDetectedAt = CACurrentMediaTime()
+        // Captured BEFORE any recovery step runs. The buffer watchdog only
+        // fires after `bufferStallTimeoutSeconds` of silence, so measuring
+        // the gap from "now" (when the watchdog/`didStopWithError` finally
+        // noticed) would omit that entire silent stretch — the largest part
+        // of the real outage. `_lastBufferTime` is the actual moment audio
+        // stopped flowing; `stopSync`/`prepare`/`start` below reset it via
+        // `resetBufferWatchdogState()`, so it must be read here, once, and
+        // carried through as a local rather than re-read after recovery.
+        let lastKnownBufferTimeAtFailure = self.lastKnownBufferTime()
         guard isActiveCaptureGeneration(generation) else { return }
         guard attemptRestart, let callback = activeFailureCallback(generation: generation) else {
             publishErrorMessage(message)
@@ -1154,10 +1186,32 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
                 try self.start(bufferCallback: callback, recoveryToken: recoveryToken)
                 guard self.shouldContinueRecovery(recoveryToken, at: "after start") else { return }
                 AppLogger.audioSystem.info("SCKAudioCapture: stream recovery succeeded")
+                // Reset the attempt budget on success, mirroring the mic
+                // path's `finalizeMicRecoveryArtifacts` resetting
+                // `recoveryAttemptCount = 0` once a recovery is confirmed.
+                // Without this, a successful proactive post-wake kick
+                // (`recoverAfterSystemWake`) would permanently spend this
+                // capture's one-attempt budget even though nothing was
+                // actually broken, leaving a LATER genuine failure in the
+                // same recording with zero attempts left — a regression
+                // from pre-wake-hook behavior. Resetting on every success
+                // (reactive or proactive) guarantees a wake kick can never
+                // reduce the recovery capacity available to a subsequent
+                // real failure.
+                self.resetRecoveryAttemptsAfterSuccess()
                 // Report the gap the same way the mic path appends an
                 // `AudioGap` once recovery is confirmed, so the interruption
-                // shows up in saved transcript health metadata.
-                let gapDuration = max(0, CACurrentMediaTime() - failureDetectedAt)
+                // shows up in saved transcript health metadata. NOTE: unlike
+                // the mic path's `waitForMicBuffer`, `start()` succeeding
+                // here only proves ScreenCaptureKit accepted the restart
+                // request, not that a real audio frame has flowed yet — SCK
+                // has no equivalent post-start buffer-wait. A stream that
+                // silently never resumes after a "successful" restart would
+                // still publish a short gap here and only be caught by the
+                // buffer-stall watchdog on its next stall detection. This is
+                // a known, intentionally-undocumented-elsewhere divergence
+                // from mic semantics, not a fixed parity.
+                let gapDuration = max(0, CACurrentMediaTime() - lastKnownBufferTimeAtFailure)
                 self.recoveryEventSubject.send(.gap(duration: gapDuration))
             } catch is SCKRecoveryCancelledError {
                 AppLogger.audioSystem.info("SCKAudioCapture: recovery stopped after cancellation")
@@ -1221,6 +1275,26 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             isWaitingForTimedOutStopCallback: isWaitingForTimedOutStopCallback,
             recoveryAttempts: recoveryAttempts
         )
+    }
+
+    /// Exercises the real production reset path directly (not a
+    /// reimplementation), since `handleMidRecordingFailure`'s full success
+    /// path cannot be driven from tests without a live ScreenCaptureKit
+    /// `prepare()`.
+    func resetRecoveryAttemptsAfterSuccessForTesting() {
+        resetRecoveryAttemptsAfterSuccess()
+    }
+
+    func resetBufferWatchdogStateForTesting() {
+        resetBufferWatchdogState()
+    }
+
+    func markBufferReceivedForTesting() {
+        markBufferReceived()
+    }
+
+    func lastKnownBufferTimeForTesting() -> CFTimeInterval {
+        lastKnownBufferTime()
     }
 }
 

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -152,6 +152,13 @@ private final class SCKStartCallbackState: @unchecked Sendable {
 @available(macOS 26.0, *)
 final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngine, SCStreamDelegate, @unchecked Sendable {
     @Published var errorMessage: String?
+    // Recovery/health event reporting seam back to `Audio`, so its bounded
+    // mid-recording stream recovery counts toward the same
+    // `Audio.deviceSwitchCount` / `Audio.recordingGaps` the mic path already
+    // feeds into `RecordingHealthInfo.captureQuality`. Only sent from
+    // `handleMidRecordingFailure`'s recovery block, which `isRecovering`
+    // already serializes to one in-flight attempt at a time.
+    private let recoveryEventSubject = PassthroughSubject<SystemAudioRecoveryEvent, Never>()
 
     private enum StreamPhase: String {
         case idle
@@ -204,8 +211,8 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     private let callbackTimeout: DispatchTimeInterval
     private let callbackTimeoutSeconds: Int
     private let testHooks: SCKAudioCaptureTestHooks
-    private static let maxRecoveryAttempts = 1
-    private static let bufferStallTimeoutSeconds: CFTimeInterval = 5
+    private static let maxRecoveryAttempts = AudioRecoveryTuning.SystemAudio.maxRecoveryAttempts
+    private static let bufferStallTimeoutSeconds: CFTimeInterval = AudioRecoveryTuning.SystemAudio.stallTimeoutSeconds
     private let watchdogQueue = DispatchQueue(label: "SCKAudioCapture.watchdog", qos: .utility)
     private var watchdogTimer: DispatchSourceTimer?
     private let watchdogLock = NSLock()
@@ -253,6 +260,10 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
 
     var errorMessagePublisher: AnyPublisher<String?, Never> {
         $errorMessage.eraseToAnyPublisher()
+    }
+
+    var recoveryEventPublisher: AnyPublisher<SystemAudioRecoveryEvent, Never> {
+        recoveryEventSubject.eraseToAnyPublisher()
     }
 
     // MARK: - Lifecycle
@@ -923,6 +934,31 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         }
     }
 
+    /// Proactive post-wake recovery hook (`SystemAudioCaptureEngine`
+    /// conformance). Mirrors `Audio.installWorkspaceSleepWakeObservers()`'s
+    /// mic-path kick, which restarts the mic graph ~1s after wake instead of
+    /// waiting for the watchdog to notice a stall — ScreenCaptureKit streams
+    /// can come back from sleep in the same silently-stuck state a stalled
+    /// mic tap does, and this path gets one chance to do the same before this
+    /// backend's own buffer-stall watchdog would otherwise take up to
+    /// `bufferStallTimeoutSeconds` to notice.
+    ///
+    /// No-ops when nothing is actively capturing, so calling this
+    /// unconditionally after every wake (recording or not) is safe. Reuses
+    /// `handleMidRecordingFailure`'s existing bounded-recovery machinery —
+    /// same one-attempt cap, same epoch/token ownership — rather than adding
+    /// a second recovery path.
+    func recoverAfterSystemWake() {
+        let state = currentStreamState()
+        guard state.isCapturing, let generation = state.generation else { return }
+        AppLogger.audioSystem.info("SCKAudioCapture: proactive recovery after system wake")
+        handleMidRecordingFailure(
+            "System audio reconnecting after system wake.",
+            generation: generation,
+            attemptRestart: true
+        )
+    }
+
     func stream(_ stream: SCStream, didStopWithError error: Error) {
         handleStoppedStream(identity: ObjectIdentifier(stream), error: error)
     }
@@ -1055,6 +1091,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         generation: UInt64,
         attemptRestart: Bool
     ) {
+        let failureDetectedAt = CACurrentMediaTime()
         guard isActiveCaptureGeneration(generation) else { return }
         guard attemptRestart, let callback = activeFailureCallback(generation: generation) else {
             publishErrorMessage(message)
@@ -1091,6 +1128,11 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             return
         }
         publishErrorMessage("System audio reconnecting after capture interruption.")
+        // Report the attempt the same way the mic path counts a device
+        // switch at the start of `recoverFromDeviceChange`, so system-audio
+        // recovery is visible in `RecordingHealthInfo` even if the attempt
+        // ultimately fails.
+        recoveryEventSubject.send(.deviceSwitch)
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
@@ -1112,6 +1154,11 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
                 try self.start(bufferCallback: callback, recoveryToken: recoveryToken)
                 guard self.shouldContinueRecovery(recoveryToken, at: "after start") else { return }
                 AppLogger.audioSystem.info("SCKAudioCapture: stream recovery succeeded")
+                // Report the gap the same way the mic path appends an
+                // `AudioGap` once recovery is confirmed, so the interruption
+                // shows up in saved transcript health metadata.
+                let gapDuration = max(0, CACurrentMediaTime() - failureDetectedAt)
+                self.recoveryEventSubject.send(.gap(duration: gapDuration))
             } catch is SCKRecoveryCancelledError {
                 AppLogger.audioSystem.info("SCKAudioCapture: recovery stopped after cancellation")
             } catch {

--- a/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
@@ -1,6 +1,24 @@
 import AVFoundation
 import Combine
 
+/// A recovery/health event a `SystemAudioCaptureEngine` backend reports so
+/// hosts can feed system-audio dropouts into the same capture-quality signal
+/// mic-path recovery already drives (`Audio.deviceSwitchCount` /
+/// `Audio.recordingGaps`, composed by `RecordingHealthInfo.from`).
+///
+/// Backends that don't perform bounded mid-recording recovery (the legacy
+/// CoreAudio `SystemAudioCapture`) never publish these — the default
+/// `recoveryEventPublisher` below is empty for them.
+public enum SystemAudioRecoveryEvent: Sendable, Equatable {
+    /// A bounded recovery attempt started (mirrors the mic path incrementing
+    /// `Audio.deviceSwitchCount` at the start of `recoverFromDeviceChange`).
+    case deviceSwitch
+    /// A bounded recovery attempt succeeded after this much silent/stopped
+    /// time (mirrors the mic path appending an `Audio.AudioGap` once
+    /// recovery is confirmed by a real audio frame).
+    case gap(duration: TimeInterval)
+}
+
 /// Common interface for system audio capture backends.
 ///
 /// The current app uses `SCKAudioCapture` (macOS 26+) — a ScreenCaptureKit
@@ -27,6 +45,12 @@ public protocol SystemAudioCaptureEngine: AnyObject {
     /// Publishes error messages for UI status updates (device changes, failures, etc.).
     var errorMessagePublisher: AnyPublisher<String?, Never> { get }
 
+    /// Publishes bounded-recovery device-switch/gap events so the host can
+    /// record them the same way it records mic-path recovery. Defaults to an
+    /// empty publisher (see the protocol extension below) for backends that
+    /// don't need it.
+    var recoveryEventPublisher: AnyPublisher<SystemAudioRecoveryEvent, Never> { get }
+
     /// Set up the capture pipeline (tap/stream creation, format negotiation).
     /// Call once before `start()`. Makes `audioFormat` available.
     func prepare() throws
@@ -40,4 +64,19 @@ public protocol SystemAudioCaptureEngine: AnyObject {
 
     /// Stop capture immediately (no delay). Use when re-preparing the same instance.
     func stopSync()
+
+    /// Give this backend a proactive recovery opportunity after system wake,
+    /// mirroring the mic path's post-wake proactive kick
+    /// (`Audio.installWorkspaceSleepWakeObservers`) instead of waiting for a
+    /// stall/stop callback. Defaults to a no-op (see the protocol extension
+    /// below) for backends without bounded mid-recording recovery.
+    func recoverAfterSystemWake()
+}
+
+extension SystemAudioCaptureEngine {
+    public var recoveryEventPublisher: AnyPublisher<SystemAudioRecoveryEvent, Never> {
+        Empty().eraseToAnyPublisher()
+    }
+
+    public func recoverAfterSystemWake() {}
 }

--- a/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
@@ -409,4 +409,103 @@ final class SCKAudioCaptureInterleavingTests: XCTestCase {
         wait(for: [deviceSwitchSeen], timeout: 1)
         cancellable.cancel()
     }
+
+    // MARK: - Recovery-attempt budget must reset on success (review fix)
+    //
+    // `recoverAfterSystemWake()` reuses the same one-attempt-capped
+    // `handleMidRecordingFailure` machinery a reactive failure uses. Without
+    // resetting `recoveryAttempts` on a confirmed success, a wake kick that
+    // succeeds (the common case — nothing was actually broken) would
+    // permanently spend the capture's only attempt, leaving a LATER genuine
+    // failure in the same recording with zero budget. This mirrors the mic
+    // path's `Audio.finalizeMicRecoveryArtifacts` resetting
+    // `recoveryAttemptCount = 0` on every successful recovery.
+
+    func testRecoveryAttemptsResetToZeroAfterSuccessfulRecovery() {
+        let stream = ControlledSCKStream()
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.installPreparedStreamForTesting(stream)
+        try? capture.start(bufferCallback: { _ in })
+
+        // Spend the (1-attempt) budget the same way the earlier tests in
+        // this file do: cancel synchronously from inside the `.deviceSwitch`
+        // handler so the background closure never reaches a real
+        // `prepare()`.
+        let deviceSwitchSeen = expectation(description: "attempt spent")
+        let cancellable = capture.recoveryEventPublisher.sink { event in
+            if event == .deviceSwitch {
+                capture.stopSync()
+                deviceSwitchSeen.fulfill()
+            }
+        }
+        capture.handleStoppedStream(
+            identity: stream.captureIdentity,
+            error: ControlledSCKTestError(message: "stream stopped")
+        )
+        wait(for: [deviceSwitchSeen], timeout: 1)
+        cancellable.cancel()
+
+        XCTAssertEqual(
+            capture.stateSnapshotForTesting().recoveryAttempts, 1,
+            "the spent attempt must be visible before the success-reset path runs"
+        )
+
+        // Exercises the real `resetRecoveryAttemptsAfterSuccess()` — the
+        // exact call `handleMidRecordingFailure`'s success branch makes —
+        // through a thin testing seam, since driving a real successful
+        // `start()` requires live ScreenCaptureKit.
+        capture.resetRecoveryAttemptsAfterSuccessForTesting()
+
+        XCTAssertEqual(
+            capture.stateSnapshotForTesting().recoveryAttempts, 0,
+            "a successful recovery must restore the budget so a later genuine failure isn't starved by an earlier wake kick"
+        )
+    }
+
+    // MARK: - Recovery gap must be measured from the last real buffer (review fix)
+
+    func testLastKnownBufferTimeReflectsLastRealBufferNotWhenAskedForIt() {
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.resetBufferWatchdogStateForTesting()
+        capture.markBufferReceivedForTesting()
+        let lastBufferTime = capture.lastKnownBufferTimeForTesting()
+
+        // Simulate silence AFTER the last real buffer — the elapsed-time
+        // window `handleMidRecordingFailure` must report as the gap, not a
+        // duration measured from whenever the watchdog/error callback
+        // happened to fire (which would omit the whole stall window).
+        Thread.sleep(forTimeInterval: 0.08)
+        let elapsedSinceRealBuffer = CACurrentMediaTime() - lastBufferTime
+
+        XCTAssertGreaterThanOrEqual(
+            elapsedSinceRealBuffer, 0.08,
+            "a gap computed from the last real buffer time must include the full silent stretch"
+        )
+        // A second read without another buffer must be stable (not "now").
+        XCTAssertEqual(capture.lastKnownBufferTimeForTesting(), lastBufferTime, accuracy: 0.001)
+    }
+
+    func testLastKnownBufferTimeAdvancesOnlyWhenARealBufferArrives() {
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.resetBufferWatchdogStateForTesting()
+        let afterReset = capture.lastKnownBufferTimeForTesting()
+
+        Thread.sleep(forTimeInterval: 0.05)
+        // No buffer arrives here — `lastKnownBufferTime()` must not silently
+        // advance just because time passed (it is not `CACurrentMediaTime()`
+        // in disguise).
+        XCTAssertEqual(capture.lastKnownBufferTimeForTesting(), afterReset, accuracy: 0.001)
+
+        capture.markBufferReceivedForTesting()
+        XCTAssertGreaterThan(capture.lastKnownBufferTimeForTesting(), afterReset)
+    }
 }

--- a/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Combine
 import Foundation
 import ScreenCaptureKit
 import XCTest
@@ -315,5 +316,97 @@ final class SCKAudioCaptureInterleavingTests: XCTestCase {
         XCTAssertEqual(state.streamIdentity, replacement.captureIdentity)
         XCTAssertEqual(state.phase, "prepared")
         XCTAssertFalse(state.isCapturing)
+    }
+
+    // MARK: - Recovery event reporting (mic-path health-seam parity)
+    //
+    // These tests exercise only the SYNCHRONOUS front half of bounded
+    // recovery: obtaining the recovery token and publishing `.deviceSwitch`
+    // happens before `handleMidRecordingFailure` dispatches its background
+    // recovery closure, which calls the REAL `prepare()` (a live
+    // `SCShareableContent` fetch). No existing test in this file lets that
+    // background closure run to completion for the same reason — it would
+    // depend on live ScreenCaptureKit/TCC state. Each test below cancels
+    // recovery (via `stopSync()`) from inside the `.deviceSwitch` handler,
+    // synchronously and on the same thread that triggered the failure, so
+    // the pending background closure observes a cancelled token and returns
+    // before ever touching a real `SCStream`.
+
+    func testMidRecordingFailurePublishesDeviceSwitchBeforeBackgroundRecoveryWork() {
+        let stream = ControlledSCKStream()
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.installPreparedStreamForTesting(stream)
+        try? capture.start(bufferCallback: { _ in })
+
+        var receivedEvents: [SystemAudioRecoveryEvent] = []
+        let eventsLock = NSLock()
+        let deviceSwitchSeen = expectation(description: "device switch event published")
+        let cancellable = capture.recoveryEventPublisher.sink { event in
+            eventsLock.lock()
+            receivedEvents.append(event)
+            eventsLock.unlock()
+            if event == .deviceSwitch {
+                // Cancel recovery synchronously, on the same thread that is
+                // still inside `handleStoppedStream` below, before its
+                // `DispatchQueue.global(...).async` recovery closure can run.
+                capture.stopSync()
+                deviceSwitchSeen.fulfill()
+            }
+        }
+
+        capture.handleStoppedStream(
+            identity: stream.captureIdentity,
+            error: ControlledSCKTestError(message: "stream stopped")
+        )
+
+        wait(for: [deviceSwitchSeen], timeout: 1)
+        cancellable.cancel()
+
+        eventsLock.lock()
+        let events = receivedEvents
+        eventsLock.unlock()
+        XCTAssertTrue(events.contains(.deviceSwitch),
+                      "a mid-recording stream failure must report a device-switch event the same way mic recovery does")
+    }
+
+    func testRecoverAfterSystemWakeNoOpsWhenNothingIsCapturing() {
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+
+        var receivedAnyEvent = false
+        let cancellable = capture.recoveryEventPublisher.sink { _ in receivedAnyEvent = true }
+
+        capture.recoverAfterSystemWake()
+        cancellable.cancel()
+
+        XCTAssertFalse(receivedAnyEvent, "a proactive wake recovery must no-op when nothing is actively capturing")
+    }
+
+    func testRecoverAfterSystemWakeGivesActiveCaptureTheSameBoundedRecoveryAsAFailure() {
+        let stream = ControlledSCKStream()
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.installPreparedStreamForTesting(stream)
+        try? capture.start(bufferCallback: { _ in })
+
+        let deviceSwitchSeen = expectation(description: "wake-triggered recovery reports a device switch")
+        let cancellable = capture.recoveryEventPublisher.sink { event in
+            if event == .deviceSwitch {
+                capture.stopSync()
+                deviceSwitchSeen.fulfill()
+            }
+        }
+
+        capture.recoverAfterSystemWake()
+
+        wait(for: [deviceSwitchSeen], timeout: 1)
+        cancellable.cancel()
     }
 }

--- a/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
@@ -1,0 +1,255 @@
+import XCTest
+@preconcurrency import AVFoundation
+import Combine
+@testable import TranscriptedCore
+
+/// Covers the mic/system-audio recovery parity work: system-audio recovery
+/// events must feed the SAME `Audio.deviceSwitchCount` / `Audio.recordingGaps`
+/// counters the mic path already uses, so system-audio dropouts stop being
+/// invisible to `RecordingHealthInfo.captureQuality`. Also covers the
+/// post-wake proactive-recovery hook reaching the system-audio backend
+/// through the existing `Audio` wake observer (no second `NSWorkspace`
+/// observer). Hardware-dependent SCK stream behavior is out of scope here —
+/// see the PR's hardware checklist.
+@available(macOS 14.0, *)
+final class SystemAudioRecoveryParityTests: XCTestCase {
+
+    private func makePaths() -> CoreStoragePaths {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SystemAudioRecoveryParityTests-\(UUID().uuidString)", isDirectory: true)
+        return CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: root.appendingPathComponent("logs", isDirectory: true)
+        )
+    }
+
+    // MARK: - Direct counter parity
+
+    func testRecordSystemAudioDeviceSwitchFeedsSameCounterAsMicPath() {
+        let audio = Audio(paths: makePaths())
+        audio.isRecording = true
+
+        audio.recordSystemAudioDeviceSwitch()
+        audio.recordSystemAudioDeviceSwitch()
+
+        XCTAssertEqual(
+            audio.deviceSwitchCount, 2,
+            "system-audio device switches must feed the same counter RecordingHealthInfo reads for mic-path switches"
+        )
+    }
+
+    func testRecordSystemAudioDeviceSwitchNoOpsWhenNotRecording() {
+        let audio = Audio(paths: makePaths())
+
+        audio.recordSystemAudioDeviceSwitch()
+
+        XCTAssertEqual(audio.deviceSwitchCount, 0)
+    }
+
+    func testRecordSystemAudioGapAppendsToRecordingGaps() {
+        let audio = Audio(paths: makePaths())
+        audio.isRecording = true
+
+        audio.recordSystemAudioGap(duration: 4.5)
+
+        XCTAssertEqual(audio.recordingGaps.count, 1)
+        XCTAssertEqual(audio.recordingGaps.first?.reason, "System audio reconnect")
+        XCTAssertEqual(audio.recordingGaps.first?.duration ?? -1, 4.5, accuracy: 0.001)
+    }
+
+    func testRecordSystemAudioGapNoOpsWhenNotRecording() {
+        let audio = Audio(paths: makePaths())
+
+        audio.recordSystemAudioGap(duration: 4.5)
+
+        XCTAssertTrue(audio.recordingGaps.isEmpty)
+    }
+
+    func testSystemAudioDeviceSwitchesAloneDegradeCaptureQualityLikeMicPath() {
+        // Before this parity fix, SCK's mid-recording restarts never touched
+        // `deviceSwitchCount`, so repeated system-audio dropouts were
+        // invisible to `RecordingHealthInfo.captureQuality`. Confirm they now
+        // degrade it exactly the way three mic-side device switches already
+        // do (see `RecordingHealthInfo.from`'s `deviceSwitchCount >= 3` rule).
+        let audio = Audio(paths: makePaths())
+        audio.isRecording = true
+        audio.recordSystemAudioDeviceSwitch()
+        audio.recordSystemAudioDeviceSwitch()
+        audio.recordSystemAudioDeviceSwitch()
+
+        let info = RecordingHealthInfo.from(audio: audio, systemCapture: nil)
+
+        XCTAssertEqual(info.captureQuality, .degraded)
+        XCTAssertEqual(info.deviceSwitches, 3)
+    }
+
+    func testSystemAudioGapAloneDegradesCaptureQualityLikeMicPath() {
+        let audio = Audio(paths: makePaths())
+        audio.isRecording = true
+        audio.recordSystemAudioGap(duration: 2.0)
+
+        let info = RecordingHealthInfo.from(audio: audio, systemCapture: nil)
+
+        // A single gap with no device switches: excellent -> good, matching
+        // the mic-path rule (`!recordingGaps.isEmpty` downgrades one step).
+        XCTAssertEqual(info.captureQuality, .good)
+        XCTAssertEqual(info.audioGaps, 1)
+        XCTAssertEqual(info.gapDescriptions.first, "System audio reconnect: 2.0s")
+    }
+
+    // MARK: - Wiring through an injected backend
+
+    func testInjectedBackendRecoveryEventsUpdateAudioCounters() {
+        let capture = RecoveryEventStubSystemAudioCapture()
+        let audio = Audio(paths: makePaths(), systemAudioCaptureForTesting: capture)
+        audio.isRecording = true
+
+        capture.emit(recoveryEvent: .deviceSwitch)
+        capture.emit(recoveryEvent: .gap(duration: 2.5))
+
+        waitForMainQueueToSettle()
+
+        XCTAssertEqual(audio.deviceSwitchCount, 1)
+        XCTAssertEqual(audio.recordingGaps.count, 1)
+        XCTAssertEqual(audio.recordingGaps.first?.duration ?? -1, 2.5, accuracy: 0.001)
+    }
+
+    func testInjectedBackendRecoveryEventsIgnoredWhenNotRecording() {
+        let capture = RecoveryEventStubSystemAudioCapture()
+        let audio = Audio(paths: makePaths(), systemAudioCaptureForTesting: capture)
+        // isRecording defaults to false.
+
+        capture.emit(recoveryEvent: .deviceSwitch)
+        capture.emit(recoveryEvent: .gap(duration: 2.5))
+
+        waitForMainQueueToSettle()
+
+        XCTAssertEqual(audio.deviceSwitchCount, 0)
+        XCTAssertTrue(audio.recordingGaps.isEmpty)
+    }
+
+    // MARK: - Post-wake proactive recovery hook
+
+    func testPostWakeProactiveRecoveryReachesInjectedSystemAudioBackend() {
+        let capture = RecoveryEventStubSystemAudioCapture()
+        let center = NotificationCenter()
+        let notifications = AudioSleepWakeNotifications(
+            center: center,
+            willSleepName: Notification.Name("SystemAudioRecoveryParityTests.WillSleep"),
+            didWakeName: Notification.Name("SystemAudioRecoveryParityTests.DidWake")
+        )
+        let audio = Audio(
+            paths: makePaths(),
+            systemAudioCaptureForTesting: capture,
+            sleepWakeNotifications: notifications
+        )
+        // Mirrors what `ensureCaptureInfrastructureConfigured()` does for a
+        // real recording; called directly here since this test injects the
+        // backend instead of going through infrastructure setup.
+        audio.installWorkspaceSleepWakeObservers()
+        audio.isRecording = true
+
+        center.post(name: notifications.willSleepName, object: nil)
+        center.post(name: notifications.didWakeName, object: nil)
+
+        // The wake handler waits ~0.5s and then ~1.0s before the proactive
+        // kick, matching the mic path's existing timing. Poll instead of a
+        // single fixed wait so a regression fails fast rather than always
+        // paying the full timeout.
+        let calledBack = expectation(description: "system-audio backend got a proactive post-wake recovery opportunity")
+        let deadline = Date().addingTimeInterval(3.0)
+        DispatchQueue.global(qos: .utility).async {
+            while Date() < deadline {
+                if capture.recoverAfterSystemWakeCallCount > 0 {
+                    calledBack.fulfill()
+                    return
+                }
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+        wait(for: [calledBack], timeout: 3.5)
+    }
+
+    func testPostWakeProactiveRecoverySkippedWhenNotRecording() {
+        let capture = RecoveryEventStubSystemAudioCapture()
+        let center = NotificationCenter()
+        let notifications = AudioSleepWakeNotifications(
+            center: center,
+            willSleepName: Notification.Name("SystemAudioRecoveryParityTests.NotRecording.WillSleep"),
+            didWakeName: Notification.Name("SystemAudioRecoveryParityTests.NotRecording.DidWake")
+        )
+        let audio = Audio(
+            paths: makePaths(),
+            systemAudioCaptureForTesting: capture,
+            sleepWakeNotifications: notifications
+        )
+        audio.installWorkspaceSleepWakeObservers()
+        // isRecording defaults to false.
+
+        center.post(name: notifications.willSleepName, object: nil)
+        center.post(name: notifications.didWakeName, object: nil)
+
+        let settled = expectation(description: "wake handling settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) { settled.fulfill() }
+        wait(for: [settled], timeout: 2.5)
+
+        XCTAssertEqual(capture.recoverAfterSystemWakeCallCount, 0,
+                       "a wake outside an active recording must not touch the system-audio backend")
+    }
+
+    // MARK: - Helpers
+
+    /// Enqueues onto the main queue and waits for it to run, so any
+    /// `.receive(on: DispatchQueue.main)` work already scheduled ahead of it
+    /// (e.g. `Audio`'s recovery-event subscription) has completed first.
+    private func waitForMainQueueToSettle() {
+        let settled = expectation(description: "main queue settled")
+        DispatchQueue.main.async { settled.fulfill() }
+        wait(for: [settled], timeout: 1.0)
+    }
+}
+
+@available(macOS 14.0, *)
+private final class RecoveryEventStubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked Sendable {
+    private let errorSubject = PassthroughSubject<String?, Never>()
+    private let recoverySubject = PassthroughSubject<SystemAudioRecoveryEvent, Never>()
+    private let lock = NSLock()
+    private var _recoverAfterSystemWakeCallCount = 0
+
+    var diagnosticBackendName: String { "recovery_event_stub" }
+    var audioFormat: AVAudioFormat?
+    var bufferSuccessRate: Double { 1.0 }
+    var deliversOwnedAudioBuffers: Bool { true }
+    var errorMessagePublisher: AnyPublisher<String?, Never> { errorSubject.eraseToAnyPublisher() }
+    var recoveryEventPublisher: AnyPublisher<SystemAudioRecoveryEvent, Never> { recoverySubject.eraseToAnyPublisher() }
+
+    var recoverAfterSystemWakeCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _recoverAfterSystemWakeCallCount
+    }
+
+    func prepare() throws {}
+    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {}
+    func stop() {}
+    func stopSync() {}
+
+    func recoverAfterSystemWake() {
+        lock.lock()
+        _recoverAfterSystemWakeCallCount += 1
+        lock.unlock()
+    }
+
+    func emit(recoveryEvent: SystemAudioRecoveryEvent) {
+        recoverySubject.send(recoveryEvent)
+    }
+
+    func emit(errorMessage: String?) {
+        errorSubject.send(errorMessage)
+    }
+}

--- a/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
@@ -202,6 +202,78 @@ final class SystemAudioRecoveryParityTests: XCTestCase {
                        "a wake outside an active recording must not touch the system-audio backend")
     }
 
+    // MARK: - deviceSwitchCount lost-update race (review fix)
+    //
+    // The mic path increments `deviceSwitchCount` from its background
+    // recovery queue; the SCK-path subscription increments it from
+    // `DispatchQueue.main` via `recordSystemAudioDeviceSwitch()`. The old
+    // `deviceSwitchCount` getter/setter pair does a get and a set as two
+    // SEPARATE lock acquisitions, so `deviceSwitchCount += 1` from two
+    // genuinely concurrent callers can interleave and drop an increment.
+    // `incrementDeviceSwitchCount()` must do the read-modify-write inside
+    // ONE lock acquisition so every concurrent increment survives.
+
+    func testIncrementDeviceSwitchCountSurvivesHighConcurrencyWithoutLostUpdates() {
+        let audio = Audio(paths: makePaths())
+        let iterationsPerQueue = 500
+        let queues = (0..<8).map { DispatchQueue(label: "IncrementRace.\($0)") }
+        let group = DispatchGroup()
+
+        for queue in queues {
+            group.enter()
+            queue.async {
+                for _ in 0..<iterationsPerQueue {
+                    audio.incrementDeviceSwitchCount()
+                }
+                group.leave()
+            }
+        }
+
+        let finished = expectation(description: "all concurrent increments completed")
+        group.notify(queue: .main) { finished.fulfill() }
+        wait(for: [finished], timeout: 10.0)
+
+        XCTAssertEqual(
+            audio.deviceSwitchCount,
+            queues.count * iterationsPerQueue,
+            "every increment across all concurrent callers must land — none may be lost to the get/set race"
+        )
+    }
+
+    func testConcurrentMicAndSystemAudioDeviceSwitchesBothLand() {
+        // Mirrors the real shape of the race: mic-path recovery increments
+        // on a background queue while the SCK recoveryEventPublisher
+        // subscription increments on main, concurrently, for the same
+        // in-flight recording.
+        let audio = Audio(paths: makePaths())
+        audio.isRecording = true
+        let iterations = 200
+        let group = DispatchGroup()
+        let backgroundQueue = DispatchQueue(label: "MicPathDeviceSwitchRace", attributes: .concurrent)
+
+        group.enter()
+        backgroundQueue.async {
+            for _ in 0..<iterations {
+                audio.incrementDeviceSwitchCount()
+            }
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.main.async {
+            for _ in 0..<iterations {
+                audio.recordSystemAudioDeviceSwitch()
+            }
+            group.leave()
+        }
+
+        let finished = expectation(description: "mic-path and system-audio increments both completed")
+        group.notify(queue: .main) { finished.fulfill() }
+        wait(for: [finished], timeout: 10.0)
+
+        XCTAssertEqual(audio.deviceSwitchCount, iterations * 2,
+                       "mic-path and system-audio device switches must both be reflected with no lost updates")
+    }
+
     // MARK: - Helpers
 
     /// Enqueues onto the main queue and waits for it to run, so any


### PR DESCRIPTION
## Summary

System-audio capture (SCK, macOS 26+ ScreenCaptureKit) was a second-class citizen in recovery/health compared to the mic path. This PR closes the gap through one reporting seam, without changing either path's tuning values:

1. **Health visibility** — `SCKAudioCapture` now reports device-switch/gap events through a new `SystemAudioCaptureEngine.recoveryEventPublisher`. `Audio` subscribes to it (in `wireSystemAudioStatusPublisher`) and feeds the events into the SAME `deviceSwitchCount` / `recordingGaps` the mic path already uses, so `RecordingHealthInfo.captureQuality` now reflects system-audio dropouts instead of being blind to them.
2. **Wake hook** — `Audio.installWorkspaceSleepWakeObservers()`'s existing wake handler now also calls `systemAudioCapture?.recoverAfterSystemWake()` (a new protocol method, default no-op) right alongside the existing mic-path proactive kick. No new `NSWorkspace` observer was added — this routes through the one that already exists.
3. **Constants** — mic and system-audio recovery tuning constants now live in one named surface, `AudioRecoveryTuning` (`Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift`), with `Mic` and `SystemAudio` sub-namespaces. **Values are unchanged** — this is mechanism unification, not a tuning change.

### Design decisions

- **Protocol-based seam, not a downcast.** Added `SystemAudioRecoveryEvent` (`.deviceSwitch` / `.gap(duration:)`) and two new `SystemAudioCaptureEngine` requirements (`recoveryEventPublisher`, `recoverAfterSystemWake()`), both with default (empty/no-op) implementations via a protocol extension. This means the legacy CoreAudio `SystemAudioCapture` and existing test stubs need zero changes — only `SCKAudioCapture` overrides them with real behavior. Mirrors the existing `errorMessagePublisher` pattern exactly.
- **Reused the existing counters, not new fields.** `RecordingHealthInfo` was NOT changed. System-audio gaps/switches feed straight into `Audio.deviceSwitchCount` / `Audio.recordingGaps` — the exact same storage `RecordingHealthInfo.from(...)` already reads for the mic path. This keeps the blast radius to `TranscriptedCore/Audio/*` — no `TranscriptFormatter`, `TranscriptSaver`, frontmatter, `docs/capture-format.md`, or `Tools/TranscriptedCaptureKit` parser changes needed. System-audio gaps are labeled with `reason: "System audio reconnect"` in the gap description so they're distinguishable in saved transcripts.
- **Wake hook reuses `handleMidRecordingFailure`, not a second recovery path.** `SCKAudioCapture.recoverAfterSystemWake()` just calls the existing bounded-recovery method with a synthetic message, guarded by "only if currently capturing." Same one-attempt cap, same epoch/token ownership — no new state machine.
- **`SystemAudio.maxRecoveryAttempts` stays at 1.** Explicitly _not_ raised to match the mic path's 5. SCK's bounded recovery restarts an entire ScreenCaptureKit stream (`stopSync` → `prepare` → `start`, including a live `SCShareableContent` fetch) — much heavier than reinstalling a mic tap. The wake hook spends that one attempt proactively on every wake during an active recording (mirroring the mic path's existing unconditional post-wake kick) — see the budget-reset rule below for why this can't starve a later genuine failure. Raising the attempt cap, and/or gating the wake kick on some cheaper liveness signal first, are both deliberate follow-ups — flagging here rather than changing behavior in a parity PR.

### Review round: 3 fixes

Codex review flagged three P2s on the initial version of this PR. All three are fixed on this branch:

1. **Wake kick could exhaust the single recovery attempt.** `recoverAfterSystemWake()` reuses `handleMidRecordingFailure`'s bounded recovery, and that recovery never reset its attempt counter on success — only a brand-new (non-recovery) `start()` did. Since the wake kick runs unconditionally on every wake during a recording (mirroring the mic path) and almost always succeeds (nothing was actually broken), it would have permanently spent SCK's one-attempt budget for the rest of the recording, so a LATER genuine dropout would find zero attempts left and fail immediately where pre-PR it would have recovered.
   **Rule implemented:** `SCKAudioCapture.recoveryAttempts` resets to `0` on every confirmed successful recovery (reactive failure or proactive wake kick alike) — exactly mirroring the mic path's `Audio.finalizeMicRecoveryArtifacts` resetting `recoveryAttemptCount = 0` on success — so a successful wake kick can never reduce the recovery capacity available to a subsequent genuine failure in the same recording. (If the ONE attempt is instead spent on a wake kick that *fails*, system audio for that recording is over regardless — that's the existing, unchanged 1-attempt-cap behavior, not something this PR changes.)
   New test: `SCKAudioCaptureInterleavingTests.testRecoveryAttemptsResetToZeroAfterSuccessfulRecovery` exercises the real `resetRecoveryAttemptsAfterSuccess()` production method (via a thin `...ForTesting` seam, since driving a full success needs live ScreenCaptureKit) to prove a spent attempt returns to `0`.

2. **Recovery-gap duration was measured from the wrong start point.** `failureDetectedAt` was captured at the top of `handleMidRecordingFailure` — i.e. AFTER the ≥5s buffer-stall watchdog had already been silently waiting, so the published gap omitted the largest part of the real outage. **Fixed:** the gap is now measured from `SCKAudioCapture`'s tracked last-real-buffer timestamp (`lastKnownBufferTime()`, the same value the buffer-stall watchdog itself compares against), captured once before any recovery step can reset it, exactly mirroring how the mic path measures its gap from `lastBufferTime` captured before `recoverFromDeviceChange` begins.
   **Residual, intentionally-not-fixed divergence from mic semantics:** unlike the mic path's `waitForMicBuffer`, SCK's recovery declares success as soon as ScreenCaptureKit's `start()` callback returns without error — it does not wait for a real audio frame to actually flow before publishing the `.gap` event. A stream that "successfully" restarts but silently never resumes delivering buffers would therefore still publish a (too-short) gap here; the next real stall would only be caught by the buffer-stall watchdog on its next cycle. Adding a post-start buffer-wait to SCK (mirroring `waitForMicBuffer`) is a larger, riskier change to an already-intricate lock/epoch state machine and is left as a deliberate follow-up rather than bolted on here — see the code comment at the `.gap` publish site.
   New tests: `testLastKnownBufferTimeReflectsLastRealBufferNotWhenAskedForIt` and `testLastKnownBufferTimeAdvancesOnlyWhenARealBufferArrives` exercise the real `lastKnownBufferTime()` / `markBufferReceived()` / `resetBufferWatchdogState()` production methods directly.

3. **`deviceSwitchCount` lost-update race.** The mic path increments this counter from its background recovery queue; the new SCK-path subscription increments it from `DispatchQueue.main`. The old property did a `get` (lock, read, unlock) then a `set` (lock, write, unlock) as two SEPARATE lock acquisitions, so `deviceSwitchCount += 1` from two genuinely concurrent callers could interleave and drop an increment. **Fixed:** added `Audio.incrementDeviceSwitchCount()`, which does the read-modify-write inside ONE lock acquisition, and routed both increment sites (`Audio.recordSystemAudioDeviceSwitch()` and the mic path's `recoverFromDeviceChange` in `AudioDeviceRecovery.swift`) through it. Checked `recordingGaps`' append path too — `appendRecordingGap` already mutates inside a single lock acquisition, so it wasn't exposed to this race and needed no change.
   New tests: `testIncrementDeviceSwitchCountSurvivesHighConcurrencyWithoutLostUpdates` (8 queues × 500 increments each) and `testConcurrentMicAndSystemAudioDeviceSwitchesBothLand` (mirrors the real shape — one background queue + main queue, concurrently). Verified both tests actually catch the bug: temporarily reverting `incrementDeviceSwitchCount()` to the old `+=` pattern made the first test fail with `1601 != 4000` (real lost updates observed), confirming the tests aren't vacuous.

### Constants table (unchanged values, now named in one place)

| | Mic (`AudioRecoveryTuning.Mic`) | System audio (`AudioRecoveryTuning.SystemAudio`) |
|---|---|---|
| Max recovery attempts | 5 | 1 |
| Stall detection threshold | 3.0s (watchdog `timeSinceLastBuffer`) | 5s (buffer watchdog) |
| Recovery cooldown | 5.0s (min seconds between attempts) | n/a (single-attempt bound, no repeat cooldown needed) |

### Files changed

- `Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift` — new `SystemAudioRecoveryEvent` enum, two new protocol requirements with default (no-op/empty) implementations
- `Sources/TranscriptedCore/Audio/SCKAudioCapture.swift` — publishes `.deviceSwitch` at recovery start and `.gap(duration:)` on recovery success (now measured from `lastKnownBufferTime()`); new `recoverAfterSystemWake()`; new `resetRecoveryAttemptsAfterSuccess()` (called on every successful recovery); constants now sourced from `AudioRecoveryTuning`; new `...ForTesting` seams for `resetRecoveryAttemptsAfterSuccess()` / `resetBufferWatchdogState()` / `markBufferReceived()` / `lastKnownBufferTime()`
- `Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift` — new `AudioRecoveryTuning` enum; mic watchdog's stall-threshold literal now reads from it; mic-path device-switch increment routed through `incrementDeviceSwitchCount()`
- `Sources/TranscriptedCore/Audio/Audio.swift` — new `recordSystemAudioDeviceSwitch()` / `recordSystemAudioGap(duration:)`; new atomic `incrementDeviceSwitchCount()`; `wireSystemAudioStatusPublisher` also subscribes to `recoveryEventPublisher`; wake handler calls `systemAudioCapture?.recoverAfterSystemWake()`; `maxRecoveryAttempts` / `recoveryCooldown` now source from `AudioRecoveryTuning.Mic`
- `Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift` (new) — counter parity, wiring through an injected backend, wake-hook reachability (recording vs. not recording), plus 2 concurrency tests for the `deviceSwitchCount` race fix
- `Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift` — `.deviceSwitch` publishes before the background recovery closure runs (proven not to touch live ScreenCaptureKit APIs by cancelling recovery synchronously from inside the event handler), `recoverAfterSystemWake()` no-ops when idle and triggers bounded recovery when capturing, budget-reset-on-success, and last-known-buffer-time behavior

## Hardware checklist (REQUIRED before merge — this PR does not merge on CI/unit tests alone)

Everything above is verified at the unit level only. `SCKAudioCapture`'s real recovery path (`prepare()` → live `SCShareableContent` fetch → `SCStream` construction) cannot be exercised in CI/SPM tests without real ScreenCaptureKit/TCC state — this matches the existing test suite's convention (no prior test exercises that path either). The following must be proven on real hardware (macOS 26+, Apple Silicon) before this merges:

- [ ] Start a meeting recording with system-audio capture enabled and granted (System Audio Recording permission).
- [ ] **Wake hook — recording through sleep:** Start a recording, put the Mac to sleep (or lid-close if a laptop), wait >10s, wake it. Confirm in `logs/debug.log` / Console that `SCKAudioCapture: proactive recovery after system wake` fires within ~1.5s of wake (alongside the existing mic-path recovery log line), and that system-audio capture resumes (system audio level meter moves again, no `"System audio unavailable"` banner).
- [ ] **Wake hook — not recording:** Put the Mac to sleep/wake with no active recording. Confirm no SCK recovery log lines fire and nothing crashes.
- [ ] **Health visibility — real dropout:** Force a system-audio interruption during a live recording (e.g., toggle System Audio Recording permission off and back on, or another repro that has triggered SCK's watchdog/`didStopWithError` before). After the meeting ends, confirm the saved transcript's YAML frontmatter (`capture_quality`, `audio_gaps`, `device_switches`) reflects the interruption — before this PR, an SCK-only dropout with no mic-side issue would have shown `capture_quality: excellent` / `device_switches: 0`.
- [ ] **No regression — mic path:** Trigger the existing mic-side device-change recovery (unplug/replug a USB or Bluetooth mic mid-recording) and confirm behavior/timing is unchanged (5 attempts, 3s stall threshold, 5s cooldown) — the constants got a new named home but the values and logic are untouched.
- [ ] **No regression — SCK reactive recovery:** With the Mac awake the whole time, trigger SCK's existing buffer-stall/`didStopWithError` recovery independent of wake (whatever repro was used to validate that path before) and confirm it still recovers the same way (still capped at 1 in-flight attempt).
- [ ] **Budget-reset rule:** In one recording, trigger TWO separate system-audio dropouts that each successfully recover (e.g., wake-then-recover, then later a real buffer-stall repro that also recovers). Confirm the second recovery is NOT skipped/terminal — proving the attempt budget really resets to 0 after each success instead of being permanently spent by the first (wake) recovery.
- [ ] Confirm no duplicate/extra `NSWorkspace` sleep or wake observers were registered (only the one `Audio.installWorkspaceSleepWakeObservers()` sets up, per the audit's existing observer-count concern).

## Test plan

- [x] `bash build-deps.sh --force`
- [x] `bash build.sh --no-open`
- [x] `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`
- [x] `bash run-integration-smoke.sh`
- [x] `swift test`
- [ ] Hardware checklist above (blocks merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
