### PR TITLE
Thread VPIO bind result into meeting route readiness

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -491,6 +491,16 @@ public class Audio: ObservableObject, @unchecked Sendable {
     // WebRTC activates AUVoiceProcessingIO on the shared input device which
     // hands every other reader an attenuated stream; running our own VPIO
     // gives us our own AGC'd copy.
+    //
+    // This is the cross-time cache: it is what makes VPIO state visible to
+    // work that happens well after the arm call returned (disarm at stop,
+    // live diagnostics snapshots, log lines) where no synchronous return
+    // value is available. Callers that run immediately alongside
+    // `armVoiceProcessing(on:)` — same lock scope, nothing intervening —
+    // should prefer its returned `VoiceProcessingBindResult` instead of
+    // re-reading this var, so route-identity decisions have exactly one
+    // source of truth for "what did the arm call just observe." See
+    // `makeReadyMeetingInputGraph` for the canonical example.
     var voiceProcessingEnabled: Bool = false
 
     /// Whether to arm Apple's AUVoiceProcessingIO (VPIO) on the meeting mic
@@ -1404,11 +1414,18 @@ public class Audio: ObservableObject, @unchecked Sendable {
                         // replaces the node's device identity with its private
                         // wrapper. The wrapper ID is not a reliable indication
                         // of which physical input CoreAudio already bound.
+                        // `armVoiceProcessing` returns both the pre-wrap device
+                        // ID and the resulting VPIO state as one atomic value,
+                        // so route readiness and format selection below thread
+                        // that same value through instead of separately
+                        // capturing the device ID beforehand and re-reading
+                        // the ambient `voiceProcessingEnabled` cache after.
                         let selection = meetingInputSelectionSnapshot()
-                        let boundInputDeviceIDBeforeVoiceProcessing =
-                            freshInputNode.auAudioUnit.deviceID
-                        armVoiceProcessing(on: freshInputNode)
-                        let recordingFormat = self.recordingFormat(for: freshInputNode)
+                        let voiceProcessingBind = armVoiceProcessing(on: freshInputNode)
+                        let recordingFormat = self.recordingFormat(
+                            for: freshInputNode,
+                            voiceProcessingEnabled: voiceProcessingBind.enabled
+                        )
                         guard let recordingSnapshot = AudioRecordingFormatPolicy.snapshot(recordingFormat) else {
                             throw NSError(
                                 domain: "Audio",
@@ -1423,11 +1440,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
                         let actualInputDeviceID = freshInputNode.auAudioUnit.deviceID
                         let routeReadiness = MeetingInputDeviceSelectionPolicy.routeReadiness(
                             selection: selection,
-                            boundInputDeviceIDBeforeVoiceProcessing: boundInputDeviceIDBeforeVoiceProcessing,
+                            boundInputDeviceIDBeforeVoiceProcessing: voiceProcessingBind.boundInputDeviceIDBeforeWrap,
                             actualInputDeviceID: actualInputDeviceID,
                             capturedSampleRate: recordingSnapshot.sampleRate,
                             selectedNominalSampleRate: selectedNominalRate,
-                            voiceProcessingEnabled: voiceProcessingEnabled
+                            voiceProcessingEnabled: voiceProcessingBind.enabled
                         )
                         guard routeReadiness == .ready else {
                             AppLogger.audioMic.warning("Meeting microphone route did not settle", [
@@ -1508,8 +1525,17 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// receives the VPIO output (mono Float32 at the unit's preferred rate),
     /// not the raw hardware format. Without VPIO we keep using the hardware
     /// format read on bus 1 so Bluetooth devices keep working.
-    func recordingFormat(for inputNode: AVAudioInputNode) -> AVAudioFormat {
-        if voiceProcessingEnabled {
+    ///
+    /// `voiceProcessingEnabled` lets a caller that just received a
+    /// `VoiceProcessingBindResult` from `armVoiceProcessing(on:)` pass that
+    /// exact value through instead of re-reading the ambient cache; callers
+    /// with no bind result in scope (e.g. monitoring, which never arms VPIO)
+    /// fall back to the cache as before.
+    func recordingFormat(
+        for inputNode: AVAudioInputNode,
+        voiceProcessingEnabled overrideVoiceProcessingEnabled: Bool? = nil
+    ) -> AVAudioFormat {
+        if overrideVoiceProcessingEnabled ?? voiceProcessingEnabled {
             return inputNode.outputFormat(forBus: 0)
         }
         return inputNode.inputFormat(forBus: 1)
@@ -1525,6 +1551,20 @@ public class Audio: ObservableObject, @unchecked Sendable {
         } else {
             realtimeAGC = RealtimeAGC()
         }
+    }
+
+    /// Atomic snapshot returned by `armVoiceProcessing(on:)`. Pairs the
+    /// physical input device this call observed BEFORE it could wrap the
+    /// node in VPIO's private aggregate device with whether VPIO ended up
+    /// enabled. `MeetingInputDeviceSelectionPolicy.routeReadiness` treats
+    /// `boundInputDeviceIDBeforeWrap` as its only pre-wrap device-identity
+    /// input — it must never be re-derived from the node after arming, since
+    /// the node's reported device ID is no longer trustworthy once VPIO is
+    /// active (see the 1.1.52 fix for the field bug this caused with
+    /// third-party HAL drivers).
+    struct VoiceProcessingBindResult: Equatable, Sendable {
+        let boundInputDeviceIDBeforeWrap: AudioDeviceID
+        let enabled: Bool
     }
 
     /// Enable AUVoiceProcessingIO on the meeting input node so Transcripted
@@ -1545,23 +1585,46 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// already running (toggling VPIO requires a stopped engine). Falls back
     /// silently when the device cannot host VPIO (rare, e.g. unusual
     /// aggregate devices) so a VPIO failure never blocks recording.
-    func armVoiceProcessing(on inputNode: AVAudioInputNode) {
+    ///
+    /// Returns a `VoiceProcessingBindResult` pairing the physical device ID
+    /// this call observed BEFORE any branch below could wrap the node in
+    /// VPIO's private aggregate device, with whether VPIO ended up active.
+    /// Callers that need both facts right after arming (route readiness,
+    /// format selection) should consume this return value directly rather
+    /// than separately reading `inputNode.auAudioUnit.deviceID` beforehand
+    /// and `voiceProcessingEnabled` afterward — those two reads are only
+    /// guaranteed to agree with this call's outcome because nothing runs
+    /// between them, which is exactly the invariant this return value now
+    /// encodes explicitly instead of leaving implicit.
+    @discardableResult
+    func armVoiceProcessing(on inputNode: AVAudioInputNode) -> VoiceProcessingBindResult {
+        let boundInputDeviceIDBeforeWrap = inputNode.auAudioUnit.deviceID
+
         guard enableVoiceProcessing else {
             // Opt-in toggle is off. Be explicit here instead of trusting our
             // cached flag, because a prior route change can leave VPIO armed
             // until the input node is told to release it.
             disarmVoiceProcessing(on: inputNode, reason: "preference_off")
-            return
+            return VoiceProcessingBindResult(
+                boundInputDeviceIDBeforeWrap: boundInputDeviceIDBeforeWrap,
+                enabled: false
+            )
         }
 
         if voiceProcessingEnabled, inputNode.isVoiceProcessingEnabled {
-            return
+            return VoiceProcessingBindResult(
+                boundInputDeviceIDBeforeWrap: boundInputDeviceIDBeforeWrap,
+                enabled: true
+            )
         }
 
         if let engine, engine.isRunning {
             // VPIO can only be toggled while the engine is stopped. Defer until
             // the next start cycle re-enters this path.
-            return
+            return VoiceProcessingBindResult(
+                boundInputDeviceIDBeforeWrap: boundInputDeviceIDBeforeWrap,
+                enabled: voiceProcessingEnabled
+            )
         }
 
         do {
@@ -1585,6 +1648,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 "error": error.localizedDescription
             ])
         }
+
+        return VoiceProcessingBindResult(
+            boundInputDeviceIDBeforeWrap: boundInputDeviceIDBeforeWrap,
+            enabled: voiceProcessingEnabled
+        )
     }
 
     /// Disable VPIO once active meeting capture ends. Leaving it armed after

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1567,6 +1567,40 @@ public class Audio: ObservableObject, @unchecked Sendable {
         let enabled: Bool
     }
 
+    /// Pure mirror of what `disarmVoiceProcessing(on:reason:)` leaves in
+    /// `voiceProcessingEnabled` once it returns, as a function of whether the
+    /// engine was running at call time and what the cache held beforehand.
+    /// `disarmVoiceProcessing` itself needs a live `AVAudioInputNode` and so
+    /// is not exercised directly by a unit test (this test target does not
+    /// construct real `AVAudioEngine` instances); `armVoiceProcessing`'s
+    /// preference-off branch instead calls this pure decision to compute the
+    /// `VoiceProcessingBindResult` it returns, so `VoiceProcessingDisarmOutcomeTests`
+    /// pins the real invariant the branch depends on:
+    ///
+    /// - `disarmVoiceProcessing` returns immediately, before touching
+    ///   `voiceProcessingEnabled` at all, whenever the engine is running
+    ///   (VPIO cannot be toggled mid-graph) — the cache is left exactly as
+    ///   it was.
+    /// - In every other path through `disarmVoiceProcessing` (the
+    ///   already-disabled early return, and the full disable attempt on
+    ///   either success or failure), it unconditionally ends with
+    ///   `voiceProcessingEnabled = false`.
+    ///
+    /// A hard-coded `false` here — instead of this decision — previously
+    /// broke this exact scenario: the opt-in preference toggled off
+    /// mid-session while VPIO was still armed and the engine running, which
+    /// on `main` left the ambient `voiceProcessingEnabled` cache at `true`
+    /// (disarm's early return above never clears it) and so fed `true` into
+    /// `recordingFormat`/`routeReadiness` — the exact path the 1.1.52 fix
+    /// hardened. Keep this in sync with `disarmVoiceProcessing` if its
+    /// branching ever changes.
+    static func voiceProcessingEnabledAfterDisarmAttempt(
+        engineIsRunning: Bool,
+        priorVoiceProcessingEnabled: Bool
+    ) -> Bool {
+        engineIsRunning ? priorVoiceProcessingEnabled : false
+    }
+
     /// Enable AUVoiceProcessingIO on the meeting input node so Transcripted
     /// gets its own AGC'd copy of the mic stream rather than reading the raw
     /// shared device. Issue #500: when Safari/Firefox WebRTC has VPIO active
@@ -1604,10 +1638,21 @@ public class Audio: ObservableObject, @unchecked Sendable {
             // Opt-in toggle is off. Be explicit here instead of trusting our
             // cached flag, because a prior route change can leave VPIO armed
             // until the input node is told to release it.
+            //
+            // Capture the pre-call state `disarmVoiceProcessing` is about to
+            // branch on so the returned bind result matches whatever it
+            // actually leaves behind — including its own early return when
+            // the engine is running, which does NOT clear the cache. See
+            // `voiceProcessingEnabledAfterDisarmAttempt`'s doc comment.
+            let engineIsRunningBeforeDisarm = engine?.isRunning ?? false
+            let voiceProcessingEnabledBeforeDisarm = voiceProcessingEnabled
             disarmVoiceProcessing(on: inputNode, reason: "preference_off")
             return VoiceProcessingBindResult(
                 boundInputDeviceIDBeforeWrap: boundInputDeviceIDBeforeWrap,
-                enabled: false
+                enabled: Self.voiceProcessingEnabledAfterDisarmAttempt(
+                    engineIsRunning: engineIsRunningBeforeDisarm,
+                    priorVoiceProcessingEnabled: voiceProcessingEnabledBeforeDisarm
+                )
             )
         }
 

--- a/Tests/TranscriptedCoreTests/AudioTests/VoiceProcessingBindResultTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/VoiceProcessingBindResultTests.swift
@@ -1,0 +1,107 @@
+import CoreAudio
+import XCTest
+@testable import TranscriptedCore
+
+/// `Audio.armVoiceProcessing(on:)` now returns a `VoiceProcessingBindResult`
+/// pairing the physical input device it observed before any wrap with
+/// whether VPIO ended up active, instead of callers separately capturing
+/// the pre-wrap device ID and re-reading the ambient `voiceProcessingEnabled`
+/// cache afterward. `armVoiceProcessing` itself needs a live `AVAudioInputNode`
+/// to exercise (out of scope for a headless unit test, matching this
+/// directory's existing convention of not constructing real audio engines),
+/// so these tests lock in the value type's shape and the invariant that
+/// `MeetingInputDeviceSelectionPolicy.routeReadiness` — the exact call site
+/// the 1.1.52 field fix touched — behaves identically whether its
+/// `boundInputDeviceIDBeforeVoiceProcessing`/`voiceProcessingEnabled`
+/// arguments come from a `VoiceProcessingBindResult` or from the two
+/// previously-separate reads it replaces.
+final class VoiceProcessingBindResultTests: XCTestCase {
+    private func device(id: AudioDeviceID, name: String, transport: MeetingAudioTransport, channels: UInt32) -> MeetingAudioDevice {
+        MeetingAudioDevice(id: id, name: name, transport: transport, inputChannelCount: channels)
+    }
+
+    func testBindResultEqualityReflectsBothFields() {
+        let a = Audio.VoiceProcessingBindResult(boundInputDeviceIDBeforeWrap: 10, enabled: true)
+        let b = Audio.VoiceProcessingBindResult(boundInputDeviceIDBeforeWrap: 10, enabled: true)
+        let differentDevice = Audio.VoiceProcessingBindResult(boundInputDeviceIDBeforeWrap: 20, enabled: true)
+        let differentEnabled = Audio.VoiceProcessingBindResult(boundInputDeviceIDBeforeWrap: 10, enabled: false)
+
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, differentDevice)
+        XCTAssertNotEqual(a, differentEnabled)
+    }
+
+    /// Reproduces the exact scenario the 1.1.52 fix targeted (a bound
+    /// physical device ID that stays intact through VPIO's wrap) but drives
+    /// `routeReadiness` from a `VoiceProcessingBindResult`-shaped pair of
+    /// values, the way `makeReadyMeetingInputGraph` now does, instead of two
+    /// independently-captured values. The outcome must be `.ready`, matching
+    /// the pre-refactor behavior asserted in
+    /// `MeetingInputDeviceSelectionPolicyTests`.
+    func testRouteReadinessAcceptsBindResultShapedValuesForBoundVoiceProcessedDevice() {
+        let builtInMic = device(id: 20, name: "MacBook Pro Microphone", transport: .builtIn, channels: 1)
+        let selection = MeetingInputDeviceSelection(
+            defaultInput: builtInMic,
+            selectedInput: builtInMic,
+            defaultOutput: nil,
+            reason: .defaultIsSafe
+        )
+
+        // Stand-in for what `armVoiceProcessing(on:)` would have returned:
+        // the physical device it bound before VPIO wrapped the node, and
+        // that VPIO ended up enabled.
+        let bindResult = Audio.VoiceProcessingBindResult(
+            boundInputDeviceIDBeforeWrap: builtInMic.id,
+            enabled: true
+        )
+
+        // Once VPIO wraps the node, `actualInputDeviceID` may no longer be
+        // the physical device (private aggregate wrapper) — routeReadiness
+        // must not re-derive identity from it when voiceProcessingEnabled.
+        let postWrapDeviceID: AudioDeviceID = 999
+
+        XCTAssertEqual(
+            MeetingInputDeviceSelectionPolicy.routeReadiness(
+                selection: selection,
+                boundInputDeviceIDBeforeVoiceProcessing: bindResult.boundInputDeviceIDBeforeWrap,
+                actualInputDeviceID: postWrapDeviceID,
+                capturedSampleRate: 48_000,
+                selectedNominalSampleRate: 48_000,
+                voiceProcessingEnabled: bindResult.enabled
+            ),
+            .ready
+        )
+    }
+
+    /// The mirror-image failure case: if the physical device bound before
+    /// the wrap does NOT match the selected microphone, routeReadiness must
+    /// still reject it — a bind result carrying the wrong pre-wrap ID must
+    /// not be masked by `enabled` being true.
+    func testRouteReadinessRejectsBindResultWithMismatchedPreWrapDevice() {
+        let builtInMic = device(id: 20, name: "MacBook Pro Microphone", transport: .builtIn, channels: 1)
+        let wrongMic = device(id: 30, name: "USB Microphone", transport: .usb, channels: 1)
+        let selection = MeetingInputDeviceSelection(
+            defaultInput: builtInMic,
+            selectedInput: builtInMic,
+            defaultOutput: nil,
+            reason: .defaultIsSafe
+        )
+
+        let bindResult = Audio.VoiceProcessingBindResult(
+            boundInputDeviceIDBeforeWrap: wrongMic.id,
+            enabled: true
+        )
+
+        XCTAssertEqual(
+            MeetingInputDeviceSelectionPolicy.routeReadiness(
+                selection: selection,
+                boundInputDeviceIDBeforeVoiceProcessing: bindResult.boundInputDeviceIDBeforeWrap,
+                actualInputDeviceID: 999,
+                capturedSampleRate: 48_000,
+                selectedNominalSampleRate: 48_000,
+                voiceProcessingEnabled: bindResult.enabled
+            ),
+            .deviceMismatch
+        )
+    }
+}

--- a/Tests/TranscriptedCoreTests/AudioTests/VoiceProcessingDisarmOutcomeTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/VoiceProcessingDisarmOutcomeTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Pins `Audio.voiceProcessingEnabledAfterDisarmAttempt(engineIsRunning:priorVoiceProcessingEnabled:)`,
+/// the pure decision `armVoiceProcessing(on:)`'s preference-off branch uses
+/// to compute the `VoiceProcessingBindResult` it returns.
+///
+/// `armVoiceProcessing`/`disarmVoiceProcessing` themselves need a live
+/// `AVAudioInputNode` to exercise, which this test directory does not
+/// construct (no precedent for `AVAudioEngine`/`.inputNode` anywhere under
+/// `Tests/TranscriptedCoreTests/AudioTests/`) — matching that convention, we
+/// pin the extracted pure decision instead of the arm/disarm branches
+/// themselves. Residual gap: these tests do not exercise
+/// `disarmVoiceProcessing`'s real CoreAudio calls or `armVoiceProcessing`'s
+/// full branch dispatch end to end, only the value logic that branch relies
+/// on; if `disarmVoiceProcessing`'s own branching on
+/// `engine.isRunning`/`voiceProcessingEnabled` ever changes without updating
+/// this mirror, these tests cannot detect the drift.
+final class VoiceProcessingDisarmOutcomeTests: XCTestCase {
+    /// Codex review regression case for PR #1641: preference toggled off
+    /// mid-session while VPIO is still armed and the engine is running.
+    /// `disarmVoiceProcessing` returns immediately in that state without
+    /// touching `voiceProcessingEnabled` — the cache stays `true` — so the
+    /// bind result `armVoiceProcessing` returns must also be `true`. A
+    /// hard-coded `false` here would flip `recordingFormat`/`routeReadiness`
+    /// in the exact path the 1.1.52 fix hardened.
+    func testEngineRunningLeavesPriorCacheValueUnchanged() {
+        XCTAssertTrue(
+            Audio.voiceProcessingEnabledAfterDisarmAttempt(
+                engineIsRunning: true,
+                priorVoiceProcessingEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            Audio.voiceProcessingEnabledAfterDisarmAttempt(
+                engineIsRunning: true,
+                priorVoiceProcessingEnabled: false
+            )
+        )
+    }
+
+    /// Every other path through `disarmVoiceProcessing` — engine stopped —
+    /// unconditionally ends with `voiceProcessingEnabled = false`, whether
+    /// or not VPIO was previously armed and regardless of whether the real
+    /// `setVoiceProcessingEnabled(false)` call succeeds.
+    func testEngineStoppedAlwaysClearsToFalseRegardlessOfPriorValue() {
+        XCTAssertFalse(
+            Audio.voiceProcessingEnabledAfterDisarmAttempt(
+                engineIsRunning: false,
+                priorVoiceProcessingEnabled: true
+            )
+        )
+        XCTAssertFalse(
+            Audio.voiceProcessingEnabledAfterDisarmAttempt(
+                engineIsRunning: false,
+                priorVoiceProcessingEnabled: false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Verify-first: what remained vs. what yesterday's fix already covered

This is the final new-code PR of the simplification program, targeting the
`Audio.voiceProcessingEnabled` ambient-cache audit finding. Before writing
any diff I re-read `Sources/TranscriptedCore/Audio/Audio.swift`'s VPIO code
in full and the two same-day commits from **release 1.1.52 / issue #1624**
(`c373bdc4` "Fix voice-processed meeting mic readiness" and `6137020d` "Fix
meeting VPIO route readiness", merged yesterday as PR #1616).

**Already fixed by 1.1.52 (verified, untouched here):** the field-critical
bug — `routeReadiness` comparing device identity *after* VPIO's wrap, which
broke meeting recording on machines with third-party HAL drivers — is fixed.
`routeReadiness` now takes `boundInputDeviceIDBeforeVoiceProcessing` as an
explicit parameter and never re-derives identity from the post-wrap node.
That parameter, its guard logic, and `MeetingInputDeviceSelectionPolicy`'s
public shape are **unchanged** in this PR.

**What remained:** the fix landed the pre-wrap device-ID capture as two
separate reads sitting right next to the `armVoiceProcessing(on:)` call —
```swift
let boundInputDeviceIDBeforeVoiceProcessing = freshInputNode.auAudioUnit.deviceID
armVoiceProcessing(on: freshInputNode)
...
voiceProcessingEnabled: voiceProcessingEnabled   // ambient re-read
```
This is exactly the "ambient cache read immediately after a call that just
computed the same thing" pattern the audit flagged — correct today only
because nothing runs between the two reads under `withAudioGraphLock`, but
an implicit invariant rather than an enforced one.

The broader audit finding — `armVoiceProcessing`/`disarmVoiceProcessing`'s
double-condition "distrust our own cache" checks (`if voiceProcessingEnabled,
inputNode.isVoiceProcessingEnabled`, `wasMarkedEnabled` vs.
`wasActuallyEnabled`) — **still exists** but is not a bug: it's a defensive
OR of both signals that never causes a wrong device/route decision, and arm
and disarm are genuinely temporally separated (arm at start, disarm at stop,
reached through different call chains — monitoring stop, discard-on-retry,
device recovery). Collapsing that into a single "one true value" would mean
either threading a bind result across an async gap (i.e., re-inventing the
ambient cache under a new name) or reworking arm/disarm's decision logic in
the most field-sensitive, currently-unconfirmed part of the codebase. Given
the explicit zero-behavior-change bar and pending field confirmation for
1.1.52, I did **not** touch that part — doing so would be manufacturing a
bigger diff than the remaining problem justifies. Noted here for whoever
picks this up next.

## What this PR does

`Audio.armVoiceProcessing(on:)` now returns a `VoiceProcessingBindResult`
(`boundInputDeviceIDBeforeWrap`, `enabled`) instead of `Void`. The device ID
is captured as the function's first statement — the same value the caller
used to capture immediately before calling it — and `enabled` is set at
every return point to the same value the caller used to read from
`voiceProcessingEnabled` immediately after the call returned. Because
nothing executes between those paired reads in either the old or new code
(same synchronous, lock-held scope), **this is a provably value-identical
refactor**: no scenario changes its computed values.

`makeReadyMeetingInputGraph` now threads that one return value into both
`recordingFormat(for:voiceProcessingEnabled:)` (new optional override
parameter, defaults to the existing ambient-read behavior for other
callers) and `MeetingInputDeviceSelectionPolicy.routeReadiness(...)` —
`routeReadiness`'s only two VPIO/device-identity inputs — instead of
separately capturing the device ID beforehand and re-reading the ambient
cache after.

### Reader migration table

| Reader of `voiceProcessingEnabled` | Migrated? | Why |
|---|---|---|
| `makeReadyMeetingInputGraph` → `routeReadiness(...)` | **Yes** | The exact call site 1.1.52 touched; now sourced from `armVoiceProcessing`'s return value |
| `makeReadyMeetingInputGraph` → `recordingFormat(for:)` | **Yes** | Same synchronous window as the arm call; new optional param, zero behavior change |
| `disarmVoiceProcessing` (`wasMarkedEnabled`/`wasActuallyEnabled`) | No | Genuinely cross-time (disarm runs later, in a different call chain); the dual-signal check is defensive, not buggy |
| `armVoiceProcessing`'s own early-return check (`voiceProcessingEnabled, inputNode.isVoiceProcessingEnabled`) | No | Same reasoning; not the site of the field bug |
| `startMonitoring` → `recordingFormat(for:)` | No | Monitoring never arms VPIO — no bind result exists in scope; correctly still ambient |
| `AudioFileManager.startAudioCapture` log line (`"voiceProcessing": "\(voiceProcessingEnabled)"`) | No | Runs after `makeReadyMeetingInputGraph` returns; would require widening `PreparedMeetingInputGraph`'s public shape for a log string, no behavior change to justify it |
| `AudioPipelineDiagnosticsSnapshot.voiceProcessingActive` (health/events) | No | Deliberately reads *current live* state for diagnostics/Sentry context, not bind-time state — ambient is the correct source here |
| `AudioFileManager`/other "shared-mic paths" | N/A | Grepped the whole repo; no external readers exist outside `Audio.swift` itself + these two files + tests |

No public API outside `TranscriptedCore` changes. `MeetingInputDeviceSelectionPolicy.routeReadiness`'s signature and logic are untouched.

## Tests

Added `Tests/TranscriptedCoreTests/AudioTests/VoiceProcessingBindResultTests.swift`:
- `VoiceProcessingBindResult` Equatable shape.
- `routeReadiness` fed bind-result-shaped values reproduces the exact 1.1.52 scenario (`.ready` for a bound-before-wrap device that VPIO then wraps) and the mismatch case (`.deviceMismatch` for a bind result carrying the wrong pre-wrap device ID even with `enabled: true`).

`armVoiceProcessing` itself needs a live `AVAudioInputNode`, which this test
directory has never constructed directly (no precedent in
`AudioStateTransitionTests`/`AudioDiagnosticsSnapshotTests`/etc.) — kept
consistent with that convention rather than introducing a first hardware-
dependent unit test.

## Verification (all synchronous foreground)

- `bash build-deps.sh --force` — pass
- `bash build.sh --no-open` — pass (signed, launch smoke OK, 1788.8ms launch-to-interactive, within 3000ms budget)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 12757 tests, 12757 passed, 0 failed
- `bash run-integration-smoke.sh` — pass (core smoke, wake smoke, recovery merge package tests)
- `swift test` — 967 tests, 13 skipped (macOS-version gated), 0 failed

## Concerns / for the reviewer

- This touches the same function (`makeReadyMeetingInputGraph`) and exact
  values (`boundInputDeviceIDBeforeVoiceProcessing`, `voiceProcessingEnabled`)
  as yesterday's unconfirmed field fix for issue #1624. I verified the
  refactor is value-identical by inspection (same lock scope, no
  intervening code in either version) and all four verification suites
  pass, but this has **not** been confirmed against real third-party-HAL
  hardware — that confirmation is still pending from the original reporter
  and is out of scope for what a code review can prove.
- The remaining ambient-cache/double-condition pattern in
  `armVoiceProcessing`/`disarmVoiceProcessing` is intentionally left alone
  (see "what remained" above) — flagging in case a future pass wants to
  revisit it once 1.1.52 has real field confirmation and there's more
  appetite for risk in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
