### PR TITLE
simplify(sanitizer-shared): apply remaining codex changes

### DIFF
--- a/Sources/Observability/LocalObservabilityPayloadSanitizer.swift
+++ b/Sources/Observability/LocalObservabilityPayloadSanitizer.swift
@@ -1,41 +1,10 @@
 import Foundation
 
 enum LocalObservabilityPayloadSanitizer {
-    private static let sensitiveContextKeys: Set<String> = [
-        "audio_device",
-        "audio_path",
-        "bundle_id",
-        "default_input_device",
-        "default_input_name",
-        "default_output_device",
-        "default_output_name",
-        "device_name",
-        "download_url",
-        "file_path",
-        "input_device",
-        "input_device_name",
-        "input_name",
-        "meeting_name",
-        "meeting_title",
-        "meeting_url",
-        "microphone_name",
-        "output_device",
-        "output_device_name",
-        "output_name",
-        "prompt_text",
-        "raw_url",
-        "selected_input_device",
-        "source_app",
-        "source_app_bundle",
-        "source_app_bundle_id",
-        "source_app_name",
-        "speaker_name",
-        "title",
-        "transcript",
-        "transcript_path",
-        "transcript_text",
-        "transcript_title",
-        "url",
+    // Local logs use the shared privacy floor plus "device" so raw hardware
+    // labels cannot bypass redaction under a new key spelling.
+    static let sensitiveKeyFragments = PayloadSanitizationCore.baseSensitiveKeyFragments + [
+        "device",
     ]
 
     static func sanitize(_ event: ObservabilityEvent) -> ObservabilityEvent {
@@ -55,7 +24,10 @@ enum LocalObservabilityPayloadSanitizer {
         guard let context else { return nil }
 
         let sanitized = context.reduce(into: [String: String]()) { result, pair in
-            if sensitiveContextKeys.contains(pair.key.lowercased()) {
+            if PayloadSanitizationCore.shouldDrop(
+                key: pair.key,
+                sensitiveFragments: sensitiveKeyFragments
+            ) {
                 result[pair.key] = "[redacted-sensitive-value]"
             } else {
                 result[pair.key] = ObservabilityTextRedactor.redact(pair.value)

--- a/Sources/Observability/PayloadSanitizationCore.swift
+++ b/Sources/Observability/PayloadSanitizationCore.swift
@@ -1,21 +1,20 @@
 import Foundation
 
-/// Destination-agnostic payload mechanics shared by `SentryPayloadSanitizer`
-/// and `AnalyticsPayloadSanitizer`.
+/// Destination-agnostic payload mechanics shared by the observability
+/// sanitizers.
 ///
-/// Both sanitizers historically duplicated `shouldDrop` and the
-/// "redact then truncate to max length" pipeline. Centralizing those keeps
-/// the two destinations from drifting when redaction rules change — each
-/// sanitizer still owns its own sensitive-key list and length cap, but the
-/// mechanics live in one place. Generic free-text patterns live in
-/// `PrivacyTextRedactor`; the app-specific path profile stays behind
-/// `ObservabilityTextRedactor`.
+/// Sentry and Analytics historically duplicated `shouldDrop` and the "redact
+/// then truncate to max length" pipeline. Centralizing those keeps the
+/// off-device destinations from drifting when redaction rules change; each
+/// destination still owns its sensitive-key list and length cap. The local
+/// sanitizer also uses the shared key-matching mechanics with its own list.
+/// Generic free-text patterns live in `PrivacyTextRedactor`; the app-specific
+/// path profile stays behind `ObservabilityTextRedactor`.
 enum PayloadSanitizationCore {
     /// Sensitive-key fragments shared by every off-device destination. A value
     /// is dropped when its lowercased key contains any of these as a substring.
-    /// Both the Sentry and Analytics sanitizers start from this list and layer
-    /// their own destination-specific fragments on top, so the common floor
-    /// cannot drift between the two.
+    /// The Sentry, Analytics, and local sanitizers start from this list and
+    /// layer their own destination-specific fragments on top.
     static let baseSensitiveKeyFragments: [String] = [
         "audio",
         "authorization",
@@ -56,8 +55,7 @@ enum PayloadSanitizationCore {
 
     /// Drop the value if any sensitive-key fragment appears as a substring
     /// of the lowercased key. Each sanitizer passes its own fragment list
-    /// because the Sentry and Analytics destinations have slightly different
-    /// risk profiles.
+    /// because the destinations have slightly different risk profiles.
     static func shouldDrop(key: String, sensitiveFragments: [String]) -> Bool {
         let normalized = key.lowercased()
         return sensitiveFragments.contains(where: { normalized.contains($0) })

--- a/Tests/LocalObservabilityPayloadSanitizerTests.swift
+++ b/Tests/LocalObservabilityPayloadSanitizerTests.swift
@@ -31,6 +31,65 @@ func testLocalObservabilityPayloadSanitizer() {
         assertEqual(sanitized.context?["duration_bucket"], "10_29s", "non-sensitive keys with nothing to redact should pass through unchanged")
     }
 
+    runSuite("LocalObservabilityPayloadSanitizer keeps every legacy sensitive key covered by the shared predicate") {
+        let legacyExactMatchKeys = [
+            "audio_device",
+            "audio_path",
+            "bundle_id",
+            "default_input_device",
+            "default_input_name",
+            "default_output_device",
+            "default_output_name",
+            "device_name",
+            "download_url",
+            "file_path",
+            "input_device",
+            "input_device_name",
+            "input_name",
+            "meeting_name",
+            "meeting_title",
+            "meeting_url",
+            "microphone_name",
+            "output_device",
+            "output_device_name",
+            "output_name",
+            "prompt_text",
+            "raw_url",
+            "selected_input_device",
+            "source_app",
+            "source_app_bundle",
+            "source_app_bundle_id",
+            "source_app_name",
+            "speaker_name",
+            "title",
+            "transcript",
+            "transcript_path",
+            "transcript_text",
+            "transcript_title",
+            "url",
+        ]
+        let sanitized = LocalObservabilityPayloadSanitizer.sanitize(
+            makeObservabilityEvent(
+                context: Dictionary(uniqueKeysWithValues: legacyExactMatchKeys.map { ($0, "private") })
+            )
+        )
+
+        for key in legacyExactMatchKeys {
+            assertTrue(
+                PayloadSanitizationCore.shouldDrop(
+                    key: key,
+                    sensitiveFragments: LocalObservabilityPayloadSanitizer.sensitiveKeyFragments
+                ),
+                "legacy sensitive key \(key) should still be dropped by the shared predicate"
+            )
+            assertEqual(
+                sanitized.context?[key],
+                "[redacted-sensitive-value]",
+                "legacy sensitive key \(key) should still be redacted by the local sanitizer"
+            )
+        }
+    }
+
     runSuite("LocalObservabilityPayloadSanitizer matches sensitive context keys case-insensitively but keeps the original key casing") {
         let event = makeObservabilityEvent(context: ["Title": "My Secret Meeting"])
 


### PR DESCRIPTION
Automated simplification-program task **sanitizer-shared** (2026-08-05 post-program audit).

Routes LocalObservabilityPayloadSanitizer through the shared PayloadSanitizationCore mechanism used by the Sentry and Analytics sanitizers, closing the silent-drift gap between the three; adds tests proving every previously-dropped key is still dropped.

Executed by OpenAI Codex CLI in an isolated worktree, orchestrated by Claude Code. Verified: bash build.sh --no-open + bash run-tests.sh (12842 passed; the initial driver verify only failed on a worktree deps-stamp freshness artifact, not the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex