### PR TITLE
simplify(test-helper-dedup): apply remaining codex changes

### DIFF
--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -183,7 +183,7 @@ func testAgentConnectionGuide() {
     }
 
     runSuite("AgentConnectionGuide.folderPathsText — stays computed from current storage paths") {
-        let source = readAgentConnectionGuideSource()
+        let source = readSourceFixture("Sources/UI/Shared/AgentConnectionGuide.swift")
         let folderText = AgentConnectionGuide.folderPathsText
 
         assertTrue(
@@ -389,10 +389,4 @@ func testAgentConnectionGuide() {
             "bundle should scope search-memory answers to the portable meeting"
         )
     }
-}
-
-private func readAgentConnectionGuideSource() -> String {
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        .appendingPathComponent("Sources/UI/Shared/AgentConnectionGuide.swift")
-    return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
 }

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -633,7 +633,7 @@ func testAnalyticsEventPolicy() {
     }
 
     runSuite("WorkflowRecoveryTelemetry emits the allowlisted recovery attempt bucket") {
-        let source = readAnalyticsPolicyRepoTextFile("Sources/Observability/WorkflowRecoveryTelemetry.swift")
+        let source = readSourceFixture("Sources/Observability/WorkflowRecoveryTelemetry.swift")
         assertTrue(
             source.contains("\"recovery_attempt_bucket\": AnalyticsReporter.countBucket(attempt)"),
             "workflow recovery helper should emit the allowlisted recovery attempt bucket key"
@@ -1663,8 +1663,8 @@ func testAnalyticsEventPolicy() {
     }
 
     runSuite("AnalyticsEventPolicy pins meeting prompt telemetry firing paths") {
-        let appSource = readAnalyticsPolicyRepoTextFile("Sources/TranscriptedApp.swift")
-        let meetingSessionSource = readAnalyticsPolicyRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let appSource = readSourceFixture("Sources/TranscriptedApp.swift")
+        let meetingSessionSource = readSourceFixture("Sources/Meeting/MeetingSessionController.swift")
 
         assertEqual(
             analyticsPolicyOccurrenceCount(of: "\"meeting_prompt_shown\"", in: appSource),
@@ -1754,15 +1754,8 @@ private func analyticsPolicyOccurrenceCount(of needle: String, in haystack: Stri
     return count
 }
 
-private func readAnalyticsPolicyRepoTextFile(_ relativePath: String) -> String {
-    let path = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        .appendingPathComponent(relativePath)
-        .path
-    return (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
-}
-
 private func documentedAnalyticsEvents() -> [String] {
-    let text = loadRepoText("docs/privacy-first-observability.md")
+    let text = readSourceFixture("docs/privacy-first-observability.md")
     let section = markdownSection(
         named: "## Allowlisted analytics events",
         in: text
@@ -1797,7 +1790,7 @@ private func reviewedNonBucketAnalyticsProperties() -> Set<String> {
 }
 
 private func taxonomyDataLines(relativePath: String) -> [String] {
-    loadRepoText(relativePath)
+    readSourceFixture(relativePath)
         .split(separator: "\n")
         .map { $0.trimmingCharacters(in: .whitespaces) }
         .filter { !$0.isEmpty && !$0.hasPrefix("#") }
@@ -1816,22 +1809,8 @@ private func markdownSection(named heading: String, in text: String) -> String {
     return String(sourceAfterHeading[..<end.lowerBound])
 }
 
-private func loadRepoText(_ relativePath: String, file: String = #file, line: Int = #line) -> String {
-    let url = repoFixtureURL(relativePath)
-
-    do {
-        return try String(contentsOf: url, encoding: .utf8)
-    } catch {
-        failedTests += 1
-        totalTests += 1
-        let loc = "\(URL(fileURLWithPath: file).lastPathComponent):\(line)"
-        print("  FAIL [\(loc)] could not load \(relativePath): \(error)")
-        return ""
-    }
-}
-
 private func mcpAgentCaptureQueryAllowedProperties() -> Set<String> {
-    let source = loadRepoText("Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift")
+    let source = readSourceFixture("Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift")
     guard let declaration = source.range(of: "static let allowedProperties: Set<String> = [") else {
         return []
     }

--- a/Tests/AudioAutomationCoverageContractTests.swift
+++ b/Tests/AudioAutomationCoverageContractTests.swift
@@ -7,7 +7,7 @@ import Foundation
 
 func testAudioAutomationCoverageContract() {
     runSuite("Audio automation coverage contract - synthetic matrix names each route lane") {
-        let script = readAudioAutomationContractFile("scripts/ops/daily-audio-reliability-check.sh")
+        let script = readSourceFixture("scripts/ops/daily-audio-reliability-check.sh")
 
         let expectedSyntheticRows = [
             "synthetic-dictation-pasteback-lifecycle",
@@ -46,9 +46,9 @@ func testAudioAutomationCoverageContract() {
     }
 
     runSuite("Audio automation coverage contract - issue 500 manual proof stays explicit") {
-        let script = readAudioAutomationContractFile("scripts/ops/daily-audio-reliability-check.sh")
-        let issue500 = readAudioAutomationContractFile("docs/qa-issue-500-meeting-audio.md")
-        let qaBench = readAudioAutomationContractFile("scripts/ops/transcripted-qa-bench.sh")
+        let script = readSourceFixture("scripts/ops/daily-audio-reliability-check.sh")
+        let issue500 = readSourceFixture("docs/qa-issue-500-meeting-audio.md")
+        let qaBench = readSourceFixture("scripts/ops/transcripted-qa-bench.sh")
 
         for manualProof in ["Safari Meet", "Firefox Meet", "Chrome Meet", "Zoom", "AirPods/Bluetooth"] {
             assertTrue(script.contains(manualProof), "synthetic report should name \(manualProof) as manual proof")
@@ -63,7 +63,7 @@ func testAudioAutomationCoverageContract() {
     }
 
     runSuite("Audio automation coverage contract - Bluetooth route tuple stays named") {
-        let script = readAudioAutomationContractFile("scripts/ops/daily-audio-reliability-check.sh")
+        let script = readSourceFixture("scripts/ops/daily-audio-reliability-check.sh")
         let expectedBluetoothTokens = [
             "mocked connect/disconnect",
             "output-only Bluetooth",
@@ -91,8 +91,8 @@ func testAudioAutomationCoverageContract() {
         // entirely while shared-smoke-sources.sh still listed the file elsewhere — so check the
         // two things independently: (a) run-e2e-smoke.sh actually expands the named array, and
         // (b) the file is a member of THAT specific array's block in shared-smoke-sources.sh.
-        let e2eScript = readAudioAutomationContractFile("scripts/entrypoints/run-e2e-smoke.sh")
-        let sharedSourcesScript = readAudioAutomationContractFile("scripts/entrypoints/lib/shared-smoke-sources.sh")
+        let e2eScript = readSourceFixture("scripts/entrypoints/run-e2e-smoke.sh")
+        let sharedSourcesScript = readSourceFixture("scripts/entrypoints/lib/shared-smoke-sources.sh")
 
         let expectedSharedMembers: [(file: String, array: String)] = [
             ("Sources/Meeting/MeetingTranscriptStyler.swift", "SHARED_TEST_STORAGE_SOURCES"),
@@ -116,12 +116,6 @@ func testAudioAutomationCoverageContract() {
             )
         }
     }
-}
-
-private func readAudioAutomationContractFile(_ relativePath: String) -> String {
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        .appendingPathComponent(relativePath)
-    return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
 }
 
 /// Extracts the body of a `NAME=(\n ... \n)` bash array literal (as used by

--- a/Tests/AuditRegressionCoverageContractTests.swift
+++ b/Tests/AuditRegressionCoverageContractTests.swift
@@ -2,7 +2,7 @@ import Foundation
 
 func testAuditRegressionCoverageContract() {
     runSuite("AuditRegressionCoverageContract — meeting overlay duration updates are whole-second throttled") {
-        let source = readAuditContractSource("Sources/UI/Overlay/MeetingOverlayController.swift")
+        let source = readSourceFixture("Sources/UI/Overlay/MeetingOverlayController.swift")
         assertTrue(
             source.contains("session.$recordingDuration"),
             "meeting overlay should subscribe to the recording-duration publisher directly"
@@ -14,7 +14,7 @@ func testAuditRegressionCoverageContract() {
     }
 
     runSuite("AuditRegressionCoverageContract — menubar duration updates stay deduped to whole seconds") {
-        let source = readAuditContractSource("Sources/UI/MenuBar/MenuBarPanelController.swift")
+        let source = readSourceFixture("Sources/UI/MenuBar/MenuBarPanelController.swift")
         assertTrue(
             source.contains(".map { Int($0) }"),
             "menubar recording-duration sink should collapse subsecond ticks"
@@ -26,7 +26,7 @@ func testAuditRegressionCoverageContract() {
     }
 
     runSuite("AuditRegressionCoverageContract — pasteback focus changes downgrade to copied before Cmd+V") {
-        let source = readAuditContractSource("Sources/Support/ClipboardRestoringTextPaster.swift")
+        let source = readSourceFixture("Sources/Support/ClipboardRestoringTextPaster.swift")
         assertTrue(
             source.contains("!target.matchesCurrentFrontmostApp()"),
             "pasteback must re-check the captured target app before dispatching Cmd+V"
@@ -44,7 +44,7 @@ func testAuditRegressionCoverageContract() {
     runSuite("AuditRegressionCoverageContract — failed meeting queue survives synchronous terminal failures") {
         // Queue-dispatch logic moved to TranscriptionQueueCoordinator.swift
         // (audit 2026-07-08 wave 2, W2-B).
-        let source = readAuditContractSource("Sources/Meeting/TranscriptionQueueCoordinator.swift")
+        let source = readSourceFixture("Sources/Meeting/TranscriptionQueueCoordinator.swift")
         assertTrue(
             source.contains("finalizeBackgroundTranscriptionStateIfNeeded()"),
             "terminal display-status handlers should revisit background queue state"
@@ -53,18 +53,5 @@ func testAuditRegressionCoverageContract() {
             source.contains("handleBackgroundTranscriptionWorkChanged(snapshot: currentBackgroundTranscriptionWorkSnapshot)"),
             "queue draining should have a no-argument path for terminal status changes that do not publish activeCount"
         )
-    }
-}
-
-private func readAuditContractSource(_ relativePath: String) -> String {
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        .appendingPathComponent(relativePath)
-    do {
-        return try String(contentsOf: url, encoding: .utf8)
-    } catch {
-        failedTests += 1
-        totalTests += 1
-        print("  FAIL [AuditRegressionCoverageContractTests.swift] could not read \(relativePath): \(error)")
-        return ""
     }
 }

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -328,7 +328,7 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - engine tap and final inference keep sample-rate pinning") {
-        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetEngine.swift")
+        let source = readSourceFixture("Sources/Speech/ParakeetEngine.swift")
         guard let tapStart = source.range(of: "private func installTapAndStartEngine"),
               let tapEnd = source.range(of: "func removeRecordingTap", range: tapStart.upperBound..<source.endIndex),
               let inferenceStart = source.range(of: "private func drainRecordedSamplesForInference"),
@@ -356,7 +356,7 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - input override happens before format reads") {
-        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetEngine.swift")
+        let source = readSourceFixture("Sources/Speech/ParakeetEngine.swift")
         guard let snapshotStart = source.range(of: "func audioInputSnapshot"),
               let snapshotEnd = source.range(of: "private func installTapAndStartEngine", range: snapshotStart.upperBound..<source.endIndex) else {
             assertTrue(false, "test should find dictation audioInputSnapshot")
@@ -386,7 +386,7 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - system input override restores after recording") {
-        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetEngine.swift")
+        let source = readSourceFixture("Sources/Speech/ParakeetEngine.swift")
         guard let snapshotStart = source.range(of: "func audioInputSnapshot"),
               let snapshotEnd = source.range(of: "private func installTapAndStartEngine", range: snapshotStart.upperBound..<source.endIndex),
               let startStart = source.range(of: "func startRecording(isRecoveryAttempt: Bool = false) async -> Bool"),
@@ -451,7 +451,7 @@ func testBluetoothRouteContract() {
             cleanupBody.contains("schedulePendingSystemInputRestore(ownedBy: pendingRestoreOwner, operation: \"cleanup\")"),
             "quit cleanup should restore its owned temporary input even though cleanup() is synchronous"
         )
-        let systemInputSource = readBluetoothRouteContractFile("Sources/Speech/ParakeetSystemInputCoordination.swift")
+        let systemInputSource = readSourceFixture("Sources/Speech/ParakeetSystemInputCoordination.swift")
         assertTrue(
             systemInputSource.contains("restoreError = try await Self.systemInputWorkCoordinator.run")
                 && systemInputSource.contains("Self.systemInputWorkCoordinator.schedule(")
@@ -482,7 +482,7 @@ func testBluetoothRouteContract() {
     runSuite("Bluetooth route contract - active startup owns its config changes") {
         // Device-change detection/recovery lives in ParakeetDeviceRecovery.swift
         // (codebase audit 2026-07-08 wave 2).
-        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetDeviceRecovery.swift")
+        let source = readSourceFixture("Sources/Speech/ParakeetDeviceRecovery.swift")
         guard let handlerStart = source.range(of: "private func handleAudioConfigChange() async"),
               let handlerEnd = source.range(of: "private func recordStableRouteChangeAnalytics", range: handlerStart.upperBound..<source.endIndex) else {
             assertTrue(false, "test should find the audio config-change handler")
@@ -501,7 +501,7 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - route telemetry commits only after debounce without gating recovery") {
-        let source = readBluetoothRouteContractFile("Sources/Speech/ParakeetDeviceRecovery.swift")
+        let source = readSourceFixture("Sources/Speech/ParakeetDeviceRecovery.swift")
         guard let handlerStart = source.range(of: "private func handleAudioConfigChange() async"),
               let handlerEnd = source.range(of: "private func recordStableRouteChangeAnalytics", range: handlerStart.upperBound..<source.endIndex),
               let reporterEnd = source.range(of: "// MARK: - Recovery execution", range: handlerEnd.upperBound..<source.endIndex) else {
@@ -526,7 +526,7 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - persistent input follows reconnects and restores on shutdown") {
-        let source = readBluetoothRouteContractFile("Sources/Speech/PersistentDictationInputController.swift")
+        let source = readSourceFixture("Sources/Speech/PersistentDictationInputController.swift")
         guard let start = source.range(of: "func start()"),
               let stop = source.range(of: "func stopAndRestore()"),
               let install = source.range(of: "private func installDefaultInputListener()"),
@@ -569,10 +569,10 @@ func testBluetoothRouteContract() {
     }
 
     runSuite("Bluetooth route contract - QA report names mocked proof boundary") {
-        let bench = readBluetoothRouteContractFile("scripts/ops/transcripted-qa-bench.sh")
-        let benchDoc = readBluetoothRouteContractFile("docs/qa-test-bench.md")
-        let dailyDoc = readBluetoothRouteContractFile("docs/audio-reliability-daily-check.md")
-        let gates = readBluetoothRouteContractFile(".agents/qa-gates.yml")
+        let bench = readSourceFixture("scripts/ops/transcripted-qa-bench.sh")
+        let benchDoc = readSourceFixture("docs/qa-test-bench.md")
+        let dailyDoc = readSourceFixture("docs/audio-reliability-daily-check.md")
+        let gates = readSourceFixture(".agents/qa-gates.yml")
 
         let boundary = "Mocked Bluetooth/AirPods route contracts are automated policy proof, not hardware proof."
         let manualProof = "Real connected AirPods/Bluetooth hardware remains manual proof."
@@ -608,10 +608,4 @@ private func bluetoothRouteBuiltInDevice(
         transport: .builtIn,
         inputChannelCount: inputChannels
     )
-}
-
-private func readBluetoothRouteContractFile(_ relativePath: String) -> String {
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        .appendingPathComponent(relativePath)
-    return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
 }

--- a/Tests/ContextCaptureEnginePolicyTests.swift
+++ b/Tests/ContextCaptureEnginePolicyTests.swift
@@ -51,7 +51,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("ContextCaptureEngine hotkey debounce — tracks toggle actions and exempts push-to-talk press") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("_lastAcceptedHotkeyTimesByAction"),
@@ -76,7 +76,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("ContextCaptureEngine hotkey unregister — preserves paste callback owner") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("var onPasteLastDictation: (() -> Void)?"),
@@ -89,7 +89,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("ContextCaptureEngine tap re-enable — reconciles missed push-to-talk release") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("reconcileActivePushToTalkAfterTapDisabled()"),
@@ -112,7 +112,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("ContextCaptureEngine delayed modifier — exact key state and ordered delivery") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("isPhysicallyDown: Self.isExactPhysicalKeyDown(keyCode)"),
@@ -153,7 +153,7 @@ func testContextCaptureEnginePolicy() {
     // all typing on the machine and raised the tapDisabledByTimeout risk.
 
     runSuite("ContextCaptureEngine binding snapshot — tap callback reads cached bindings, not per-event UserDefaults") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("physicalShortcutDetector.updateShortcutBindings(Self.currentShortcutBindings())"),
@@ -166,7 +166,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("ContextCaptureEngine event tap — serviced on dedicated run loop instead of main") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("TranscriptedPhysicalShortcutTap"),
@@ -183,7 +183,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("ContextCaptureEngine tap-disabled recovery — reconciles missed push-to-talk release") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("reconcileActivePushToTalkAfterTapDisabled()"),
@@ -209,7 +209,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("ContextCaptureEngine Accessibility retry — re-registers after permission is granted") {
-        let source = readContextCaptureEngineSource()
+        let source = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             source.contains("accessibilityRetryTask"),
@@ -226,8 +226,8 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("TranscriptedAppState wake recovery — uses registration error, not advisory warning") {
-        let appStateSource = readRepoSource("Sources/TranscriptedAppState.swift")
-        let contextSource = readContextCaptureEngineSource()
+        let appStateSource = readSourceFixture("Sources/TranscriptedAppState.swift")
+        let contextSource = readSourceFixture("Sources/Capture/ContextCaptureEngine.swift")
 
         assertTrue(
             contextSource.contains("var hotkeyRegistrationError: String?"),
@@ -244,7 +244,7 @@ func testContextCaptureEnginePolicy() {
     }
 
     runSuite("DictationSessionController finishing hotkey — shows visible feedback instead of silent swallow") {
-        let source = readRepoSource("Sources/UI/Overlay/DictationSessionController.swift")
+        let source = readSourceFixture("Sources/UI/Overlay/DictationSessionController.swift")
 
         assertTrue(
             source.contains("if overlayController.state == .drafting"),
@@ -816,14 +816,4 @@ private func makeContextCaptureDefaults() -> (UserDefaults, String) {
     let defaults = UserDefaults(suiteName: suiteName)!
     defaults.removePersistentDomain(forName: suiteName)
     return (defaults, suiteName)
-}
-
-private func readContextCaptureEngineSource() -> String {
-    readRepoSource("Sources/Capture/ContextCaptureEngine.swift")
-}
-
-private func readRepoSource(_ path: String) -> String {
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        .appendingPathComponent(path)
-    return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
 }

--- a/Tests/FocusOrderContractTests.swift
+++ b/Tests/FocusOrderContractTests.swift
@@ -71,10 +71,10 @@ func testFocusOrderContract() {
     }
 
     runSuite("Focus order contract - menu bar rows join the keyboard loop") {
-        let rowSource = readFocusContractFile("Sources/UI/MenuBar/MenuBarActionRowView.swift")
-        let primarySource = readFocusContractFile("Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift")
-        let utilitySource = readFocusContractFile("Sources/UI/MenuBar/MenuBarUtilityActionsView.swift")
-        let contentSource = readFocusContractFile("Sources/UI/MenuBar/MenuBarContentView.swift")
+        let rowSource = readSourceFixture("Sources/UI/MenuBar/MenuBarActionRowView.swift")
+        let primarySource = readSourceFixture("Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift")
+        let utilitySource = readSourceFixture("Sources/UI/MenuBar/MenuBarUtilityActionsView.swift")
+        let contentSource = readSourceFixture("Sources/UI/MenuBar/MenuBarContentView.swift")
 
         // Rows must be focusable controls that activate by keyboard and draw a
         // focus ring, otherwise Tab can never land on or trigger them.
@@ -117,8 +117,8 @@ func testFocusOrderContract() {
     }
 
     runSuite("Focus order contract - settings sidebar nav matches the declared order") {
-        let pagesSource = readFocusContractFile("Sources/UI/Settings/TranscriptedSettingsPage.swift")
-        let sidebarSource = readFocusContractFile("Sources/UI/Settings/TranscriptedSettingsSidebar.swift")
+        let pagesSource = readSourceFixture("Sources/UI/Settings/TranscriptedSettingsPage.swift")
+        let sidebarSource = readSourceFixture("Sources/UI/Settings/TranscriptedSettingsSidebar.swift")
 
         // The contract pins the produced identifiers: most pages interpolate
         // `transcripted.settings.sidebar.<rawValue>`, connect-agent uses a
@@ -146,10 +146,6 @@ func testFocusOrderContract() {
             "settings sidebar focus order should cover the four primary navigation pages"
         )
     }
-}
-
-private func readFocusContractFile(_ relativePath: String) -> String {
-    (try? String(contentsOf: repoFixtureURL(relativePath), encoding: .utf8)) ?? ""
 }
 
 /// True when each identifier's `setAutomationIdentifier("…")` attachment appears

--- a/Tests/PermissionStateHarnessContractTests.swift
+++ b/Tests/PermissionStateHarnessContractTests.swift
@@ -7,8 +7,8 @@ import Foundation
 
 func testPermissionStateHarnessContract() {
     runSuite("Permission state harness contract - QA CLI exposes stable command") {
-        let entrypoint = readPermissionHarnessContractFile("Tools/TranscriptedQA/Sources/TranscriptedQA/TranscriptedQA.swift")
-        let command = readPermissionHarnessContractFile("Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PermissionState.swift")
+        let entrypoint = readSourceFixture("Tools/TranscriptedQA/Sources/TranscriptedQA/TranscriptedQA.swift")
+        let command = readSourceFixture("Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PermissionState.swift")
 
         assertTrue(
             entrypoint.contains("PermissionState.self"),
@@ -29,7 +29,7 @@ func testPermissionStateHarnessContract() {
     }
 
     runSuite("Permission state harness contract - QA bench gates live automation") {
-        let qaBench = readPermissionHarnessContractFile("scripts/ops/transcripted-qa-bench.sh")
+        let qaBench = readSourceFixture("scripts/ops/transcripted-qa-bench.sh")
         let permissionIndex = qaBench.range(of: "transcripted-qa permission-state --mode live-capture")?.lowerBound
         let liveSmokeIndex = qaBench.range(of: "bash run-live-capture-smoke.sh --skip-build")?.lowerBound
 
@@ -54,8 +54,8 @@ func testPermissionStateHarnessContract() {
     }
 
     runSuite("Permission state harness contract - docs keep TCC blockers incomplete") {
-        let qaDocs = readPermissionHarnessContractFile("docs/qa-test-bench.md")
-        let gateDocs = readPermissionHarnessContractFile(".agents/qa-gates.yml")
+        let qaDocs = readSourceFixture("docs/qa-test-bench.md")
+        let gateDocs = readSourceFixture(".agents/qa-gates.yml")
 
         assertTrue(
             qaDocs.contains("permission-state")
@@ -69,10 +69,4 @@ func testPermissionStateHarnessContract() {
             "agent QA gates should preserve the permission-state boundary"
         )
     }
-}
-
-private func readPermissionHarnessContractFile(_ relativePath: String) -> String {
-    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        .appendingPathComponent(relativePath)
-    return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
 }

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -177,11 +177,11 @@ func assertPostAwaitOwnershipGuard(
     )
 }
 
-private func readSourceFixture(
+func readSourceFixture(
     _ relativePath: String,
-    description: String,
-    file: String,
-    line: Int
+    description: String? = nil,
+    file: String = #file,
+    line: Int = #line
 ) -> String {
     let url = repoFixtureURL(relativePath)
     do {
@@ -190,7 +190,7 @@ private func readSourceFixture(
         totalTests += 1
         failedTests += 1
         let loc = "\(URL(fileURLWithPath: file).lastPathComponent):\(line)"
-        print("  FAIL [\(loc)] could not read \(description): \(error)")
+        print("  FAIL [\(loc)] could not read \(description ?? relativePath): \(error)")
         return ""
     }
 }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -5,7 +5,7 @@
 //
 // Adding a new contract guard is purely additive: call `contractSource("Sources/.../X.swift")`
 // inline inside an assertion. Do NOT reintroduce a top-of-suite block of
-// `let xSource = readUIAutomationContractFile(...)` declarations — that append-only
+// `let xSource = readSourceFixture(...)` declarations — that append-only
 // hotspot is what made two concurrent UI PRs collide on a duplicate `let` declaration
 // (the same pattern that bit AnalyticsEventPolicy.swift). `contractSource` reads and
 // memoizes each file on demand, so repeated reads of the same path are free and two
@@ -20,7 +20,7 @@ private func contractSource(_ relativePath: String) -> String {
     if let cached = uiAutomationContractSourceCache[relativePath] {
         return cached
     }
-    let contents = readUIAutomationContractFile(relativePath)
+    let contents = readSourceFixture(relativePath)
     uiAutomationContractSourceCache[relativePath] = contents
     return contents
 }
@@ -1013,8 +1013,4 @@ private func sourceBlock(named startMarker: String, endingBefore endMarker: Stri
 private func countOccurrences(of needle: String, in haystack: String) -> Int {
     guard !needle.isEmpty else { return 0 }
     return haystack.components(separatedBy: needle).count - 1
-}
-
-private func readUIAutomationContractFile(_ relativePath: String) -> String {
-    (try? String(contentsOf: repoFixtureURL(relativePath), encoding: .utf8)) ?? ""
 }


### PR DESCRIPTION
Automated simplification-program task **test-helper-dedup** (2026-08-05 post-program audit).

Executed by OpenAI Codex CLI in an isolated worktree, orchestrated by Claude Code; verified headlessly before push (see commit message and verify log).

Verification run: touch deps-libs/.build-deps-stamp 2>/dev/null || true;bash build.sh --no-open;bash run-tests.sh;

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex