### PR TITLE
Route pipeline failure display copy through PipelineErrorKind

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/PipelineFailureDisplayCopy.swift
+++ b/Sources/TranscriptedCore/Pipeline/PipelineFailureDisplayCopy.swift
@@ -1,0 +1,93 @@
+// PipelineFailureDisplayCopy.swift
+// Per-flow user-facing failure copy keyed by the typed `PipelineErrorKind`
+// classification. This table replaced the pair of structurally identical
+// string-matching chains that used to re-derive the failure bucket from the
+// diagnostic message text inside `TranscriptionTaskManager`.
+//
+// This file must depend only on `PipelineErrorKind` (Models/FailedTranscription.swift):
+// the root fast-test runner compiles it flatly next to
+// Tests/PipelineErrorKindContractTests.swift, which pins the full per-kind
+// copy table for both flows.
+
+enum PipelineFailureDisplayCopy {
+
+    enum Flow {
+        /// Transcribing a user-imported audio/video file.
+        case importedAudio
+        /// Re-transcribing retained audio beside an already-saved transcript.
+        case savedAudioRetranscription
+    }
+
+    static func message(for kind: PipelineErrorKind, flow: Flow) -> String {
+        let copy = copy(for: kind)
+        switch flow {
+        case .importedAudio:
+            return copy.importedAudio
+        case .savedAudioRetranscription:
+            return copy.savedAudioRetranscription
+        }
+    }
+
+    private struct Copy {
+        let importedAudio: String
+        let savedAudioRetranscription: String
+    }
+
+    private static func copy(for kind: PipelineErrorKind) -> Copy {
+        switch kind {
+        case .transcriptionAlreadyInProgress:
+            return Copy(
+                importedAudio: "Another transcript is already running. Wait for it to finish, then import the file again.",
+                savedAudioRetranscription: "Another transcript is already running. Wait for it to finish, then try again."
+            )
+        case .recordingTooShort:
+            return Copy(
+                importedAudio: "That audio file is too short to transcribe. Choose audio that is at least two seconds long.",
+                savedAudioRetranscription: "That saved audio is too short to transcribe again."
+            )
+        case .emptyAudioFile:
+            return Copy(
+                importedAudio: "That audio file has no readable audio. Choose a different recording and try again.",
+                savedAudioRetranscription: "That saved audio has no readable audio. Try another saved recording."
+            )
+        case .noSpeechDetected:
+            return Copy(
+                importedAudio: "No speech was found in that audio file. Choose a file with clear spoken audio and try again.",
+                savedAudioRetranscription: "No speech was found in that saved audio. Try a recording with clearer spoken audio."
+            )
+        case .invalidAudioFormat:
+            return Copy(
+                importedAudio: "Transcripted couldn't read that audio file. Choose a WAV, MP3, M4A, AAC, or AIFF file.",
+                savedAudioRetranscription: "Transcripted couldn't read that saved audio. Try another retained recording."
+            )
+        case .saveFailed:
+            return Copy(
+                importedAudio: "Transcripted couldn't save the transcript. Check your capture folder and try again.",
+                savedAudioRetranscription: "Transcripted couldn't save the transcript. Check your capture folder and try again."
+            )
+        case .modelNotLoaded:
+            return Copy(
+                importedAudio: "The local transcription model was not ready. Try again after Models finishes loading.",
+                savedAudioRetranscription: "The local transcription model was not ready. Try again after Models finishes loading."
+            )
+        case .diarizationFailed:
+            return Copy(
+                importedAudio: "Transcripted couldn't separate speakers in that file. Try importing it again.",
+                savedAudioRetranscription: "Transcripted couldn't separate speakers in that saved audio. Try again with the retained recording."
+            )
+        case .transcriptionInferenceFailed:
+            return Copy(
+                importedAudio: "The local transcription model couldn't process that file. Try converting it to WAV or M4A and import again.",
+                savedAudioRetranscription: "The local transcription model couldn't process that saved audio. Try again, or start a new recording if the retained audio is damaged."
+            )
+        case .missingSystemAudio, .microphoneAudioUnusable, .pipelineFailed:
+            // No kind-specific copy: the old string-matching chains had no
+            // branch for these buckets either, so they keep the generic
+            // per-flow fallback they always showed.
+            return Copy(
+                importedAudio: "Transcripted couldn't transcribe that audio file. Try converting it to WAV or M4A and import again.",
+                savedAudioRetranscription: "Transcripted couldn't re-transcribe that saved audio. Try again, or start a new recording if the retained audio is damaged."
+            )
+        }
+    }
+}

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -560,12 +560,7 @@ public class TranscriptionTaskManager: ObservableObject {
                     ) {
                         recoverySession?.scratchCleanupConfirmed()
                     }
-                    let diagnosticMessage = Self.safeFailureDiagnosticMessage(for: error)
-                    self.publishFailure(
-                        displayMessage: Self.importedAudioFailureDisplayMessage(forDiagnosticMessage: diagnosticMessage),
-                        diagnosticMessage: diagnosticMessage,
-                        errorKind: Self.failureKind(for: error)
-                    )
+                    self.publishFailure(Self.failurePresentation(for: error, flow: .importedAudio))
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: taskId)
                     self.scheduleStatusReset(delay: 4)
@@ -671,12 +666,7 @@ public class TranscriptionTaskManager: ObservableObject {
 
                 await MainActor.run {
                     guard !self.finishCancelledTaskIfNeeded(taskId: taskId, error: error) else { return }
-                    let diagnosticMessage = Self.safeFailureDiagnosticMessage(for: error)
-                    self.publishFailure(
-                        displayMessage: Self.savedAudioRetranscriptionFailureDisplayMessage(forDiagnosticMessage: diagnosticMessage),
-                        diagnosticMessage: diagnosticMessage,
-                        errorKind: Self.failureKind(for: error)
-                    )
+                    self.publishFailure(Self.failurePresentation(for: error, flow: .savedAudioRetranscription))
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: taskId)
                     self.scheduleStatusReset(delay: 4)
@@ -689,6 +679,38 @@ public class TranscriptionTaskManager: ObservableObject {
 
     public static func safeFailureDiagnosticMessage(for error: Error) -> String {
         failureClassification(for: error).message
+    }
+
+    /// Everything a failure call site publishes for a thrown pipeline error,
+    /// derived from one classification pass.
+    struct FailurePresentation {
+        let displayMessage: String
+        let diagnosticMessage: String
+        /// The narrow typed kind that gets PERSISTED — see `failureKind(for:)`.
+        /// nil for anything that didn't arrive as a genuine typed `PipelineError`,
+        /// even though `displayMessage` still uses the broad text classification.
+        let errorKind: PipelineErrorKind?
+    }
+
+    /// Classifies `error` once and routes the resulting `PipelineErrorKind`
+    /// through the per-flow `PipelineFailureDisplayCopy` table, instead of
+    /// re-deriving the failure bucket by string-matching the diagnostic
+    /// message it just produced.
+    ///
+    /// One deliberate behavior change from the old string-matching chains:
+    /// a typed `PipelineError.modelInferenceFailed` produces the diagnostic
+    /// "<model> inference failed", which the old chains failed to match
+    /// (they only looked for "transcription inference failed"), silently
+    /// dropping typed inference failures to the generic fallback copy. The
+    /// kind-routed table now shows the inference-specific copy for both the
+    /// typed and text-classified paths.
+    static func failurePresentation(for error: Error, flow: PipelineFailureDisplayCopy.Flow) -> FailurePresentation {
+        let classification = failureClassification(for: error)
+        return FailurePresentation(
+            displayMessage: PipelineFailureDisplayCopy.message(for: classification.kind, flow: flow),
+            diagnosticMessage: classification.message,
+            errorKind: failureKind(for: error)
+        )
     }
 
     /// Typed classification to PERSIST as `FailedTranscription.errorKind` —
@@ -751,10 +773,11 @@ public class TranscriptionTaskManager: ObservableObject {
         }
     }
 
-    /// Backs `safeFailureDiagnosticMessage(for:)` only. Its `kind` half is an
-    /// implementation detail of picking the right `message` string — it is
-    /// deliberately NOT the source of `failureKind(for:)` above, which uses
-    /// its own narrower, typed-only switch instead of this text-inclusive one.
+    /// Backs `safeFailureDiagnosticMessage(for:)` and the display-copy routing
+    /// in `failurePresentation(for:flow:)`. Its `kind` half is the BROAD
+    /// display classification — it is deliberately NOT the source of
+    /// `failureKind(for:)` above, which uses its own narrower, typed-only
+    /// switch instead of this text-inclusive one.
     private static func failureClassification(for error: Error) -> (kind: PipelineErrorKind, message: String) {
         if let pipelineError = error as? PipelineError {
             switch pipelineError {
@@ -773,6 +796,9 @@ public class TranscriptionTaskManager: ObservableObject {
             case .modelNotLoaded(let model):
                 return (.modelNotLoaded, "\(model) model not loaded")
             case .modelInferenceFailed(let model, _):
+                // Assumes transcription, like failureKind(for:) — see the NOTE
+                // there about the latent diarization-model-name divergence from
+                // the legacy text net. Display copy inherits the same assumption.
                 return (.transcriptionInferenceFailed, "\(model) inference failed")
             case .saveFailed:
                 return (.saveFailed, "Failed to save transcript")
@@ -890,72 +916,26 @@ public class TranscriptionTaskManager: ObservableObject {
         return (.pipelineFailed, "Pipeline failed")
     }
 
-    private static func importedAudioFailureDisplayMessage(forDiagnosticMessage message: String) -> String {
-        let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    // Text-based display-copy entry points, kept only for diagnostic strings
+    // that arrive without the original error in hand. The production failure
+    // paths classify the thrown error directly via `failurePresentation(for:flow:)`;
+    // these reuse the same text classifier + kind table rather than a separate
+    // string-matching chain.
 
-        if normalized.contains("transcription already in progress") {
-            return "Another transcript is already running. Wait for it to finish, then import the file again."
-        }
-        if normalized.contains("recording too short") {
-            return "That audio file is too short to transcribe. Choose audio that is at least two seconds long."
-        }
-        if normalized.contains("empty audio file") {
-            return "That audio file has no readable audio. Choose a different recording and try again."
-        }
-        if normalized.contains("no speech detected") {
-            return "No speech was found in that audio file. Choose a file with clear spoken audio and try again."
-        }
-        if normalized.contains("invalid audio format") {
-            return "Transcripted couldn't read that audio file. Choose a WAV, MP3, M4A, AAC, or AIFF file."
-        }
-        if normalized.contains("failed to save transcript") {
-            return "Transcripted couldn't save the transcript. Check your capture folder and try again."
-        }
-        if normalized.contains("model not loaded") {
-            return "The local transcription model was not ready. Try again after Models finishes loading."
-        }
-        if normalized.contains("diarization failed") {
-            return "Transcripted couldn't separate speakers in that file. Try importing it again."
-        }
-        if normalized.contains("transcription inference failed") {
-            return "The local transcription model couldn't process that file. Try converting it to WAV or M4A and import again."
-        }
-
-        return "Transcripted couldn't transcribe that audio file. Try converting it to WAV or M4A and import again."
+    static func importedAudioFailureDisplayMessage(forDiagnosticMessage message: String) -> String {
+        PipelineFailureDisplayCopy.message(for: failureClassification(forText: message).kind, flow: .importedAudio)
     }
 
     static func savedAudioRetranscriptionFailureDisplayMessage(forDiagnosticMessage message: String) -> String {
-        let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        PipelineFailureDisplayCopy.message(for: failureClassification(forText: message).kind, flow: .savedAudioRetranscription)
+    }
 
-        if normalized.contains("transcription already in progress") {
-            return "Another transcript is already running. Wait for it to finish, then try again."
-        }
-        if normalized.contains("recording too short") {
-            return "That saved audio is too short to transcribe again."
-        }
-        if normalized.contains("empty audio file") {
-            return "That saved audio has no readable audio. Try another saved recording."
-        }
-        if normalized.contains("no speech detected") {
-            return "No speech was found in that saved audio. Try a recording with clearer spoken audio."
-        }
-        if normalized.contains("invalid audio format") {
-            return "Transcripted couldn't read that saved audio. Try another retained recording."
-        }
-        if normalized.contains("failed to save transcript") {
-            return "Transcripted couldn't save the transcript. Check your capture folder and try again."
-        }
-        if normalized.contains("model not loaded") {
-            return "The local transcription model was not ready. Try again after Models finishes loading."
-        }
-        if normalized.contains("diarization failed") {
-            return "Transcripted couldn't separate speakers in that saved audio. Try again with the retained recording."
-        }
-        if normalized.contains("transcription inference failed") {
-            return "The local transcription model couldn't process that saved audio. Try again, or start a new recording if the retained audio is damaged."
-        }
-
-        return "Transcripted couldn't re-transcribe that saved audio. Try again, or start a new recording if the retained audio is damaged."
+    private func publishFailure(_ failure: FailurePresentation) {
+        publishFailure(
+            displayMessage: failure.displayMessage,
+            diagnosticMessage: failure.diagnosticMessage,
+            errorKind: failure.errorKind
+        )
     }
 
     private func publishFailure(displayMessage: String, diagnosticMessage: String, errorKind: PipelineErrorKind? = nil) {

--- a/Tests/PipelineErrorKindContractTests.swift
+++ b/Tests/PipelineErrorKindContractTests.swift
@@ -2,6 +2,10 @@
 // Pins the typed `PipelineErrorKind` classification path against the legacy
 // string-matching fallback so they cannot silently drift apart while the
 // fallback still exists for pre-typed-error `FailedTranscription` entries.
+// Also pins the per-flow `PipelineFailureDisplayCopy` table (golden copy for
+// every kind in both the imported-audio and saved-audio-retranscription
+// flows) now that display copy is routed by kind instead of re-matching the
+// diagnostic message text.
 //
 // The canonical messages below are the exact strings
 // `TranscriptionTaskManager.safeFailureDiagnosticMessage` produces for each
@@ -26,6 +30,80 @@ private let pipelineErrorKindCanonicalMessages: [(kind: PipelineErrorKind, messa
     (.diarizationFailed, "Diarization failed"),
     (.transcriptionInferenceFailed, "Transcription inference failed"),
     (.pipelineFailed, "Pipeline failed"),
+]
+
+// Golden per-flow display copy for every PipelineErrorKind, pinning the
+// `PipelineFailureDisplayCopy` table that replaced the old per-flow
+// string-matching chains in `TranscriptionTaskManager`. These strings are the
+// exact copy those chains produced for each kind's canonical diagnostic
+// message, with one deliberate improvement: `.transcriptionInferenceFailed`
+// now shows its specific copy for typed model-inference failures too (the old
+// chains only matched the text-classified "Transcription inference failed"
+// diagnostic and dropped typed "<model> inference failed" to the generic
+// fallback).
+private let pipelineFailureDisplayCopyFixtures: [(kind: PipelineErrorKind, importedAudio: String, savedAudioRetranscription: String)] = [
+    (
+        .transcriptionAlreadyInProgress,
+        "Another transcript is already running. Wait for it to finish, then import the file again.",
+        "Another transcript is already running. Wait for it to finish, then try again."
+    ),
+    (
+        .recordingTooShort,
+        "That audio file is too short to transcribe. Choose audio that is at least two seconds long.",
+        "That saved audio is too short to transcribe again."
+    ),
+    (
+        .emptyAudioFile,
+        "That audio file has no readable audio. Choose a different recording and try again.",
+        "That saved audio has no readable audio. Try another saved recording."
+    ),
+    (
+        .noSpeechDetected,
+        "No speech was found in that audio file. Choose a file with clear spoken audio and try again.",
+        "No speech was found in that saved audio. Try a recording with clearer spoken audio."
+    ),
+    (
+        .invalidAudioFormat,
+        "Transcripted couldn't read that audio file. Choose a WAV, MP3, M4A, AAC, or AIFF file.",
+        "Transcripted couldn't read that saved audio. Try another retained recording."
+    ),
+    (
+        .saveFailed,
+        "Transcripted couldn't save the transcript. Check your capture folder and try again.",
+        "Transcripted couldn't save the transcript. Check your capture folder and try again."
+    ),
+    (
+        .modelNotLoaded,
+        "The local transcription model was not ready. Try again after Models finishes loading.",
+        "The local transcription model was not ready. Try again after Models finishes loading."
+    ),
+    (
+        .diarizationFailed,
+        "Transcripted couldn't separate speakers in that file. Try importing it again.",
+        "Transcripted couldn't separate speakers in that saved audio. Try again with the retained recording."
+    ),
+    (
+        .transcriptionInferenceFailed,
+        "The local transcription model couldn't process that file. Try converting it to WAV or M4A and import again.",
+        "The local transcription model couldn't process that saved audio. Try again, or start a new recording if the retained audio is damaged."
+    ),
+    // The next three had no branch in the old string-matching chains, so they
+    // pin the generic per-flow fallback.
+    (
+        .missingSystemAudio,
+        "Transcripted couldn't transcribe that audio file. Try converting it to WAV or M4A and import again.",
+        "Transcripted couldn't re-transcribe that saved audio. Try again, or start a new recording if the retained audio is damaged."
+    ),
+    (
+        .microphoneAudioUnusable,
+        "Transcripted couldn't transcribe that audio file. Try converting it to WAV or M4A and import again.",
+        "Transcripted couldn't re-transcribe that saved audio. Try again, or start a new recording if the retained audio is damaged."
+    ),
+    (
+        .pipelineFailed,
+        "Transcripted couldn't transcribe that audio file. Try converting it to WAV or M4A and import again.",
+        "Transcripted couldn't re-transcribe that saved audio. Try again, or start a new recording if the retained audio is damaged."
+    ),
 ]
 
 private func makeFailedTranscription(errorMessage: String, errorKind: PipelineErrorKind?) -> FailedTranscription {
@@ -66,6 +144,42 @@ func testPipelineErrorKindContract() {
                 typedEntry.isRetryable,
                 legacyEntry.isRetryable,
                 "typed kind \(fixture.kind.rawValue) disagreed with legacy string matching on isRetryable for its canonical message"
+            )
+        }
+    }
+
+    runSuite("PipelineFailureDisplayCopy covers every PipelineErrorKind") {
+        assertEqual(
+            Set(pipelineFailureDisplayCopyFixtures.map(\.kind)),
+            Set(PipelineErrorKind.allCases),
+            "every PipelineErrorKind case needs a per-flow display copy fixture here, or the golden checks below silently skip it"
+        )
+    }
+
+    for fixture in pipelineFailureDisplayCopyFixtures {
+        runSuite("PipelineFailureDisplayCopy.\(fixture.kind.rawValue) — per-flow copy pinned") {
+            assertEqual(
+                PipelineFailureDisplayCopy.message(for: fixture.kind, flow: .importedAudio),
+                fixture.importedAudio,
+                "imported-audio display copy drifted for kind \(fixture.kind.rawValue)"
+            )
+            assertEqual(
+                PipelineFailureDisplayCopy.message(for: fixture.kind, flow: .savedAudioRetranscription),
+                fixture.savedAudioRetranscription,
+                "saved-audio-retranscription display copy drifted for kind \(fixture.kind.rawValue)"
+            )
+        }
+
+        runSuite("PipelineFailureDisplayCopy.\(fixture.kind.rawValue) — copy stays in its flow's lane") {
+            let importedCopy = PipelineFailureDisplayCopy.message(for: fixture.kind, flow: .importedAudio).lowercased()
+            let savedCopy = PipelineFailureDisplayCopy.message(for: fixture.kind, flow: .savedAudioRetranscription).lowercased()
+            assertTrue(
+                !savedCopy.contains("import"),
+                "saved-audio failures must not tell the user to import the file again (kind \(fixture.kind.rawValue))"
+            )
+            assertTrue(
+                !importedCopy.contains("saved audio"),
+                "imported-audio failures must not reference saved audio (kind \(fixture.kind.rawValue))"
             )
         }
     }

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineErrorPolicyTests.swift
@@ -231,6 +231,97 @@ final class TranscriptionPipelineErrorPolicyTests: XCTestCase {
         )
     }
 
+    // MARK: - failurePresentation(for:flow:) — what the failure call sites publish
+
+    func testFailurePresentationRoutesTypedErrorsThroughTheKindTable() {
+        // For every genuine typed PipelineError, the display message must come
+        // from the per-flow kind table for the broad classification kind, the
+        // diagnostic must match safeFailureDiagnosticMessage, and the persisted
+        // errorKind must match the (narrower) failureKind(for:).
+        let typedErrors: [(error: PipelineError, displayKind: PipelineErrorKind)] = [
+            (.emptyAudioFile, .emptyAudioFile),
+            (.microphoneAudioUnusable, .microphoneAudioUnusable),
+            (.noSpeechDetected, .noSpeechDetected),
+            (.recordingTooShort(duration: 0.5), .recordingTooShort),
+            (.invalidAudioFormat(detail: "bad"), .invalidAudioFormat),
+            (.missingSystemAudio, .missingSystemAudio),
+            (.modelNotLoaded(model: "Parakeet"), .modelNotLoaded),
+            (.modelInferenceFailed(model: "Parakeet", underlying: "boom"), .transcriptionInferenceFailed),
+            (.saveFailed(detail: "disk full"), .saveFailed),
+        ]
+
+        for testCase in typedErrors {
+            for flow in [PipelineFailureDisplayCopy.Flow.importedAudio, .savedAudioRetranscription] {
+                let presentation = TranscriptionTaskManager.failurePresentation(for: testCase.error, flow: flow)
+                XCTAssertEqual(
+                    presentation.displayMessage,
+                    PipelineFailureDisplayCopy.message(for: testCase.displayKind, flow: flow),
+                    "display copy for \(testCase.error) should route through kind \(testCase.displayKind.rawValue)"
+                )
+                XCTAssertEqual(
+                    presentation.diagnosticMessage,
+                    TranscriptionTaskManager.safeFailureDiagnosticMessage(for: testCase.error)
+                )
+                XCTAssertEqual(
+                    presentation.errorKind,
+                    TranscriptionTaskManager.failureKind(for: testCase.error),
+                    "persisted errorKind must stay the narrow typed-only classification"
+                )
+            }
+        }
+    }
+
+    func testFailurePresentationTextFallbackAgreesWithDiagnosticMessageWrappers() {
+        // Untyped errors take the text-classification fallback. The display
+        // copy the call sites publish must agree with what the text-based
+        // wrapper derives from the same diagnostic message — the typed and
+        // text paths share one kind table, so they cannot drift.
+        let untypedErrors: [Error] = [
+            NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "TRANSCRIPTION ALREADY IN PROGRESS"]),
+            NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Audio recording was too short — at least 2 seconds required"]),
+            NSError(domain: "com.apple.coreaudio.avfaudio", code: -50, userInfo: [NSLocalizedDescriptionKey: "avfaudio error -50"]),
+            NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "pyannote raised an internal error"]),
+            NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Parakeet prediction failed at step 42"]),
+            NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "Something opaque happened in an unrelated subsystem"]),
+        ]
+
+        for error in untypedErrors {
+            let imported = TranscriptionTaskManager.failurePresentation(for: error, flow: .importedAudio)
+            XCTAssertEqual(
+                imported.displayMessage,
+                TranscriptionTaskManager.importedAudioFailureDisplayMessage(forDiagnosticMessage: imported.diagnosticMessage)
+            )
+            let saved = TranscriptionTaskManager.failurePresentation(for: error, flow: .savedAudioRetranscription)
+            XCTAssertEqual(
+                saved.displayMessage,
+                TranscriptionTaskManager.savedAudioRetranscriptionFailureDisplayMessage(forDiagnosticMessage: saved.diagnosticMessage)
+            )
+            XCTAssertNil(imported.errorKind, "untyped errors must not persist an errorKind")
+            XCTAssertNil(saved.errorKind, "untyped errors must not persist an errorKind")
+        }
+    }
+
+    func testTypedModelInferenceFailureGetsInferenceSpecificDisplayCopy() {
+        // Deliberate behavior change from the old string-matching chains: the
+        // typed diagnostic is "Parakeet inference failed", which the old chains
+        // failed to match (they only looked for "transcription inference
+        // failed"), so typed inference failures showed the generic fallback.
+        // Kind routing now shows the inference-specific copy on both flows.
+        let error = PipelineError.modelInferenceFailed(model: "Parakeet", underlying: "boom")
+
+        let imported = TranscriptionTaskManager.failurePresentation(for: error, flow: .importedAudio)
+        XCTAssertEqual(
+            imported.displayMessage,
+            "The local transcription model couldn't process that file. Try converting it to WAV or M4A and import again."
+        )
+
+        let saved = TranscriptionTaskManager.failurePresentation(for: error, flow: .savedAudioRetranscription)
+        XCTAssertEqual(
+            saved.displayMessage,
+            "The local transcription model couldn't process that saved audio. Try again, or start a new recording if the retained audio is damaged."
+        )
+    }
+
     // MARK: - failureKind(for:) — narrower than safeFailureDiagnosticMessage
     //
     // `failureKind(for:)` only returns non-nil for a genuine typed

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -366,6 +366,7 @@ APP_SOURCES=(
     "Sources/Reliability/WakeRecoveryCoordinator.swift"
     "Sources/TranscriptedCore/Models/SpeakerMapping.swift"
     "Sources/TranscriptedCore/Models/FailedTranscription.swift"
+    "Sources/TranscriptedCore/Pipeline/PipelineFailureDisplayCopy.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerMatchOutcome.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerPeopleReviewPolicy.swift"


### PR DESCRIPTION
## Summary

TranscriptionTaskManager classified pipeline failures into a typed `PipelineErrorKind`, produced a canonical diagnostic message from that classification, then threw the message away and re-derived the user-facing display copy by string-matching the diagnostic text through two structurally identical 9-condition contains-chains — one for imported-audio failures, one for saved-audio retranscription failures. That's ~170 lines of duplicated keyword matching (two 33-line display-message functions + a 104-line classifier) re-deriving a category the code already had in typed form, one line away from the `PipelineErrorKind` it just computed.

This replaces both chains with a single per-flow copy table keyed by the typed kind (`PipelineFailureDisplayCopy.swift`), derived in one classification pass via `failurePresentation(for:flow:)`. The text-matching classifier still exists, but only as a fallback path for errors that never carried a typed `PipelineError` — the persisted `errorKind` path (`failureKind(for:)`) is unchanged.

One deliberate behavior fix along the way: a typed `.modelInferenceFailed` produced the diagnostic `"<model> inference failed"`, which the old chains never matched (they only looked for the string `"transcription inference failed"`), silently dropping typed inference failures to the generic fallback copy. Kind-based routing now shows the inference-specific copy on both flows.

- `Sources/TranscriptedCore/Pipeline/PipelineFailureDisplayCopy.swift` (new) — per-flow copy table keyed by `PipelineErrorKind`, depends only on that enum so the root fast-test runner can compile it flatly next to `Tests/PipelineErrorKindContractTests.swift`
- `Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift` — both failure call sites now go through `failurePresentation(for:flow:)`; the old 33-line `importedAudioFailureDisplayMessage`/`savedAudioRetranscriptionFailureDisplayMessage` string chains are replaced with thin wrappers over the same table for the text-only fallback path

## Verification

Rebased cleanly onto current `main` (no conflicts — main hadn't touched `Sources/TranscriptedCore/Pipeline/` since this branch diverged). Full matrix for Core changes, all green:

- `bash build-deps.sh --force` — OK
- `bash build.sh --no-open` — OK
- `bash run-tests.sh` — 12891 tests, 12891 passed, 0 failed (includes `PipelineErrorKindContractTests` pinning the full per-kind golden copy table for both flows, and `TranscriptionPipelineErrorPolicyTests` pinning typed/text-path agreement plus the `modelInferenceFailed` copy fix)
- `bash run-integration-smoke.sh` — passed
- `swift test` — 978 tests, 13 skipped, 0 failures

No fixes were needed after rebase — everything passed on the first run.

## Test plan

- [x] `bash build-deps.sh --force`
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh`
- [x] `bash run-integration-smoke.sh`
- [x] `swift test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)