### PR TITLE
Post-review cleanup: four P3 findings from the simplification-PR reviews

### DIFF
--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -33,7 +33,7 @@ anonymous analytics, and Sparkle update plumbing.
 - `ObservabilityTextRedactor.swift` — app-specific adapter over TranscriptedCore's generic `PrivacyTextRedactor`, preserving the existing observability path-boundary profile for support-facing and diagnostic strings
 - `SentryEventPolicy.swift` — explicit allowlist of non-fatal events permitted to reach Sentry
 - `SentryPayloadSanitizer.swift` — strips obvious sensitive values before Sentry sends
-- `PayloadSanitizationCore.swift` — shared `shouldDrop(key:)` + `redactAndCap(_:maxValueLength:)` payload mechanics used by both off-device sanitizers while each destination keeps its own length cap and sensitive-key list
+- `PayloadSanitizationCore.swift` — shared `shouldDrop(key:)` + `redactAndCap(_:maxValueLength:)` payload mechanics used by all three payload sanitizers (Sentry, Analytics, and the on-disk `LocalObservabilityPayloadSanitizer`) while each destination keeps its own length cap and sensitive-key list
 - `SentryRuntimeConfiguration.swift` — resolves Sentry DSN, environment, release, and dist from `Info.plist` or process environment
 - `SparkleUpdaterController.swift` — live Sparkle update controller used by the menubar app, including update-state telemetry and ready-to-install restart flows
 - `UpdateFailureKind.swift` — canonical Sparkle/update failure taxonomy used to normalize network, appcast, download, signature, install, and busy-session errors for analytics

--- a/Sources/Speech/ParakeetRecoveryState.swift
+++ b/Sources/Speech/ParakeetRecoveryState.swift
@@ -74,7 +74,7 @@ struct ParakeetRecoveryState: Equatable {
 
     private func currentToken(matching generation: UInt64) -> SupersessionEpoch.Token? {
         let token = epoch.snapshot()
-        guard token.rawValue == generation, epoch.isCurrent(token) else { return nil }
+        guard token.rawValue == generation else { return nil }
         return token
     }
 }
@@ -209,7 +209,7 @@ struct ParakeetZombieRecoveryState: Equatable {
 
     private func currentToken(matching generation: UInt64) -> SupersessionEpoch.Token? {
         let token = epoch.snapshot()
-        guard token.rawValue == generation, epoch.isCurrent(token) else { return nil }
+        guard token.rawValue == generation else { return nil }
         return token
     }
 }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
@@ -278,8 +278,13 @@ final class TranscriptIndexTests: XCTestCase {
     }
 
     func testGetSpeakerHistoryPreviewUsesFirstMatchingUtterance() throws {
+        // The "You" (mic_0) utterance is timestamped earlier than either Jenny
+        // utterance. If the correlated preview subquery ever dropped its
+        // `u.speaker_name = ms.speaker_name` filter, this earlier other-speaker
+        // line would win and this assertion would catch it.
         let fixture = makeFixtureJSON(
             utterances: [
+                ("mic_0", 0.0, 1.0, "Earliest but different speaker comment"),
                 ("system_0", 8.0, 12.0, "Later Jenny comment"),
                 ("system_0", 2.0, 6.0, "First Jenny comment"),
             ]

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -225,7 +225,7 @@ Current high-ingestion files to treat carefully, ranked by agent pain:
 5. `Sources/UI/Settings/PermissionsOnboardingView.swift` - first-run onboarding flow
 6. `Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift` - tested transcript/frontmatter rewrite logic
 7. `Sources/UI/Overlay/DictationSessionController.swift` - dictation start/stop, paste, save, and telemetry orchestration
-8. `Sources/UI/Overlay/MeetingOverlayController.swift` - meeting prompt/recording panel, views, and tokens
+8. `Sources/UI/Overlay/MeetingOverlayController.swift` - meeting prompt/recording panel controller (~1444 lines); views and tokens now live in `MeetingOverlayPanel.swift`, `MeetingOverlayRootView.swift`, and `MeetingPillBodyView.swift`
 9. `Sources/UI/Settings/SpeakerPeopleSettingsSection.swift` - people settings view model and row composition
 10. `Sources/Meeting/LiveMeetingCodexSession.swift` - live sidecar state, file writes, handoff text, and preview HTML
 11. `Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift` - Core queueing, retries, task lifecycle, and metadata handoff


### PR DESCRIPTION
## Summary

Four small fixes flagged by adversarial reviews of merged PRs #1644-#1650:

- **Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift**: `testGetSpeakerHistoryPreviewUsesFirstMatchingUtterance` only fed utterances from one speaker, so it never actually pinned the correlated preview subquery's `speaker_name` filter. Added an utterance from a second speaker ("You"/mic_0) timestamped earlier than the target speaker's earliest line; the test now asserts the preview still resolves to the target speaker's own earliest line.
- **Sources/Speech/ParakeetRecoveryState.swift** (both `ParakeetRecoveryState` and its twin `ParakeetZombieRecoveryState`): `currentToken(matching:)` called `epoch.isCurrent(token)` on a token just obtained from `epoch.snapshot()` — tautologically true, since `snapshot()` returns the current token directly. Simplified to compare `token.rawValue == generation` and return the token, dropping the vacuous check in both structs' helpers.
- **Sources/Observability/CLAUDE.md**: the `PayloadSanitizationCore.swift` bullet said it's "used by both off-device sanitizers" — stale now that it's shared by three (Sentry, Analytics, and the on-disk `LocalObservabilityPayloadSanitizer`). Updated the description.
- **docs/agent-onboarding.md**: the hotspot entry for `Sources/UI/Overlay/MeetingOverlayController.swift` still said "meeting prompt/recording panel, views, and tokens" — post-split it's controller-only (~1444 lines); views/tokens moved to `MeetingOverlayPanel.swift`/`MeetingOverlayRootView.swift`/`MeetingPillBodyView.swift`. Updated the description.

## Test plan

- [x] `swift test --package-path Tools/TranscriptedMCP` — 192 tests, 0 failures (includes the updated speaker-history test)
- [x] `bash build.sh --no-open` — build succeeds
- [x] `bash run-tests.sh` — 12842 tests, 0 failures
- [x] Docs-only fixes (3 and 4) require no build

🤖 Generated with [Claude Code](https://claude.com/claude-code)