### PR TITLE
Fix meeting start failures and partial audio recovery

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -31,6 +31,9 @@ final class MeetingCaptureBridge: ObservableObject {
     @Published private(set) var recordingDuration: TimeInterval = 0
     @Published private(set) var systemAudioStatus: SystemAudioStatus = .unknown
     @Published private(set) var errorMessage: String?
+    var systemAudioStartPermissionExplicitlyDenied: Bool {
+        audio.systemAudioStartPermissionExplicitlyDenied
+    }
     /// One-shot per recording: true once Core fired the issue #500
     /// `.micAttenuatedByForeignVoiceProcessing` cue. Reset at the next start.
     @Published private(set) var micAttenuationCueObserved: Bool = false

--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -17,10 +17,30 @@ struct MeetingFailureCopy: Equatable {
                 title: "Turn on System Audio Recording",
                 detail: "Turn on System Audio Recording in System Settings, then retry the meeting."
             )
+        case .systemAudioPermissionCheckInconclusive:
+            return MeetingFailureCopy(
+                title: "Couldn't verify system audio access",
+                detail: "Try again. If it keeps happening, review System Audio Recording in System Settings."
+            )
         case .microphonePermission:
             return MeetingFailureCopy(
                 title: "Turn on Microphone",
                 detail: "Turn on Microphone access in System Settings, then retry the meeting."
+            )
+        case .microphoneStartFailed:
+            return MeetingFailureCopy(
+                title: "Microphone didn't start",
+                detail: "Check your input device, then try again."
+            )
+        case .systemAudioStartFailed:
+            return MeetingFailureCopy(
+                title: "System audio didn't start",
+                detail: "Try again. If it keeps happening, quit and reopen Transcripted."
+            )
+        case .meetingAudioStartFailed:
+            return MeetingFailureCopy(
+                title: "Meeting audio didn't start",
+                detail: "Check your audio devices, then try again."
             )
         case .microphoneAudioUnusable:
             return MeetingFailureCopy(

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -5,7 +5,11 @@ import TranscriptedCore
 
 enum MeetingFailureKind: String {
     case systemAudioPermission = "system_audio_permission"
+    case systemAudioPermissionCheckInconclusive = "system_audio_permission_check_inconclusive"
     case microphonePermission = "microphone_permission"
+    case microphoneStartFailed = "microphone_start_failed"
+    case systemAudioStartFailed = "system_audio_start_failed"
+    case meetingAudioStartFailed = "meeting_audio_start_failed"
     case microphoneMissing = "microphone_missing"
     case microphoneAudioUnusable = "microphone_audio_unusable"
     case audioDeviceUnavailable = "audio_device_unavailable"
@@ -132,6 +136,15 @@ enum MeetingFailureKind: String {
         }
 
         if normalized.contains(anyOf: [
+            "couldn't verify system audio",
+            "could not verify system audio",
+            "inconclusive access check",
+            "system audio recording check unavailable",
+        ]) {
+            return .systemAudioPermissionCheckInconclusive
+        }
+
+        if normalized.contains(anyOf: [
             "system audio is required",
             "system audio recording",
             "screen recording",
@@ -146,6 +159,24 @@ enum MeetingFailureKind: String {
             "mic_not_authorized",
         ]) {
             return .microphonePermission
+        }
+
+        let describesStartFailure = normalized.contains(anyOf: [
+            "didn't start",
+            "couldn't start",
+            "could not start",
+            "did not become ready",
+            "unavailable",
+        ])
+        if describesStartFailure,
+           normalized.contains(anyOf: ["microphone", "mic route", "input device"]) {
+            return .microphoneStartFailed
+        }
+        if describesStartFailure, normalized.contains("system audio") {
+            return .systemAudioStartFailed
+        }
+        if describesStartFailure, normalized.contains("meeting audio") {
+            return .meetingAudioStartFailed
         }
 
         if normalized.contains("no microphone found") {

--- a/Sources/Meeting/MeetingRecordingStartGate.swift
+++ b/Sources/Meeting/MeetingRecordingStartGate.swift
@@ -5,6 +5,21 @@ struct MeetingRecordingStartDecision: Equatable {
     let errorMessage: String?
     let failureReason: String?
     let missingPermissions: [String]
+    let systemAudioPermissionCheckWasInconclusive: Bool
+
+    init(
+        canStart: Bool,
+        errorMessage: String?,
+        failureReason: String?,
+        missingPermissions: [String],
+        systemAudioPermissionCheckWasInconclusive: Bool = false
+    ) {
+        self.canStart = canStart
+        self.errorMessage = errorMessage
+        self.failureReason = failureReason
+        self.missingPermissions = missingPermissions
+        self.systemAudioPermissionCheckWasInconclusive = systemAudioPermissionCheckWasInconclusive
+    }
 
     static let allowed = MeetingRecordingStartDecision(
         canStart: true,
@@ -12,6 +27,16 @@ struct MeetingRecordingStartDecision: Equatable {
         failureReason: nil,
         missingPermissions: []
     )
+
+    func markingSystemAudioPermissionCheckInconclusive() -> MeetingRecordingStartDecision {
+        MeetingRecordingStartDecision(
+            canStart: canStart,
+            errorMessage: errorMessage,
+            failureReason: failureReason,
+            missingPermissions: missingPermissions,
+            systemAudioPermissionCheckWasInconclusive: true
+        )
+    }
 }
 
 enum MeetingRecordingStartGate {
@@ -70,5 +95,45 @@ enum MeetingRecordingStartGate {
                 missingPermissions: missingPermissions
             )
         }
+    }
+
+    /// A ScreenCaptureKit probe can be inconclusive even when the user has not
+    /// denied access. Keep that distinct from the missing-permission copy so a
+    /// transient macOS audio-service failure never tells the user to toggle a
+    /// permission we did not actually observe as denied.
+    static func systemAudioVerificationUnavailable() -> MeetingRecordingStartDecision {
+        MeetingRecordingStartDecision(
+            canStart: false,
+            errorMessage: "Transcripted couldn't verify System Audio Recording because macOS didn't finish the check. Try recording again. If it keeps happening, confirm System Audio Recording is on in System Settings.",
+            failureReason: "system_audio_recording_check_unavailable",
+            missingPermissions: [],
+            systemAudioPermissionCheckWasInconclusive: true
+        )
+    }
+
+    /// If a cached grant survived an inconclusive preflight, a later capture
+    /// service error is not proof that the user revoked access. Strip only the
+    /// permission-specific blame from that start failure; ordinary mic, stream,
+    /// and timeout errors keep their more precise copy.
+    static func captureFailureMessage(
+        _ rawMessage: String,
+        systemAudioPermissionCheckWasInconclusive: Bool,
+        explicitSystemAudioPermissionDenialObserved: Bool = false
+    ) -> String {
+        // A typed denial from the actual capture attempt outranks the earlier
+        // inconclusive preflight. Keep the direct Settings recovery copy.
+        guard !explicitSystemAudioPermissionDenialObserved else { return rawMessage }
+        guard systemAudioPermissionCheckWasInconclusive else { return rawMessage }
+
+        let normalized = rawMessage.lowercased()
+        let blamesSystemAudioPermission = normalized.contains("system audio")
+            && (
+                normalized.contains("system settings")
+                    || normalized.contains("enable system audio recording")
+                    || normalized.contains("permission")
+            )
+        guard blamesSystemAudioPermission else { return rawMessage }
+
+        return "System audio didn't start after macOS returned an inconclusive access check. Try recording again. If it keeps happening, quit and reopen Transcripted."
     }
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -668,6 +668,7 @@ final class MeetingSessionController: ObservableObject {
 
         let startDecision = await resolveStartRecordingPermissionDecision(trigger: trigger)
         guard startDecision.canStart else {
+            let permissionCheckWasInconclusive = startDecision.systemAudioPermissionCheckWasInconclusive
             ProductFrictionTelemetry.track(
                 surface: .meeting,
                 stage: "permission_start",
@@ -678,8 +679,12 @@ final class MeetingSessionController: ObservableObject {
             DiagnosticsTrail.record(
                 level: .warning,
                 engine: "meeting",
-                event: "meeting_start_blocked_permission",
-                message: "Meeting recording blocked because a required permission is missing",
+                event: permissionCheckWasInconclusive
+                    ? "meeting_start_permission_check_inconclusive"
+                    : "meeting_start_blocked_permission",
+                message: permissionCheckWasInconclusive
+                    ? "Meeting recording blocked because system audio access could not be verified"
+                    : "Meeting recording blocked because a required permission is missing",
                 context: baseDiagnosticsContext(
                     extra: [
                         "trigger": trigger.rawValue,
@@ -738,7 +743,12 @@ final class MeetingSessionController: ObservableObject {
             clearActiveRecordingIdentity()
             activeRecordingSuggestedTitle = nil
             activeRecordingStartedAt = nil
-            let failureMessage = capture.errorMessage ?? "Meeting recording couldn't start. Check Transcripted's permissions and audio setup, then try again."
+            let rawFailureMessage = capture.errorMessage ?? "Meeting audio didn't start. Check your audio devices, then try again."
+            let failureMessage = MeetingRecordingStartGate.captureFailureMessage(
+                rawFailureMessage,
+                systemAudioPermissionCheckWasInconclusive: startDecision.systemAudioPermissionCheckWasInconclusive,
+                explicitSystemAudioPermissionDenialObserved: capture.systemAudioStartPermissionExplicitlyDenied
+            )
             let pipelineSnapshot = capture.pipelineDiagnosticsSnapshot()
             let failureProperties = meetingCaptureAnalyticsProperties(snapshot: pipelineSnapshot).merging(
                 [
@@ -855,27 +865,55 @@ final class MeetingSessionController: ObservableObject {
             )
         )
 
-        systemAudioRecordingGranted = await TranscriptedPermissionAccess.requestSystemAudioRecordingAccessIfNeeded(
+        let systemAudioAccess = await TranscriptedPermissionAccess.systemAudioRecordingAccessDecision(
             forceRefresh: shouldRevalidateCachedSystemAudioPermission
         )
-        startDecision = MeetingRecordingStartGate.evaluate(
-            microphoneGranted: microphoneGranted,
-            systemAudioRecordingGranted: systemAudioRecordingGranted
-        )
+        systemAudioRecordingGranted = systemAudioAccess.canProceed
+        if !systemAudioAccess.canProceed,
+           systemAudioAccess.probeResult?.isIndeterminate == true {
+            startDecision = MeetingRecordingStartGate.systemAudioVerificationUnavailable()
+        } else {
+            startDecision = MeetingRecordingStartGate.evaluate(
+                microphoneGranted: microphoneGranted,
+                systemAudioRecordingGranted: systemAudioRecordingGranted
+            )
+            if systemAudioAccess.probeResult?.isIndeterminate == true {
+                startDecision = startDecision.markingSystemAudioPermissionCheckInconclusive()
+            }
+        }
+
+        let permissionProbeResult = systemAudioAccess.probeResult?.diagnosticName ?? "cached_grant"
+        let permissionEvent: String
+        let permissionMessage: String
+        let permissionLevel: EventLevel
+        if systemAudioAccess.probeResult?.isIndeterminate == true {
+            permissionEvent = systemAudioRecordingGranted
+                ? "meeting_start_system_audio_permission_check_inconclusive_continued"
+                : "meeting_start_system_audio_permission_check_inconclusive"
+            permissionMessage = systemAudioRecordingGranted
+                ? "System audio permission check was inconclusive; preserving the previously verified grant"
+                : "System audio permission check was inconclusive without a previously verified grant"
+            permissionLevel = .warning
+        } else {
+            permissionEvent = systemAudioRecordingGranted
+                ? "meeting_start_system_audio_permission_granted"
+                : "meeting_start_system_audio_permission_missing"
+            permissionMessage = systemAudioRecordingGranted
+                ? "System audio permission is ready for meeting capture"
+                : "System audio permission is still missing for meeting capture"
+            permissionLevel = systemAudioRecordingGranted ? .info : .warning
+        }
 
         DiagnosticsTrail.record(
-            level: systemAudioRecordingGranted ? .info : .warning,
+            level: permissionLevel,
             engine: "meeting",
-            event: systemAudioRecordingGranted
-                ? "meeting_start_system_audio_permission_granted"
-                : "meeting_start_system_audio_permission_missing",
-            message: systemAudioRecordingGranted
-                ? "System audio permission is ready for meeting capture"
-                : "System audio permission is still missing for meeting capture",
+            event: permissionEvent,
+            message: permissionMessage,
             context: baseDiagnosticsContext(
                 extra: [
                     "trigger": trigger.rawValue,
-                    "permission_check": permissionCheckMode
+                    "permission_check": permissionCheckMode,
+                    "permission_probe_result": permissionProbeResult,
                 ]
             )
         )
@@ -1010,6 +1048,9 @@ final class MeetingSessionController: ObservableObject {
         if files.systemURL == nil {
             finalizedHealthInfo = finalizedHealthInfo.markingSystemAudioMissing()
         }
+        if files.micURL == nil, files.systemURL != nil {
+            finalizedHealthInfo = finalizedHealthInfo.markingMicrophoneAudioUnusable()
+        }
         activeRecordingTrigger = .unknown
         activeRecordingSuggestedTitle = nil
         activeRecordingStartedAt = nil
@@ -1031,7 +1072,7 @@ final class MeetingSessionController: ObservableObject {
         )
 
         DiagnosticsTrail.record(
-            level: recordingSnapshot.systemAudioStatus.isWarning || files.systemURL == nil ? .warning : .info,
+            level: recordingSnapshot.systemAudioStatus.isWarning || files.systemURL == nil || files.micURL == nil ? .warning : .info,
             engine: "meeting",
             event: "meeting_recording_stopped",
             message: "Meeting recording stopped",
@@ -1079,8 +1120,8 @@ final class MeetingSessionController: ObservableObject {
         )
 
         // Every timed-out stop keeps the preallocated task ID used by its late
-        // completion callback. Handle this before the generic missing-mic path
-        // so an initially absent mic URL cannot create an unrelated failed row.
+        // completion callback. Handle this before partial-source recovery so an
+        // initially absent mic URL cannot create an unrelated failed row.
         if stopResult.didTimeOut {
             Self.runtimeDiagnosticsRecorder?.recordStall(
                 kind: "meeting",
@@ -1122,38 +1163,42 @@ final class MeetingSessionController: ObservableObject {
             return
         }
 
-        guard let micURL = files.micURL else {
-            let preserved = failedMeetingStore.preserveFailedMeetingForRetry(
-                micAudioURL: nil,
-                systemAudioURL: files.systemURL,
-                errorMessage: "Recording stopped without microphone audio.",
-                meetingTitle: recordingSnapshot.suggestedTitle,
-                recordingDate: recordingSnapshot.recordingStartedAt
-            )
+        guard files.micURL != nil || files.systemURL != nil else {
             DiagnosticsTrail.record(
                 level: .error,
                 engine: "meeting",
-                event: "meeting_recording_missing_mic_audio",
-                message: "Meeting recording stopped without a microphone file",
+                event: "meeting_recording_missing_audio",
+                message: "Meeting recording stopped without any audio files",
                 context: baseDiagnosticsContext(
                     extra: [
                         "reason": reason.rawValue,
-                        "system_file_present": boolString(files.systemURL != nil),
-                        "preserved_for_retry": boolString(preserved)
+                        "system_file_present": boolString(false),
+                        "preserved_for_retry": boolString(false)
                     ]
                 )
             )
             Self.runtimeDiagnosticsRecorder?.clearSession(
                 kind: "meeting",
-                outcome: files.systemURL == nil ? "no_audio_captured" : "missing_mic_audio"
+                outcome: "no_audio_captured"
             )
-            transition(
-                to: files.systemURL == nil
-                    ? .error("No meeting audio was captured.")
-                    : .error("Microphone audio was missing. Open Transcripted Home to retry the system audio."),
-                reason: "stop_missing_mic_audio"
-            )
+            transition(to: .error("No meeting audio was captured."), reason: "stop_missing_audio")
             return
+        }
+
+        if files.micURL == nil {
+            DiagnosticsTrail.record(
+                level: .warning,
+                engine: "meeting",
+                event: "meeting_recording_missing_mic_audio_system_only",
+                message: "Meeting recording will continue through the system-audio-only recovery pipeline",
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "reason": reason.rawValue,
+                        "system_file_present": boolString(true),
+                        "partial_output": boolString(true)
+                    ]
+                )
+            )
         }
 
         if files.systemURL == nil {
@@ -1173,7 +1218,7 @@ final class MeetingSessionController: ObservableObject {
         }
 
         let outcome = transcriptionQueue.enqueueTranscriptionJob(
-            micURL: micURL,
+            micURL: files.micURL,
             systemURL: files.systemURL,
             healthInfo: finalizedHealthInfo,
             captureDiagnostics: stopCaptureDiagnostics,

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -197,6 +197,7 @@ enum MeetingTranscriptStyler {
             durationSeconds: TranscriptFrontmatter.durationSeconds(from: duration) ?? 0,
             totalWords: words,
             totalUtterances: utterances,
+            microphoneAudioUnusable: values["microphone_audio_unusable"] == "true",
             transcriptEntries: transcriptEntries,
             preservedTrailingSections: trailingBodySections(in: frontmatter.body)
         )
@@ -333,6 +334,12 @@ enum MeetingTranscriptStyler {
         # \(title)
 
         \(detailParts.joined(separator: "  •  "))
+        """
+        if document.microphoneAudioUnusable {
+            rendered += "\n\n> **Recording note:** The microphone track was missing or could not be transcribed, so this meeting contains system audio only."
+        }
+        rendered += """
+
 
         ## Transcript
 
@@ -530,6 +537,7 @@ private struct ParsedDocument {
     let durationSeconds: Int
     let totalWords: Int
     let totalUtterances: Int
+    let microphoneAudioUnusable: Bool
     let transcriptEntries: [TranscriptEntry]
     let preservedTrailingSections: String?
 }

--- a/Sources/Meeting/TranscriptionQueueCoordinator.swift
+++ b/Sources/Meeting/TranscriptionQueueCoordinator.swift
@@ -27,7 +27,7 @@ final class TranscriptionQueueCoordinator {
     struct QueuedTranscriptionJob {
         enum Kind {
             case recorded(
-                micURL: URL,
+                micURL: URL?,
                 systemURL: URL?,
                 healthInfo: RecordingHealthInfo,
                 captureDiagnostics: [String: String],
@@ -114,7 +114,7 @@ final class TranscriptionQueueCoordinator {
     }
 
     func enqueueTranscriptionJob(
-        micURL: URL,
+        micURL: URL?,
         systemURL: URL?,
         healthInfo: RecordingHealthInfo,
         captureDiagnostics: [String: String],

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -6,7 +6,7 @@ import EventKit
 import ScreenCaptureKit
 
 enum TranscriptedPermissionAccess {
-    enum SystemAudioPermissionState {
+    enum SystemAudioPermissionState: Equatable, Sendable {
         case granted
         case denied
         case unknown
@@ -14,6 +14,55 @@ enum TranscriptedPermissionAccess {
         var isGranted: Bool {
             self == .granted
         }
+    }
+
+    /// A permission probe can fail for reasons that say nothing about the
+    /// user's TCC choice. Keep those transport failures distinct from an
+    /// explicit denial so a transient ScreenCaptureKit/daemon problem cannot
+    /// overwrite a previously verified grant and manufacture a permission
+    /// popup at meeting start.
+    enum SystemAudioPermissionProbeStage: String, CaseIterable, Sendable {
+        case timedOut = "timed_out"
+        case cancelled
+        case shareableContent = "shareable_content"
+        case displayUnavailable = "display_unavailable"
+        case addStreamOutput = "add_stream_output"
+        case startCapture = "start_capture"
+        case stopCapture = "stop_capture"
+    }
+
+    enum SystemAudioPermissionProbeResult: Equatable, Sendable {
+        case granted
+        case explicitlyDenied
+        case indeterminate(SystemAudioPermissionProbeStage)
+
+        var diagnosticName: String {
+            switch self {
+            case .granted:
+                return "granted"
+            case .explicitlyDenied:
+                return "explicitly_denied"
+            case .indeterminate(let stage):
+                return "indeterminate_\(stage.rawValue)"
+            }
+        }
+
+        var isIndeterminate: Bool {
+            if case .indeterminate = self { return true }
+            return false
+        }
+
+        var wasCancelled: Bool {
+            self == .indeterminate(.cancelled)
+        }
+    }
+
+    struct SystemAudioPermissionAccessDecision: Equatable, Sendable {
+        let canProceed: Bool
+        let state: SystemAudioPermissionState
+        /// Nil means a cached verified grant satisfied the request without a
+        /// live probe. Non-nil records the privacy-safe terminal probe class.
+        let probeResult: SystemAudioPermissionProbeResult?
     }
 
     private static let systemAudioRecordingGrantedKey = "systemAudioRecordingPermissionGranted"
@@ -185,14 +234,24 @@ enum TranscriptedPermissionAccess {
 
     @MainActor
     static func requestSystemAudioRecordingAccessIfNeeded(forceRefresh: Bool = false) async -> Bool {
+        await systemAudioRecordingAccessDecision(forceRefresh: forceRefresh).canProceed
+    }
+
+    @MainActor
+    static func systemAudioRecordingAccessDecision(
+        forceRefresh: Bool = false
+    ) async -> SystemAudioPermissionAccessDecision {
         if !forceRefresh, systemAudioRecordingStatus() == .granted {
-            return true
+            return SystemAudioPermissionAccessDecision(
+                canProceed: true,
+                state: .granted,
+                probeResult: nil
+            )
         }
 
         activateForPermissionPrompt()
-        let granted = await performSystemAudioRecordingAccessRequest()
-        setSystemAudioRecordingGranted(granted)
-        return granted
+        let result = await performSystemAudioRecordingAccessRequest()
+        return applySystemAudioRecordingProbeResult(result)
     }
 
     @MainActor
@@ -205,8 +264,8 @@ enum TranscriptedPermissionAccess {
         }
 
         let task = Task { @MainActor in
-            let granted = await performSystemAudioRecordingAccessRequest()
-            setSystemAudioRecordingGranted(granted)
+            let result = await performSystemAudioRecordingAccessRequest()
+            let granted = applySystemAudioRecordingProbeResult(result).canProceed
             notifyPermissionsDidChange(kind: .systemAudioRecording)
             return granted
         }
@@ -225,7 +284,7 @@ enum TranscriptedPermissionAccess {
             return systemAudioRecordingGranted()
         }
         let granted = await requester()
-        setSystemAudioRecordingGranted(granted)
+        _ = applySystemAudioRecordingProbeResult(granted ? .granted : .explicitlyDenied)
         notifyPermissionsDidChange(kind: .systemAudioRecording)
         return granted
     }
@@ -240,12 +299,31 @@ enum TranscriptedPermissionAccess {
         }
 
         let granted = await requester()
-        setSystemAudioRecordingGranted(granted)
+        _ = applySystemAudioRecordingProbeResult(granted ? .granted : .explicitlyDenied)
         return granted
     }
 
+    /// Typed test/integration seam for exercising transport failures without
+    /// turning them into a synthetic denial. Production callers use the
+    /// no-requester overload above.
     @MainActor
-    private static func performSystemAudioRecordingAccessRequest() async -> Bool {
+    static func systemAudioRecordingAccessDecision(
+        forceRefresh: Bool = false,
+        probeRequester: @escaping @MainActor () async -> SystemAudioPermissionProbeResult
+    ) async -> SystemAudioPermissionAccessDecision {
+        if !forceRefresh, systemAudioRecordingStatus() == .granted {
+            return SystemAudioPermissionAccessDecision(
+                canProceed: true,
+                state: .granted,
+                probeResult: nil
+            )
+        }
+
+        return applySystemAudioRecordingProbeResult(await probeRequester())
+    }
+
+    @MainActor
+    private static func performSystemAudioRecordingAccessRequest() async -> SystemAudioPermissionProbeResult {
         let requester = SystemAudioPermissionRequester()
         let attempt = SystemAudioPermissionRequestAttempt()
 
@@ -256,6 +334,33 @@ enum TranscriptedPermissionAccess {
             cleanup: {
                 requester.cancel()
             }
+        )
+    }
+
+    @MainActor
+    private static func applySystemAudioRecordingProbeResult(
+        _ result: SystemAudioPermissionProbeResult
+    ) -> SystemAudioPermissionAccessDecision {
+        switch result {
+        case .granted:
+            setSystemAudioRecordingGranted(true)
+        case .explicitlyDenied:
+            setSystemAudioRecordingGranted(false)
+        case .indeterminate:
+            // Preserve the existing state. A probe timeout, daemon failure,
+            // missing display, or stream setup/teardown error is not evidence
+            // that the user revoked access.
+            break
+        }
+
+        let state = systemAudioRecordingStatus()
+        return SystemAudioPermissionAccessDecision(
+            // Cancellation says nothing about the persisted TCC choice, but it
+            // does revoke this caller's authority to continue into capture.
+            // Preserve a cached grant while still stopping this start attempt.
+            canProceed: state == .granted && !result.wasCancelled,
+            state: state,
+            probeResult: result
         )
     }
 
@@ -288,21 +393,22 @@ extension Notification.Name {
 /// continuation twice or revive a finished request.
 @MainActor
 final class SystemAudioPermissionRequestAttempt {
-    typealias Completion = (Bool) -> Void
+    typealias ProbeResult = TranscriptedPermissionAccess.SystemAudioPermissionProbeResult
+    typealias Completion = (ProbeResult) -> Void
     typealias TimeoutScheduler = @MainActor (@escaping @MainActor () -> Void) -> @MainActor () -> Void
 
     private let scheduleTimeout: TimeoutScheduler
     private let onTimeout: () -> Void
-    private let onResolved: (Bool) -> Void
-    private var continuation: CheckedContinuation<Bool, Never>?
+    private let onResolved: (ProbeResult) -> Void
+    private var continuation: CheckedContinuation<ProbeResult, Never>?
     private var cancelTimeout: (() -> Void)?
     private var cleanup: (() -> Void)?
-    private var result: Bool?
+    private var result: ProbeResult?
 
     init(
         scheduleTimeout: @escaping TimeoutScheduler = SystemAudioPermissionRequestAttempt.liveTimeoutScheduler,
         onTimeout: @escaping () -> Void = {},
-        onResolved: @escaping (Bool) -> Void = { _ in }
+        onResolved: @escaping (ProbeResult) -> Void = { _ in }
     ) {
         self.scheduleTimeout = scheduleTimeout
         self.onTimeout = onTimeout
@@ -312,7 +418,7 @@ final class SystemAudioPermissionRequestAttempt {
     func awaitResult(
         start: @escaping (@escaping Completion) -> Void,
         cleanup: @escaping () -> Void
-    ) async -> Bool {
+    ) async -> ProbeResult {
         await withTaskCancellationHandler(operation: {
             await withCheckedContinuation { continuation in
                 if let result {
@@ -333,7 +439,7 @@ final class SystemAudioPermissionRequestAttempt {
             }
         }, onCancel: { [weak self] in
             Task { @MainActor [weak self] in
-                self?.finish(false)
+                self?.finish(.indeterminate(.cancelled))
             }
         })
     }
@@ -341,12 +447,12 @@ final class SystemAudioPermissionRequestAttempt {
     private func timeout() {
         guard result == nil else { return }
         onTimeout()
-        finish(false)
+        finish(.indeterminate(.timedOut))
     }
 
-    private func finish(_ granted: Bool) {
-        guard result == nil else { return }
-        result = granted
+    private func finish(_ result: ProbeResult) {
+        guard self.result == nil else { return }
+        self.result = result
 
         let continuation = continuation
         self.continuation = nil
@@ -357,8 +463,8 @@ final class SystemAudioPermissionRequestAttempt {
 
         cancelTimeout?()
         cleanup?()
-        onResolved(granted)
-        continuation?.resume(returning: granted)
+        onResolved(result)
+        continuation?.resume(returning: result)
     }
 
     private static func liveTimeoutScheduler(
@@ -381,12 +487,15 @@ final class SystemAudioPermissionRequestAttempt {
 @available(macOS 26.0, *)
 @MainActor
 private final class SystemAudioPermissionRequester: NSObject, SCStreamOutput {
+    typealias ProbeResult = TranscriptedPermissionAccess.SystemAudioPermissionProbeResult
+    typealias ProbeStage = TranscriptedPermissionAccess.SystemAudioPermissionProbeStage
+
     private var stream: SCStream?
     private let sampleHandlerQueue = DispatchQueue(label: "Transcripted.SystemAudioPermission")
-    private var completion: ((Bool) -> Void)?
+    private var completion: ((ProbeResult) -> Void)?
     private var stopCaptureRequested = false
 
-    func requestAccess(completion: @escaping (Bool) -> Void) {
+    func requestAccess(completion: @escaping (ProbeResult) -> Void) {
         self.completion = completion
 
         SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) { [weak self] content, error in
@@ -415,13 +524,13 @@ private final class SystemAudioPermissionRequester: NSObject, SCStreamOutput {
     private func handleShareableContent(_ content: SCShareableContent?, error: Error?) {
         guard completion != nil else { return }
 
-        if error != nil {
-            finish(granted: false)
+        if let error {
+            finish(SystemAudioPermissionProbeClassifier.result(for: error, stage: .shareableContent))
             return
         }
 
         guard let display = content?.displays.first else {
-            finish(granted: false)
+            finish(.indeterminate(.displayUnavailable))
             return
         }
 
@@ -442,7 +551,7 @@ private final class SystemAudioPermissionRequester: NSObject, SCStreamOutput {
         do {
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: sampleHandlerQueue)
         } catch {
-            finish(granted: false)
+            finish(SystemAudioPermissionProbeClassifier.result(for: error, stage: .addStreamOutput))
             return
         }
 
@@ -456,24 +565,43 @@ private final class SystemAudioPermissionRequester: NSObject, SCStreamOutput {
     private func handleStartCapture(error: Error?) {
         guard let stream, completion != nil else { return }
 
-        if error != nil {
-            finish(granted: false)
+        if let error {
+            finish(SystemAudioPermissionProbeClassifier.result(for: error, stage: .startCapture))
             return
         }
 
+        // Once startCapture succeeds, ScreenCaptureKit has already proved the
+        // TCC grant. A teardown/daemon error is cleanup noise, not evidence that
+        // access was denied, so resolve granted before the best-effort stop.
         stopCaptureRequested = true
-        stream.stopCapture { [weak self] error in
-            Task { @MainActor [weak self] in
-                guard let self, self.stream != nil, self.completion != nil else { return }
-                self.finish(granted: error == nil)
-            }
-        }
+        finish(SystemAudioPermissionProbeClassifier.resultAfterSuccessfulStart())
+        stream.stopCapture { _ in }
     }
 
-    private func finish(granted: Bool) {
+    private func finish(_ result: ProbeResult) {
         let completion = completion
         self.completion = nil
-        completion?(granted)
+        completion?(result)
+    }
+}
+
+enum SystemAudioPermissionProbeClassifier {
+    typealias ProbeResult = TranscriptedPermissionAccess.SystemAudioPermissionProbeResult
+    typealias ProbeStage = TranscriptedPermissionAccess.SystemAudioPermissionProbeStage
+
+    static func result(for error: Error, stage: ProbeStage) -> ProbeResult {
+        let nsError = error as NSError
+        if nsError.domain == SCStreamErrorDomain,
+           nsError.code == SCStreamError.Code.userDeclined.rawValue {
+            return .explicitlyDenied
+        }
+        return .indeterminate(stage)
+    }
+
+    /// `startCapture` success is the permission proof. Teardown happens after
+    /// that proof and cannot turn it back into a denial or unknown state.
+    static func resultAfterSuccessfulStart() -> ProbeResult {
+        .granted
     }
 }
 

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -62,7 +62,7 @@ public enum SystemAudioStatus: Equatable {
         case .healthy: return ""
         case .reconnecting: return "Reconnecting..."
         case .silent: return "System audio silent"
-        case .failed: return "System audio unavailable \u{2014} enable System Audio Recording for Transcripted in System Settings"
+        case .failed: return "System audio unavailable \u{2014} try recording again"
         }
     }
 }
@@ -190,6 +190,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
     @Published public var systemAudioLevelHistory: [Float] = Array(repeating: 0.0, count: 15)
     @Published public var error: String?
     @Published public var systemAudioStatus: SystemAudioStatus = .unknown
+    /// True only when the current start attempt received ScreenCaptureKit's
+    /// typed `userDeclined` error. Kept separate from display copy so a prior
+    /// inconclusive preflight cannot soften a later confirmed denial.
+    @Published public private(set) var systemAudioStartPermissionExplicitlyDenied = false
 
     // Silence detection for "Still Recording?" prompt
     //
@@ -1838,6 +1842,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // and buffer timestamp.
         stopWatchdog()
         error = nil
+        systemAudioStartPermissionExplicitlyDenied = false
         systemBufferCount = 0  // Reset debug counter (lock-protected)
         micBufferCount = 0
         micAudioStreaming = false  // Re-gate readiness on a fresh first buffer
@@ -1873,6 +1878,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // Any leftover journal ownership belongs to a session that never
         // stopped cleanly; the new session gets a fresh token at begin().
         journalSession = nil
+    }
+
+    func recordSystemAudioStartPermissionDenial(_ observed: Bool) {
+        systemAudioStartPermissionExplicitlyDenied = observed
     }
 
     private func beginStartIntent() -> UUID {

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -1,6 +1,23 @@
 import Foundation
 @preconcurrency import AVFoundation
 import QuartzCore
+import ScreenCaptureKit
+
+enum SystemAudioCaptureFailureCopy {
+    static func isExplicitPermissionDenial(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == SCStreamErrorDomain
+            && nsError.code == SCStreamError.Code.userDeclined.rawValue
+    }
+
+    static func message(for error: Error) -> String {
+        if isExplicitPermissionDenial(error) {
+            return "System Audio Recording is off. Turn it on for Transcripted in System Settings, then try again."
+        }
+
+        return "System audio couldn't start. Try recording again. If it keeps happening, quit and reopen Transcripted."
+    }
+}
 
 /// Serializes start and stop for one system-audio capture attempt. A stop that
 /// arrives during `prepare()` marks the attempt cancelled; a stop that races
@@ -385,7 +402,10 @@ extension Audio {
                         guard strongSelf.recordingSessionGeneration == sessionGeneration else {
                             return
                         }
-                        strongSelf.error = "System audio unavailable \u{2014} can only record your microphone. To capture Zoom/Teams audio, go to System Settings \u{2192} Privacy & Security \u{2192} System Audio Recording and enable Transcripted."
+                        strongSelf.recordSystemAudioStartPermissionDenial(
+                            SystemAudioCaptureFailureCopy.isExplicitPermissionDenial(error)
+                        )
+                        strongSelf.error = SystemAudioCaptureFailureCopy.message(for: error)
                         strongSelf.systemAudioFileURL = nil
                         strongSelf.systemAudioFailed = true
                     }

--- a/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
+++ b/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
@@ -613,19 +613,56 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
         }
     }
 
-    /// Removes the journal matching a meeting's mic audio file, tolerating the
-    /// `_merged` rename the segment merger applies.
-    static func removeJournal(forMicAudioURL micURL: URL, allowedRoots: [URL]) {
+    /// Removes the journal after a durable handoff. Prefer the deterministic
+    /// mic stem when present; system-only recovery falls back to the journal's
+    /// recorded system filename and refuses ambiguous or unverifiable matches.
+    @discardableResult
+    static func removeJournal(
+        micAudioURL: URL?,
+        systemAudioURL: URL?,
+        allowedRoots: [URL]
+    ) -> Bool {
         let canonicalRoots = allowedRoots.map { canonicalURL($0) }
-        guard isContained(micURL, in: canonicalRoots) else { return }
-        for journalURL in journalURLs(forMicAudioURL: micURL) {
-            if isContained(journalURL, in: canonicalRoots),
-               FileManager.default.fileExists(atPath: journalURL.path) {
-                try? unlinkFileOnly(at: journalURL)
-                AppLogger.audio.debug("Removed recording journal after durable handoff", [
-                    "file": journalURL.lastPathComponent
-                ])
+        if let micAudioURL, isContained(micAudioURL, in: canonicalRoots) {
+            var removed = false
+            for journalURL in journalURLs(forMicAudioURL: micAudioURL) {
+                if removeJournalArtifact(at: journalURL, allowedRoots: canonicalRoots) {
+                    removed = true
+                    AppLogger.audio.debug("Removed recording journal after durable handoff", [
+                        "lookup": "microphone",
+                        "file": journalURL.lastPathComponent
+                    ])
+                }
             }
+            if removed { return true }
         }
+
+        guard let systemAudioURL else { return false }
+        let lookup = systemJournalLookup(
+            forSystemAudioURL: systemAudioURL,
+            canonicalRoots: canonicalRoots
+        )
+        guard !lookup.hasUnverifiableCandidate,
+              lookup.matchingURLs.count == 1,
+              let journalURL = lookup.matchingURLs.first else {
+            return false
+        }
+        let removed = removeJournalArtifact(at: journalURL, allowedRoots: canonicalRoots)
+        if removed {
+            AppLogger.audio.debug("Removed recording journal after durable handoff", [
+                "lookup": "system_audio",
+                "file": journalURL.lastPathComponent
+            ])
+        }
+        return removed
+    }
+
+    /// Backward-compatible mic-keyed convenience for existing terminal paths.
+    static func removeJournal(forMicAudioURL micURL: URL, allowedRoots: [URL]) {
+        _ = removeJournal(
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            allowedRoots: allowedRoots
+        )
     }
 }

--- a/Sources/TranscriptedCore/Models/DisplayStatus.swift
+++ b/Sources/TranscriptedCore/Models/DisplayStatus.swift
@@ -81,7 +81,7 @@ public enum DisplayStatus: Equatable {
 
 public struct TranscriptionTask: Identifiable {
     public let id: UUID
-    public let micURL: URL
+    public let micURL: URL?
     public let systemURL: URL?
     public let outputFolder: URL
     public let startTime: Date
@@ -92,7 +92,7 @@ public struct TranscriptionTask: Identifiable {
 
     public init(
         id: UUID = UUID(),
-        micURL: URL,
+        micURL: URL?,
         systemURL: URL?,
         outputFolder: URL,
         healthInfo: RecordingHealthInfo? = nil,

--- a/Sources/TranscriptedCore/Models/RecordingHealthInfo.swift
+++ b/Sources/TranscriptedCore/Models/RecordingHealthInfo.swift
@@ -33,6 +33,9 @@ public struct RecordingHealthInfo: Sendable {
     public let micBoostPrompt: String?
     /// True when only microphone audio was available for recovery/transcription.
     public let systemAudioMissing: Bool?
+    /// True when microphone audio was missing or could not contribute usable
+    /// speech. The system-audio transcript was still saved as a partial result.
+    public let microphoneAudioUnusable: Bool?
 
     public init(
         captureQuality: CaptureQuality,
@@ -41,7 +44,8 @@ public struct RecordingHealthInfo: Sendable {
         gapDescriptions: [String],
         micAttenuatedByCallApp: Bool? = nil,
         micBoostPrompt: String? = nil,
-        systemAudioMissing: Bool? = nil
+        systemAudioMissing: Bool? = nil,
+        microphoneAudioUnusable: Bool? = nil
     ) {
         self.captureQuality = captureQuality
         self.audioGaps = audioGaps
@@ -50,6 +54,7 @@ public struct RecordingHealthInfo: Sendable {
         self.micAttenuatedByCallApp = micAttenuatedByCallApp
         self.micBoostPrompt = micBoostPrompt
         self.systemAudioMissing = systemAudioMissing
+        self.microphoneAudioUnusable = microphoneAudioUnusable
     }
 
     public func markingSystemAudioMissing() -> RecordingHealthInfo {
@@ -60,7 +65,8 @@ public struct RecordingHealthInfo: Sendable {
             gapDescriptions: gapDescriptions,
             micAttenuatedByCallApp: micAttenuatedByCallApp,
             micBoostPrompt: micBoostPrompt,
-            systemAudioMissing: true
+            systemAudioMissing: true,
+            microphoneAudioUnusable: microphoneAudioUnusable
         )
     }
 
@@ -72,7 +78,8 @@ public struct RecordingHealthInfo: Sendable {
             gapDescriptions: gapDescriptions,
             micAttenuatedByCallApp: true,
             micBoostPrompt: micBoostPrompt,
-            systemAudioMissing: systemAudioMissing
+            systemAudioMissing: systemAudioMissing,
+            microphoneAudioUnusable: microphoneAudioUnusable
         )
     }
 
@@ -84,7 +91,21 @@ public struct RecordingHealthInfo: Sendable {
             gapDescriptions: gapDescriptions,
             micAttenuatedByCallApp: micAttenuatedByCallApp,
             micBoostPrompt: micBoostPrompt,
-            systemAudioMissing: systemAudioMissing
+            systemAudioMissing: systemAudioMissing,
+            microphoneAudioUnusable: microphoneAudioUnusable
+        )
+    }
+
+    public func markingMicrophoneAudioUnusable() -> RecordingHealthInfo {
+        RecordingHealthInfo(
+            captureQuality: .degraded,
+            audioGaps: audioGaps,
+            deviceSwitches: deviceSwitches,
+            gapDescriptions: gapDescriptions,
+            micAttenuatedByCallApp: micAttenuatedByCallApp,
+            micBoostPrompt: micBoostPrompt,
+            systemAudioMissing: systemAudioMissing,
+            microphoneAudioUnusable: true
         )
     }
 

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -34,6 +34,16 @@ public struct TranscriptionUtterance: Sendable {
 
 /// Complete transcription result from the local pipeline
 public struct TranscriptionResult: Sendable {
+    public enum MicrophoneAudioOutcome: String, Sendable, Equatable {
+        /// A microphone track was supplied and passed the sustained-signal gate.
+        case usable
+        /// The flow intentionally had no microphone track (for example import).
+        case notProvided = "not_provided"
+        /// A track existed, but it could not be decoded or had no usable signal.
+        /// System audio may still produce a valid partial transcript.
+        case unusable
+    }
+
     public let micUtterances: [TranscriptionUtterance]
     public let systemUtterances: [TranscriptionUtterance]
     public let systemSpeakerContexts: [String: ChannelSpeakerContext]
@@ -42,6 +52,7 @@ public struct TranscriptionResult: Sendable {
     public let duration: TimeInterval
     public let processingTime: TimeInterval
     public let droppedSegments: Int
+    public let microphoneAudioOutcome: MicrophoneAudioOutcome
 
     public init(
         micUtterances: [TranscriptionUtterance],
@@ -51,7 +62,8 @@ public struct TranscriptionResult: Sendable {
         newlyCreatedMicProfileIds: Set<UUID> = [],
         duration: TimeInterval,
         processingTime: TimeInterval,
-        droppedSegments: Int = 0
+        droppedSegments: Int = 0,
+        microphoneAudioOutcome: MicrophoneAudioOutcome = .usable
     ) {
         self.micUtterances = micUtterances
         self.systemUtterances = systemUtterances
@@ -61,6 +73,7 @@ public struct TranscriptionResult: Sendable {
         self.duration = duration
         self.processingTime = processingTime
         self.droppedSegments = droppedSegments
+        self.microphoneAudioOutcome = microphoneAudioOutcome
     }
 
     /// All utterances merged and sorted by start time
@@ -234,6 +247,8 @@ public struct SpeakerNamingRequest {
     public let systemAudioURL: URL
     public let micAudioURL: URL?
     public let shouldRemoveTemporaryAudioOnCleanup: Bool
+    public let shouldRemoveMicAudioOnCleanup: Bool
+    public let shouldRemoveSystemAudioOnCleanup: Bool
     public let sourceFailedTranscriptionId: UUID?
     public let importedRecoverySession: (any ImportedTranscriptionRecoverySession)?
     public let onComplete: ([SpeakerNameUpdate]) -> Void
@@ -247,6 +262,8 @@ public struct SpeakerNamingRequest {
         systemAudioURL: URL,
         micAudioURL: URL?,
         shouldRemoveTemporaryAudioOnCleanup: Bool = true,
+        shouldRemoveMicAudioOnCleanup: Bool? = nil,
+        shouldRemoveSystemAudioOnCleanup: Bool? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
         importedRecoverySession: (any ImportedTranscriptionRecoverySession)? = nil,
         onComplete: @escaping ([SpeakerNameUpdate]) -> Void
@@ -258,7 +275,11 @@ public struct SpeakerNamingRequest {
         self.transcriptId = transcriptId
         self.systemAudioURL = systemAudioURL
         self.micAudioURL = micAudioURL
-        self.shouldRemoveTemporaryAudioOnCleanup = shouldRemoveTemporaryAudioOnCleanup
+        let removeMic = shouldRemoveMicAudioOnCleanup ?? shouldRemoveTemporaryAudioOnCleanup
+        let removeSystem = shouldRemoveSystemAudioOnCleanup ?? shouldRemoveTemporaryAudioOnCleanup
+        self.shouldRemoveTemporaryAudioOnCleanup = removeMic && removeSystem
+        self.shouldRemoveMicAudioOnCleanup = removeMic
+        self.shouldRemoveSystemAudioOnCleanup = removeSystem
         self.sourceFailedTranscriptionId = sourceFailedTranscriptionId
         self.importedRecoverySession = importedRecoverySession
         self.onComplete = onComplete

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -66,14 +66,24 @@ extension Transcription {
             // entire diarize → transcribe → merge run.
             var systemSamples = try AudioResampler.loadAndResample(url: systemURL, targetRate: 16000)
             var micSamples: [Float]
+            var microphoneAudioOutcome: TranscriptionResult.MicrophoneAudioOutcome
             if let micURL {
                 do {
                     micSamples = try AudioResampler.loadAndResample(url: micURL, targetRate: 16000)
-                } catch PipelineError.emptyAudioFile {
-                    throw PipelineError.microphoneAudioUnusable
+                    microphoneAudioOutcome = micSamples.isEmpty ? .unusable : .usable
+                } catch {
+                    // A damaged/empty local track must not erase a valid remote
+                    // conversation. Keep the artifact for retry, but run the
+                    // transcription as system-audio-only partial success.
+                    micSamples = []
+                    microphoneAudioOutcome = .unusable
+                    AppLogger.transcription.warning("Microphone audio could not be loaded; continuing with system audio", [
+                        "fallback": "system_audio_only"
+                    ])
                 }
             } else {
                 micSamples = []
+                microphoneAudioOutcome = .notProvided
             }
 
             let resampleTime = CFAbsoluteTimeGetCurrent() - resampleStart
@@ -86,16 +96,20 @@ extension Transcription {
                 AppLogger.transcription.debug("Mic: skipped for system-audio-only transcription")
             }
 
-            let micSignalAnalysis: AudioSignalAnalysis?
+            var micSignalAnalysis: AudioSignalAnalysis?
             if micURL != nil, !micSamples.isEmpty {
                 let rawMicAnalysis = AudioSignalRecovery.analyze(samples: micSamples, sampleRate: 16000)
                 var context = rawMicAnalysis.context
                 context["suggested_gain"] = String(format: "%.2f", AudioSignalRecovery.normalizationGain(for: rawMicAnalysis))
                 AppLogger.transcription.info("Analyzed meeting mic signal", context)
-                micSignalAnalysis = rawMicAnalysis
-                guard AudioSignalRecovery.hasUsableCaptureSignal(samples: micSamples, sampleRate: 16000) else {
-                    AppLogger.transcription.error("Microphone artifact had no usable capture signal", context)
-                    throw PipelineError.microphoneAudioUnusable
+                if AudioSignalRecovery.hasUsableCaptureSignal(samples: micSamples, sampleRate: 16000) {
+                    micSignalAnalysis = rawMicAnalysis
+                } else {
+                    context["fallback"] = "system_audio_only"
+                    AppLogger.transcription.warning("Microphone artifact had no usable capture signal; continuing with system audio", context)
+                    micSamples = []
+                    micSignalAnalysis = nil
+                    microphoneAudioOutcome = .unusable
                 }
             } else {
                 micSignalAnalysis = nil
@@ -518,100 +532,122 @@ extension Transcription {
             var micSpeakerContexts: [String: ChannelSpeakerContext] = [:]
             var newlyCreatedMicProfileIds: Set<UUID> = []
 
-            if micURL != nil {
-                // Step 4: Transcribe mic audio.
-                // Two modes:
-                //   A) splitLocalSpeakers == false (default): silence-split, tag as single "You"
-                //   B) splitLocalSpeakers == true: diarize mic, run same classification path
-                //      used for system audio, emit per-speaker utterances
-                await MainActor.run {
-                    self.processingStatus = "Transcribing mic audio..."
-                }
-
-                if splitLocalSpeakers {
-                    // B) Mic diarization path
-                    let diarizationMicSamples = AudioSignalRecovery.normalizeForSpeech(
-                        samples: micSamples,
-                        sampleRate: 16000,
-                        analysis: micSignalAnalysis
-                    ).samples
-                    // Normalization above was the last use of the raw mic
-                    // buffer in this mode — release it so only the normalized
-                    // copy stays alive during mic diarization + transcription.
-                    // (`diarizationMicSamples` itself dies at the end of this
-                    // branch scope.)
-                    micSamples = []
-                    let micResult = try await Self.processMicChannelWithDiarization(
-                        samples: diarizationMicSamples,
-                        diarization: diarization,
-                        parakeet: parakeet,
-                        speakerDB: speakerDB,
-                        existingProfiles: existingProfiles,
-                        droppedSegments: &droppedSegments,
-                        onProgress: onProgress
-                    )
-                    micUtterances = micResult.utterances
-                    micSpeakerContexts = micResult.speakerContexts
-                    newlyCreatedMicProfileIds = micResult.newlyCreatedProfileIds
-                    AppLogger.transcription.info("Mic audio diarized + transcribed", [
-                        "utterances": "\(micUtterances.count)",
-                        "speakers": "\(Set(micUtterances.map { $0.speakerId }).count)",
-                        "newProfiles": "\(newlyCreatedMicProfileIds.count)"
-                    ])
-                } else {
-                    // A) Default: silence-split, single speaker
-                    let micSegments = Self.detectSpeechSegments(samples: micSamples, sampleRate: 16000)
-                    AppLogger.transcription.info("Mic audio segmented by silence", ["segments": "\(micSegments.count)"])
-
-                    for (index, segment) in micSegments.enumerated() {
-                        try Task.checkCancellation()
-
-                        let segmentSamples = AudioResampler.extractSlice(
-                            from: micSamples,
-                            sampleRate: 16000,
-                            startTime: segment.start,
-                            endTime: segment.end
-                        )
-
-                        guard let preparedSegment = Self.prepareMicSegmentForTranscription(
-                            samples: segmentSamples,
-                            sampleRate: 16000
-                        ) else {
-                            droppedSegments += 1
-                            continue
-                        }
-
-                        let text = try await parakeet.transcribeSegment(samples: preparedSegment.samples, source: .microphone)
-                        guard !text.isEmpty else {
-                            var context = preparedSegment.analysis.context
-                            context["segment_index"] = "\(index)"
-                            context["gain"] = String(format: "%.2f", preparedSegment.gain)
-                            context["padded_samples"] = "\(preparedSegment.paddedSampleCount)"
-                            AppLogger.transcription.warning("Mic segment returned empty transcription", context)
-                            continue
-                        }
-
-                        micUtterances.append(TranscriptionUtterance(
-                            start: segment.start,
-                            end: segment.end,
-                            channel: 0,
-                            speakerId: 0,
-                            persistentSpeakerId: nil,
-                            matchSimilarity: nil,
-                            transcript: text
-                        ))
-
-                        // Update progress (65% to 90% during mic transcription)
-                        let micProgress = 0.65 + (Double(index + 1) / Double(max(1, micSegments.count))) * 0.25
-                        onProgress?(micProgress)
+            if microphoneAudioOutcome == .usable, micURL != nil {
+                do {
+                    // Step 4: Transcribe mic audio.
+                    // Two modes:
+                    //   A) splitLocalSpeakers == false (default): silence-split, tag as single "You"
+                    //   B) splitLocalSpeakers == true: diarize mic, run same classification path
+                    //      used for system audio, emit per-speaker utterances
+                    await MainActor.run {
+                        self.processingStatus = "Transcribing mic audio..."
                     }
 
-                    // Segment slicing above was the last use of the
-                    // whole-meeting mic buffer — release it before the
-                    // merge/save phase.
-                    micSamples = []
+                    if splitLocalSpeakers {
+                        // B) Mic diarization path
+                        let diarizationMicSamples = AudioSignalRecovery.normalizeForSpeech(
+                            samples: micSamples,
+                            sampleRate: 16000,
+                            analysis: micSignalAnalysis
+                        ).samples
+                        // Normalization above was the last use of the raw mic
+                        // buffer in this mode — release it so only the normalized
+                        // copy stays alive during mic diarization + transcription.
+                        // (`diarizationMicSamples` itself dies at the end of this
+                        // branch scope.)
+                        micSamples = []
+                        let micResult = try await Self.processMicChannelWithDiarization(
+                            samples: diarizationMicSamples,
+                            diarization: diarization,
+                            parakeet: parakeet,
+                            speakerDB: speakerDB,
+                            existingProfiles: existingProfiles,
+                            droppedSegments: &droppedSegments,
+                            onProgress: onProgress
+                        )
+                        micUtterances = micResult.utterances
+                        micSpeakerContexts = micResult.speakerContexts
+                        newlyCreatedMicProfileIds = micResult.newlyCreatedProfileIds
+                        AppLogger.transcription.info("Mic audio diarized + transcribed", [
+                            "utterances": "\(micUtterances.count)",
+                            "speakers": "\(Set(micUtterances.map { $0.speakerId }).count)",
+                            "newProfiles": "\(newlyCreatedMicProfileIds.count)"
+                        ])
+                    } else {
+                        // A) Default: silence-split, single speaker
+                        let micSegments = Self.detectSpeechSegments(samples: micSamples, sampleRate: 16000)
+                        AppLogger.transcription.info("Mic audio segmented by silence", ["segments": "\(micSegments.count)"])
 
-                    AppLogger.transcription.info("Mic audio transcribed", ["utterances": "\(micUtterances.count)"])
+                        for (index, segment) in micSegments.enumerated() {
+                            try Task.checkCancellation()
+
+                            let segmentSamples = AudioResampler.extractSlice(
+                                from: micSamples,
+                                sampleRate: 16000,
+                                startTime: segment.start,
+                                endTime: segment.end
+                            )
+
+                            guard let preparedSegment = Self.prepareMicSegmentForTranscription(
+                                samples: segmentSamples,
+                                sampleRate: 16000
+                            ) else {
+                                droppedSegments += 1
+                                continue
+                            }
+
+                            let text = try await parakeet.transcribeSegment(samples: preparedSegment.samples, source: .microphone)
+                            guard !text.isEmpty else {
+                                var context = preparedSegment.analysis.context
+                                context["segment_index"] = "\(index)"
+                                context["gain"] = String(format: "%.2f", preparedSegment.gain)
+                                context["padded_samples"] = "\(preparedSegment.paddedSampleCount)"
+                                AppLogger.transcription.warning("Mic segment returned empty transcription", context)
+                                continue
+                            }
+
+                            micUtterances.append(TranscriptionUtterance(
+                                start: segment.start,
+                                end: segment.end,
+                                channel: 0,
+                                speakerId: 0,
+                                persistentSpeakerId: nil,
+                                matchSimilarity: nil,
+                                transcript: text
+                            ))
+
+                            // Update progress (65% to 90% during mic transcription)
+                            let micProgress = 0.65 + (Double(index + 1) / Double(max(1, micSegments.count))) * 0.25
+                            onProgress?(micProgress)
+                        }
+
+                        // Segment slicing above was the last use of the
+                        // whole-meeting mic buffer — release it before the
+                        // merge/save phase.
+                        micSamples = []
+
+                        AppLogger.transcription.info("Mic audio transcribed", ["utterances": "\(micUtterances.count)"])
+                    }
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    // Mic-only failures must not erase a completed system-audio
+                    // transcript. Cancellation still wins; every other mic
+                    // decode/diarization/STT failure becomes an honest partial
+                    // result and keeps the original artifact for retry.
+                    try Task.checkCancellation()
+                    guard !systemUtterances.isEmpty else {
+                        throw error
+                    }
+                    micSamples = []
+                    micUtterances = []
+                    micSpeakerContexts = [:]
+                    newlyCreatedMicProfileIds = []
+                    microphoneAudioOutcome = .unusable
+                    AppLogger.transcription.warning("Microphone processing failed; continuing with system audio", [
+                        "fallback": "system_audio_only",
+                        "errorType": "\(type(of: error))"
+                    ])
                 }
             } else {
                 AppLogger.transcription.info("Mic audio skipped", ["reason": "system_audio_only"])
@@ -659,7 +695,8 @@ extension Transcription {
                 newlyCreatedMicProfileIds: newlyCreatedMicProfileIds,
                 duration: duration,
                 processingTime: processingTime,
-                droppedSegments: droppedSegments
+                droppedSegments: droppedSegments,
+                microphoneAudioOutcome: microphoneAudioOutcome
             )
 
         } catch {
@@ -776,7 +813,8 @@ extension Transcription {
                 systemUtterances: [],
                 duration: duration,
                 processingTime: processingTime,
-                droppedSegments: droppedSegments
+                droppedSegments: droppedSegments,
+                microphoneAudioOutcome: .usable
             )
         } catch {
             await MainActor.run {
@@ -790,8 +828,8 @@ extension Transcription {
 
     nonisolated private static func longestAudioDuration(micURL: URL?, systemURL: URL) throws -> TimeInterval {
         var durations = [try audioDuration(at: systemURL)]
-        if let micURL {
-            durations.append(try audioDuration(at: micURL))
+        if let micURL, let micDuration = try? audioDuration(at: micURL) {
+            durations.append(micDuration)
         }
         return durations.max() ?? 0
     }
@@ -867,6 +905,48 @@ extension Transcription {
             "after": "\(postProcessedSpeakerCount)",
             "segments": "\(speakerSegments.count)"
         ])
+
+        // Finish every throwing/cancellable mic operation before mutating the
+        // speaker database. If mic STT fails after the system channel already
+        // succeeded, the caller can safely keep the system-only transcript
+        // without leaving partial mic speaker profiles behind.
+        var transcribedSegments: [(segment: SpeakerSegment, text: String)] = []
+        let totalSegments = speakerSegments.count
+        for (index, segment) in speakerSegments.enumerated() {
+            try Task.checkCancellation()
+
+            let segmentSamples = AudioResampler.extractSlice(
+                from: samples,
+                sampleRate: 16000,
+                startTime: segment.startTime,
+                endTime: segment.endTime
+            )
+            guard let preparedSegment = Self.prepareMicSegmentForTranscription(
+                samples: segmentSamples,
+                sampleRate: 16000
+            ) else {
+                droppedSegments += 1
+                continue
+            }
+
+            let text = try await parakeet.transcribeSegment(
+                samples: preparedSegment.samples,
+                source: .microphone
+            )
+            guard !text.isEmpty else {
+                var context = preparedSegment.analysis.context
+                context["segment_index"] = "\(index)"
+                context["gain"] = String(format: "%.2f", preparedSegment.gain)
+                context["padded_samples"] = "\(preparedSegment.paddedSampleCount)"
+                AppLogger.transcription.warning("Mic diarization segment returned empty transcription", context)
+                continue
+            }
+
+            transcribedSegments.append((segment: segment, text: text))
+            let progress = 0.65 + (Double(index + 1) / Double(max(1, totalSegments))) * 0.25
+            onProgress?(progress)
+        }
+        try Task.checkCancellation()
 
         // Aggregate embeddings per diarizer speaker ID. Same quality gates as the system
         // path (>=0.3 quality, >=1.0s duration). No cross-channel contamination gate —
@@ -1017,36 +1097,11 @@ extension Transcription {
             )
         }
 
-        // Transcribe each segment
+        // All mic STT completed before the speaker-store writes above. Building
+        // utterances from those local results is now non-throwing.
         var utterances: [TranscriptionUtterance] = []
-        let totalSegments = speakerSegments.count
-        for (index, segment) in speakerSegments.enumerated() {
-            try Task.checkCancellation()
-
-            let segmentSamples = AudioResampler.extractSlice(
-                from: samples,
-                sampleRate: 16000,
-                startTime: segment.startTime,
-                endTime: segment.endTime
-            )
-            guard let preparedSegment = Self.prepareMicSegmentForTranscription(
-                samples: segmentSamples,
-                sampleRate: 16000
-            ) else {
-                droppedSegments += 1
-                continue
-            }
-
-            let text = try await parakeet.transcribeSegment(samples: preparedSegment.samples, source: .microphone)
-            guard !text.isEmpty else {
-                var context = preparedSegment.analysis.context
-                context["segment_index"] = "\(index)"
-                context["gain"] = String(format: "%.2f", preparedSegment.gain)
-                context["padded_samples"] = "\(preparedSegment.paddedSampleCount)"
-                AppLogger.transcription.warning("Mic diarization segment returned empty transcription", context)
-                continue
-            }
-
+        for transcribed in transcribedSegments {
+            let segment = transcribed.segment
             let effectiveSpeakerId = speakerIdRemap[segment.speakerId] ?? segment.speakerId
             let persistentId: UUID?
             let similarity: Double?
@@ -1065,11 +1120,8 @@ extension Transcription {
                 speakerId: effectiveSpeakerId,
                 persistentSpeakerId: persistentId,
                 matchSimilarity: similarity,
-                transcript: text
+                transcript: transcribed.text
             ))
-
-            let progress = 0.65 + (Double(index + 1) / Double(max(1, totalSegments))) * 0.25
-            onProgress?(progress)
         }
 
         return MicChannelResult(

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -5,6 +5,33 @@ import AVFoundation
 
 extension TranscriptionTaskManager {
 
+    struct SavedTranscriptAudioResolution: Sendable {
+        let includesMicrophone: Bool
+        let healthInfo: RecordingHealthInfo?
+    }
+
+    /// A failed microphone track is a partial-success condition when system
+    /// audio produced a transcript. Exclude the unusable channel from source
+    /// metadata, mark the artifact degraded, and keep the original URL flowing
+    /// through the normal archive path below for a future retry.
+    nonisolated static func savedTranscriptAudioResolution(
+        microphoneURLWasProvided: Bool,
+        microphoneOutcome: TranscriptionResult.MicrophoneAudioOutcome,
+        healthInfo: RecordingHealthInfo?
+    ) -> SavedTranscriptAudioResolution {
+        guard microphoneURLWasProvided, microphoneOutcome == .unusable else {
+            return SavedTranscriptAudioResolution(
+                includesMicrophone: microphoneURLWasProvided,
+                healthInfo: healthInfo
+            )
+        }
+
+        return SavedTranscriptAudioResolution(
+            includesMicrophone: false,
+            healthInfo: (healthInfo ?? .perfect).markingMicrophoneAudioUnusable()
+        )
+    }
+
     struct SpeakerClassificationKnowledge: Sendable {
         let speakerId: String
         let profile: SpeakerProfile
@@ -89,7 +116,7 @@ extension TranscriptionTaskManager {
     /// - Returns: URL of saved transcript with speaker attribution
     /// Note: nonisolated to keep heavy async work off the main thread
     nonisolated func transcribeWithSpeakerIdentification(
-        micURL: URL,
+        micURL: URL?,
         systemURL: URL?,
         outputFolder: URL,
         taskId: UUID,
@@ -102,6 +129,9 @@ extension TranscriptionTaskManager {
     ) async throws -> URL {
 
         guard let systemURL else {
+            guard let micURL else {
+                throw PipelineError.invalidAudioFormat(detail: "No meeting audio files were available")
+            }
             return try await transcribeMicrophoneOnlyPipeline(
                 micURL: micURL,
                 outputFolder: outputFolder,
@@ -228,7 +258,7 @@ extension TranscriptionTaskManager {
             rollback: rollback
         )
 
-        if archiveOutcome.didArchiveRecordingAudio && removeSourceAudioAfterArchive && sourceFailedTranscriptionId == nil {
+        if archiveOutcome.canRemoveMicScratch && removeSourceAudioAfterArchive && sourceFailedTranscriptionId == nil {
             removeManagedCleanupFile(micURL, label: "completed mic-only scratch")
         }
 
@@ -521,8 +551,16 @@ extension TranscriptionTaskManager {
             self.displayStatus = .finishing
             return self.notifier
         }
+        let savedAudio = Self.savedTranscriptAudioResolution(
+            microphoneURLWasProvided: micURL != nil,
+            microphoneOutcome: result.microphoneAudioOutcome,
+            healthInfo: healthInfo
+        )
         let formatOptions = await MainActor.run {
-            self.resolvedTranscriptFormatOptions(hasMicAudio: micURL != nil, hasSystemAudio: true)
+            self.resolvedTranscriptFormatOptions(
+                hasMicAudio: savedAudio.includesMicrophone,
+                hasSystemAudio: true
+            )
         }
 
         let transcriptDate = recordingDate ?? Date()
@@ -534,7 +572,7 @@ extension TranscriptionTaskManager {
             speakerDbIds: speakerDbIds,
             directory: outputFolder,
             meetingTitle: meetingTitle,
-            healthInfo: healthInfo,
+            healthInfo: savedAudio.healthInfo,
             notifier: nil,
             speakerStore: speakerDB,
             statsStore: DeferredTranscriptStatsStore(),
@@ -582,7 +620,8 @@ extension TranscriptionTaskManager {
                 savedURL: savedURL
             )
             : RecordingAudioArchiveOutcome(
-                didArchiveRecordingAudio: false,
+                canRemoveMicScratch: false,
+                canRemoveSystemScratch: false,
                 retainedAudioDirectory: nil,
                 retainedAudioURLs: []
             )
@@ -592,7 +631,9 @@ extension TranscriptionTaskManager {
             into: rollback
         )
         try await rollback.checkCancellation()
-        let shouldRemoveScratchAudio = archiveOutcome.didArchiveRecordingAudio && removeSourceAudioAfterArchive
+        let shouldRemoveMicScratchAudio = archiveOutcome.canRemoveMicScratch && removeSourceAudioAfterArchive
+        let shouldRemoveSystemScratchAudio = archiveOutcome.canRemoveSystemScratch && removeSourceAudioAfterArchive
+        let shouldRemoveAllScratchAudio = shouldRemoveMicScratchAudio && shouldRemoveSystemScratchAudio
 
         // Phase 3: Speaker naming — for system speakers that need action, plus any mic
         // speakers surfaced by local-speaker split. Entries from both channels flow
@@ -718,7 +759,9 @@ extension TranscriptionTaskManager {
                     transcriptId: transcriptId,
                     systemAudioURL: systemURL,
                     micAudioURL: micURL,
-                    shouldRemoveTemporaryAudioOnCleanup: shouldRemoveScratchAudio && sourceFailedTranscriptionId == nil,
+                    shouldRemoveTemporaryAudioOnCleanup: shouldRemoveAllScratchAudio && sourceFailedTranscriptionId == nil,
+                    shouldRemoveMicAudioOnCleanup: shouldRemoveMicScratchAudio && sourceFailedTranscriptionId == nil,
+                    shouldRemoveSystemAudioOnCleanup: shouldRemoveSystemScratchAudio && sourceFailedTranscriptionId == nil,
                     sourceFailedTranscriptionId: sourceFailedTranscriptionId,
                     importedRecoverySession: importedRecoverySession,
                     onComplete: { [weak self] updates in
@@ -729,7 +772,9 @@ extension TranscriptionTaskManager {
                             transcriptionResult: result,
                             micURL: micURL,
                             systemURL: systemURL,
-                            shouldRemoveTemporaryAudio: shouldRemoveScratchAudio,
+                            shouldRemoveTemporaryAudio: shouldRemoveAllScratchAudio,
+                            shouldRemoveMicAudio: shouldRemoveMicScratchAudio,
+                            shouldRemoveSystemAudio: shouldRemoveSystemScratchAudio,
                             sourceFailedTranscriptionId: sourceFailedTranscriptionId,
                             clips: capturedEntries,
                             importedRecoverySession: importedRecoverySession
@@ -786,13 +831,16 @@ extension TranscriptionTaskManager {
         // No naming needed — clean up scratch audio after the saved outcome has
         // committed, so a late cancellation cannot delete transcript + retained
         // audio after scratch files are gone.
-        if shouldRemoveScratchAudio, sourceFailedTranscriptionId == nil {
+        if (shouldRemoveMicScratchAudio || shouldRemoveSystemScratchAudio),
+           sourceFailedTranscriptionId == nil {
             let cleanupPrepared = await MainActor.run {
                 self.prepareImportedTranscriptionScratchCleanup(taskId: taskId)
             }
             if cleanupPrepared {
-                let removedMic = removeManagedCleanupFile(micURL, label: "completed mic scratch")
-                let removedSystem = removeManagedCleanupFile(systemURL, label: "completed system scratch")
+                let removedMic = !shouldRemoveMicScratchAudio
+                    || removeManagedCleanupFile(micURL, label: "completed mic scratch")
+                let removedSystem = !shouldRemoveSystemScratchAudio
+                    || removeManagedCleanupFile(systemURL, label: "completed system scratch")
                 if removedMic && removedSystem {
                     await MainActor.run {
                         self.confirmImportedTranscriptionScratchCleanup(taskId: taskId)
@@ -805,7 +853,8 @@ extension TranscriptionTaskManager {
     }
 
     private struct RecordingAudioArchiveOutcome {
-        let didArchiveRecordingAudio: Bool
+        let canRemoveMicScratch: Bool
+        let canRemoveSystemScratch: Bool
         let retainedAudioDirectory: URL?
         let retainedAudioURLs: [URL]
     }
@@ -901,7 +950,11 @@ extension TranscriptionTaskManager {
         let retainedAudioDirectory = await MainActor.run { self.resolvedRetainedAudioDirectory() }
         guard let retainedAudioDirectory else {
             return RecordingAudioArchiveOutcome(
-                didArchiveRecordingAudio: true,
+                // Retention is disabled, so the committed transcript is the
+                // terminal owner and both scratch sources can follow the
+                // existing cleanup path.
+                canRemoveMicScratch: true,
+                canRemoveSystemScratch: true,
                 retainedAudioDirectory: nil,
                 retainedAudioURLs: []
             )
@@ -914,12 +967,25 @@ extension TranscriptionTaskManager {
                 transcriptURL: savedURL,
                 archiveRoot: retainedAudioDirectory
             )
+            let archivedEveryProvidedSource = (micURL == nil || retainedAudio.micURL != nil)
+                && (systemURL == nil || retainedAudio.systemURL != nil)
+            if !archivedEveryProvidedSource {
+                AppLogger.pipeline.warning("Retained only part of the meeting audio; leaving scratch files in place", [
+                    "micArchived": "\(retainedAudio.micURL != nil)",
+                    "systemArchived": "\(retainedAudio.systemURL != nil)"
+                ])
+            }
             AppLogger.pipeline.info("Retained meeting audio files", [
                 "hasMic": "\(retainedAudio.micURL != nil)",
                 "hasSystem": "\(retainedAudio.systemURL != nil)"
             ])
             return RecordingAudioArchiveOutcome(
-                didArchiveRecordingAudio: true,
+                // Clean only a source with a durable retained copy. If the
+                // other copy failed, its original remains available for the
+                // bounded temp/recovery path instead of making both successful
+                // and failed sources permanent scratch orphans.
+                canRemoveMicScratch: micURL == nil || retainedAudio.micURL != nil,
+                canRemoveSystemScratch: systemURL == nil || retainedAudio.systemURL != nil,
                 retainedAudioDirectory: retainedAudio.directory,
                 retainedAudioURLs: [retainedAudio.micURL, retainedAudio.systemURL].compactMap { $0 }
             )
@@ -930,7 +996,8 @@ extension TranscriptionTaskManager {
                 "errorType": "\(type(of: error))"
             ])
             return RecordingAudioArchiveOutcome(
-                didArchiveRecordingAudio: false,
+                canRemoveMicScratch: false,
+                canRemoveSystemScratch: false,
                 retainedAudioDirectory: nil,
                 retainedAudioURLs: []
             )

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -214,7 +214,7 @@ public class TranscriptionTaskManager: ObservableObject {
     /// preserves the single-"You" behavior.
     public func startTranscription(
         taskId: UUID = UUID(),
-        micURL: URL,
+        micURL: URL?,
         systemURL: URL?,
         outputFolder: URL,
         healthInfo: RecordingHealthInfo? = nil,
@@ -223,10 +223,19 @@ public class TranscriptionTaskManager: ObservableObject {
         recordingDate: Date? = nil
     ) {
 
+        guard micURL != nil || systemURL != nil else {
+            publishFailure(
+                displayMessage: "No meeting audio was captured",
+                diagnosticMessage: "No meeting audio files were available"
+            )
+            scheduleStatusReset(delay: 4)
+            return
+        }
+
         // Guard: reject concurrent pipelines to prevent model contention
         if !activeTasks.isEmpty {
             AppLogger.pipeline.warning("Rejecting transcription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
-            addFailedTranscriptionRetainingAudio(
+            addFailedTranscriptionRetainingAvailableAudio(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
                 errorMessage: "Transcription already in progress",
@@ -246,19 +255,22 @@ public class TranscriptionTaskManager: ObservableObject {
         // intact and fully transcribable, so don't throw away the whole recording just
         // because the mic side is below Parakeet's minimum length.
         let minDuration: TimeInterval = 2.0
-        let micDuration = audioDuration(url: micURL)
+        let micDuration = micURL.flatMap { audioDuration(url: $0) }
         let systemDuration = systemURL.flatMap { audioDuration(url: $0) }
         let hasUsableMicAudio = micDuration.map { $0 >= minDuration } ?? false
         let hasUsableSystemAudio = systemDuration.map { $0 >= minDuration } ?? false
-        let hasUnknownDuration = micDuration == nil || (systemURL != nil && systemDuration == nil)
+        let hasUnknownDuration = (micURL != nil && micDuration == nil)
+            || (systemURL != nil && systemDuration == nil)
 
         guard hasUsableMicAudio || hasUsableSystemAudio || hasUnknownDuration else {
             AppLogger.pipeline.info("Recording too short, skipping transcription", [
-                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? "unknown",
+                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? (micURL == nil ? "none" : "unknown"),
                 "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? "none"
             ])
 
-            removeRecordingFile(micURL, label: "short mic recording")
+            if let micURL {
+                removeRecordingFile(micURL, label: "short mic recording")
+            }
             if let systemURL {
                 removeRecordingFile(systemURL, label: "short system recording")
             }
@@ -273,24 +285,27 @@ public class TranscriptionTaskManager: ObservableObject {
 
         if hasUnknownDuration {
             AppLogger.pipeline.warning("Recording duration could not be verified; preserving retry path instead of treating it as short", [
-                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? "unknown",
+                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? (micURL == nil ? "none" : "unknown"),
                 "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? (systemURL == nil ? "none" : "unknown")
             ])
         }
 
         if !hasUsableMicAudio, hasUsableSystemAudio {
-            AppLogger.pipeline.warning("Proceeding with short mic capture because system audio is still usable", [
-                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? "unknown",
+            AppLogger.pipeline.warning("Proceeding without usable mic audio because system audio is still usable", [
+                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? (micURL == nil ? "none" : "unknown"),
                 "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? "unknown"
             ])
         }
 
+        let effectiveHealthInfo = micURL == nil && systemURL != nil
+            ? (healthInfo ?? .perfect).markingMicrophoneAudioUnusable()
+            : healthInfo
         let task = TranscriptionTask(
             id: taskId,
             micURL: micURL,
             systemURL: systemURL,
             outputFolder: outputFolder,
-            healthInfo: healthInfo,
+            healthInfo: effectiveHealthInfo,
             splitLocalSpeakers: splitLocalSpeakers,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate
@@ -1114,14 +1129,26 @@ public class TranscriptionTaskManager: ObservableObject {
         clearRecordingJournalAfterPersistence: Bool = true,
         errorKind: PipelineErrorKind? = nil
     ) -> Bool {
-        let failedSystemURL = retainedAudio?.systemURL ?? originalSystemURL
+        let retainedMicURL = existingAudioURL(retainedAudio?.micURL)
+        let retainedSystemURL = existingAudioURL(retainedAudio?.systemURL)
+        let originalMicURLForRetry = existingAudioURL(originalMicURL)
+        let originalSystemURLForRetry = existingAudioURL(originalSystemURL)
+        let pendingOriginalSystemURL = retainedAudio == nil ? originalSystemURL : nil
+        let failedSystemURL = retainedSystemURL ?? originalSystemURLForRetry ?? pendingOriginalSystemURL
+        let placeholderSystemURL = retainedSystemURL ?? originalSystemURLForRetry
         let placeholderMicURL = makeSilentMicPlaceholderIfNeeded(
             retainedAudio: retainedAudio,
-            hasOriginalMic: originalMicURL != nil,
-            failedSystemURL: failedSystemURL,
+            hasOriginalMic: originalMicURLForRetry != nil,
+            failedSystemURL: placeholderSystemURL,
             taskId: taskId
         )
-        guard let failedMicURL = retainedAudio?.micURL ?? originalMicURL ?? placeholderMicURL else {
+        // A timeout row may intentionally point at a mic path that will appear
+        // after late finalization. Preserve that legacy future path only when
+        // there is no readable system track that can own a real placeholder.
+        let pendingMicURL = originalSystemURLForRetry == nil && retainedSystemURL == nil
+            ? originalMicURL
+            : nil
+        guard let failedMicURL = retainedMicURL ?? originalMicURLForRetry ?? placeholderMicURL ?? pendingMicURL else {
             AppLogger.pipeline.error("Failed transcription was not queued because no microphone track or placeholder is available")
             return false
         }
@@ -1145,9 +1172,10 @@ public class TranscriptionTaskManager: ObservableObject {
         // A normal failed row owns all of its audio after persistence. A timed-
         // out multi-segment stop keeps the journal until late finalization so a
         // crash cannot lose segment filenames that are not represented by the row.
-        if clearRecordingJournalAfterPersistence, let originalMicURL {
+        if clearRecordingJournalAfterPersistence {
             MeetingRecordingJournalStore.removeJournal(
-                forMicAudioURL: originalMicURL,
+                micAudioURL: originalMicURL,
+                systemAudioURL: originalSystemURL,
                 allowedRoots: cleanupDirectories
             )
         }
@@ -1580,6 +1608,16 @@ public class TranscriptionTaskManager: ObservableObject {
         }
     }
 
+    /// A non-nil URL is not enough for durable retry ownership. Late capture
+    /// finalization and partial archive failures can leave a path whose file was
+    /// never created, so only persist sources that are actually readable.
+    private func existingAudioURL(_ url: URL?) -> URL? {
+        guard let url, FileManager.default.isReadableFile(atPath: url.path) else {
+            return nil
+        }
+        return url
+    }
+
     private static func writeSilentWAV(to url: URL, duration: TimeInterval) throws {
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -1851,9 +1889,10 @@ public class TranscriptionTaskManager: ObservableObject {
         audio?.importedRecoverySession?.transcriptCommitConfirmed()
         // The imported journal remains through scratch cleanup. The separate
         // live-recording journal can retire once the transcript is durable.
-        if let micURL = audio?.micURL {
+        if let audio {
             MeetingRecordingJournalStore.removeJournal(
-                forMicAudioURL: micURL,
+                micAudioURL: audio.micURL,
+                systemAudioURL: audio.systemURL,
                 allowedRoots: cleanupDirectories
             )
         }
@@ -2268,20 +2307,24 @@ public class TranscriptionTaskManager: ObservableObject {
         originalMicCleanupLabel: String,
         originalSystemCleanupLabel: String
     ) {
+        let retainedMicURL = existingAudioURL(retainedAudio.micURL)
+        let retainedSystemURL = existingAudioURL(retainedAudio.systemURL)
+        let originalMicURLForRetry = existingAudioURL(micURL)
+        let originalSystemURLForRetry = existingAudioURL(systemURL)
         let placeholderMicURL = makeSilentMicPlaceholderIfNeeded(
             retainedAudio: retainedAudio,
-            hasOriginalMic: micURL != nil,
-            failedSystemURL: retainedAudio.systemURL ?? systemURL,
+            hasOriginalMic: originalMicURLForRetry != nil,
+            failedSystemURL: retainedSystemURL ?? originalSystemURLForRetry,
             taskId: taskId
         )
-        guard let updatedMicURL = retainedAudio.micURL ?? micURL ?? placeholderMicURL else {
+        guard let updatedMicURL = retainedMicURL ?? originalMicURLForRetry ?? placeholderMicURL else {
             removeRetainedFailedAudio(retainedAudio)
             return
         }
         let didPersist = failedTranscriptionManager.updateFailedTranscriptionAudio(
             id: taskId,
             micAudioURL: updatedMicURL,
-            systemAudioURL: retainedAudio.systemURL ?? systemURL
+            systemAudioURL: retainedSystemURL ?? originalSystemURLForRetry
         )
 
         guard didPersist else {
@@ -2290,11 +2333,77 @@ public class TranscriptionTaskManager: ObservableObject {
         }
 
         guard removeOriginalsAfterArchive else { return }
-        if retainedAudio.micURL != nil {
-            removeManagedCleanupFile(micURL, label: originalMicCleanupLabel)
+        if let retainedMicURL = retainedAudio.micURL {
+            removeSupersededFailedAudioSource(
+                micURL,
+                replacementURL: retainedMicURL,
+                taskId: taskId,
+                label: originalMicCleanupLabel
+            )
         }
-        if retainedAudio.systemURL != nil {
-            removeManagedCleanupFile(systemURL, label: originalSystemCleanupLabel)
+        if let retainedSystemURL = retainedAudio.systemURL {
+            removeSupersededFailedAudioSource(
+                systemURL,
+                replacementURL: retainedSystemURL,
+                taskId: taskId,
+                label: originalSystemCleanupLabel
+            )
+        }
+    }
+
+    /// A failed row may already point inside the retained-audio root when a
+    /// later finalizer re-archives it. Normal scratch cleanup intentionally
+    /// refuses that root, so retire the superseded retained file through a
+    /// separate containment-checked path after the queue update is durable.
+    private func removeSupersededFailedAudioSource(
+        _ originalURL: URL?,
+        replacementURL: URL,
+        taskId: UUID,
+        label: String
+    ) {
+        guard let originalURL,
+              Self.canonicalURL(originalURL) != Self.canonicalURL(replacementURL) else {
+            return
+        }
+
+        if isSafeCleanupURL(originalURL) {
+            _ = removeRecordingFile(originalURL, label: label)
+            return
+        }
+
+        guard let retainedRoot = resolvedRetainedAudioDirectory(),
+              Self.isFile(originalURL, containedIn: retainedRoot) else {
+            AppLogger.pipeline.warning("Refused to remove superseded failed audio outside managed roots", [
+                "label": label,
+                "file": originalURL.lastPathComponent
+            ])
+            return
+        }
+        let isStillReferenced = failedTranscriptionManager.failedTranscriptions.contains { failed in
+            failed.id != taskId
+                && (Self.canonicalURL(failed.micAudioURL) == Self.canonicalURL(originalURL)
+                    || failed.systemAudioURL.map(Self.canonicalURL) == Self.canonicalURL(originalURL))
+        }
+        guard !isStillReferenced else { return }
+
+        do {
+            try FileManager.default.removeItem(at: originalURL)
+            let parent = originalURL.deletingLastPathComponent()
+            let remaining = (try? FileManager.default.contentsOfDirectory(
+                at: parent,
+                includingPropertiesForKeys: nil
+            )) ?? []
+            if remaining.isEmpty, Self.isFile(parent, containedIn: retainedRoot) {
+                try? FileManager.default.removeItem(at: parent)
+            }
+        } catch {
+            if (error as NSError).code != NSFileNoSuchFileError {
+                AppLogger.pipeline.warning("Failed to remove superseded retained failed audio", [
+                    "label": label,
+                    "file": originalURL.lastPathComponent,
+                    "errorType": "\(type(of: error))"
+                ])
+            }
         }
     }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -46,10 +46,14 @@ extension TranscriptionTaskManager {
         micURL: URL?,
         systemURL: URL,
         shouldRemoveTemporaryAudio: Bool = true,
+        shouldRemoveMicAudio: Bool? = nil,
+        shouldRemoveSystemAudio: Bool? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
         clips: [SpeakerNamingEntry],
         importedRecoverySession: (any ImportedTranscriptionRecoverySession)? = nil
     ) {
+        let removeMicAudio = shouldRemoveMicAudio ?? shouldRemoveTemporaryAudio
+        let removeSystemAudio = shouldRemoveSystemAudio ?? shouldRemoveTemporaryAudio
         let speakerDB = transcription.speakerDB
         let clipsDirectory = transcription.speakerClipsDirectory
         let clipsBySpeakerId = Dictionary(uniqueKeysWithValues: clips.map {
@@ -93,7 +97,8 @@ extension TranscriptionTaskManager {
                     clips: clips,
                     micURL: micURL,
                     systemURL: systemURL,
-                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && sourceFailedTranscriptionId == nil,
+                    shouldRemoveMicAudio: removeMicAudio && sourceFailedTranscriptionId == nil,
+                    shouldRemoveSystemAudio: removeSystemAudio && sourceFailedTranscriptionId == nil,
                     importedRecoverySession: importedRecoverySession
                 )
 
@@ -233,7 +238,8 @@ extension TranscriptionTaskManager {
                     clips: clips,
                     micURL: micURL,
                     systemURL: systemURL,
-                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && !shouldKeepAudioForFailedRetry,
+                    shouldRemoveMicAudio: removeMicAudio && !shouldKeepAudioForFailedRetry,
+                    shouldRemoveSystemAudio: removeSystemAudio && !shouldKeepAudioForFailedRetry,
                     importedRecoverySession: importedRecoverySession
                 )
             }
@@ -256,7 +262,8 @@ extension TranscriptionTaskManager {
                         clips: clips,
                         micURL: micURL,
                         systemURL: systemURL,
-                        shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio,
+                        shouldRemoveMicAudio: removeMicAudio,
+                        shouldRemoveSystemAudio: removeSystemAudio,
                         importedRecoverySession: importedRecoverySession
                     )
                 case .metadataPublicationFailed:
@@ -266,7 +273,8 @@ extension TranscriptionTaskManager {
                         clips: clips,
                         micURL: micURL,
                         systemURL: systemURL,
-                        shouldRemoveTemporaryAudio: false
+                        shouldRemoveMicAudio: false,
+                        shouldRemoveSystemAudio: false
                     )
                 case .transcriptFinalizationFailed:
                     break
@@ -349,10 +357,12 @@ extension TranscriptionTaskManager {
     }
 
     private func cleanupSpeakerNamingRequest(_ request: SpeakerNamingRequest) {
-        if request.shouldRemoveTemporaryAudioOnCleanup {
+        if request.shouldRemoveMicAudioOnCleanup || request.shouldRemoveSystemAudioOnCleanup {
             if request.importedRecoverySession?.prepareForScratchCleanup() != false {
-                let removedMic = removeManagedCleanupFile(request.micAudioURL, label: "pending mic audio")
-                let removedSystem = removeManagedCleanupFile(request.systemAudioURL, label: "pending system audio")
+                let removedMic = !request.shouldRemoveMicAudioOnCleanup
+                    || removeManagedCleanupFile(request.micAudioURL, label: "pending mic audio")
+                let removedSystem = !request.shouldRemoveSystemAudioOnCleanup
+                    || removeManagedCleanupFile(request.systemAudioURL, label: "pending system audio")
                 if removedMic && removedSystem {
                     request.importedRecoverySession?.scratchCleanupConfirmed()
                 }
@@ -398,14 +408,17 @@ extension TranscriptionTaskManager {
         clips: [SpeakerNamingEntry],
         micURL: URL?,
         systemURL: URL,
-        shouldRemoveTemporaryAudio: Bool,
+        shouldRemoveMicAudio: Bool,
+        shouldRemoveSystemAudio: Bool,
         importedRecoverySession: (any ImportedTranscriptionRecoverySession)? = nil
     ) {
         cleanupSpeakerClips(clips)
-        guard shouldRemoveTemporaryAudio else { return }
+        guard shouldRemoveMicAudio || shouldRemoveSystemAudio else { return }
         guard importedRecoverySession?.prepareForScratchCleanup() != false else { return }
-        let removedMic = removeManagedCleanupFile(micURL, label: "mic audio")
-        let removedSystem = removeManagedCleanupFile(systemURL, label: "system audio")
+        let removedMic = !shouldRemoveMicAudio
+            || removeManagedCleanupFile(micURL, label: "mic audio")
+        let removedSystem = !shouldRemoveSystemAudio
+            || removeManagedCleanupFile(systemURL, label: "system audio")
         if removedMic && removedSystem {
             importedRecoverySession?.scratchCleanupConfirmed()
         }

--- a/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
+++ b/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
@@ -22,23 +22,55 @@ enum RecordingAudioArchiver {
             "\(transcriptURL.deletingPathExtension().lastPathComponent)_audio",
             isDirectory: true
         )
+        let directoryAlreadyExisted = fileManager.fileExists(atPath: directory.path)
         try createPrivateDirectory(at: directory, fileManager: fileManager)
 
-        let archivedMicURL = try micURL.map {
-            try copyAudioFile(
-                from: $0,
-                to: directory.appendingPathComponent("microphone").appendingPathExtension(fileExtension(for: $0)),
-                fileManager: fileManager
-            )
+        var firstCopyError: Error?
+        let archivedMicURL: URL?
+        if let micURL {
+            do {
+                archivedMicURL = try copyAudioFile(
+                    from: micURL,
+                    to: directory.appendingPathComponent("microphone").appendingPathExtension(fileExtension(for: micURL)),
+                    fileManager: fileManager
+                )
+            } catch {
+                firstCopyError = error
+                archivedMicURL = nil
+            }
+        } else {
+            archivedMicURL = nil
         }
 
         let systemStem = micURL == nil ? "recording" : "system_audio"
-        let archivedSystemURL = try systemURL.map {
-            try copyAudioFile(
-                from: $0,
-                to: directory.appendingPathComponent(systemStem).appendingPathExtension(fileExtension(for: $0)),
-                fileManager: fileManager
-            )
+        let archivedSystemURL: URL?
+        if let systemURL {
+            do {
+                archivedSystemURL = try copyAudioFile(
+                    from: systemURL,
+                    to: directory.appendingPathComponent(systemStem).appendingPathExtension(fileExtension(for: systemURL)),
+                    fileManager: fileManager
+                )
+            } catch {
+                firstCopyError = firstCopyError ?? error
+                archivedSystemURL = nil
+            }
+        } else {
+            archivedSystemURL = nil
+        }
+
+        // A damaged local track must not prevent the valid remote track from
+        // becoming durable (or vice versa). Report failure only when none of the
+        // supplied sources could be retained; callers can compare supplied and
+        // returned URLs to avoid deleting a source that was not copied.
+        guard archivedMicURL != nil || archivedSystemURL != nil else {
+            // Do not leave an empty archive folder after a total copy failure.
+            // Never remove a pre-existing folder: it may contain audio retained
+            // by an earlier run with the same transcript stem.
+            if !directoryAlreadyExisted {
+                try? fileManager.removeItem(at: directory)
+            }
+            throw firstCopyError ?? CocoaError(.fileNoSuchFile)
         }
 
         return RetainedRecordingAudio(

--- a/Sources/TranscriptedCore/Storage/TranscriptFormatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFormatter.swift
@@ -138,6 +138,9 @@ extension TranscriptSaver {
             if health.systemAudioMissing == true {
                 yaml += "\nsystem_audio_missing: true"
             }
+            if health.microphoneAudioUnusable == true {
+                yaml += "\nmicrophone_audio_unusable: true"
+            }
         }
 
         // Add speaker identification metadata.
@@ -190,6 +193,11 @@ extension TranscriptSaver {
         var doc = yaml
         doc += "\n# Meeting Recording - \(dateString)\n\n"
         doc += "**Duration:** \(durationString) | **Words:** \(totalWordCount) | **Utterances:** \(totalUtterances)\n\n"
+
+        if healthInfo?.microphoneAudioUnusable == true {
+            doc += "> **Recording note:** The microphone track was missing or could not be transcribed, so this meeting contains system audio only.\n\n"
+        }
+
         doc += "---\n\n"
 
         // SECTION 1: Channel & Speaker Analytics

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -57,6 +57,43 @@ func testFailedMeetingPresentation() {
         )
     }
 
+    runSuite("FailedMeetingPresentation inconclusive checks do not claim permission is off") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "System audio didn't start after macOS returned an inconclusive access check.",
+            shortErrorMessage: "System audio didn't start.",
+            isRetryable: true
+        )
+
+        assertEqual(copy.title, "Couldn't verify system audio access", "inconclusive probes need honest copy")
+        assertEqual(
+            copy.detail,
+            "Try again. If it keeps happening, review System Audio Recording in System Settings.",
+            "the detail may offer settings as a fallback without asserting denial"
+        )
+    }
+
+    runSuite("FailedMeetingPresentation capture-start failures do not look like transcript retries") {
+        let mic = MeetingFailureCopy.make(
+            forMessage: "Microphone didn't start. Check your input device.",
+            shortErrorMessage: "Microphone didn't start.",
+            isRetryable: true
+        )
+        let system = MeetingFailureCopy.make(
+            forMessage: "System audio couldn't start. Try recording again.",
+            shortErrorMessage: "System audio couldn't start.",
+            isRetryable: true
+        )
+        let both = MeetingFailureCopy.make(
+            forMessage: "Meeting audio didn't start. Check your audio devices.",
+            shortErrorMessage: "Meeting audio didn't start.",
+            isRetryable: true
+        )
+
+        assertEqual(mic.title, "Microphone didn't start", "mic start failure should name the input")
+        assertEqual(system.title, "System audio didn't start", "system start failure should name the stream")
+        assertEqual(both.title, "Meeting audio didn't start", "generic start failure should name the capture stage")
+    }
+
     runSuite("FailedMeetingPresentation save failures keep the short error detail") {
         let copy = MeetingFailureCopy.make(
             forMessage: "Failed to save transcript: Could not write transcript to meetings",

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -62,6 +62,36 @@ func testMeetingFailureKind() {
         assertEqual(kind, .microphonePermission, "microphone access wording should stay centralized in the canonical classifier")
     }
 
+    runSuite("MeetingFailureKind keeps inconclusive access checks out of the denial bucket") {
+        let kind = MeetingFailureKind.classify(
+            message: "System audio didn't start after macOS returned an inconclusive access check."
+        )
+
+        assertEqual(
+            kind,
+            .systemAudioPermissionCheckInconclusive,
+            "a transport failure must not be presented as a permission denial"
+        )
+    }
+
+    runSuite("MeetingFailureKind classifies capture-start failures by observed source") {
+        assertEqual(
+            MeetingFailureKind.classify(message: "Microphone didn't start. Check your input device."),
+            .microphoneStartFailed,
+            "mic readiness failures should stay start-specific"
+        )
+        assertEqual(
+            MeetingFailureKind.classify(message: "System audio couldn't start. Try recording again."),
+            .systemAudioStartFailed,
+            "system stream failures should stay start-specific"
+        )
+        assertEqual(
+            MeetingFailureKind.classify(message: "Meeting audio didn't start. Check your audio devices."),
+            .meetingAudioStartFailed,
+            "unknown/both-source failures should stay start-specific"
+        )
+    }
+
     runSuite("MeetingFailureKind classifies no-speech results") {
         let kind = MeetingFailureKind.classify(
             message: "No speech detected in the audio."

--- a/Tests/MeetingRecordingStartGateTests.swift
+++ b/Tests/MeetingRecordingStartGateTests.swift
@@ -13,6 +13,10 @@ func testMeetingRecordingStartGate() {
         )
 
         assertEqual(decision, .allowed, "meeting capture should start normally when both permissions are granted")
+        assertFalse(
+            decision.systemAudioPermissionCheckWasInconclusive,
+            "the ordinary granted path should not carry an inconclusive probe marker"
+        )
     }
 
     runSuite("MeetingRecordingStartGate.evaluate — blocks meeting capture when System Audio Recording is missing") {
@@ -63,6 +67,76 @@ func testMeetingRecordingStartGate() {
             decision.missingPermissions,
             ["microphone", "system_audio_recording"],
             "combined permission failures should preserve a stable missing-permission list"
+        )
+    }
+
+    runSuite("MeetingRecordingStartGate.systemAudioVerificationUnavailable — does not claim permission was denied") {
+        let decision = MeetingRecordingStartGate.systemAudioVerificationUnavailable()
+
+        assertFalse(decision.canStart, "an unverified first-run permission state should not claim capture is ready")
+        assertEqual(
+            decision.failureReason,
+            "system_audio_recording_check_unavailable",
+            "probe transport failures should stay distinct from a missing permission"
+        )
+        assertEqual(
+            decision.missingPermissions,
+            [],
+            "an inconclusive probe must not report a permission as missing"
+        )
+        assertTrue(
+            decision.errorMessage?.contains("couldn't verify System Audio Recording") == true,
+            "user copy should describe an inconclusive macOS check rather than telling them access is off"
+        )
+        assertTrue(
+            decision.systemAudioPermissionCheckWasInconclusive,
+            "the blocked decision should retain the probe classification for diagnostics and later copy mapping"
+        )
+    }
+
+    runSuite("MeetingRecordingStartGate.captureFailureMessage — removes false permission blame after an inconclusive cached-grant check") {
+        let permissionLooking = "System audio unavailable — can only record your microphone. Go to System Settings and enable System Audio Recording."
+        let mapped = MeetingRecordingStartGate.captureFailureMessage(
+            permissionLooking,
+            systemAudioPermissionCheckWasInconclusive: true
+        )
+
+        assertTrue(mapped.contains("inconclusive access check"), "capture copy should explain what was actually observed")
+        assertFalse(mapped.contains("enable System Audio Recording"), "capture copy must not claim access is off")
+        assertEqual(
+            MeetingStartFailureClassifier.kind(from: mapped),
+            "system_stream_unavailable",
+            "the mapped failure should stay a stream failure rather than becoming a permission denial"
+        )
+    }
+
+    runSuite("MeetingRecordingStartGate.captureFailureMessage — preserves precise failures") {
+        let timeout = "System audio capture did not become ready in time."
+        assertEqual(
+            MeetingRecordingStartGate.captureFailureMessage(
+                timeout,
+                systemAudioPermissionCheckWasInconclusive: true
+            ),
+            timeout,
+            "an accurate readiness timeout should not be rewritten"
+        )
+        let explicitDenial = "Turn on System Audio Recording before recording a meeting."
+        assertEqual(
+            MeetingRecordingStartGate.captureFailureMessage(
+                explicitDenial,
+                systemAudioPermissionCheckWasInconclusive: false
+            ),
+            explicitDenial,
+            "an explicitly denied preflight should keep its direct recovery copy"
+        )
+        assertEqual(
+            MeetingRecordingStartGate.captureFailureMessage(
+                explicitDenial,
+                systemAudioPermissionCheckWasInconclusive: true,
+                explicitSystemAudioPermissionDenialObserved: true
+            ),
+            explicitDenial,
+            "a typed denial from capture must outrank an earlier inconclusive probe"
         )
     }
 

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -24,7 +24,36 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerUsesTimeOnlyFallbackTitle()
         testMeetingTranscriptStylerRewritesTranscriptStyleMarker()
         testMeetingTranscriptStylerLeavesLegacyFilesWithoutFormatVersion()
+        testMeetingTranscriptStylerPreservesSystemOnlyRecordingNote()
     }
+}
+
+private func testMeetingTranscriptStylerPreservesSystemOnlyRecordingNote() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    let raw = sampleVersionedMeetingTranscript().replacingOccurrences(
+        of: "transcript_style: raw",
+        with: "transcript_style: raw\nmicrophone_audio_unusable: true"
+    )
+    try? raw.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let firstPass = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let firstUpdated = (try? String(contentsOf: firstPass.url, encoding: .utf8)) ?? ""
+    let secondPass = MeetingTranscriptStyler.restyleTranscript(at: firstPass.url)
+    let secondUpdated = (try? String(contentsOf: secondPass.url, encoding: .utf8)) ?? ""
+    let note = "> **Recording note:** The microphone track was missing or could not be transcribed, so this meeting contains system audio only."
+
+    assertTrue(
+        firstUpdated.contains(note),
+        "Restyling must keep the partial-transcript warning visible to the user"
+    )
+    assertEqual(
+        secondUpdated.components(separatedBy: note).count - 1,
+        1,
+        "Repeated restyles must preserve exactly one system-only warning"
+    )
 }
 
 private func testMeetingTranscriptStylerRewritesTranscriptStyleMarker() {

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
@@ -1,11 +1,32 @@
 import XCTest
 @preconcurrency import AVFoundation
+import ScreenCaptureKit
 @testable import TranscriptedCore
 
 @available(macOS 14.0, *)
 final class AudioFileManagerTests: XCTestCase {
     private final class StubSystemCapture {}
     private final class StubSystemWriter {}
+
+    func testSystemAudioStartFailureCopyReservesSettingsForExplicitDenial() {
+        let denial = NSError(
+            domain: SCStreamErrorDomain,
+            code: SCStreamError.Code.userDeclined.rawValue
+        )
+        let transient = NSError(
+            domain: SCStreamErrorDomain,
+            code: SCStreamError.Code.failedToStart.rawValue
+        )
+
+        XCTAssertTrue(SystemAudioCaptureFailureCopy.message(for: denial).contains("System Settings"))
+        XCTAssertFalse(SystemAudioCaptureFailureCopy.message(for: transient).contains("System Settings"))
+        XCTAssertTrue(SystemAudioCaptureFailureCopy.isExplicitPermissionDenial(denial))
+        XCTAssertFalse(SystemAudioCaptureFailureCopy.isExplicitPermissionDenial(transient))
+        XCTAssertTrue(
+            SystemAudioCaptureFailureCopy.message(for: transient)
+                .localizedCaseInsensitiveContains("try recording again")
+        )
+    }
 
     // MARK: - Test scaffolding
 

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioFormatPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioFormatPolicyTests.swift
@@ -63,15 +63,13 @@ final class AudioFormatPolicyTests: XCTestCase {
         XCTAssertFalse(SystemAudioStatus.failed.isRecovering)
     }
 
-    func testSystemAudioStatusDisplayTextSurfacesUserGuidanceForFailedCase() {
+    func testSystemAudioStatusDisplayTextUsesNeutralRetryGuidanceForFailedCase() {
         XCTAssertEqual(SystemAudioStatus.unknown.displayText, "")
         XCTAssertEqual(SystemAudioStatus.healthy.displayText, "")
         XCTAssertEqual(SystemAudioStatus.reconnecting.displayText, "Reconnecting...")
         XCTAssertEqual(SystemAudioStatus.silent.displayText, "System audio silent")
-        XCTAssertTrue(
-            SystemAudioStatus.failed.displayText.contains("System Settings"),
-            "failed status should point users at the System Settings remediation path"
-        )
+        XCTAssertEqual(SystemAudioStatus.failed.displayText, "System audio unavailable — try recording again")
+        XCTAssertFalse(SystemAudioStatus.failed.displayText.contains("System Settings"))
     }
 
     // MARK: - AudioInputTapTeardownPolicy drain delay

--- a/Tests/TranscriptedCoreTests/AudioTests/MeetingRecordingJournalTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/MeetingRecordingJournalTests.swift
@@ -358,4 +358,25 @@ final class MeetingRecordingJournalTests: XCTestCase {
         )
         XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
     }
+
+    func testRemoveJournalMatchesSystemAudioWhenMicIsMissing() throws {
+        let store = MeetingRecordingJournalStore(directory: temporaryDirectory)
+        let expectedMicURL = temporaryDirectory.appendingPathComponent("meeting_system_only_mic.wav")
+        let systemURL = temporaryDirectory.appendingPathComponent("meeting_system_only_system.wav")
+        let journalURL = temporaryDirectory.appendingPathComponent("meeting_system_only_mic.recording.json")
+        let session = store.begin(primaryMicURL: expectedMicURL)
+        store.recordSystemAudio(systemURL, session: session)
+        store.flush()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journalURL.path))
+        XCTAssertTrue(MeetingRecordingJournalStore.removeJournal(
+            micAudioURL: nil,
+            systemAudioURL: systemURL,
+            allowedRoots: [temporaryDirectory]
+        ))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: journalURL.path),
+            "a durable system-only handoff must retire its recovery journal"
+        )
+    }
 }

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionPipelineHelpersTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Combine
 import FluidAudio
+import AVFoundation
 @testable import TranscriptedCore
 
 @available(macOS 14.0, *)
@@ -138,6 +139,196 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
             ),
             .waiting
         )
+    }
+
+    @MainActor
+    func testUnusableMicContinuesWithSystemAudioTranscript() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionPipelinePartialMicTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let micURL = root.appendingPathComponent("mic.wav")
+        let systemURL = root.appendingPathComponent("system.wav")
+        try writeMonoWAV(
+            to: micURL,
+            samples: [Float](repeating: 0, count: 32_000)
+        )
+        try writeMonoWAV(
+            to: systemURL,
+            samples: alternatingSamples(amplitude: 0.08, count: 32_000)
+        )
+
+        let speakerDB = try temporarySpeakerDatabase()
+        let transcription = Transcription(
+            speechToText: PipelineStubSpeechToTextEngine(transcript: "Remote participant speaking."),
+            diarization: PipelineStubDiarizationEngine(segments: [
+                speakerSegment(
+                    speakerId: 0,
+                    start: 0,
+                    end: 2,
+                    embedding: [1, 0],
+                    qualityScore: 0.95
+                )
+            ]),
+            speakerStore: speakerDB,
+            speakerClipsDirectory: root.appendingPathComponent("clips")
+        )
+
+        let result = try await transcription.transcribeMultichannel(
+            micURL: micURL,
+            systemURL: systemURL
+        )
+
+        XCTAssertEqual(result.microphoneAudioOutcome, .unusable)
+        XCTAssertTrue(result.micUtterances.isEmpty)
+        XCTAssertEqual(result.systemUtterances.map(\.transcript), ["Remote participant speaking."])
+    }
+
+    @MainActor
+    func testMicSTTFailureContinuesWithCompletedSystemTranscript() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionPipelineMicSTTFailureTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let micURL = root.appendingPathComponent("mic.wav")
+        let systemURL = root.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: micURL, samples: alternatingSamples(amplitude: 0.08, count: 32_000))
+        try writeMonoWAV(to: systemURL, samples: alternatingSamples(amplitude: 0.08, count: 32_000))
+
+        let speakerDB = try temporarySpeakerDatabase()
+        let transcription = Transcription(
+            speechToText: PipelineStubSpeechToTextEngine(
+                transcript: "Remote participant speaking.",
+                failureSource: .microphone,
+                error: NSError(domain: "MicSTT", code: 17)
+            ),
+            diarization: PipelineStubDiarizationEngine(segments: [
+                speakerSegment(
+                    speakerId: 0,
+                    start: 0,
+                    end: 2,
+                    embedding: [1, 0],
+                    qualityScore: 0.95
+                )
+            ]),
+            speakerStore: speakerDB,
+            speakerClipsDirectory: root.appendingPathComponent("clips")
+        )
+
+        let result = try await transcription.transcribeMultichannel(
+            micURL: micURL,
+            systemURL: systemURL
+        )
+
+        XCTAssertEqual(result.microphoneAudioOutcome, .unusable)
+        XCTAssertTrue(result.micUtterances.isEmpty)
+        XCTAssertEqual(result.systemUtterances.map(\.transcript), ["Remote participant speaking."])
+    }
+
+    @MainActor
+    func testSplitMicSTTFailureDoesNotCreatePartialSpeakerProfile() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionPipelineSplitMicFailureTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+
+        let micURL = root.appendingPathComponent("mic.wav")
+        let systemURL = root.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: micURL, samples: alternatingSamples(amplitude: 0.08, count: 32_000))
+        try writeMonoWAV(to: systemURL, samples: alternatingSamples(amplitude: 0.08, count: 32_000))
+
+        let speakerDB = try temporarySpeakerDatabase()
+        let transcription = Transcription(
+            speechToText: PipelineStubSpeechToTextEngine(
+                transcript: "Remote participant speaking.",
+                failureSource: .microphone,
+                error: NSError(domain: "MicSTT", code: 18)
+            ),
+            diarization: PipelineStubDiarizationEngine(segments: [
+                speakerSegment(
+                    speakerId: 0,
+                    start: 0,
+                    end: 2,
+                    embedding: [1, 0],
+                    qualityScore: 0.95
+                )
+            ]),
+            speakerStore: speakerDB,
+            speakerClipsDirectory: root.appendingPathComponent("clips")
+        )
+
+        let result = try await transcription.transcribeMultichannel(
+            micURL: micURL,
+            systemURL: systemURL,
+            splitLocalSpeakers: true
+        )
+
+        XCTAssertEqual(result.microphoneAudioOutcome, .unusable)
+        XCTAssertTrue(result.newlyCreatedMicProfileIds.isEmpty)
+        XCTAssertEqual(speakerDB.allSpeakers().count, 1, "only the completed system speaker may mutate the store")
+    }
+
+    @MainActor
+    func testMicDiarizationCancellationPropagatesBeforeSpeakerMutation() async throws {
+        let speakerDB = try temporarySpeakerDatabase()
+        var droppedSegments = 0
+
+        do {
+            _ = try await Transcription.processMicChannelWithDiarization(
+                samples: alternatingSamples(amplitude: 0.08, count: 32_000),
+                diarization: PipelineStubDiarizationEngine(segments: [
+                    speakerSegment(speakerId: 0, start: 0, end: 2, embedding: [1, 0], qualityScore: 0.95)
+                ]),
+                parakeet: PipelineStubSpeechToTextEngine(
+                    transcript: "unused",
+                    failureSource: .microphone,
+                    error: CancellationError()
+                ),
+                speakerDB: speakerDB,
+                existingProfiles: [],
+                droppedSegments: &droppedSegments,
+                onProgress: nil
+            )
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected: cancellation is never downgraded to partial success.
+        }
+
+        XCTAssertTrue(speakerDB.allSpeakers().isEmpty)
+    }
+
+    func testSavedTranscriptResolutionExcludesUnusableMicAndMarksDegraded() {
+        let resolution = TranscriptionTaskManager.savedTranscriptAudioResolution(
+            microphoneURLWasProvided: true,
+            microphoneOutcome: .unusable,
+            healthInfo: .perfect
+        )
+
+        XCTAssertFalse(resolution.includesMicrophone)
+        XCTAssertEqual(resolution.healthInfo?.captureQuality, .degraded)
+        XCTAssertEqual(resolution.healthInfo?.microphoneAudioUnusable, true)
+    }
+
+    func testSavedTranscriptResolutionLeavesUsableMicHealthUntouched() {
+        let health = RecordingHealthInfo(
+            captureQuality: .good,
+            audioGaps: 1,
+            deviceSwitches: 0,
+            gapDescriptions: ["Recovered gap"]
+        )
+        let resolution = TranscriptionTaskManager.savedTranscriptAudioResolution(
+            microphoneURLWasProvided: true,
+            microphoneOutcome: .usable,
+            healthInfo: health
+        )
+
+        XCTAssertTrue(resolution.includesMicrophone)
+        XCTAssertEqual(resolution.healthInfo?.captureQuality, .good)
+        XCTAssertNil(resolution.healthInfo?.microphoneAudioUnusable)
     }
 
     func testMergeConsecutiveUtterancesMergesSameSpeakerAndPropagatesSpeakerMetadata() {
@@ -486,6 +677,35 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         return SpeakerDatabase(path: root.appendingPathComponent("speakers.sqlite").path)
     }
 
+    private func writeMonoWAV(to url: URL, samples: [Float], sampleRate: Double = 16_000) throws {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        )!
+        let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        )!
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        guard let channel = buffer.floatChannelData?[0] else {
+            XCTFail("Could not create mono audio buffer")
+            return
+        }
+        samples.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else { return }
+            channel.update(from: baseAddress, count: samples.count)
+        }
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: format.settings,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+        try file.write(from: buffer)
+    }
+
     private func utterance(
         start: Double,
         end: Double,
@@ -513,9 +733,17 @@ private final class PipelineStubSpeechToTextEngine: SpeechToTextEngine {
     nonisolated let objectWillChange = ObservableObjectPublisher()
     var isReady = true
     private let transcript: String
+    private let failureSource: AudioSource?
+    private let error: Error?
 
-    init(transcript: String) {
+    init(
+        transcript: String,
+        failureSource: AudioSource? = nil,
+        error: Error? = nil
+    ) {
         self.transcript = transcript
+        self.failureSource = failureSource
+        self.error = error
     }
 
     func initialize() async {
@@ -523,7 +751,10 @@ private final class PipelineStubSpeechToTextEngine: SpeechToTextEngine {
     }
 
     func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String {
-        transcript
+        if source == failureSource, let error {
+            throw error
+        }
+        return transcript
     }
 
     func cleanup() {

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
@@ -39,6 +39,103 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertTrue(markdown.contains("Mic only recovery worked."))
     }
 
+    func testStartTranscriptionAllowsSystemOnlyRecovery() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Remote system audio survived."),
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments(duration: 2.5)),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let systemURL = scratchDirectory.appendingPathComponent("system-only.wav")
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+        let expectedMicURL = scratchDirectory.appendingPathComponent("system-only-mic.wav")
+        let journalURL = scratchDirectory.appendingPathComponent("system-only-mic.recording.json")
+        let journal = MeetingRecordingJournalStore(directory: scratchDirectory)
+        let journalSession = journal.begin(primaryMicURL: expectedMicURL)
+        journal.recordSystemAudio(systemURL, session: journalSession)
+        journal.flush()
+
+        manager.startTranscription(
+            micURL: nil,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "System-only recovery"
+        )
+
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: transcriptURL))
+        XCTAssertEqual(values["sources"], "[system_audio]")
+        XCTAssertEqual(values["capture_quality"], "degraded")
+        XCTAssertEqual(values["microphone_audio_unusable"], "true")
+        XCTAssertFalse(markdown.contains("### Microphone"))
+        XCTAssertTrue(markdown.contains("Remote system audio survived."))
+        XCTAssertTrue(markdown.contains("The microphone track was missing or could not be transcribed"))
+        let retainedFiles = FileManager.default
+            .enumerator(at: retainedAudioDirectory, includingPropertiesForKeys: nil)?
+            .compactMap { $0 as? URL } ?? []
+        XCTAssertTrue(retainedFiles.contains { $0.lastPathComponent == "recording.wav" })
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: journalURL.path),
+            "a saved system-only transcript must retire the recording journal"
+        )
+    }
+
+    func testPartialSuccessfulArchiveRemovesCopiedSystemScratch() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Remote audio remained useful."),
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments(duration: 2.5)),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let missingMicURL = scratchDirectory.appendingPathComponent("missing-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("partial-system.wav")
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.startTranscription(
+            micURL: missingMicURL,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Partial archive cleanup"
+        )
+
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+
+        if let request = manager.speakerNamingRequest {
+            XCTAssertFalse(request.shouldRemoveMicAudioOnCleanup)
+            XCTAssertTrue(request.shouldRemoveSystemAudioOnCleanup)
+            manager.cancelSpeakerNamingRequest(transcriptId: request.transcriptId)
+            try await waitUntil {
+                manager.speakerNamingRequest == nil
+            }
+        }
+
+        try await waitUntil {
+            !FileManager.default.fileExists(atPath: systemURL.path)
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: systemURL.path),
+            "a source with a durable retained copy must not remain as orphaned scratch audio"
+        )
+        let retainedFiles = FileManager.default
+            .enumerator(at: retainedAudioDirectory, includingPropertiesForKeys: nil)?
+            .compactMap { $0 as? URL } ?? []
+        XCTAssertTrue(retainedFiles.contains { $0.lastPathComponent == "system_audio.wav" })
+    }
+
     func testStartTranscriptionRejectsTooShortLiveAudioWithoutQueueingRetry() throws {
         let manager = makeManager()
         let scratchDirectory = tempDirectory.appendingPathComponent("audio")
@@ -232,6 +329,12 @@ extension TranscriptionTaskManagerMetadataTests {
         try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
         let systemURL = scratchDirectory.appendingPathComponent("system.wav")
         try writeMonoWAV(to: systemURL, duration: 2.5)
+        let expectedMicURL = scratchDirectory.appendingPathComponent("system-only-mic.wav")
+        let journalURL = scratchDirectory.appendingPathComponent("system-only-mic.recording.json")
+        let journal = MeetingRecordingJournalStore(directory: scratchDirectory)
+        let journalSession = journal.begin(primaryMicURL: expectedMicURL)
+        journal.recordSystemAudio(systemURL, session: journalSession)
+        journal.flush()
 
         let didQueue = manager.addFailedTranscriptionRetainingAvailableAudio(
             micAudioURL: nil,
@@ -247,6 +350,65 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: failed.systemAudioURL?.path ?? ""))
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should be removed after archive")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: journalURL.path),
+            "a persisted system-only failed row must retire the recording journal"
+        )
+
+        let originalPlaceholderURL = failed.micAudioURL
+        let originalRetainedSystemURL = try XCTUnwrap(failed.systemAudioURL)
+        XCTAssertTrue(manager.promoteFinalizedFailedTranscriptionAudio(
+            id: failed.id,
+            micAudioURL: scratchDirectory.appendingPathComponent("still-missing-mic.wav"),
+            systemAudioURL: originalRetainedSystemURL
+        ))
+        let promoted = try XCTUnwrap(
+            manager.failedTranscriptionManager.failedTranscriptions.first(where: { $0.id == failed.id })
+        )
+        XCTAssertNotEqual(promoted.micAudioURL, originalPlaceholderURL)
+        XCTAssertNotEqual(promoted.systemAudioURL, originalRetainedSystemURL)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: originalPlaceholderURL.path),
+            "re-archiving must remove the superseded retained mic placeholder"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: originalRetainedSystemURL.path),
+            "re-archiving must remove the superseded retained system source"
+        )
+        XCTAssertTrue(promoted.audioFilesExist())
+    }
+
+    func testMissingMicPathUsesPlaceholderAndSystemAudioSurvivesQueueReload() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let failedQueueURL = tempDirectory.appendingPathComponent("failed_transcriptions.json")
+        let manager = makeManager(
+            retainedAudioDirectory: retainedAudioDirectory,
+            failedQueueURL: failedQueueURL
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let missingMicURL = scratchDirectory.appendingPathComponent("never-created-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: missingMicURL,
+            systemAudioURL: systemURL,
+            errorMessage: "System-only recovery fixture"
+        ))
+
+        let firstRow = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(firstRow.micAudioURL.lastPathComponent.hasPrefix("microphone_placeholder"))
+        XCTAssertTrue(firstRow.audioFilesExist())
+
+        let reloadedManager = makeManager(
+            retainedAudioDirectory: retainedAudioDirectory,
+            failedQueueURL: failedQueueURL
+        )
+        let reloadedRow = try XCTUnwrap(reloadedManager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(reloadedRow.micAudioURL.lastPathComponent.hasPrefix("microphone_placeholder"))
+        XCTAssertTrue(reloadedRow.audioFilesExist(), "a reload must keep both the placeholder and retained system track retryable")
     }
 
     func testUnreadableAudioIsPreservedForRetryInsteadOfDeletedAsTooShort() async throws {
@@ -314,6 +476,49 @@ extension TranscriptionTaskManagerMetadataTests {
         let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: transcriptURL))
 
         XCTAssertEqual(values["duration"], "0:04", "meeting metadata should use the longest readable track, not a short mic placeholder")
+    }
+
+    func testSilentMicSavesSystemTranscriptAndRetainsBothOriginalTracks() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Remote participant speaking."),
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments(duration: 2.5)),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("silent-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5, amplitude: 0)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.startTranscription(
+            micURL: micURL,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Partial microphone recovery"
+        )
+
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: transcriptURL))
+        XCTAssertEqual(values["sources"], "[system_audio]")
+        XCTAssertEqual(values["capture_quality"], "degraded")
+        XCTAssertEqual(values["microphone_audio_unusable"], "true")
+        XCTAssertTrue(markdown.contains("Remote participant speaking."))
+        XCTAssertTrue(markdown.contains("The microphone track was missing or could not be transcribed"))
+
+        let retainedFiles = FileManager.default
+            .enumerator(at: retainedAudioDirectory, includingPropertiesForKeys: nil)?
+            .compactMap { $0 as? URL } ?? []
+        XCTAssertTrue(retainedFiles.contains { $0.lastPathComponent == "microphone.wav" })
+        XCTAssertTrue(retainedFiles.contains { $0.lastPathComponent == "system_audio.wav" })
     }
 
     func testCancelAllSuppressesLateTranscriptSaveAndFailedQueue() async throws {

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerMetadataTests.swift
@@ -531,7 +531,12 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         """
     }
 
-    func writeMonoWAV(to url: URL, duration: TimeInterval, sampleRate: Double = 16_000) throws {
+    func writeMonoWAV(
+        to url: URL,
+        duration: TimeInterval,
+        sampleRate: Double = 16_000,
+        amplitude: Float = 0.25
+    ) throws {
         let frameCount = Int(duration * sampleRate)
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -558,7 +563,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         buffer.frameLength = AVAudioFrameCount(frameCount)
         if let channelData = buffer.floatChannelData?[0] {
             for index in 0..<frameCount {
-                channelData[index] = 0.25
+                channelData[index] = amplitude
             }
         }
 

--- a/Tests/TranscriptedCoreTests/StorageTests/RecordingAudioArchiverTests.swift
+++ b/Tests/TranscriptedCoreTests/StorageTests/RecordingAudioArchiverTests.swift
@@ -86,4 +86,66 @@ final class RecordingAudioArchiverTests: XCTestCase {
         XCTAssertNil(retained.systemURL)
         XCTAssertEqual(try Data(contentsOf: retained.micURL!), Data("mic".utf8))
     }
+
+    func testArchiveStillRetainsSystemAudioWhenMicCopyFails() throws {
+        let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
+        let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let missingMicURL = scratch.appendingPathComponent("missing-mic.wav")
+        let systemURL = scratch.appendingPathComponent("meeting_system.wav")
+        let transcriptURL = tempRoot.appendingPathComponent("Partial Meeting.md")
+        try Data("system".utf8).write(to: systemURL)
+
+        let retained = try RecordingAudioArchiver.archive(
+            micURL: missingMicURL,
+            systemURL: systemURL,
+            transcriptURL: transcriptURL,
+            archiveRoot: archiveRoot
+        )
+
+        XCTAssertNil(retained.micURL)
+        XCTAssertEqual(retained.systemURL?.lastPathComponent, "system_audio.wav")
+        XCTAssertEqual(try Data(contentsOf: retained.systemURL!), Data("system".utf8))
+    }
+
+    func testArchiveStillRetainsMicAudioWhenSystemCopyFails() throws {
+        let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
+        let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let micURL = scratch.appendingPathComponent("meeting_mic.wav")
+        let missingSystemURL = scratch.appendingPathComponent("missing-system.wav")
+        let transcriptURL = tempRoot.appendingPathComponent("Partial Meeting.md")
+        try Data("mic".utf8).write(to: micURL)
+
+        let retained = try RecordingAudioArchiver.archive(
+            micURL: micURL,
+            systemURL: missingSystemURL,
+            transcriptURL: transcriptURL,
+            archiveRoot: archiveRoot
+        )
+
+        XCTAssertEqual(retained.micURL?.lastPathComponent, "microphone.wav")
+        XCTAssertNil(retained.systemURL)
+        XCTAssertEqual(try Data(contentsOf: retained.micURL!), Data("mic".utf8))
+    }
+
+    func testArchiveFailsWhenNoProvidedSourceCanBeCopied() {
+        let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        let expectedDirectory = archiveRoot.appendingPathComponent("Missing Meeting_audio", isDirectory: true)
+
+        XCTAssertThrowsError(
+            try RecordingAudioArchiver.archive(
+                micURL: tempRoot.appendingPathComponent("missing-mic.wav"),
+                systemURL: tempRoot.appendingPathComponent("missing-system.wav"),
+                transcriptURL: tempRoot.appendingPathComponent("Missing Meeting.md"),
+                archiveRoot: archiveRoot
+            )
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: expectedDirectory.path),
+            "a total copy failure should not leave an empty archive directory"
+        )
+    }
 }

--- a/Tests/TranscriptedCoreTests/StorageTests/TranscriptFormatterAudioHealthTests.swift
+++ b/Tests/TranscriptedCoreTests/StorageTests/TranscriptFormatterAudioHealthTests.swift
@@ -68,7 +68,26 @@ final class TranscriptFormatterAudioHealthTests: XCTestCase {
         XCTAssertNil(values?["mic_boost_prompt"], "a nil prompt outcome should omit the key entirely")
     }
 
-    private func makeResult() -> TranscriptionResult {
+    func testUnusableMicrophoneEmitsFlatPartialTranscriptMetadataAndVisibleNote() {
+        let health = RecordingHealthInfo.perfect.markingMicrophoneAudioUnusable()
+        let markdown = TranscriptSaver.formatTranscriptMarkdown(
+            result: makeResult(microphoneOutcome: .unusable),
+            transcriptId: UUID(uuidString: "00000000-0000-0000-0000-000000000503")!,
+            date: Date(timeIntervalSince1970: 0),
+            healthInfo: health,
+            formatOptions: TranscriptFormatOptions(audioSources: [.systemAudio])
+        )
+
+        let values = TranscriptFrontmatter.document(in: markdown)?.values
+        XCTAssertEqual(values?["capture_quality"], "degraded")
+        XCTAssertEqual(values?["microphone_audio_unusable"], "true")
+        XCTAssertEqual(values?["sources"], "[system_audio]")
+        XCTAssertTrue(markdown.contains("The microphone track was missing or could not be transcribed"))
+    }
+
+    private func makeResult(
+        microphoneOutcome: TranscriptionResult.MicrophoneAudioOutcome = .usable
+    ) -> TranscriptionResult {
         TranscriptionResult(
             micUtterances: [],
             systemUtterances: [
@@ -83,7 +102,8 @@ final class TranscriptFormatterAudioHealthTests: XCTestCase {
                 )
             ],
             duration: 2,
-            processingTime: 0.5
+            processingTime: 0.5,
+            microphoneAudioOutcome: microphoneOutcome
         )
     }
 }

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import EventKit
+import ScreenCaptureKit
 
 @MainActor
 private final class PermissionRequestBox {
@@ -8,12 +9,14 @@ private final class PermissionRequestBox {
 
 @MainActor
 private final class SystemAudioPermissionAttemptDriver {
-    var completion: ((Bool) -> Void)?
+    typealias ProbeResult = TranscriptedPermissionAccess.SystemAudioPermissionProbeResult
+
+    var completion: ((ProbeResult) -> Void)?
     var timeoutAction: (() -> Void)?
     var cleanupCount = 0
     var timeoutCancellationCount = 0
 
-    func start(_ completion: @escaping (Bool) -> Void) {
+    func start(_ completion: @escaping (ProbeResult) -> Void) {
         self.completion = completion
     }
 
@@ -54,10 +57,10 @@ func testTranscriptedPermissionAccess() async {
         }
     }
 
-    await runSuite("SystemAudioPermissionRequestAttempt — stalled requester times out with one denied result") {
+    await runSuite("SystemAudioPermissionRequestAttempt — stalled requester times out as indeterminate") {
         let driver = SystemAudioPermissionAttemptDriver()
         var timeoutCount = 0
-        var resolved: [Bool] = []
+        var resolved: [TranscriptedPermissionAccess.SystemAudioPermissionProbeResult] = []
         let attempt = SystemAudioPermissionRequestAttempt(
             scheduleTimeout: driver.scheduleTimeout,
             onTimeout: { timeoutCount += 1 },
@@ -75,18 +78,18 @@ func testTranscriptedPermissionAccess() async {
             "the deterministic requester should start before its timeout is fired"
         )
         driver.fireTimeout()
-        let granted = await resultTask.value
+        let result = await resultTask.value
 
-        assertFalse(granted, "a stalled permission requester must resolve as denied")
+        assertEqual(result, .indeterminate(.timedOut), "a stalled permission requester must not manufacture a denial")
         assertEqual(timeoutCount, 1, "the timeout diagnostic hook should fire once")
-        assertEqual(resolved, [false], "timeout should resolve the request exactly once")
+        assertEqual(resolved, [.indeterminate(.timedOut)], "timeout should resolve the request exactly once")
         assertEqual(driver.cleanupCount, 1, "timeout should clean up the in-flight requester")
         assertEqual(driver.timeoutCancellationCount, 1, "timeout should cancel its pending timer once")
     }
 
     await runSuite("SystemAudioPermissionRequestAttempt — ignores a late success after timeout") {
         let driver = SystemAudioPermissionAttemptDriver()
-        var resolved: [Bool] = []
+        var resolved: [TranscriptedPermissionAccess.SystemAudioPermissionProbeResult] = []
         let attempt = SystemAudioPermissionRequestAttempt(
             scheduleTimeout: driver.scheduleTimeout,
             onResolved: { resolved.append($0) }
@@ -100,16 +103,16 @@ func testTranscriptedPermissionAccess() async {
 
         assertTrue(await waitForSystemAudioPermissionAttemptStart(driver), "the requester should start")
         driver.fireTimeout()
-        let granted = await resultTask.value
-        driver.completion?(true)
+        let result = await resultTask.value
+        driver.completion?(.granted)
         await Task.yield()
 
-        assertFalse(granted, "a timeout must not be upgraded to a late success")
-        assertEqual(resolved, [false], "a late ScreenCaptureKit callback must be harmless")
+        assertEqual(result, .indeterminate(.timedOut), "a timeout must not be upgraded to a late success")
+        assertEqual(resolved, [.indeterminate(.timedOut)], "a late ScreenCaptureKit callback must be harmless")
         assertEqual(driver.cleanupCount, 1, "late callbacks must not repeat cleanup")
     }
 
-    await runSuite("SystemAudioPermissionRequestAttempt — returns real success and failure") {
+    await runSuite("SystemAudioPermissionRequestAttempt — returns real success and explicit denial") {
         let successDriver = SystemAudioPermissionAttemptDriver()
         let successAttempt = SystemAudioPermissionRequestAttempt(scheduleTimeout: successDriver.scheduleTimeout)
         let successTask = Task { @MainActor in
@@ -119,8 +122,8 @@ func testTranscriptedPermissionAccess() async {
             )
         }
         assertTrue(await waitForSystemAudioPermissionAttemptStart(successDriver), "the success requester should start")
-        successDriver.completion?(true)
-        assertTrue(await successTask.value, "a successful ScreenCaptureKit probe should be granted")
+        successDriver.completion?(.granted)
+        assertEqual(await successTask.value, .granted, "a successful ScreenCaptureKit probe should be granted")
 
         let failureDriver = SystemAudioPermissionAttemptDriver()
         let failureAttempt = SystemAudioPermissionRequestAttempt(scheduleTimeout: failureDriver.scheduleTimeout)
@@ -131,15 +134,15 @@ func testTranscriptedPermissionAccess() async {
             )
         }
         assertTrue(await waitForSystemAudioPermissionAttemptStart(failureDriver), "the failure requester should start")
-        failureDriver.completion?(false)
-        assertFalse(await failureTask.value, "a failed ScreenCaptureKit probe should stay denied")
+        failureDriver.completion?(.explicitlyDenied)
+        assertEqual(await failureTask.value, .explicitlyDenied, "an explicit ScreenCaptureKit denial should stay denied")
         assertEqual(successDriver.cleanupCount, 1, "success should clean up the probe stream")
         assertEqual(failureDriver.cleanupCount, 1, "failure should clean up the probe stream")
     }
 
     await runSuite("SystemAudioPermissionRequestAttempt — duplicate callbacks and cancellation resolve once") {
         let duplicateDriver = SystemAudioPermissionAttemptDriver()
-        var duplicateResolved: [Bool] = []
+        var duplicateResolved: [TranscriptedPermissionAccess.SystemAudioPermissionProbeResult] = []
         let duplicateAttempt = SystemAudioPermissionRequestAttempt(
             scheduleTimeout: duplicateDriver.scheduleTimeout,
             onResolved: { duplicateResolved.append($0) }
@@ -151,15 +154,15 @@ func testTranscriptedPermissionAccess() async {
             )
         }
         assertTrue(await waitForSystemAudioPermissionAttemptStart(duplicateDriver), "the duplicate-callback requester should start")
-        duplicateDriver.completion?(true)
-        assertTrue(await duplicateTask.value, "the first callback should win")
-        duplicateDriver.completion?(false)
+        duplicateDriver.completion?(.granted)
+        assertEqual(await duplicateTask.value, .granted, "the first callback should win")
+        duplicateDriver.completion?(.explicitlyDenied)
         await Task.yield()
-        assertEqual(duplicateResolved, [true], "duplicate callbacks must not resume twice")
+        assertEqual(duplicateResolved, [.granted], "duplicate callbacks must not resume twice")
         assertEqual(duplicateDriver.cleanupCount, 1, "duplicate callbacks must not repeat cleanup")
 
         let cancellationDriver = SystemAudioPermissionAttemptDriver()
-        var cancellationResolved: [Bool] = []
+        var cancellationResolved: [TranscriptedPermissionAccess.SystemAudioPermissionProbeResult] = []
         let cancellationAttempt = SystemAudioPermissionRequestAttempt(
             scheduleTimeout: cancellationDriver.scheduleTimeout,
             onResolved: { cancellationResolved.append($0) }
@@ -172,8 +175,12 @@ func testTranscriptedPermissionAccess() async {
         }
         assertTrue(await waitForSystemAudioPermissionAttemptStart(cancellationDriver), "the cancellable requester should start")
         cancellationTask.cancel()
-        assertFalse(await cancellationTask.value, "cancelling a request should return an honest denied result")
-        assertEqual(cancellationResolved, [false], "cancellation must resolve exactly once")
+        assertEqual(
+            await cancellationTask.value,
+            .indeterminate(.cancelled),
+            "cancelling a request should not be persisted as a permission denial"
+        )
+        assertEqual(cancellationResolved, [.indeterminate(.cancelled)], "cancellation must resolve exactly once")
         assertEqual(cancellationDriver.cleanupCount, 1, "cancellation should clean up the probe stream")
     }
 
@@ -286,6 +293,134 @@ func testTranscriptedPermissionAccess() async {
         assertFalse(
             UserDefaults.standard.bool(forKey: grantedKey),
             "a failed forced recheck should clear the cached granted state"
+        )
+    }
+
+    await runSuite("TranscriptedPermissionAccess.systemAudioRecordingAccessDecision — preserves cached grants across every indeterminate probe stage") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+        }
+
+        for stage in TranscriptedPermissionAccess.SystemAudioPermissionProbeStage.allCases
+            where stage != .cancelled {
+            UserDefaults.standard.set(true, forKey: knownKey)
+            UserDefaults.standard.set(true, forKey: grantedKey)
+
+            let decision = await TranscriptedPermissionAccess.systemAudioRecordingAccessDecision(
+                forceRefresh: true,
+                probeRequester: { .indeterminate(stage) }
+            )
+
+            assertTrue(decision.canProceed, "cached grant should survive an indeterminate \(stage.rawValue) probe")
+            assertEqual(decision.state, .granted, "indeterminate \(stage.rawValue) should not rewrite cached state")
+            assertEqual(
+                decision.probeResult,
+                .indeterminate(stage),
+                "the decision should retain the privacy-safe probe stage"
+            )
+            assertTrue(
+                UserDefaults.standard.bool(forKey: grantedKey),
+                "indeterminate \(stage.rawValue) should leave the persisted grant intact"
+            )
+        }
+    }
+
+    await runSuite("TranscriptedPermissionAccess.systemAudioRecordingAccessDecision — cancellation preserves cached grant but blocks this start") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+        }
+
+        UserDefaults.standard.set(true, forKey: knownKey)
+        UserDefaults.standard.set(true, forKey: grantedKey)
+
+        let decision = await TranscriptedPermissionAccess.systemAudioRecordingAccessDecision(
+            forceRefresh: true,
+            probeRequester: { .indeterminate(.cancelled) }
+        )
+
+        assertFalse(decision.canProceed, "a cancelled caller must not continue into meeting capture")
+        assertEqual(decision.state, .granted, "cancellation must not rewrite the persisted TCC grant")
+        assertEqual(decision.probeResult, .indeterminate(.cancelled), "the decision should retain cancellation as its terminal stage")
+        assertTrue(UserDefaults.standard.bool(forKey: grantedKey), "cancellation must preserve the cached grant for a future attempt")
+    }
+
+    await runSuite("TranscriptedPermissionAccess.systemAudioRecordingAccessDecision — explicit denial clears a cached grant") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+        }
+
+        UserDefaults.standard.set(true, forKey: knownKey)
+        UserDefaults.standard.set(true, forKey: grantedKey)
+
+        let decision = await TranscriptedPermissionAccess.systemAudioRecordingAccessDecision(
+            forceRefresh: true,
+            probeRequester: { .explicitlyDenied }
+        )
+
+        assertFalse(decision.canProceed, "an explicit TCC denial should still block meeting start")
+        assertEqual(decision.state, .denied, "an explicit denial should replace the stale grant")
+        assertFalse(UserDefaults.standard.bool(forKey: grantedKey), "explicit denial should clear the cached grant")
+    }
+
+    await runSuite("TranscriptedPermissionAccess.systemAudioRecordingAccessDecision — first-run indeterminate stays unknown") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+        }
+
+        UserDefaults.standard.removeObject(forKey: knownKey)
+        UserDefaults.standard.removeObject(forKey: grantedKey)
+
+        let decision = await TranscriptedPermissionAccess.systemAudioRecordingAccessDecision(
+            probeRequester: { .indeterminate(.shareableContent) }
+        )
+
+        assertFalse(decision.canProceed, "an unverified first-run state should not claim capture is ready")
+        assertEqual(decision.state, .unknown, "a transient first-run failure should remain unknown, not denied")
+        assertFalse(UserDefaults.standard.bool(forKey: knownKey), "an indeterminate probe should not persist a known denial")
+    }
+
+    runSuite("SystemAudioPermissionProbeClassifier — only user-declined errors become permission denials") {
+        let explicitDenial = NSError(
+            domain: SCStreamErrorDomain,
+            code: SCStreamError.Code.userDeclined.rawValue
+        )
+        let transientStartFailure = NSError(
+            domain: SCStreamErrorDomain,
+            code: SCStreamError.Code.failedToStart.rawValue
+        )
+        let unrelatedFailure = NSError(domain: NSCocoaErrorDomain, code: NSFileReadUnknownError)
+
+        assertEqual(
+            SystemAudioPermissionProbeClassifier.result(for: explicitDenial, stage: .startCapture),
+            .explicitlyDenied,
+            "the explicit ScreenCaptureKit user-declined code should clear a cached grant"
+        )
+        assertEqual(
+            SystemAudioPermissionProbeClassifier.result(for: transientStartFailure, stage: .startCapture),
+            .indeterminate(.startCapture),
+            "a ScreenCaptureKit transport/start failure should not impersonate TCC denial"
+        )
+        assertEqual(
+            SystemAudioPermissionProbeClassifier.result(for: unrelatedFailure, stage: .shareableContent),
+            .indeterminate(.shareableContent),
+            "unrelated service failures should remain indeterminate"
+        )
+        assertEqual(
+            SystemAudioPermissionProbeClassifier.resultAfterSuccessfulStart(),
+            .granted,
+            "a cleanup failure after startCapture succeeds must not downgrade a proven grant"
         )
     }
 

--- a/docs/capture-format.md
+++ b/docs/capture-format.md
@@ -103,6 +103,7 @@ Recording-health keys (optional, only when health info exists):
 | `gap_events` | — | **Nested** list of quoted strings; invisible to flat parsers. Omitted when empty. |
 | `audio_health` | `mic_attenuated_by_call_app` | Flat; omitted for healthy meetings. |
 | `mic_boost_prompt` | `"declined"` | Flat; only alongside `audio_health`. |
+| `microphone_audio_unusable` | `true` | Flat; microphone audio was missing or unusable and excluded from a system-audio-only partial transcript. |
 
 Speaker metadata (optional, **nested** `speakers:` block — flat parsers skip
 it; CaptureKit and the app re-read the raw lines):


### PR DESCRIPTION
## What this fixes

- Stops treating transient or timed-out ScreenCaptureKit permission probes as proof that System Audio Recording was denied.
- Preserves a previously verified grant across inconclusive probes, while still blocking a cancelled start and honoring a typed `userDeclined` result from the real capture attempt.
- Replaces false permission-blaming meeting popups with source-specific start failures and actionable retry copy.
- Saves a degraded system-audio-only transcript when the microphone track is missing, silent, corrupt, or fails mic STT/diarization after the system channel succeeds.
- Retains microphone and system audio independently, so one damaged source cannot discard the other source or make successful archive cleanup leak files.
- Makes failed-queue and recording-journal ownership work for system-only captures, late finalization, retries, cancellation, app quit, and superseded retained files.
- Defers mic speaker-database writes until all throwing/cancellable mic work has completed.

## Production evidence used

Aggregate, privacy-safe evidence only; no transcript text, audio, names, email addresses, paths, or device identifiers were retained.

- PostHog, trailing 30 days: 688 meeting starts and 126 reported start failures. 111 were `mic_unavailable` across 11 anonymous devices; 10 were system-stream failures across 6; 4 were unexpected across 3; 1 was permission-classified across 1.
- Public 1.1.52 had no observed start-failure events at query time, but four current transcript failures across two anonymous devices were `microphone_audio_unusable`; three involved Bluetooth plus Apple voice processing.
- Sentry current-release evidence included four microphone-unusable outcomes, plus noisy capture-degraded warnings and two speaker-finalization failures.
- Six support reporters covered the same families: false start/permission popups, meetings that never begin while dictation still works, silent Bluetooth/USB/WebRTC microphone tracks, and damaged recording artifacts.

## Review

Independent Codex review found and we fixed:

- cancellation continuing into capture because a cached permission grant existed;
- system-only failed-queue handoff leaving a live recording journal;
- a typed capture-time denial being softened by an earlier inconclusive probe;
- a partial successful archive leaving the copied scratch source behind;
- a retry archive leaving a superseded retained source behind.

Final independent review verdict: clean, with no accepted/actionable findings.

## Verification

- `bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test` — 1,000 executed, 13 skipped, 0 failures
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash scripts/ops/transcripted-qa-bench.sh --mode full`
  - PASS: 15 checks, 0 failures, 1 non-blocking local-artifact warning
  - signed app build, deterministic E2E, slow-pasteback smoke, integration, QA CLI, imported-audio artifact, synthetic audio reliability, release-health, and PostHog fixture gates all passed

QA report: `/tmp/transcripted-qa-bench/qa-20260807-123318/qa-report.md`

## Manual proof boundary

Real AirPods/Bluetooth hardware, Zoom/WebRTC route contention, and live macOS TCC behavior are still manual proof. Synthetic and CI coverage is green, but this PR does not claim those physical scenarios were exercised on this run.

## Release

After merge, cut 1.1.53 through the full signed/notarized GitHub + Sparkle + Homebrew release contract.
