### PR TITLE
Fix blank Settings window

### DIFF
--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -21,10 +21,37 @@ struct TranscriptedApp: App {
     }
 
     var body: some Scene {
-        Settings { EmptyView() }
-            .commands {
-                TranscriptedMenuCommands(appDelegate: appDelegate)
+        // The app owns a richer AppKit Settings window. Keep this scene as a
+        // harmless recovery surface for any system path that opens the SwiftUI
+        // Settings scene directly; the normal Settings command is replaced in
+        // TranscriptedMenuCommands and routes to the real window.
+        Settings {
+            TranscriptedSettingsFallbackView {
+                appDelegate.menuOpenSettings()
             }
+        }
+        .commands {
+            TranscriptedMenuCommands(appDelegate: appDelegate)
+        }
+    }
+}
+
+private struct TranscriptedSettingsFallbackView: View {
+    let openSettings: () -> Void
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Text("Transcripted Settings")
+                .font(.headline)
+            Text("Open the full Transcripted window to change settings.")
+                .foregroundStyle(.secondary)
+            Button("Open Settings", action: openSettings)
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("transcripted.settings.fallback.open")
+        }
+        .multilineTextAlignment(.center)
+        .padding(32)
+        .frame(width: 360, height: 180)
     }
 }
 
@@ -537,7 +564,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
         bindStatusItemUpdateBadge()
         bindStatusItemRecordingIndicator()
-        installSettingsMenuHandler()
 
         // Set up popover (pure AppKit — no NSHostingController, no AttributeGraph)
         let pop = NSPopover()
@@ -934,11 +960,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 "paste_available": "unknown",
             ]
         )
-    }
-
-    @objc private func openSettingsFromAppMenu(_ sender: Any?) {
-        closePopover()
-        showSettingsWindow(source: "app_menu")
     }
 
     private func configureStatusItemButton(_ button: NSStatusBarButton) {
@@ -1390,16 +1411,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
     }
 
-    private func installSettingsMenuHandler() {
-        guard let appMenu = NSApp.mainMenu?.item(withTitle: "Transcripted")?.submenu,
-              let settingsItem = appMenu.items.first(where: { $0.title.hasPrefix("Settings") }) else {
-            return
-        }
-
-        settingsItem.target = self
-        settingsItem.action = #selector(openSettingsFromAppMenu(_:))
-    }
-
     private func closePopover() {
         menuPanelController.prepareForClose()
         popover?.performClose(nil)
@@ -1737,6 +1748,11 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
     func menuOpenPage(_ page: TranscriptedSettingsPage) {
         showSettingsWindow(page: page, source: "menu_command")
+    }
+
+    func menuOpenSettings() {
+        closePopover()
+        showSettingsWindow(page: .general, source: "app_menu")
     }
 
     func menuFindSpeaker() {

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -37,6 +37,7 @@ struct TranscriptedApp: App {
 }
 
 private struct TranscriptedSettingsFallbackView: View {
+    @Environment(\.dismiss) private var dismiss
     let openSettings: () -> Void
 
     var body: some View {
@@ -45,9 +46,12 @@ private struct TranscriptedSettingsFallbackView: View {
                 .font(.headline)
             Text("Open the full Transcripted window to change settings.")
                 .foregroundStyle(.secondary)
-            Button("Open Settings", action: openSettings)
-                .keyboardShortcut(.defaultAction)
-                .accessibilityIdentifier("transcripted.settings.fallback.open")
+            Button("Open Settings") {
+                dismiss()
+                openSettings()
+            }
+            .keyboardShortcut(.defaultAction)
+            .accessibilityIdentifier("transcripted.settings.fallback.open")
         }
         .multilineTextAlignment(.center)
         .padding(32)

--- a/Sources/TranscriptedMenuCommands.swift
+++ b/Sources/TranscriptedMenuCommands.swift
@@ -15,6 +15,16 @@ struct TranscriptedMenuCommands: Commands {
     let appDelegate: TranscriptedAppDelegate
 
     var body: some Commands {
+        // Replace SwiftUI's native Settings action declaratively. A previous
+        // one-shot AppKit menu mutation could miss menu construction and leave
+        // the empty fallback scene on screen when the user pressed Command-,.
+        CommandGroup(replacing: .appSettings) {
+            Button("Settings…") {
+                appDelegate.menuOpenSettings()
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
+
         // Capture — the two recording actions plus file import.
         CommandMenu("Capture") {
             Button("Start Dictation") {

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -147,8 +147,10 @@ func testUIAutomationSurfaceContract() {
         )
         assertTrue(
             appSource.contains("TranscriptedSettingsFallbackView")
-                && appSource.contains("transcripted.settings.fallback.open"),
-            "direct SwiftUI Settings-scene opens should provide a visible recovery action instead of a blank window"
+                && appSource.contains("transcripted.settings.fallback.open")
+                && appSource.contains("@Environment(\\.dismiss)")
+                && appSource.contains("dismiss()"),
+            "direct SwiftUI Settings-scene opens should provide a visible recovery action and close before opening the owned window"
         )
         assertFalse(
             appSource.contains("Settings { EmptyView() }")

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -126,6 +126,38 @@ func testUIAutomationSurfaceContract() {
         }
     }
 
+    runSuite("UI automation surface contract - native Settings routes to the real window") {
+        for requiredCommandHook in [
+            "CommandGroup(replacing: .appSettings)",
+            "Button(\"Settings…\")",
+            "appDelegate.menuOpenSettings()",
+            ".keyboardShortcut(\",\", modifiers: .command)",
+        ] {
+            assertTrue(
+                contractSource("Sources/TranscriptedMenuCommands.swift").contains(requiredCommandHook),
+                "\(requiredCommandHook) should keep Settings… and Command-, routed through the real Transcripted window"
+            )
+        }
+
+        let appSource = contractSource("Sources/TranscriptedApp.swift")
+        assertTrue(
+            appSource.contains("func menuOpenSettings()")
+                && appSource.contains("showSettingsWindow(page: .general, source: \"app_menu\")"),
+            "the declarative app Settings command should open the owned General settings page"
+        )
+        assertTrue(
+            appSource.contains("TranscriptedSettingsFallbackView")
+                && appSource.contains("transcripted.settings.fallback.open"),
+            "direct SwiftUI Settings-scene opens should provide a visible recovery action instead of a blank window"
+        )
+        assertFalse(
+            appSource.contains("Settings { EmptyView() }")
+                || appSource.contains("installSettingsMenuHandler()")
+                || appSource.contains("openSettingsFromAppMenu"),
+            "Settings must not depend on a blank scene plus a one-shot AppKit menu mutation"
+        )
+    }
+
     runSuite("UI automation surface contract - app commands expose primary Go shortcuts") {
         for requiredCommandHook in [
             "CommandMenu(\"Go\")",


### PR DESCRIPTION
## Why

Command-, and Transcripted → Settings… could open a completely blank native Settings window. The app declared an empty SwiftUI Settings scene, then tried to retarget the menu item once during launch. If that timing-sensitive lookup missed, macOS displayed the empty scene.

## What changed

- replace the native app Settings command declaratively with the existing Transcripted Settings window
- open the populated General page from both Command-, and the app menu
- replace the empty SwiftUI scene with a small recovery surface for unexpected direct scene opens
- close that fallback scene before opening the owned AppKit window, avoiding duplicate Settings windows
- add a regression contract that rejects the empty-scene / one-shot-menu-mutation design

## Verification

- `bash scripts/dev/agent-preflight.sh`
- `bash build.sh --no-open` — signed build, launch smoke, and performance budget passed
- `bash run-tests.sh` — 12,139/12,139 passed on the final diff
- focused UI automation contract — 249/249 passed on the final diff
- isolated clean-build AX proof:
  - Command-, opened `transcripted.settings.page.general`
  - Transcripted → Settings… opened `transcripted.settings.page.general`
  - populated controls and all three settings tabs were present
- `git diff --check`

## Independent review

Verdict: clean after one accepted P2 finding.

- Accepted: the fallback recovery button could leave its SwiftUI window open behind the real AppKit Settings window.
- Fixed in `9e1e6c1e` by dismissing the fallback window before opening the owned window, with regression coverage.
- No other blockers and no rejected findings.
- The direct automated `codex review --base origin/main` entered a recursive review/build loop and was stopped safely; an independent agent completed the full manual diff review against the real base.
- Non-blocking coverage note: a dedicated runtime Command-, smoke would be stronger than source-string coverage. This PR also has isolated live AX proof for both entry points.

No transcript, audio, analytics, permissions, capture, or storage behavior changed.