### PR TITLE
Improve meeting transcript review

### DIFF
--- a/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
+++ b/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
@@ -1,14 +1,30 @@
 import Foundation
 
+enum HomeMeetingSpeakerChannel: String, Equatable, Hashable, Sendable {
+    case mic
+    case system
+}
+
+struct HomeMeetingSpeakerIdentity: Equatable, Hashable, Sendable {
+    let displayName: String
+    /// Exact label inside the transcript's brackets, including source and any
+    /// Obsidian link syntax. This lets legacy transcript-scoped edits stay exact.
+    let rawLabel: String
+    let channel: HomeMeetingSpeakerChannel?
+    let diarizerSpeakerID: String?
+    let persistentSpeakerID: UUID?
+}
+
 struct HomeMeetingPreviewContent {
     let fallbackText: String
     let transcriptLines: [HomeMeetingTranscriptLine]
 
     static func make(from markdown: String) -> HomeMeetingPreviewContent {
         let readableLines = readableMarkdownLines(from: markdown)
+        let speakers = frontmatterSpeakers(from: markdown)
         return HomeMeetingPreviewContent(
             fallbackText: readableLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines),
-            transcriptLines: parseTranscriptLines(readableLines)
+            transcriptLines: parseTranscriptLines(readableLines, speakers: speakers)
         )
     }
 
@@ -33,7 +49,10 @@ struct HomeMeetingPreviewContent {
         }
     }
 
-    private static func parseTranscriptLines(_ lines: [String]) -> [HomeMeetingTranscriptLine] {
+    private static func parseTranscriptLines(
+        _ lines: [String],
+        speakers: [FrontmatterSpeaker]
+    ) -> [HomeMeetingTranscriptLine] {
         var parsed: [HomeMeetingTranscriptLine] = []
         var pending: PendingTranscriptLine?
 
@@ -45,7 +64,8 @@ struct HomeMeetingPreviewContent {
             if !text.isEmpty {
                 parsed.append(HomeMeetingTranscriptLine(
                     time: current.time,
-                    speaker: current.speaker,
+                    startTimeSeconds: timestampSeconds(current.time),
+                    identity: current.identity,
                     text: text
                 ))
             }
@@ -60,7 +80,7 @@ struct HomeMeetingPreviewContent {
                 flushPending()
                 pending = PendingTranscriptLine(
                     time: marker.time,
-                    speaker: marker.speaker,
+                    identity: speakerIdentity(for: marker.rawSpeakerLabel, speakers: speakers),
                     textParts: marker.remainder.isEmpty ? [] : [marker.remainder]
                 )
                 continue
@@ -109,16 +129,83 @@ struct HomeMeetingPreviewContent {
     }
 
     private static func parseSpeakerAndText(time: String, remainder: String) -> TranscriptMarker {
-        var speaker = "Speaker"
+        var rawSpeakerLabel = "Speaker"
         var text = remainder
 
         if text.hasPrefix("["),
-           let speakerEnd = text.firstIndex(of: "]") {
-            speaker = cleanSpeaker(String(text[text.index(after: text.startIndex)..<speakerEnd]))
+           let speakerEnd = matchingClosingBracket(in: text) {
+            rawSpeakerLabel = String(text[text.index(after: text.startIndex)..<speakerEnd])
             text = text[text.index(after: speakerEnd)...].trimmingCharacters(in: .whitespacesAndNewlines)
         }
 
-        return TranscriptMarker(time: time, speaker: speaker, remainder: text)
+        return TranscriptMarker(time: time, rawSpeakerLabel: rawSpeakerLabel, remainder: text)
+    }
+
+    /// Finds the outer closing bracket, so `[System/[[Alex]]]` does not stop
+    /// at the first bracket in the nested Obsidian link.
+    private static func matchingClosingBracket(in value: String) -> String.Index? {
+        var depth = 0
+        for index in value.indices {
+            switch value[index] {
+            case "[":
+                depth += 1
+            case "]":
+                depth -= 1
+                if depth == 0 { return index }
+            default:
+                break
+            }
+        }
+        return nil
+    }
+
+    private static func speakerIdentity(
+        for rawLabel: String,
+        speakers: [FrontmatterSpeaker]
+    ) -> HomeMeetingSpeakerIdentity {
+        let trimmedRawLabel = rawLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let split = trimmedRawLabel.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+
+        let channel: HomeMeetingSpeakerChannel?
+        let sourceName: String
+        if split.count == 2,
+           let parsedChannel = sourceChannel(String(split[0])) {
+            channel = parsedChannel
+            sourceName = cleanSpeaker(String(split[1]))
+        } else {
+            channel = nil
+            sourceName = cleanSpeaker(trimmedRawLabel)
+        }
+
+        let displayName = sourceName.isEmpty ? "Speaker" : sourceName
+        let candidates = speakers.filter { speaker in
+            speaker.name == displayName && (channel == nil || speaker.channel == channel)
+        }
+        let matchedSpeaker: FrontmatterSpeaker?
+        if candidates.count == 1 {
+            matchedSpeaker = candidates[0]
+        } else if let genericID = genericSpeakerID(from: displayName) {
+            let matchingIDs = candidates.filter { $0.id == genericID }
+            matchedSpeaker = matchingIDs.count == 1 ? matchingIDs[0] : nil
+        } else {
+            matchedSpeaker = nil
+        }
+
+        return HomeMeetingSpeakerIdentity(
+            displayName: displayName,
+            rawLabel: trimmedRawLabel,
+            channel: channel,
+            diarizerSpeakerID: matchedSpeaker?.id,
+            persistentSpeakerID: matchedSpeaker?.dbID
+        )
+    }
+
+    private static func sourceChannel(_ value: String) -> HomeMeetingSpeakerChannel? {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "mic": return .mic
+        case "system": return .system
+        default: return nil
+        }
     }
 
     private static func cleanSpeaker(_ raw: String) -> String {
@@ -128,31 +215,184 @@ struct HomeMeetingPreviewContent {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private static func genericSpeakerID(from name: String) -> String? {
+        let prefix = "Speaker "
+        guard name.hasPrefix(prefix) else { return nil }
+        let suffix = String(name.dropFirst(prefix.count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return suffix.isEmpty ? nil : suffix
+    }
+
     private static func looksLikeTimestamp(_ value: String) -> Bool {
         let parts = value.split(separator: ":")
         guard parts.count == 2 || parts.count == 3 else { return false }
         return parts.allSatisfy { !$0.isEmpty && $0.allSatisfy(\.isNumber) }
     }
 
+    private static func timestampSeconds(_ value: String) -> TimeInterval? {
+        let parts = value.split(separator: ":").compactMap { TimeInterval($0) }
+        guard parts.count == 2 || parts.count == 3 else { return nil }
+        if parts.count == 3 {
+            return (parts[0] * 3_600) + (parts[1] * 60) + parts[2]
+        }
+        return (parts[0] * 60) + parts[1]
+    }
+
     private static func isSectionNoise(_ line: String) -> Bool {
         line.hasPrefix("#") || line.hasPrefix("Recorded ")
+    }
+
+    private struct FrontmatterSpeaker {
+        let id: String
+        let channel: HomeMeetingSpeakerChannel
+        let dbID: UUID?
+        let name: String
+    }
+
+    private static func frontmatterSpeakers(from markdown: String) -> [FrontmatterSpeaker] {
+        let lines = markdown.components(separatedBy: .newlines)
+        guard lines.first?.trimmingCharacters(in: .whitespacesAndNewlines) == "---" else { return [] }
+
+        var speakers: [FrontmatterSpeaker] = []
+        var inSpeakersBlock = false
+        var current: [String: String]?
+
+        func finishCurrent() {
+            guard let current,
+                  let id = current["id"],
+                  let name = current["name"] else { return }
+            let channel = current["channel"]
+                .flatMap(sourceChannel) ?? .system
+            speakers.append(FrontmatterSpeaker(
+                id: id,
+                channel: channel,
+                dbID: current["db_id"].flatMap(UUID.init(uuidString:)),
+                name: cleanSpeaker(name)
+            ))
+        }
+
+        for line in lines.dropFirst() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" {
+                finishCurrent()
+                break
+            }
+            if trimmed == "speakers:" {
+                inSpeakersBlock = true
+                continue
+            }
+            guard inSpeakersBlock else { continue }
+
+            if !line.hasPrefix("  "), !trimmed.isEmpty {
+                finishCurrent()
+                break
+            }
+            if trimmed.hasPrefix("- ") {
+                finishCurrent()
+                current = [:]
+                writeKeyValue(String(trimmed.dropFirst(2)), into: &current)
+            } else if current != nil {
+                writeKeyValue(trimmed, into: &current)
+            }
+        }
+
+        return speakers
+    }
+
+    private static func writeKeyValue(_ line: String, into current: inout [String: String]?) {
+        let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { return }
+        let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = parts[1]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            .replacingOccurrences(of: "\\\"", with: "\"")
+            .replacingOccurrences(of: "\\\\", with: "\\")
+        current?[key] = value
     }
 }
 
 struct HomeMeetingTranscriptLine: Equatable {
     let time: String
-    let speaker: String
+    let startTimeSeconds: TimeInterval?
+    let identity: HomeMeetingSpeakerIdentity
     let text: String
+
+    var speaker: String { identity.displayName }
+}
+
+enum HomeMeetingTranscriptPlaybackSource: Equatable {
+    case all
+    case mic
+    case system
+}
+
+enum HomeMeetingTranscriptPlaybackPolicy {
+    static func source(forPlaybackChoiceID choiceID: String?) -> HomeMeetingTranscriptPlaybackSource {
+        guard let stem = choiceID?.split(separator: ":", maxSplits: 1).first else { return .all }
+        switch stem {
+        case "microphone": return .mic
+        case "system_audio": return .system
+        default: return .all
+        }
+    }
+
+    static func activeLineIndices(
+        lines: [HomeMeetingTranscriptLine],
+        currentTime: TimeInterval,
+        source: HomeMeetingTranscriptPlaybackSource
+    ) -> Set<Int> {
+        let eligible = lines.enumerated().compactMap { index, line -> (Int, TimeInterval)? in
+            guard let start = line.startTimeSeconds,
+                  start <= currentTime,
+                  sourceMatches(line.identity.channel, source: source) else { return nil }
+            return (index, start)
+        }
+        guard let activeTime = eligible.map(\.1).max() else { return [] }
+        return Set(eligible.filter { $0.1 == activeTime }.map(\.0))
+    }
+
+    static func visibleLineIndices(
+        totalCount: Int,
+        activeIndices: Set<Int>,
+        limit: Int
+    ) -> [Int] {
+        guard totalCount > 0, limit > 0 else { return [] }
+        guard totalCount > limit else { return Array(0..<totalCount) }
+        guard let firstActive = activeIndices.min() else { return Array(0..<limit) }
+
+        let lastActive = activeIndices.max() ?? firstActive
+        var start = max(0, firstActive - (limit / 2))
+        start = min(start, totalCount - limit)
+        if lastActive >= start + limit {
+            start = min(lastActive - limit + 1, totalCount - limit)
+        }
+        return Array(start..<(start + limit))
+    }
+
+    private static func sourceMatches(
+        _ channel: HomeMeetingSpeakerChannel?,
+        source: HomeMeetingTranscriptPlaybackSource
+    ) -> Bool {
+        switch source {
+        case .all:
+            return true
+        case .mic:
+            return channel == .mic || channel == nil
+        case .system:
+            return channel == .system || channel == nil
+        }
+    }
 }
 
 private struct PendingTranscriptLine {
     let time: String
-    let speaker: String
+    let identity: HomeMeetingSpeakerIdentity
     var textParts: [String]
 }
 
 private struct TranscriptMarker {
     let time: String
-    let speaker: String
+    let rawSpeakerLabel: String
     let remainder: String
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -367,6 +367,7 @@ struct HomeMeetingPreview: Identifiable {
     let transcriptURL: URL
     let audio: MeetingAudioAttachment?
     let markdown: String
+    let content: HomeMeetingPreviewContent
     let readError: String?
     let feedbackTarget: HomeFeedbackTarget
 
@@ -381,6 +382,7 @@ struct HomeMeetingPreview: Identifiable {
         transcriptURL = item.transcriptURL
         audio = item.audio
         self.markdown = markdown
+        content = HomeMeetingPreviewContent.make(from: markdown)
         self.readError = readError
         feedbackTarget = HomeFeedbackTarget.meeting(item)
     }
@@ -392,6 +394,7 @@ struct HomeMeetingPreview: Identifiable {
         transcriptURL: URL,
         audio: MeetingAudioAttachment?,
         markdown: String,
+        content: HomeMeetingPreviewContent,
         readError: String?,
         feedbackTarget: HomeFeedbackTarget
     ) {
@@ -401,6 +404,7 @@ struct HomeMeetingPreview: Identifiable {
         self.transcriptURL = transcriptURL
         self.audio = audio
         self.markdown = markdown
+        self.content = content
         self.readError = readError
         self.feedbackTarget = feedbackTarget
     }
@@ -419,6 +423,22 @@ struct HomeMeetingPreview: Identifiable {
             transcriptURL: transcriptURL,
             audio: audio,
             markdown: markdown,
+            content: content,
+            readError: readError,
+            feedbackTarget: feedbackTarget
+        )
+    }
+
+    /// Returns a copy with freshly-read transcript text after an inline speaker edit.
+    func updatingMarkdown(_ markdown: String, readError: String? = nil) -> HomeMeetingPreview {
+        HomeMeetingPreview(
+            id: id,
+            title: title,
+            date: date,
+            transcriptURL: transcriptURL,
+            audio: audio,
+            markdown: markdown,
+            content: HomeMeetingPreviewContent.make(from: markdown),
             readError: readError,
             feedbackTarget: feedbackTarget
         )

--- a/Sources/UI/Settings/QuietHomeLibrary.swift
+++ b/Sources/UI/Settings/QuietHomeLibrary.swift
@@ -238,8 +238,10 @@ struct QuietMeetingExpansion: View {
     /// the caller should treat an empty or unchanged value as a no-op (this
     /// view already skips the call in both of those cases).
     let onRename: (String) -> Void
+    let onRenameSpeaker: (HomeMeetingSpeakerIdentity, String) -> Void
     let menuItems: [HomeRowMenuItem]
 
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
     @State private var showsFullTranscript = false
     @State private var isEditingTitle = false
     @State private var editedTitle = ""
@@ -337,7 +339,7 @@ struct QuietMeetingExpansion: View {
                     .font(LibraryTokens.body)
                     .foregroundStyle(LibraryTokens.attention)
             } else {
-                transcript(for: HomeMeetingPreviewContent.make(from: preview.markdown))
+                transcript(for: preview.content)
             }
         } else {
             HStack(spacing: 8) {
@@ -366,11 +368,19 @@ struct QuietMeetingExpansion: View {
                     .lineLimit(showsFullTranscript ? nil : 12)
                     .textSelection(.enabled)
             } else {
-                let lines = showsFullTranscript
-                    ? content.transcriptLines
-                    : Array(content.transcriptLines.prefix(Self.visibleLineLimit))
-                ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
-                    transcriptLine(line)
+                let activeIndices = activeTranscriptLineIndices(in: content)
+                let visibleIndices = showsFullTranscript
+                    ? Array(content.transcriptLines.indices)
+                    : HomeMeetingTranscriptPlaybackPolicy.visibleLineIndices(
+                        totalCount: content.transcriptLines.count,
+                        activeIndices: activeIndices,
+                        limit: Self.visibleLineLimit
+                    )
+                ForEach(visibleIndices, id: \.self) { index in
+                    transcriptLine(
+                        content.transcriptLines[index],
+                        isActive: activeIndices.contains(index)
+                    )
                 }
                 if content.transcriptLines.count > Self.visibleLineLimit {
                     Button(showsFullTranscript
@@ -392,7 +402,10 @@ struct QuietMeetingExpansion: View {
         }
     }
 
-    private func transcriptLine(_ line: HomeMeetingTranscriptLine) -> some View {
+    private func transcriptLine(
+        _ line: HomeMeetingTranscriptLine,
+        isActive: Bool
+    ) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 12) {
             if !line.time.isEmpty {
                 Text(line.time)
@@ -401,17 +414,45 @@ struct QuietMeetingExpansion: View {
                     .frame(width: 52, alignment: .leading)
             }
             if !line.speaker.isEmpty {
-                Text(line.speaker)
-                    .font(.system(size: 12.5, weight: .semibold))
-                    .foregroundStyle(line.speaker == "You" ? LibraryTokens.accent : LibraryTokens.ink2)
-                    .frame(width: 72, alignment: .leading)
-                    .lineLimit(1)
+                QuietMeetingSpeakerLabel(
+                    identity: line.identity,
+                    onRename: onRenameSpeaker
+                )
             }
             Text(line.text)
                 .font(.system(size: 12.5))
                 .foregroundStyle(.primary.opacity(0.9))
                 .textSelection(.enabled)
         }
+        .padding(.horizontal, 7)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(isActive ? LibraryTokens.accent.opacity(0.10) : Color.clear)
+        )
+        .overlay(alignment: .leading) {
+            if isActive {
+                Capsule()
+                    .fill(LibraryTokens.accent)
+                    .frame(width: 3)
+                    .padding(.vertical, 5)
+            }
+        }
+        .animation(.easeOut(duration: 0.12), value: isActive)
+    }
+
+    private func activeTranscriptLineIndices(
+        in content: HomeMeetingPreviewContent
+    ) -> Set<Int> {
+        guard let audio = item.audio, playback.isActive(audio) else { return [] }
+        let source = HomeMeetingTranscriptPlaybackPolicy.source(
+            forPlaybackChoiceID: playback.activeChoice(for: audio)?.id
+        )
+        return HomeMeetingTranscriptPlaybackPolicy.activeLineIndices(
+            lines: content.transcriptLines,
+            currentTime: playback.currentTime,
+            source: source
+        )
     }
 
     private func quietAction(title: String, symbol: String, tint: Color, action: @escaping () -> Void) -> some View {
@@ -487,6 +528,79 @@ struct QuietMeetingExpansion: View {
         formatter.timeStyle = .short
         return formatter
     }()
+}
+
+/// Prominent, editable speaker name used by every transcript line. Double-click
+/// is the fast path; the context menu and accessibility action expose the same
+/// rename behavior without requiring a gesture.
+private struct QuietMeetingSpeakerLabel: View {
+    let identity: HomeMeetingSpeakerIdentity
+    let onRename: (HomeMeetingSpeakerIdentity, String) -> Void
+
+    @State private var isEditing = false
+    @State private var editedName = ""
+    @FocusState private var fieldIsFocused: Bool
+
+    private var canRename: Bool {
+        !identity.displayName.isEmpty && identity.rawLabel != "Speaker"
+    }
+
+    var body: some View {
+        Group {
+            if isEditing {
+                TextField("Speaker name", text: $editedName)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 13, weight: .semibold))
+                    .focused($fieldIsFocused)
+                    .onSubmit { commit() }
+                    .onExitCommand { cancel() }
+                    .onAppear { fieldIsFocused = true }
+                    .onChange(of: fieldIsFocused) { _, focused in
+                        if !focused && isEditing { commit() }
+                    }
+                    .accessibilityIdentifier("transcripted.home.expansion.speaker.field")
+            } else {
+                Text(identity.displayName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(speakerColor)
+                    .lineLimit(1)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) { beginEditing() }
+                    .contextMenu {
+                        if canRename {
+                            Button("Rename Speaker…") { beginEditing() }
+                        }
+                    }
+                    .accessibilityAction(named: "Rename speaker") { beginEditing() }
+                    .help(canRename ? "Double-click to rename \(identity.displayName)" : "")
+                    .accessibilityIdentifier("transcripted.home.expansion.speaker")
+            }
+        }
+        .frame(width: 116, alignment: .leading)
+    }
+
+    private var speakerColor: Color {
+        if identity.displayName == "You" { return LibraryTokens.accent }
+        return HomeMeetingSpeakerColor.color(for: identity.displayName)
+    }
+
+    private func beginEditing() {
+        guard canRename else { return }
+        editedName = identity.displayName
+        isEditing = true
+    }
+
+    private func commit() {
+        isEditing = false
+        let trimmed = editedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != identity.displayName else { return }
+        onRename(identity, trimmed)
+    }
+
+    private func cancel() {
+        isEditing = false
+        editedName = identity.displayName
+    }
 }
 
 // MARK: - Background tap catcher

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -98,7 +98,9 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
         window.contentView = contentView
         window.isReleasedWhenClosed = false
         window.level = .modalPanel
-        window.sharingType = .none
+        // A normal titled review window should behave like other Mac app
+        // windows in screenshots and screen sharing.
+        window.sharingType = .readOnly
 
         super.init(window: window)
         window.delegate = self

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -368,15 +368,23 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         }
     }
 
-    func rename(profile: SpeakerProfile, to newName: String) {
+    func rename(
+        profile: SpeakerProfile,
+        to newName: String,
+        completion: ((Bool) -> Void)? = nil
+    ) {
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !trimmed.isEmpty else {
+            completion?(false)
+            return
+        }
 
         let profileId = profile.id
         let speakerDatabase = self.speakerDatabase
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            var didRename = false
             // Routed through the canonical mutation service (audit 2026-08-04): this used
             // to write the DB first and best-effort-scan transcripts second with no
             // rollback, so a transcript write failure left the DB and saved transcripts
@@ -388,6 +396,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
                     .rename(profileId: profileId, newName: trimmed),
                     speakerDB: speakerDatabase
                 )
+                didRename = outcome.succeeded
                 if !outcome.succeeded {
                     AppLogger.speakers.error("Manual speaker rename failed", ["profileId": profileId.uuidString])
                 }
@@ -401,6 +410,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             )
             DispatchQueue.main.async {
                 self?.applySnapshot(snapshot)
+                completion?(didRename)
             }
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -703,6 +703,11 @@ struct TranscriptedSettingsView: View {
                             : nil) ?? HomeMeetingPreview(item: meeting, markdown: "")
                         renameMeetingPreview(preview, to: newTitle)
                     },
+                    onRenameSpeaker: { identity, newName in
+                        guard let preview = homeExpandedMeetingPreview,
+                              preview.id == meeting.id else { return }
+                        renameMeetingSpeaker(identity, in: preview, to: newName)
+                    },
                     menuItems: meetingRowMenuItems(for: meeting)
                 )
             } else {
@@ -1353,6 +1358,91 @@ struct TranscriptedSettingsView: View {
                         renameMeetingPreview(preview, to: rawTitle)
                     }
                 )
+            }
+        }
+    }
+
+    private func renameMeetingSpeaker(
+        _ identity: HomeMeetingSpeakerIdentity,
+        in preview: HomeMeetingPreview,
+        to rawName: String
+    ) {
+        trackSettingsAction("rename_meeting_speaker", page: .home)
+
+        if let persistentSpeakerID = identity.persistentSpeakerID {
+            guard let profile = speakerPeopleModel.profiles.first(where: { $0.id == persistentSpeakerID }) else {
+                speakerPeopleModel.refresh()
+                presentHomeActionFailure(
+                    title: "Could not rename speaker",
+                    message: "Transcripted couldn't find that saved speaker identity. Refresh the meeting and try again.",
+                    retry: {
+                        renameMeetingSpeaker(identity, in: preview, to: rawName)
+                    }
+                )
+                return
+            }
+
+            // Saved identities use the canonical transactional rename path so
+            // the people database and every linked transcript stay aligned.
+            speakerPeopleModel.rename(profile: profile, to: rawName) { didRename in
+                if didRename {
+                    reloadExpandedMeetingPreview(preview)
+                    refreshRecentCaptures(force: true)
+                } else {
+                    presentHomeActionFailure(
+                        title: "Could not rename speaker",
+                        message: "Transcripted couldn't update this saved speaker and its linked transcripts.",
+                        retry: {
+                            renameMeetingSpeaker(identity, in: preview, to: rawName)
+                        }
+                    )
+                }
+            }
+            return
+        }
+
+        // Older transcripts can lack a persistent speaker id. Keep that edit
+        // scoped to this file and exact source label, avoiding Mic/System bleed.
+        let transcriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [preview.transcriptURL])
+            ?? preview.transcriptURL
+        Task { @MainActor in
+            do {
+                _ = try await Task.detached(priority: .userInitiated) {
+                    try HomeMeetingSpeakerRename.rename(
+                        transcriptAt: transcriptURL,
+                        identity: identity,
+                        to: rawName
+                    )
+                }.value
+                reloadExpandedMeetingPreview(preview)
+                refreshRecentCaptures(force: true)
+            } catch {
+                presentHomeActionFailure(
+                    title: "Could not rename speaker",
+                    message: "Transcripted couldn't update this speaker in the saved transcript.",
+                    details: error.localizedDescription,
+                    retry: {
+                        renameMeetingSpeaker(identity, in: preview, to: rawName)
+                    }
+                )
+            }
+        }
+    }
+
+    private func reloadExpandedMeetingPreview(_ preview: HomeMeetingPreview) {
+        // A rename can finish after the user has collapsed this meeting or
+        // opened another one. Do not cancel that newer preview's load task.
+        guard homeExpandedMeetingPreview?.id == preview.id else { return }
+        homeMeetingPreviewLoadTask?.cancel()
+        homeMeetingPreviewLoadTask = Task { @MainActor in
+            let readResult = await Self.readMeetingMarkdown(at: preview.transcriptURL)
+            guard !Task.isCancelled,
+                  homeExpandedMeetingPreview?.id == preview.id else { return }
+            switch readResult {
+            case .success(let markdown):
+                homeExpandedMeetingPreview = preview.updatingMarkdown(markdown)
+            case .failure(let message):
+                homeExpandedMeetingPreview = preview.updatingMarkdown("", readError: message)
             }
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -45,9 +45,9 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
         window.contentViewController = hostingController
         window.contentMinSize = NSSize(width: 880, height: 640)
         window.isReleasedWhenClosed = false
-        // The reusable Settings shell can surface recent captures, speaker
-        // review, and storage diagnostics, so keep the whole window protected.
-        window.sharingType = .none
+        // This is a normal user-facing app window. Keep it available to the
+        // standard macOS window screenshot and screen-sharing tools.
+        window.sharingType = .readOnly
         window.center()
 
         super.init(window: window)

--- a/Sources/UI/Shared/HomeMeetingRename.swift
+++ b/Sources/UI/Shared/HomeMeetingRename.swift
@@ -8,6 +8,202 @@ struct HomeMeetingRenameResult: Equatable {
     let title: String
 }
 
+enum HomeMeetingSpeakerRenameError: Error, Equatable, LocalizedError {
+    case emptyName
+    case speakerNotFound
+    case readFailed
+    case writeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName:
+            return "Enter a speaker name."
+        case .speakerNotFound:
+            return "That speaker label changed before the rename could be saved."
+        case .readFailed:
+            return "The meeting transcript could not be read."
+        case .writeFailed:
+            return "The meeting transcript could not be updated."
+        }
+    }
+}
+
+/// Transcript-scoped fallback for older meetings that do not have a saved
+/// speaker profile. Identified speakers use `SpeakerIdentityMutationService`
+/// through the Settings view model instead, so the database and every linked
+/// transcript stay in sync.
+enum HomeMeetingSpeakerRename {
+    @discardableResult
+    static func rename(
+        transcriptAt url: URL,
+        identity: HomeMeetingSpeakerIdentity,
+        to rawName: String,
+        fileManager: FileManager = .default
+    ) throws -> String {
+        try MeetingTranscriptFileUpdateSerializer.sync {
+            guard let name = normalizedName(rawName) else {
+                throw HomeMeetingSpeakerRenameError.emptyName
+            }
+
+            let raw: String
+            do {
+                raw = try String(contentsOf: url, encoding: .utf8)
+            } catch {
+                throw HomeMeetingSpeakerRenameError.readFailed
+            }
+
+            var lines = raw.components(separatedBy: "\n")
+            let metadataChanged = rewriteFrontmatterSpeaker(
+                in: &lines,
+                identity: identity,
+                newName: name
+            )
+
+            var rewritten = lines.joined(separator: "\n")
+            let oldToken = "[\(identity.rawLabel)]"
+            let newToken = "[\(replacementRawLabel(for: identity, newName: name))]"
+            let bodyChanged = rewritten.contains(oldToken)
+            if bodyChanged {
+                rewritten = rewritten.replacingOccurrences(of: oldToken, with: newToken)
+            }
+
+            guard metadataChanged || bodyChanged else {
+                throw HomeMeetingSpeakerRenameError.speakerNotFound
+            }
+
+            do {
+                try rewritten.write(to: url, atomically: true, encoding: .utf8)
+                fileManager.restrictFileToOwnerOnly(at: url)
+            } catch {
+                throw HomeMeetingSpeakerRenameError.writeFailed
+            }
+            return name
+        }
+    }
+
+    private static func normalizedName(_ raw: String) -> String? {
+        let normalized = raw
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func replacementRawLabel(
+        for identity: HomeMeetingSpeakerIdentity,
+        newName: String
+    ) -> String {
+        guard let slash = identity.rawLabel.firstIndex(of: "/") else {
+            let linked = identity.rawLabel.hasPrefix("[[") && identity.rawLabel.hasSuffix("]]")
+            return linked ? "[[\(newName)]]" : newName
+        }
+
+        let prefix = identity.rawLabel[...slash]
+        let oldName = identity.rawLabel[identity.rawLabel.index(after: slash)...]
+        let linked = oldName.hasPrefix("[[") && oldName.hasSuffix("]]")
+        return "\(prefix)\(linked ? "[[\(newName)]]" : newName)"
+    }
+
+    /// Updates a single matching `speakers:` row when legacy metadata exists.
+    /// Body labels are still the source of truth for older files, so failure to
+    /// find a metadata row does not block an otherwise exact label rewrite.
+    private static func rewriteFrontmatterSpeaker(
+        in lines: inout [String],
+        identity: HomeMeetingSpeakerIdentity,
+        newName: String
+    ) -> Bool {
+        guard let diarizerID = identity.diarizerSpeakerID else { return false }
+
+        var inFrontmatter = false
+        var inSpeakers = false
+        var entryStarts: [Int] = []
+        for index in lines.indices {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" {
+                if !inFrontmatter {
+                    inFrontmatter = true
+                } else {
+                    break
+                }
+                continue
+            }
+            guard inFrontmatter else { continue }
+            if trimmed == "speakers:" {
+                inSpeakers = true
+                continue
+            }
+            guard inSpeakers else { continue }
+            if !lines[index].hasPrefix("  "), !trimmed.isEmpty {
+                break
+            }
+            if trimmed.hasPrefix("- ") {
+                entryStarts.append(index)
+            }
+        }
+
+        var matches: [(nameIndex: Int, sourceIndex: Int?)] = []
+        for (offset, start) in entryStarts.enumerated() {
+            let end = offset + 1 < entryStarts.count ? entryStarts[offset + 1] : frontmatterEntryEnd(after: start, in: lines)
+            var values: [String: String] = [:]
+            var nameIndex: Int?
+            var sourceIndex: Int?
+
+            for index in start..<end {
+                let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+                let keyValue = trimmed.hasPrefix("- ") ? String(trimmed.dropFirst(2)) : trimmed
+                let parts = keyValue.split(separator: ":", maxSplits: 1).map(String.init)
+                guard parts.count == 2 else { continue }
+                let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+                let value = normalizeFrontmatterValue(parts[1])
+                values[key] = value
+                if key == "name" { nameIndex = index }
+                if key == "source" { sourceIndex = index }
+            }
+
+            let rowChannel = HomeMeetingSpeakerChannel(rawValue: values["channel"] ?? "system")
+            let persistentID = values["db_id"].flatMap(UUID.init(uuidString:))
+            guard values["id"] == diarizerID,
+                  identity.channel == nil || rowChannel == identity.channel,
+                  identity.persistentSpeakerID == nil || persistentID == identity.persistentSpeakerID,
+                  let nameIndex else { continue }
+            matches.append((nameIndex, sourceIndex))
+        }
+
+        guard matches.count == 1, let match = matches.first else { return false }
+        let nameIndent = lines[match.nameIndex].prefix(while: { $0 == " " })
+        lines[match.nameIndex] = "\(nameIndent)name: \"\(escapeYAML(newName))\""
+        if let sourceIndex = match.sourceIndex {
+            let sourceIndent = lines[sourceIndex].prefix(while: { $0 == " " })
+            lines[sourceIndex] = "\(sourceIndent)source: user_manual"
+        }
+        return true
+    }
+
+    private static func frontmatterEntryEnd(after start: Int, in lines: [String]) -> Int {
+        guard start + 1 < lines.count else { return lines.count }
+        for index in (start + 1)..<lines.count {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" || (!lines[index].hasPrefix("  ") && !trimmed.isEmpty) {
+                return index
+            }
+        }
+        return lines.count
+    }
+
+    private static func normalizeFrontmatterValue(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+
+    private static func escapeYAML(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}
+
 enum HomeMeetingRenameError: Error, Equatable {
     /// The new title was empty after normalization — callers should treat this as a cancel.
     case emptyTitle

--- a/Tests/E2E/TranscriptedE2ESmoke.swift
+++ b/Tests/E2E/TranscriptedE2ESmoke.swift
@@ -337,7 +337,8 @@ private final class TranscriptedE2ESmokeHarness {
     private func verifyHomePreview(fixtures: SmokeFixtures) throws {
         let preview = HomeMeetingPreviewContent.make(from: fixtures.meetingMarkdown)
         try expect(preview.transcriptLines.count == 3, "Home preview should parse all meeting transcript rows")
-        try expect(preview.transcriptLines.first?.speaker == "Mic/You", "Home preview should keep source and speaker")
+        try expect(preview.transcriptLines.first?.speaker == "You", "Home preview should show the speaker name without the source prefix")
+        try expect(preview.transcriptLines.first?.identity.channel == .mic, "Home preview should retain the source channel internally")
         try expect(
             preview.transcriptLines.first?.text.contains("download verification") == true,
             "Home preview should include readable transcript text"

--- a/Tests/HomeMeetingPreviewFormatterTests.swift
+++ b/Tests/HomeMeetingPreviewFormatterTests.swift
@@ -6,7 +6,14 @@ func testHomeMeetingPreviewFormatter() {
 
         assertEqual(content.transcriptLines.count, 4, "Styled transcript blocks should become readable rows")
         assertEqual(content.transcriptLines.first?.time, "00:00", "First row should keep the timestamp")
-        assertEqual(content.transcriptLines.first?.speaker, "System/Speaker 1", "First row should keep the source/speaker label")
+        assertEqual(content.transcriptLines.first?.startTimeSeconds, 0, "Timestamp should be available for audio sync")
+        assertEqual(content.transcriptLines.first?.speaker, "Speaker 1", "Preview should show only the speaker name")
+        assertEqual(content.transcriptLines.first?.identity.channel, .system, "Source should stay available without appearing in the name")
+        assertEqual(
+            content.transcriptLines.first?.identity.persistentSpeakerID,
+            UUID(uuidString: "11111111-1111-1111-1111-111111111111"),
+            "Frontmatter identity should follow the visible transcript row"
+        )
         assertTrue(
             content.transcriptLines.first?.text.hasPrefix("touch screen. Yeah.") == true,
             "Text on the line after the timestamp should be attached to the row"
@@ -19,7 +26,55 @@ func testHomeMeetingPreviewFormatter() {
 
         assertEqual(content.transcriptLines.count, 2, "Legacy inline transcript rows should still preview cleanly")
         assertEqual(content.transcriptLines[0].text, "Hello there.", "Inline text should stay on the row")
-        assertEqual(content.transcriptLines[1].speaker, "System/Alex", "Obsidian speaker links should be cleaned for preview")
+        assertEqual(content.transcriptLines[0].speaker, "You", "Mic source prefixes should not appear in the speaker name")
+        assertEqual(content.transcriptLines[1].speaker, "Alex", "Obsidian speaker links should be cleaned for preview")
+        assertEqual(content.transcriptLines[1].text, "Nice to meet you.", "Nested speaker links should not leak closing brackets into text")
+    }
+
+    runSuite("HomeMeetingTranscriptPlaybackPolicy highlights the audible source and follows it") {
+        let lines = HomeMeetingPreviewContent.make(from: styledMeetingMarkdown()).transcriptLines
+
+        assertEqual(
+            HomeMeetingTranscriptPlaybackPolicy.activeLineIndices(
+                lines: lines,
+                currentTime: 0,
+                source: .all
+            ),
+            Set([0, 1]),
+            "Mixed playback should highlight simultaneous mic and system rows"
+        )
+        assertEqual(
+            HomeMeetingTranscriptPlaybackPolicy.activeLineIndices(
+                lines: lines,
+                currentTime: 0,
+                source: .system
+            ),
+            Set([0]),
+            "System-only playback should highlight only the system row"
+        )
+        assertEqual(
+            HomeMeetingTranscriptPlaybackPolicy.activeLineIndices(
+                lines: lines,
+                currentTime: 13,
+                source: .mic
+            ),
+            Set([2]),
+            "Playback should advance to the latest timestamp at or before the playhead"
+        )
+        assertEqual(
+            HomeMeetingTranscriptPlaybackPolicy.source(forPlaybackChoiceID: "microphone:/tmp/microphone.wav"),
+            .mic,
+            "Mic playback choices should select mic transcript rows"
+        )
+        assertEqual(
+            HomeMeetingTranscriptPlaybackPolicy.visibleLineIndices(
+                totalCount: 12,
+                activeIndices: Set([10]),
+                limit: 8
+            ),
+            Array(4...11),
+            "The collapsed excerpt should follow a later active row"
+        )
     }
 }
 
@@ -30,6 +85,20 @@ private func styledMeetingMarkdown() -> String {
     capture_id: "297F08B7-62AE-4291-9EA3-41EB0B17A64A"
     capture_type: meeting
     total_word_count: 117
+    speakers:
+      - id: "1"
+        channel: system
+        db_id: "11111111-1111-1111-1111-111111111111"
+        name: "Speaker 1"
+        source: db_pending
+      - id: "0"
+        channel: mic
+        name: "Linus"
+        source: user_manual
+      - id: "2"
+        channel: system
+        name: "Linus"
+        source: user_manual
     ---
 
     # Meeting with Linus

--- a/Tests/HomeMeetingRenameTests.swift
+++ b/Tests/HomeMeetingRenameTests.swift
@@ -118,6 +118,114 @@ func testHomeMeetingRename() {
         assertTrue(rewritten.contains("# Brand New"), "first heading should be rewritten")
         assertFalse(rewritten.contains("# Old heading"), "old heading should be replaced")
     }
+
+    runSuite("HomeMeetingSpeakerRename updates one source-scoped speaker") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Scoped Speaker.md")
+            let markdown = """
+            ---
+            capture_type: meeting
+            speakers:
+              - id: "0"
+                channel: mic
+                name: "You"
+                source: unknown
+              - id: "0"
+                channel: system
+                name: "You"
+                source: unknown
+            ---
+
+            # Scoped Speaker
+
+            ## Transcript
+
+            **00:00** [Mic/You]
+            Local line.
+
+            **00:02** [System/You]
+            Remote line.
+            """
+            try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            guard let identity = HomeMeetingPreviewContent.make(from: markdown).transcriptLines.first?.identity else {
+                assertionFailure("fixture should expose a speaker identity")
+                return
+            }
+
+            do {
+                _ = try HomeMeetingSpeakerRename.rename(
+                    transcriptAt: transcriptURL,
+                    identity: identity,
+                    to: "  Justin  "
+                )
+                let updated = try String(contentsOf: transcriptURL, encoding: .utf8)
+                assertTrue(updated.contains("[Mic/Justin]"), "the selected mic label should be renamed")
+                assertTrue(updated.contains("[System/You]"), "a same-name system speaker should stay untouched")
+                assertTrue(updated.contains("name: \"Justin\""), "the matching frontmatter row should be renamed")
+                assertTrue(updated.contains("source: user_manual"), "the matching metadata should record the manual edit")
+            } catch {
+                assertionFailure("speaker rename should not throw: \(error)")
+            }
+        }
+    }
+
+    runSuite("HomeMeetingSpeakerRename preserves legacy Obsidian speaker links") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Legacy Speaker.md")
+            let markdown = """
+            # Legacy Speaker
+
+            ## Full Transcript
+
+            [00:05] [System/[[Alex]]] Nice to meet you.
+            """
+            try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            guard let identity = HomeMeetingPreviewContent.make(from: markdown).transcriptLines.first?.identity else {
+                assertionFailure("fixture should expose a legacy speaker identity")
+                return
+            }
+
+            do {
+                _ = try HomeMeetingSpeakerRename.rename(
+                    transcriptAt: transcriptURL,
+                    identity: identity,
+                    to: "Morgan"
+                )
+                let updated = try String(contentsOf: transcriptURL, encoding: .utf8)
+                assertTrue(updated.contains("[System/[[Morgan]]]"), "legacy link syntax should be preserved")
+                assertFalse(updated.contains("[[Alex]]"), "the old linked name should be removed")
+            } catch {
+                assertionFailure("legacy speaker rename should not throw: \(error)")
+            }
+        }
+    }
+
+    runSuite("HomeMeetingSpeakerRename refuses empty names without changing the file") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Empty Speaker.md")
+            let markdown = "[00:00] [Mic/You] Hello."
+            try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            guard let identity = HomeMeetingPreviewContent.make(from: markdown).transcriptLines.first?.identity else {
+                assertionFailure("fixture should expose a speaker identity")
+                return
+            }
+
+            do {
+                _ = try HomeMeetingSpeakerRename.rename(
+                    transcriptAt: transcriptURL,
+                    identity: identity,
+                    to: "   "
+                )
+                assertionFailure("empty speaker name should throw")
+            } catch let error as HomeMeetingSpeakerRenameError {
+                assertEqual(error, .emptyName, "empty names should map to .emptyName")
+                let unchanged = (try? String(contentsOf: transcriptURL, encoding: .utf8)) ?? ""
+                assertEqual(unchanged, markdown, "empty rename should leave the transcript untouched")
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+        }
+    }
 }
 
 private func withTemporaryHomeMeetingRenameLibrary(_ body: (URL) throws -> Void) {

--- a/Tests/OverlayScreenSharePrivacyTests.swift
+++ b/Tests/OverlayScreenSharePrivacyTests.swift
@@ -1,14 +1,11 @@
 // OverlayScreenSharePrivacyTests.swift
-// Guards that privacy-sensitive Transcripted AppKit surfaces stay excluded from
-// screen capture / screen sharing, while explicitly support-safe onboarding
-// stays capturable.
+// Guards that transient Transcripted overlays stay excluded from screen capture
+// / screen sharing, while normal titled app windows stay capturable.
 //
 // AppKit windows and panels default to `NSWindow.SharingType.readOnly`, which
 // ScreenCaptureKit and Screenshot window capture can use. That is the right
-// choice for first-run onboarding, which shows demo/support setup content. The
-// reusable Settings shell and live overlays must opt out with
-// `sharingType = .none` so screen sharing and screenshots do not silently leak
-// transcript, speaker-review, or storage-diagnostic content.
+// choice for normal windows, where users expect standard macOS screenshots to
+// work. Only live/transient overlays opt out with `sharingType = .none`.
 
 import AppKit
 import Foundation
@@ -82,9 +79,6 @@ func testOverlayScreenSharePrivacy() async {
         let capturePill = overlayPrivacySource("Sources/UI/Overlay/CapturePillController.swift")
         let panelSource = overlayPrivacySource("Sources/UI/Overlay/MeetingOverlayPanel.swift")
         let pasteFeedback = overlayPrivacySource("Sources/UI/MenuBar/PasteLastDictationFeedback.swift")
-        let settingsWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedSettingsWindowController.swift")
-        let speakerNaming = overlayPrivacySource("Sources/UI/Settings/SpeakerNamingSheet.swift")
-
         let inits: [(name: String, body: String)] = [
             (
                 "FloatingOverlayPanel",
@@ -126,10 +120,26 @@ func testOverlayScreenSharePrivacy() async {
                     to: "override var canBecomeKey"
                 )
             ),
+        ]
+
+        for entry in inits {
+            assertTrue(
+                entry.body.contains("sharingType = .none"),
+                "\(entry.name) init must set sharingType = .none so the surface stays out of screen capture"
+            )
+        }
+    }
+
+    runSuite("normal titled Transcripted windows stay capturable") {
+        let onboardingWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedOnboardingWindowController.swift")
+        let settingsWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedSettingsWindowController.swift")
+        let speakerNaming = overlayPrivacySource("Sources/UI/Settings/SpeakerNamingSheet.swift")
+
+        let inits: [(name: String, body: String)] = [
             (
-                "NamingWindowController",
+                "TranscriptedOnboardingWindowController",
                 overlayPrivacySlice(
-                    speakerNaming,
+                    onboardingWindow,
                     from: "let window = NSWindow(",
                     to: "super.init(window: window)"
                 )
@@ -142,33 +152,26 @@ func testOverlayScreenSharePrivacy() async {
                     to: "super.init(window: window)"
                 )
             ),
+            (
+                "NamingWindowController",
+                overlayPrivacySlice(
+                    speakerNaming,
+                    from: "let window = NSWindow(",
+                    to: "super.init(window: window)"
+                )
+            ),
         ]
 
         for entry in inits {
             assertTrue(
+                entry.body.contains("sharingType = .readOnly"),
+                "\(entry.name) should support normal macOS screenshots"
+            )
+            assertFalse(
                 entry.body.contains("sharingType = .none"),
-                "\(entry.name) init must set sharingType = .none so the surface stays out of screen capture"
+                "\(entry.name) must not opt itself out of screenshots"
             )
         }
-    }
-
-    runSuite("first-run onboarding stays capturable") {
-        let onboardingWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedOnboardingWindowController.swift")
-
-        let onboardingInit = overlayPrivacySlice(
-            onboardingWindow,
-            from: "let window = NSWindow(",
-            to: "super.init(window: window)"
-        )
-
-        assertTrue(
-            onboardingInit.contains("sharingType = .readOnly"),
-            "first-run onboarding should stay capturable for support and QA walkthroughs"
-        )
-        assertFalse(
-            onboardingInit.contains("sharingType = .none"),
-            "first-run onboarding must not opt itself out of screenshots"
-        )
     }
 
     runSuite("new NSWindow/NSPanel surfaces must be reviewed by the capture policy contract") {


### PR DESCRIPTION
## What changed

- normal Transcripted Settings, Meetings, and speaker-naming windows can be captured with standard macOS screenshots while transient recording overlays remain private
- meeting transcript rows now show the speaker name without the raw `Mic/` or `System/` channel prefix
- double-clicking a speaker name enables inline rename; saved identities use the canonical people database path and older transcripts use a safe transcript-scoped fallback
- audio playback now highlights the active transcript line and moves the collapsed eight-line excerpt with playback
- transcript parsing is cached so quarter-second playback updates do not repeatedly parse the full Markdown file

## Why

The main window explicitly used `NSWindow.SharingType.none`, which blocks macOS window capture. Meeting review also exposed internal channel labels, lacked a direct rename interaction, and did not connect playback time to transcript rows.

## User impact

Meeting review is cleaner and easier to follow. Users can screenshot normal app windows, see prominent names, rename speakers in place, and follow the words currently playing. Exact end timestamps are not stored in existing Markdown, so the highlight selects the latest transcript start time at or before playback.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh --no-open` (signed app, launch smoke, and performance budget passed)
- `bash run-tests.sh` — 12,133 passed, 0 failed
- `bash run-e2e-smoke.sh` — deterministic capture contract passed
- focused formatter/playback tests — 18 passed
- focused rename tests — 30 passed
- focused window-sharing policy tests — 23 passed
- `bash scripts/dev/agent-preflight.sh`
- UI QA bench preflight passed; its normal run stopped at the duplicate-instance safety gate because the user's Transcripted process was already running
- isolated real-app verification captured the built Transcripted Meetings window successfully without touching the user's running app
- independent full-diff review verdict: no actionable findings
- rejected review findings: none
- GitHub protected-branch checks: app build, full checks/E2E, Swift package/integration tests, build-and-test, and repo hygiene all passed

## CI follow-up

The first CI run found one stale deterministic-smoke assertion that still expected the old visible `Mic/You` label. The test now asserts visible `You` and retained internal `.mic` metadata separately; the corrected run is green.
