### PR TITLE
Settings dead-code pass: delete unreachable navigation, panels, and QA button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,7 @@ Rules:
 11. Preserve the user verification path when touching the integrations:
    - Settings should still expose the crash-reporting toggle
    - Settings should still expose the anonymous analytics toggle
-   - Settings should still expose the `Send Test Sentry Event` action when Sentry is configured
+   - About should still expose the `Send diagnostics` action when Sentry is configured (the old `Send Test Sentry Event` settings row was removed by owner decision in the 2026-08 settings simplification)
 12. Preferred verification for observability-related changes:
    - `bash build.sh --no-open`
    - `bash run-tests.sh`

--- a/Sources/Observability/ActivationTelemetry.swift
+++ b/Sources/Observability/ActivationTelemetry.swift
@@ -77,7 +77,6 @@ enum ActivationTelemetry {
 
     enum AgentPromptKind: String {
         case localAgentPrompt = "local_agent_prompt"
-        case claudeDesktopSetup = "claude_desktop_setup"
         case folderPaths = "folder_paths"
         case codexInboxSetup = "codex_inbox_setup"
         case meetingBundle = "meeting_bundle"

--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -179,24 +179,6 @@ final class CrashReporter {
     }
 
     @discardableResult
-    func sendTestEvent() -> String? {
-        captureMessageEvent(
-            level: .warning,
-            title: "sentry_test_event",
-            message: "Manual Sentry verification from Transcripted Settings",
-            tags: [
-                "source": "manual_test",
-                "engine": "settings",
-                "event": "sentry_test_event",
-            ],
-            extra: [
-                "recommended_check": "Search for sentry_test_event in the Sentry issue list",
-            ],
-            fingerprint: ["settings", "sentry_test_event"]
-        )
-    }
-
-    @discardableResult
     private func captureMessageEvent(
         level: SentryLevel,
         title: String,

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -1424,9 +1424,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         PermissionsOnboardingView(
             onComplete: { [weak self] in
                 self?.finishOnboarding()
-            },
-            onOpenSettings: { [weak self] page in
-                self?.showSettingsWindow(page: page, source: "onboarding")
             }
         )
     }

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -92,7 +92,7 @@ onboarding connect stage. Both keep one mental model:
 - `Settings/TranscriptedSettingsActions.swift` — focused capture and support callbacks (start dictation, start meeting, import audio, send feedback, and send a diagnostic event) injected into the settings view
 - `Settings/TranscriptedSettingsComponents.swift` — shared SwiftUI building blocks (`SettingsPageIntro`, `SettingsSection`) used across settings pages
 - `Settings/TranscriptedSettingsNavigationModel.swift` — observable navigation state for the current `TranscriptedSettingsPage` selection
-- `Settings/TranscriptedSettingsPage.swift` — enum of window pages (home, dictations, people, connectAgent, plus the gear-gated settings pages) with titles, summaries, and SF Symbol names; legacy model, shortcut, privacy, beta, and support cases remain deep-link aliases (`consolidatedDestination`) into General/About
+- `Settings/TranscriptedSettingsPage.swift` — enum of window pages (home, dictations, general, people, storage, connectAgent, about) with titles, SF Symbol names, and navigation shortcuts; the legacy model/shortcut/privacy/beta/support alias cases and their `consolidatedDestination` routing were deleted once no live caller produced them
 - `Settings/TranscriptedSettingsRows.swift` — reusable Settings rows for correction editing, model choices, and Auto Enter apps
 - `Settings/TranscriptedSettingsSidebar.swift` — sidebar section model: content-first primary rows (Home/Dictations/Speakers/Agent); settings pages render as a tab strip (General/Storage/About) in the content pane, reached from the sidebar gear
 - `Settings/TranscriptedSettingsView.swift` — main settings view

--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -7,9 +7,9 @@ import SwiftUI
 /// keeping its own row — the page should look empty once everything's wired
 /// up. Every row points the agent's own config at the same installed
 /// `transcripted-mcp` helper; the universal copy-prompt row covers everything
-/// else. The long tail (folders) lives behind Advanced; Codex inbox
-/// automation and Claude Desktop config details stay implemented but off the
-/// view tree (see `codexInboxDetails` / `claudeDesktopConfigDetails`).
+/// else. The long tail (folders) lives behind Advanced; the Codex inbox
+/// automation stays implemented but off the view tree (see
+/// `codexInboxDetails`).
 struct AgentConnectionSettingsPage: View {
     private enum RowPhase: Equatable {
         case idle
@@ -29,7 +29,6 @@ struct AgentConnectionSettingsPage: View {
     @State private var configRepairNotices: [AgentMCPAgent: String] = [:]
     @State private var claudeDesktopSelfTest: TranscriptedMCPSelfTest?
     @State private var copiedLocalAgentPrompt = false
-    @State private var copiedClaudeDesktopConfig = false
     @State private var copiedFolderPaths = false
     @State private var openedCodexInboxSetup = false
     @State private var codexInboxSetupError: String?
@@ -312,11 +311,10 @@ struct AgentConnectionSettingsPage: View {
         }
     }
 
-    // The Codex inbox automation and Claude Desktop config-details groups are
-    // intentionally not on the view tree (see `advancedSection` above). Their
-    // implementations stay in place — including telemetry, failure copy, and
-    // automation identifiers — so restoring them to Advanced is a one-line
-    // change, not a rewrite.
+    // The Codex inbox automation group is intentionally not on the view tree
+    // (see `advancedSection` above). Its implementation stays in place —
+    // including telemetry, failure copy, and automation identifiers — so
+    // restoring it to Advanced is a one-line change, not a rewrite.
 
     private var codexInboxDetails: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -343,38 +341,6 @@ struct AgentConnectionSettingsPage: View {
                     details: codexInboxSetupErrorDetails,
                     detailsAutomationIdentifier: "transcripted.settings.agent.codex-inbox.error-details"
                 )
-            }
-        }
-    }
-
-    private var claudeDesktopConfigDetails: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Label("Claude Desktop config", systemImage: "gearshape.2")
-                .font(.subheadline.weight(.semibold))
-
-            HStack(spacing: 10) {
-                SettingsInlineActionButton(
-                    title: copiedClaudeDesktopConfig ? "Copied" : "Copy Claude Config",
-                    symbolName: "doc.on.doc"
-                ) {
-                    ActivationTelemetry.trackAgentPromptAction(
-                        promptKind: .claudeDesktopSetup,
-                        actionKind: .copied,
-                        agentTarget: .claudeDesktop,
-                        surface: .agentSettings
-                    )
-                    copyText(
-                        ClaudeDesktopIntegrationInstaller.configSnippet(),
-                        showingCopiedFeedback: $copiedClaudeDesktopConfig
-                    )
-                }
-
-                let claudeDesktopConfigExists = FileManager.default.fileExists(atPath: ClaudeDesktopIntegrationInstaller.claudeDesktopConfigURL.path)
-                SettingsInlineActionButton(title: "Show Config", symbolName: "folder") {
-                    revealClaudeDesktopConfig()
-                }
-                .disabled(!claudeDesktopConfigExists)
-                .help(claudeDesktopConfigExists ? "" : "No Claude Desktop config file exists yet.")
             }
         }
     }
@@ -660,10 +626,6 @@ struct AgentConnectionSettingsPage: View {
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             flag.wrappedValue = false
         }
-    }
-
-    private func revealClaudeDesktopConfig() {
-        NSWorkspace.shared.activateFileViewerSelecting([ClaudeDesktopIntegrationInstaller.claudeDesktopConfigURL])
     }
 
     private func openClaudeDesktopDownload() {

--- a/Sources/UI/Settings/CLAUDE.md
+++ b/Sources/UI/Settings/CLAUDE.md
@@ -17,9 +17,9 @@ settings-side agent connection flow.
   content section (Home/Dictations/Speakers/Agent); the settings pages are
   reached via the sidebar gear and an in-content tab strip (General, Storage,
   About — the settings redesign phase 1 pass dissolved the Beta and Support
-  tabs; `.beta`/`.support` remain as `TranscriptedSettingsPage` cases so old
-  deep-links keep working, routed via `consolidatedDestination` into
-  General/About).
+  tabs, and the legacy `.models`/`.shortcuts`/`.privacy`/`.beta`/`.support`
+  alias cases were later deleted from `TranscriptedSettingsPage` once no live
+  caller produced them).
 - `TranscriptedSettingsGeneralControls.swift` - compact General-page rows,
   disclosure rows, headings, and info popovers.
 - `TranscriptedSettingsRows.swift` - small reusable rows used by Settings:
@@ -45,9 +45,9 @@ settings-side agent connection flow.
   `TranscriptedSettingsView` (`AboutSettingsPage.swift`,
   `DictationsSettingsPage.swift`, `GeneralSettingsPage.swift`,
   `PeopleSettingsPage.swift`, and `StorageSettingsPage.swift`). Model,
-  shortcut, and privacy editors still live behind General disclosures; their
-  legacy page identifiers remain deep-link aliases. New settings pages should
-  land here as their own file instead of growing the shell.
+  shortcut, and privacy editors still live behind General disclosures. New
+  settings pages should land here as their own file instead of growing the
+  shell.
   `BetaSettingsPage.swift` and `SupportSettingsPage.swift` were dissolved in
   the settings redesign phase 1 pass: the two Support rows (email support,
   send diagnostics) moved into `AboutSettingsPage.swift` under a "Support"

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -19,7 +19,6 @@ extension Notification.Name {
 @MainActor
 struct PermissionsOnboardingView: View {
     var onComplete: () -> Void
-    var onOpenSettings: (TranscriptedSettingsPage) -> Void
 
     static let preferredSize = NSSize(width: 640, height: 560)
 
@@ -37,12 +36,8 @@ struct PermissionsOnboardingView: View {
     @State private var pendingSystemSettingsHandoff = false
     @State private var lastPermissionStatuses: [TranscriptedPermissionKind: String] = [:]
 
-    init(
-        onComplete: @escaping () -> Void,
-        onOpenSettings: @escaping (TranscriptedSettingsPage) -> Void = { _ in }
-    ) {
+    init(onComplete: @escaping () -> Void) {
         self.onComplete = onComplete
-        self.onOpenSettings = onOpenSettings
     }
 
     private static let steps: [OnboardingStepKind] = [.welcome, .permissions, .done]

--- a/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
+++ b/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
@@ -10,7 +10,7 @@ enum SettingsRecentCaptureRefreshPolicy {
         switch page {
         case .home, .dictations:
             return .homeDashboard
-        case .general, .models, .shortcuts, .people, .storage, .connectAgent, .beta, .privacy, .support, .about:
+        case .general, .people, .storage, .connectAgent, .about:
             return .none
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -4,14 +4,9 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
     case home
     case dictations
     case general
-    case models
-    case shortcuts
     case people
     case storage
     case connectAgent
-    case beta
-    case privacy
-    case support
     case about
 
     var id: String { rawValue }
@@ -34,30 +29,14 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         }
     }
 
-    var consolidatedDestination: TranscriptedSettingsPage {
-        switch self {
-        case .models, .shortcuts, .privacy, .beta:
-            return .general
-        case .support:
-            return .about
-        default:
-            return self
-        }
-    }
-
     var title: String {
         switch self {
         case .home: return "Meetings"
         case .dictations: return "Dictations"
         case .general: return "General"
-        case .models: return "Models"
-        case .shortcuts: return "Shortcuts"
         case .people: return "Speakers"
         case .storage: return "Storage"
         case .connectAgent: return "Agent"
-        case .beta: return "Beta"
-        case .privacy: return "Privacy"
-        case .support: return "Support"
         case .about: return "About"
         }
     }
@@ -88,14 +67,9 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .home: return "bubble.left.and.bubble.right.fill"
         case .dictations: return "mic.fill"
         case .general: return "gearshape.fill"
-        case .models: return "cpu.fill"
-        case .shortcuts: return "keyboard"
         case .people: return "person.2.fill"
         case .storage: return "externaldrive.fill"
         case .connectAgent: return "sparkles"
-        case .beta: return "wand.and.stars"
-        case .privacy: return "lock.shield.fill"
-        case .support: return "questionmark.bubble.fill"
         case .about: return "info.circle.fill"
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -47,7 +47,6 @@ struct TranscriptedSettingsView: View {
     @State private var autoEnterAppCandidates: [AutoEnterAppCandidate] = []
     @State private var crashReportingEnabled = CrashReportingPreferences.isEnabled()
     @State private var anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
-    @State private var sentryTestStatus: String?
     @State private var diagnosticsActionStatus: String?
     @State private var permissionStates = PermissionSnapshot.current()
     @State private var permissionRevalidationTask: Task<Void, Never>?
@@ -166,7 +165,6 @@ struct TranscriptedSettingsView: View {
         }
         .task(id: navigation.presentationID) {
             refreshState()
-            expandGeneralDisclosureForPresentedPage()
             trackSettingsPageViewed(
                 navigation.selectedPage,
                 source: navigation.presentationSource,
@@ -184,7 +182,7 @@ struct TranscriptedSettingsView: View {
             if pageShowsAutoEnterSettings(page) {
                 refreshAutoEnterPreferences(includeCandidates: true)
             }
-            let isPresentationSelectionChange = page == navigation.presentedPage.consolidatedDestination
+            let isPresentationSelectionChange = page == navigation.presentedPage
             trackSettingsPageViewed(
                 page,
                 source: "navigation",
@@ -438,7 +436,7 @@ struct TranscriptedSettingsView: View {
             homePage
         case .dictations:
             dictationsPage
-        case .general, .models, .shortcuts, .privacy, .beta:
+        case .general:
             generalPage
         case .people:
             peoplePage
@@ -446,7 +444,7 @@ struct TranscriptedSettingsView: View {
             storagePage
         case .connectAgent:
             connectAgentPage
-        case .about, .support:
+        case .about:
             aboutPage
         }
     }
@@ -2171,7 +2169,6 @@ struct TranscriptedSettingsView: View {
                         track: { trackSettingsToggle("crash_reporting", enabled: $0, page: .general) },
                         sideEffect: { _ in
                             CrashReporter.applySessionTrackingPreference()
-                            sentryTestStatus = nil
                             diagnosticsActionStatus = nil
                         }
                     )
@@ -2202,24 +2199,6 @@ struct TranscriptedSettingsView: View {
                     )
                 )
                 .disabled(!AnalyticsReporter.isAvailable)
-
-                HStack {
-                SettingsInlineActionButton(
-                    title: "Send Test Sentry Event",
-                    tone: .warning,
-                    automationIdentifier: "transcripted.settings.general.send-test-sentry-event"
-                ) {
-                    trackSettingsAction("send_test_sentry_event", page: .general)
-                    sendTestSentryEvent()
-                }
-                    .disabled(!CrashReporter.isAvailable || !crashReportingEnabled)
-
-                    if let sentryTestStatus {
-                        Text(sentryTestStatus)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
 
                 Text("Never sent: transcript text, audio, names, emails, file paths, raw URLs, or meeting titles.")
                     .font(.caption)
@@ -2610,19 +2589,6 @@ struct TranscriptedSettingsView: View {
         }
     }
 
-    private func expandGeneralDisclosureForPresentedPage() {
-        switch navigation.presentedPage {
-        case .models:
-            showGeneralModelSettings = true
-        case .shortcuts:
-            showGeneralShortcutSettings = true
-        case .privacy:
-            showGeneralPrivacySettings = true
-        default:
-            break
-        }
-    }
-
     private func trackSettingsPageViewed(
         _ page: TranscriptedSettingsPage,
         source: String,
@@ -2692,15 +2658,9 @@ struct TranscriptedSettingsView: View {
             return .captureLibrary
         case .connectAgent:
             return .agentSetup
-        case .beta:
-            return nil
-        case .privacy:
-            return .permissions
-        case .support:
-            return .support
         case .about:
             return .updateSettings
-        case .general, .models, .shortcuts:
+        case .general:
             return nil
         }
     }
@@ -3000,25 +2960,6 @@ struct TranscriptedSettingsView: View {
         showAdvancedModelControls = true
         trackSettingsAction("switch_model", page: page)
         TranscriptionModelPreferences.setPreferredModel(model)
-    }
-
-    private func sendTestSentryEvent() {
-        guard CrashReporter.isAvailable else {
-            sentryTestStatus = "Sentry is not configured in this build yet."
-            return
-        }
-
-        guard crashReportingEnabled else {
-            sentryTestStatus = "Turn on crash and error reports first."
-            return
-        }
-
-        guard let eventID = CrashReporter.shared.sendTestEvent() else {
-            sentryTestStatus = "Sentry test event could not be queued."
-            return
-        }
-
-        sentryTestStatus = "Queued test event \(eventID.prefix(8)). Check Sentry in a few seconds."
     }
 
     private func sendDiagnosticEvent() {

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -59,16 +59,15 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
 
     func present(page: TranscriptedSettingsPage = .home, source: String = "unknown") {
         guard let window else { return }
-        let presentedPage = page.consolidatedDestination
         speakerPeopleModel.refresh()
         navigationModel.presentedPage = page
-        navigationModel.selectedPage = presentedPage
+        navigationModel.selectedPage = page
         navigationModel.presentationSource = source
         navigationModel.presentationID = UUID()
         AnalyticsReporter.track(
             "settings_opened",
             properties: [
-                "page_id": presentedPage.analyticsValue,
+                "page_id": page.analyticsValue,
                 "source": source,
             ]
         )

--- a/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
+++ b/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
@@ -12,7 +12,7 @@ func testSettingsRecentCaptureRefreshPolicy() {
     }
 
     runSuite("SettingsRecentCaptureRefreshPolicy.mode — skips recent capture work on non-list pages") {
-        for page in [TranscriptedSettingsPage.general, .models, .shortcuts, .people, .storage, .connectAgent, .beta, .privacy, .support, .about] {
+        for page in [TranscriptedSettingsPage.general, .people, .storage, .connectAgent, .about] {
             assertEqual(
                 SettingsRecentCaptureRefreshPolicy.mode(for: page),
                 .none,
@@ -90,7 +90,7 @@ func testSettingsRecentCaptureRefreshPolicy() {
     runSuite("SettingsRecentCaptureRefreshPolicy.shouldStartDashboardRefresh — force does not bypass page gating") {
         let now = Date(timeIntervalSinceReferenceDate: 20)
 
-        for page in [TranscriptedSettingsPage.general, .models, .shortcuts, .people, .storage, .connectAgent, .beta, .privacy, .support, .about] {
+        for page in [TranscriptedSettingsPage.general, .people, .storage, .connectAgent, .about] {
             assertFalse(
                 SettingsRecentCaptureRefreshPolicy.shouldStartDashboardRefresh(
                     for: page,
@@ -135,15 +135,7 @@ func testSettingsRecentCaptureRefreshPolicy() {
     runSuite("TranscriptedSettingsPage keeps user-facing navigation metadata stable") {
         assertEqual(TranscriptedSettingsPage.connectAgent.analyticsValue, "connect_agent", "agent page analytics should stay snake_case")
         assertEqual(TranscriptedSettingsPage.connectAgent.title, "Agent", "agent page title should stay short")
-        assertEqual(TranscriptedSettingsPage.beta.title, "Beta", "beta page title should stay short")
-        assertEqual(TranscriptedSettingsPage.beta.systemImage, "wand.and.stars", "beta page should keep an experimental affordance")
         assertEqual(TranscriptedSettingsPage.people.title, "Speakers", "people page should stay focused on speaker naming")
-        assertEqual(TranscriptedSettingsPage.privacy.systemImage, "lock.shield.fill", "privacy page should keep the shield affordance")
-        assertEqual(TranscriptedSettingsPage.models.consolidatedDestination, .general, "models should now open inside General")
-        assertEqual(TranscriptedSettingsPage.shortcuts.consolidatedDestination, .general, "shortcuts should now open inside General")
-        assertEqual(TranscriptedSettingsPage.privacy.consolidatedDestination, .general, "privacy should now open inside General")
-        assertEqual(TranscriptedSettingsPage.beta.consolidatedDestination, .general, "beta dissolved into General; deep-links should still land there")
-        assertEqual(TranscriptedSettingsPage.support.consolidatedDestination, .about, "support merged into About; deep-links should still land there")
         assertEqual(
             Set(TranscriptedSettingsPage.allCases.map(\.rawValue)).count,
             TranscriptedSettingsPage.allCases.count,

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -236,14 +236,9 @@ func testUIAutomationSurfaceContract() {
             "case home",
             "case dictations",
             "case general",
-            "case models",
-            "case shortcuts",
             "case people",
             "case storage",
             "case connectAgent",
-            "case beta",
-            "case privacy",
-            "case support",
             "case about",
         ] {
             assertTrue(contractSource("Sources/UI/Settings/TranscriptedSettingsPage.swift").contains(pageCase), "\(pageCase) should stay in the settings navigation surface map")
@@ -658,7 +653,6 @@ func testUIAutomationSurfaceContract() {
             "transcripted.settings.general.disclosure.privacy",
             "transcripted.settings.general.disclosure.corrections",
             "transcripted.settings.general.transcribe-audio-file",
-            "transcripted.settings.general.send-test-sentry-event",
             "transcripted.settings.general.corrections.clear-all",
         ] {
             assertTrue(settingsSurfaceContractContains(identifier), "\(identifier) should stay attached to Settings click-flow controls")

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -66,7 +66,9 @@ references, meeting titles, speaker names, local paths, or user identifiers.
 8. Verify Settings also shows separate toggles for:
    - crash and error reports
    - anonymous usage statistics
-9. Use `Send Test Sentry Event` to verify Sentry wiring.
+9. Use About > `Send diagnostics` to verify Sentry wiring (the dedicated
+   `Send Test Sentry Event` settings row was removed in the settings
+   simplification).
 10. Leave anonymous usage statistics on and verify only allowlisted events arrive
    in PostHog.
 11. If intentionally testing Sentry app-hang tracking, launch locally with

--- a/docs/ui-settings-menubar-spec.md
+++ b/docs/ui-settings-menubar-spec.md
@@ -243,7 +243,6 @@ Contents:
 - meeting microphone processing toggle
 - `Send crash and error reports`
 - `Send anonymous usage statistics`
-- `Send Test Sentry Event`
 
 ### About
 


### PR DESCRIPTION
## Summary

Part 2 of the settings-simplification stack (stacked on #1672 — merge that first; this diff shows only the dead-code pass once rebased). Every deletion was adversarially verified unreachable before cutting, except the Sentry button which is an explicit owner decision:

- **Legacy page cases**: delete `.models`/`.shortcuts`/`.privacy`/`.beta`/`.support` from `TranscriptedSettingsPage` plus `consolidatedDestination`, the pageBody alias arms, and `expandGeneralDisclosureForPresentedPage`. Verified: zero live call sites produce these values (all `present(page:)` callers traced), no URL-scheme/state-restoration producer exists, navigation state is in-memory only. Home's attention pills use their own `HomeAttentionIssue.Destination` enum — untouched.
- **Dead onboarding callback**: `PermissionsOnboardingView.onOpenSettings` was wired by settings phase 4 into the old 14-step onboarding; the 3-step quiet-library rewrite (commit 4cbb64ae) deleted all its call sites. Dropped the property and the `TranscriptedApp` wiring.
- **Unmounted agent panel**: delete `claudeDesktopConfigDetails` (off the view tree since the quiet-library redesign) plus its reveal helper, copied-state, and the now-unused `ActivationTelemetry.claudeDesktopSetup` case. The codex-inbox panel deliberately **stays**: a prior 7-finder dead-code audit (2ac13d27) kept it, and deleting it would orphan tested `AgentConnectionGuide` scaffolding — flagged separately as a product decision.
- **Send Test Sentry Event**: removed the button, its status text, and `CrashReporter.sendTestEvent` per owner decision, overriding the AGENTS.md protected-path line. AGENTS.md, `docs/privacy-first-observability.md`, and `docs/ui-settings-menubar-spec.md` updated in the same change; About > "Send diagnostics" remains the user verification path.

Contract tests pinning the deleted cases/IDs updated (`UIAutomationSurfaceContractTests`, `SettingsRecentCaptureRefreshPolicyTests`).

## Verification

```
export TRANSCRIPTED_DISABLE_FILE_LOGGER=1
bash build.sh --no-open   # passed
bash run-tests.sh         # 12071 tests, 0 failed
```

## Test plan

- [ ] Open Settings, click every sidebar page and the General/Storage/About tab strip
- [ ] Menu bar "Send Feedback" and onboarding links still land on real pages
- [ ] General > Advanced > Privacy shows the two reporting toggles, no test-event button
- [ ] Agent page Advanced disclosure still shows folder reveals

🤖 Generated with [Claude Code](https://claude.com/claude-code)