### PR TITLE
Storage/About simplification: one cleanup action, tri-state updates

### DIFF
--- a/Sources/UI/Settings/Pages/AboutSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/AboutSettingsPage.swift
@@ -263,8 +263,11 @@ struct AboutSettingsPage: View {
 
     private var currentAutomaticUpdatePolicy: AutomaticUpdatePolicy {
         let settings = sparkleUpdater.automaticUpdateSettings
-        if settings.automaticDownloadsEnabled { return .download }
-        if settings.automaticChecksEnabled { return .notify }
+        // Clamp downloads-enabled to .notify when Sparkle reports downloads
+        // unavailable: the .download segment isn't offered then, and checks
+        // are what actually still run.
+        if settings.automaticDownloadsEnabled, settings.automaticDownloadsAllowed { return .download }
+        if settings.automaticChecksEnabled || settings.automaticDownloadsEnabled { return .notify }
         return .off
     }
 
@@ -272,35 +275,39 @@ struct AboutSettingsPage: View {
         Binding(
             get: { currentAutomaticUpdatePolicy },
             set: { newPolicy in
+                // The controller's setters have no unchanged-value guard —
+                // every call emits update_setting_changed telemetry and an
+                // enable also kicks refreshUpdateStatus() — so only call a
+                // setter when its underlying boolean actually flips. The
+                // controller still enforces the ladder internally (checks off
+                // forces downloads off; downloads on forces checks on).
                 let settings = sparkleUpdater.automaticUpdateSettings
                 switch newPolicy {
                 case .off:
+                    if settings.automaticDownloadsEnabled {
+                        onTrackSettingsToggle("automatic_update_downloads", false, .about)
+                    }
                     if settings.automaticChecksEnabled {
                         onTrackSettingsToggle("automatic_update_checks", false, .about)
+                        sparkleUpdater.setAutomaticallyChecksForUpdates(false)
                     }
+                case .notify:
                     if settings.automaticDownloadsEnabled {
                         onTrackSettingsToggle("automatic_update_downloads", false, .about)
+                        sparkleUpdater.setAutomaticallyDownloadsUpdates(false)
                     }
-                    // The controller forces downloads off when checks go off.
-                    sparkleUpdater.setAutomaticallyChecksForUpdates(false)
-                case .notify:
                     if !settings.automaticChecksEnabled {
                         onTrackSettingsToggle("automatic_update_checks", true, .about)
+                        sparkleUpdater.setAutomaticallyChecksForUpdates(true)
                     }
-                    if settings.automaticDownloadsEnabled {
-                        onTrackSettingsToggle("automatic_update_downloads", false, .about)
-                    }
-                    sparkleUpdater.setAutomaticallyChecksForUpdates(true)
-                    sparkleUpdater.setAutomaticallyDownloadsUpdates(false)
                 case .download:
                     if !settings.automaticChecksEnabled {
                         onTrackSettingsToggle("automatic_update_checks", true, .about)
                     }
                     if !settings.automaticDownloadsEnabled {
                         onTrackSettingsToggle("automatic_update_downloads", true, .about)
+                        sparkleUpdater.setAutomaticallyDownloadsUpdates(true)
                     }
-                    // The controller forces checks on when downloads go on.
-                    sparkleUpdater.setAutomaticallyDownloadsUpdates(true)
                 }
             }
         )

--- a/Sources/UI/Settings/Pages/AboutSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/AboutSettingsPage.swift
@@ -57,38 +57,28 @@ struct AboutSettingsPage: View {
 
                 AboutHairline()
 
-                SettingsToggleRow(
-                    title: "Check automatically",
-                    detail: sparkleUpdater.automaticUpdateSettings.automaticChecksEnabled
-                        ? "Transcripted checks for updates in the background."
-                        : "Transcripted only checks when you ask.",
-                    isOn: Binding(
-                        get: { sparkleUpdater.automaticUpdateSettings.automaticChecksEnabled },
-                        set: { newValue in
-                            onTrackSettingsToggle("automatic_update_checks", newValue, .about)
-                            sparkleUpdater.setAutomaticallyChecksForUpdates(newValue)
+                // One control for what was two coupled booleans: the
+                // controller already enforces the ladder (checks off forces
+                // downloads off; downloads on forces checks on), so the UI
+                // exposes it as the three states users actually choose
+                // between. Writes route through the existing setters so
+                // update_setting_changed telemetry keeps firing unchanged.
+                VStack(alignment: .leading, spacing: 6) {
+                    Picker("Automatic updates", selection: automaticUpdatePolicyBinding) {
+                        ForEach(availableAutomaticUpdatePolicies) { policy in
+                            Text(policy.title).tag(policy)
                         }
-                    )
-                )
-                .padding(.vertical, 10)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 420)
 
-                AboutHairline()
-
-                SettingsToggleRow(
-                    title: "Download automatically",
-                    detail: sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled
-                        ? "Transcripted downloads available updates in the background."
-                        : "Transcripted waits before downloading updates.",
-                    isOn: Binding(
-                        get: { sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled },
-                        set: { newValue in
-                            onTrackSettingsToggle("automatic_update_downloads", newValue, .about)
-                            sparkleUpdater.setAutomaticallyDownloadsUpdates(newValue)
-                        }
-                    )
-                )
+                    if !sparkleUpdater.automaticUpdateSettings.automaticDownloadsAllowed {
+                        Text("Automatic downloads aren't available for this install.")
+                            .font(.caption)
+                            .foregroundStyle(LibraryTokens.ink3)
+                    }
+                }
                 .padding(.vertical, 10)
-                .disabled(!sparkleUpdater.automaticUpdateSettings.automaticDownloadsAllowed)
 
                 Text(automaticUpdatesDetail)
                     .font(.caption)
@@ -144,6 +134,13 @@ struct AboutSettingsPage: View {
                         isEnabled: CrashReporter.isAvailable && crashReportingEnabled,
                         action: onSendDiagnosticEvent
                     )
+
+                    if let diagnosticsDisabledReason {
+                        Text(diagnosticsDisabledReason)
+                            .font(.caption)
+                            .foregroundStyle(LibraryTokens.ink3)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
 
                 SupportPrivacyNote()
@@ -238,7 +235,85 @@ struct AboutSettingsPage: View {
         if settings.automaticChecksEnabled {
             return "Transcripted will check in the background and show an update badge when one is ready."
         }
-        return "Turn on automatic checks to see updates sooner."
+        return "Transcripted only checks for updates when you ask."
+    }
+
+    /// The three real states behind the two coupled Sparkle booleans.
+    private enum AutomaticUpdatePolicy: String, CaseIterable, Identifiable {
+        case off
+        case notify
+        case download
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .off: return "Off"
+            case .notify: return "Notify me"
+            case .download: return "Download automatically"
+            }
+        }
+    }
+
+    private var availableAutomaticUpdatePolicies: [AutomaticUpdatePolicy] {
+        sparkleUpdater.automaticUpdateSettings.automaticDownloadsAllowed
+            ? AutomaticUpdatePolicy.allCases
+            : [.off, .notify]
+    }
+
+    private var currentAutomaticUpdatePolicy: AutomaticUpdatePolicy {
+        let settings = sparkleUpdater.automaticUpdateSettings
+        if settings.automaticDownloadsEnabled { return .download }
+        if settings.automaticChecksEnabled { return .notify }
+        return .off
+    }
+
+    private var automaticUpdatePolicyBinding: Binding<AutomaticUpdatePolicy> {
+        Binding(
+            get: { currentAutomaticUpdatePolicy },
+            set: { newPolicy in
+                let settings = sparkleUpdater.automaticUpdateSettings
+                switch newPolicy {
+                case .off:
+                    if settings.automaticChecksEnabled {
+                        onTrackSettingsToggle("automatic_update_checks", false, .about)
+                    }
+                    if settings.automaticDownloadsEnabled {
+                        onTrackSettingsToggle("automatic_update_downloads", false, .about)
+                    }
+                    // The controller forces downloads off when checks go off.
+                    sparkleUpdater.setAutomaticallyChecksForUpdates(false)
+                case .notify:
+                    if !settings.automaticChecksEnabled {
+                        onTrackSettingsToggle("automatic_update_checks", true, .about)
+                    }
+                    if settings.automaticDownloadsEnabled {
+                        onTrackSettingsToggle("automatic_update_downloads", false, .about)
+                    }
+                    sparkleUpdater.setAutomaticallyChecksForUpdates(true)
+                    sparkleUpdater.setAutomaticallyDownloadsUpdates(false)
+                case .download:
+                    if !settings.automaticChecksEnabled {
+                        onTrackSettingsToggle("automatic_update_checks", true, .about)
+                    }
+                    if !settings.automaticDownloadsEnabled {
+                        onTrackSettingsToggle("automatic_update_downloads", true, .about)
+                    }
+                    // The controller forces checks on when downloads go on.
+                    sparkleUpdater.setAutomaticallyDownloadsUpdates(true)
+                }
+            }
+        )
+    }
+
+    private var diagnosticsDisabledReason: String? {
+        if !CrashReporter.isAvailable {
+            return "Not available in this build: crash reporting is not configured."
+        }
+        if !crashReportingEnabled {
+            return "To enable this, turn on \"Send crash and error reports\" in General > Advanced > Privacy."
+        }
+        return nil
     }
 }
 

--- a/Sources/UI/Settings/Pages/StorageSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/StorageSettingsPage.swift
@@ -44,6 +44,7 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
     @State private var showReclaimableCacheCleanupConfirmation = false
     @State private var showModelCacheCleanupConfirmation = false
     @State private var showWhisperCacheCleanupConfirmation = false
+    @State private var showStorageDetails = false
     @State private var showSupportFolders = false
 
     var body: some View {
@@ -146,22 +147,6 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
             LibrarySectionLabel(text: "Audio & Models")
 
             VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .top, spacing: 12) {
-                    Image(systemName: "waveform.badge.magnifyingglass")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(LibraryTokens.ink2)
-                        .frame(width: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Compress WAV to M4A automatically")
-                            .font(LibraryTokens.rowTitle)
-                        Text("After a transcript is saved, Transcripted keeps replay audio in a smaller format and removes the original WAV only after conversion succeeds.")
-                            .font(.caption)
-                            .foregroundStyle(LibraryTokens.ink2)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-
                 Picker("Delete audio after", selection: audioRetentionWindowBinding) {
                     ForEach(AudioRetentionWindow.allCases) { window in
                         Text(window.title).tag(window)
@@ -174,9 +159,10 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                     .font(.caption)
                     .foregroundStyle(LibraryTokens.ink2)
 
-                Text("Choosing 7 or 30 days asks before deleting old replay audio.")
+                Text("Choosing 7 or 30 days asks before deleting old replay audio. Replay audio is compressed from WAV to a smaller M4A automatically after each transcript saves.")
                     .font(.caption)
                     .foregroundStyle(LibraryTokens.ink3)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Hairline()
 
@@ -202,62 +188,72 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                     )
                     if reclaimableBytes > 0 {
                         SettingsInlineActionButton(
-                            title: modelCacheCleanupInProgress ? "Removing..." : "Remove Reclaimable Cache",
+                            title: modelCacheCleanupInProgress ? "Removing..." : "Free Up Space",
                             tone: .destructive
                         ) {
                             showReclaimableCacheCleanupConfirmation = true
                         }
                         .disabled(modelCacheCleanupInProgress || modelCacheLoading)
                         .help(modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : "")
-                    }
-                    ModelCacheMetricRow(
-                        title: "FluidAudio models",
-                        value: snapshot.formattedFluidAudioModelsSize,
-                        detail: "Parakeet, diarization, and related local model files."
-                    )
-                    ModelCacheMetricRow(
-                        title: "Whisper cache",
-                        value: snapshot.formattedWhisperModelsSize,
-                        detail: "Optional Whisper models stored by Transcripted."
-                    )
-                    if snapshot.whisperModelsBytes > 0 {
-                        SettingsInlineActionButton(
-                            title: modelCacheCleanupInProgress ? "Removing..." : "Remove Whisper Cache",
-                            tone: .destructive
-                        ) {
-                            showWhisperCacheCleanupConfirmation = true
-                        }
-                        .disabled(effectiveTranscriptionModelIsWhisper || modelCacheCleanupInProgress || modelCacheLoading)
-                        .help(effectiveTranscriptionModelIsWhisper
-                            ? "Switch back to Parakeet before removing the Whisper cache."
-                            : (modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : ""))
-
-                        if effectiveTranscriptionModelIsWhisper {
-                            Text("Switch back to Parakeet before removing the Whisper cache.")
-                                .font(.caption)
-                                .foregroundStyle(LibraryTokens.ink2)
-                        }
-                    }
-
-                    if snapshot.staleFluidAudioModelBytes > 0 {
-                        ModelCacheMetricRow(
-                            title: "Known stale candidates",
-                            value: snapshot.formattedStaleFluidAudioModelSize,
-                            detail: snapshot.staleModelSummary
-                        )
-
-                        SettingsInlineActionButton(
-                            title: modelCacheCleanupInProgress ? "Removing..." : "Remove Known Stale Models",
-                            tone: .destructive
-                        ) {
-                            showModelCacheCleanupConfirmation = true
-                        }
-                        .disabled(modelCacheCleanupInProgress || modelCacheLoading)
-                        .help(modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : "")
                     } else {
-                        Text("No known stale Parakeet model folders found.")
+                        Text("Nothing to clean up right now.")
                             .font(.caption)
                             .foregroundStyle(LibraryTokens.ink2)
+                    }
+
+                    DisclosureGroup("Storage details", isExpanded: $showStorageDetails) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            ModelCacheMetricRow(
+                                title: "FluidAudio models",
+                                value: snapshot.formattedFluidAudioModelsSize,
+                                detail: "Parakeet, diarization, and related local model files."
+                            )
+                            ModelCacheMetricRow(
+                                title: "Whisper cache",
+                                value: snapshot.formattedWhisperModelsSize,
+                                detail: "Optional Whisper models stored by Transcripted."
+                            )
+                            if snapshot.whisperModelsBytes > 0 {
+                                SettingsInlineActionButton(
+                                    title: modelCacheCleanupInProgress ? "Removing..." : "Remove Whisper Cache",
+                                    tone: .destructive
+                                ) {
+                                    showWhisperCacheCleanupConfirmation = true
+                                }
+                                .disabled(effectiveTranscriptionModelIsWhisper || modelCacheCleanupInProgress || modelCacheLoading)
+                                .help(effectiveTranscriptionModelIsWhisper
+                                    ? "Switch back to Parakeet before removing the Whisper cache."
+                                    : (modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : ""))
+
+                                if effectiveTranscriptionModelIsWhisper {
+                                    Text("Switch back to Parakeet before removing the Whisper cache.")
+                                        .font(.caption)
+                                        .foregroundStyle(LibraryTokens.ink2)
+                                }
+                            }
+
+                            if snapshot.staleFluidAudioModelBytes > 0 {
+                                ModelCacheMetricRow(
+                                    title: "Known stale candidates",
+                                    value: snapshot.formattedStaleFluidAudioModelSize,
+                                    detail: snapshot.staleModelSummary
+                                )
+
+                                SettingsInlineActionButton(
+                                    title: modelCacheCleanupInProgress ? "Removing..." : "Remove Known Stale Models",
+                                    tone: .destructive
+                                ) {
+                                    showModelCacheCleanupConfirmation = true
+                                }
+                                .disabled(modelCacheCleanupInProgress || modelCacheLoading)
+                                .help(modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : "")
+                            } else {
+                                Text("No known stale Parakeet model folders found.")
+                                    .font(.caption)
+                                    .foregroundStyle(LibraryTokens.ink2)
+                            }
+                        }
+                        .padding(.top, 12)
                     }
 
                     if let modelCacheCleanupStatus {
@@ -295,7 +291,7 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                 }
             )
         }
-        .alert("Remove reclaimable cache?", isPresented: $showReclaimableCacheCleanupConfirmation) {
+        .alert("Free up space?", isPresented: $showReclaimableCacheCleanupConfirmation) {
             Button("Remove", role: .destructive) {
                 onRemoveReclaimableModelCaches()
             }
@@ -327,11 +323,11 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
         }
     }
 
-    // MARK: Support Folders
+    // MARK: Advanced (support folders)
 
     private var supportFoldersGroup: some View {
         VStack(alignment: .leading, spacing: 8) {
-            LibrarySectionLabel(text: "Support Folders")
+            LibrarySectionLabel(text: "Advanced")
 
             DisclosureGroup("Show support folders", isExpanded: $showSupportFolders) {
                 VStack(alignment: .leading, spacing: 12) {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1950,9 +1950,14 @@ struct TranscriptedSettingsView: View {
                 Text("Your \(speakerPeopleModel.profiles.filter { $0.displayName != nil }.count) saved people stay safe. Call matching uses a separate memory, so for the first few meetings it may ask who's who again, then re-learns them. Nothing is deleted, and switching back instantly restores your current people.")
             }
 
-            Text("Changes here apply from the next recording.")
+            // The two toggles activate differently: the local-speaker split is
+            // read per recording, but the matching engine is resolved once at
+            // meeting-controller initialization, so flipping it either way
+            // needs an app restart.
+            Text("Identifying multiple people applies from the next recording. Switching the matching engine takes effect after you restart Transcripted.")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -34,9 +34,11 @@ Future agents should treat this as a release requirement:
   finds a newer release
 - the settings sidebar footer becomes an update-ready restart action only after
   Sparkle has staged the update
-- the About settings page exposes `Check automatically` and `Download
-  automatically`; if Sparkle has already downloaded an update, the primary
-  action becomes `Restart to Update`
+- the About settings page exposes one `Automatic updates` control with three
+  positions — `Off` / `Notify me` / `Download automatically` — backed by the
+  same two Sparkle booleans (`Download automatically` is hidden when Sparkle
+  reports automatic downloads unavailable); if Sparkle has already downloaded
+  an update, the primary action becomes `Restart to Update`
 
 ## In-app update prompt surfaces (inventory)
 


### PR DESCRIPTION
## Summary

Part 4 of the settings-simplification stack (stacked on the General regroup).

**Storage**
- Merge the three overlapping destructive cache buttons (Reclaimable = stale + optional Whisper) into one primary **"Free Up Space"** action; per-cache metrics and the narrower Whisper/stale removals move behind a "Storage details" disclosure. All callbacks + confirmation alerts unchanged.
- Remove the "Compress WAV to M4A automatically" row — styled like a setting, but it had no control (always-on behavior). Its copy folds into the "Delete audio after" caption.
- Retitle "Support Folders" to "Advanced" (pure debug path-reveals shouldn't sit on par with Capture Library).

**About**
- Fold the two coupled Sparkle booleans into one segmented **"Automatic updates"** control: Off / Notify me / Download automatically. The controller already enforces the ladder invariant (checks-off forces downloads-off, downloads-on forces checks-on), so the four bool combinations collapse 1:1 onto these three states — no migration. Writes route through the existing setters so `update_setting_changed`/`settings_toggle_changed` telemetry is unchanged; the Download position is hidden when Sparkle reports downloads unavailable (previously a silently disabled toggle).
- "Send diagnostics" now explains *why* it's disabled (unconfigured crash reporting, or the General > Advanced > Privacy toggle) instead of greying out silently.

`docs/sparkle-updates.md` updated per its own same-change convention.

## Verification

```
export TRANSCRIPTED_DISABLE_FILE_LOGGER=1
bash build.sh --no-open   # passed
bash run-tests.sh         # 12075 tests, 0 failed
```

## Test plan

- [ ] Storage shows one Free Up Space action; details disclosure reveals per-cache metrics/removals
- [ ] Whisper removal still blocked while a Whisper model is selected
- [ ] About's Automatic updates control cycles Off / Notify me / Download automatically and persists across relaunch
- [ ] With crash reporting off, Send diagnostics shows the explanatory caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)