### PR TITLE
Make meeting speaker names easy to correct

### DIFF
--- a/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
+++ b/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
@@ -13,6 +13,214 @@ struct HomeMeetingSpeakerIdentity: Equatable, Hashable, Sendable {
     let channel: HomeMeetingSpeakerChannel?
     let diarizerSpeakerID: String?
     let persistentSpeakerID: UUID?
+
+    /// Stable UI/persistence key for one detected voice. The rendered name is
+    /// intentionally not part of the key: correcting a name must not create a
+    /// different row, and duplicate visible names must stay distinguishable.
+    var stableID: String {
+        if let persistentSpeakerID {
+            return "profile:\(persistentSpeakerID.uuidString.lowercased())"
+        }
+        if let diarizerSpeakerID {
+            return "voice:\(channel?.rawValue ?? "unknown"):\(diarizerSpeakerID)"
+        }
+        return "label:\(channel?.rawValue ?? "unknown"):\(rawLabel)"
+    }
+}
+
+/// One explicit speaker correction staged by the meeting transcript UI.
+/// `targetProfileID` is preserved separately from `newName`, so choosing one
+/// of two saved people with the same display name never becomes ambiguous.
+struct HomeMeetingSpeakerAssignment: Equatable, Sendable {
+    let identity: HomeMeetingSpeakerIdentity
+    let newName: String
+    let targetProfileID: UUID?
+}
+
+struct HomeMeetingSpeakerNamingDraft: Identifiable, Equatable, Sendable {
+    var id: String { identity.stableID }
+    let identity: HomeMeetingSpeakerIdentity
+    let sampleTexts: [String]
+    var name: String
+    var selectedProfileID: UUID?
+}
+
+enum HomeMeetingSpeakerNamingPolicy {
+    private static let sampleLimit = 2
+
+    /// Builds one first-seen row per actual voice, with up to two useful quotes
+    /// to make identification possible without scrubbing through the meeting.
+    static func drafts(from lines: [HomeMeetingTranscriptLine]) -> [HomeMeetingSpeakerNamingDraft] {
+        var drafts: [HomeMeetingSpeakerNamingDraft] = []
+        var indexByID: [String: Int] = [:]
+
+        for line in lines {
+            let id = line.identity.stableID
+            let sample = line.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let index = indexByID[id] {
+                if !sample.isEmpty,
+                   drafts[index].sampleTexts.count < sampleLimit,
+                   !drafts[index].sampleTexts.contains(sample) {
+                    drafts[index] = HomeMeetingSpeakerNamingDraft(
+                        identity: drafts[index].identity,
+                        sampleTexts: drafts[index].sampleTexts + [sample],
+                        name: drafts[index].name,
+                        selectedProfileID: drafts[index].selectedProfileID
+                    )
+                }
+                continue
+            }
+
+            indexByID[id] = drafts.count
+            drafts.append(HomeMeetingSpeakerNamingDraft(
+                identity: line.identity,
+                sampleTexts: sample.isEmpty ? [] : [sample],
+                name: line.identity.displayName,
+                selectedProfileID: nil
+            ))
+        }
+
+        return drafts
+    }
+
+    static func assignment(from draft: HomeMeetingSpeakerNamingDraft) -> HomeMeetingSpeakerAssignment? {
+        let normalizedName = normalize(draft.name)
+        guard !normalizedName.isEmpty else { return nil }
+
+        let selectedDifferentProfile = draft.selectedProfileID != nil
+            && draft.selectedProfileID != draft.identity.persistentSpeakerID
+        guard selectedDifferentProfile || normalizedName != draft.identity.displayName else { return nil }
+
+        return HomeMeetingSpeakerAssignment(
+            identity: draft.identity,
+            newName: normalizedName,
+            targetProfileID: selectedDifferentProfile ? draft.selectedProfileID : nil
+        )
+    }
+
+    static func assignments(from drafts: [HomeMeetingSpeakerNamingDraft]) -> [HomeMeetingSpeakerAssignment] {
+        drafts.compactMap(assignment(from:))
+    }
+
+    /// Returns a safe sequential order for saved-profile mutations. Renames
+    /// happen first, then merge chains run from their leaves toward the final
+    /// target (A -> B before B -> C). Cycles and duplicate source mutations
+    /// fail closed before any profile is changed.
+    static func savedAssignmentsInCommitOrder(
+        _ assignments: [HomeMeetingSpeakerAssignment]
+    ) -> [HomeMeetingSpeakerAssignment]? {
+        var sourceIDs = Set<UUID>()
+        for assignment in assignments {
+            guard let sourceID = assignment.identity.persistentSpeakerID,
+                  sourceIDs.insert(sourceID).inserted else { return nil }
+        }
+
+        let renames = assignments.filter {
+            $0.targetProfileID == nil || $0.targetProfileID == $0.identity.persistentSpeakerID
+        }
+        let merges = assignments.enumerated().compactMap { index, assignment
+            -> (index: Int, assignment: HomeMeetingSpeakerAssignment)? in
+            guard let sourceID = assignment.identity.persistentSpeakerID,
+                  let targetID = assignment.targetProfileID,
+                  targetID != sourceID else { return nil }
+            return (index, assignment)
+        }
+        guard let mergeTargets = mergeTargetsBySource(from: assignments) else { return nil }
+
+        var orderedMerges: [(index: Int, depth: Int, assignment: HomeMeetingSpeakerAssignment)] = []
+        for merge in merges {
+            guard let sourceID = merge.assignment.identity.persistentSpeakerID,
+                  let depth = mergeDepth(from: sourceID, mergeTargets: mergeTargets) else {
+                return nil
+            }
+            orderedMerges.append((merge.index, depth, merge.assignment))
+        }
+        orderedMerges.sort { lhs, rhs in
+            if lhs.depth != rhs.depth { return lhs.depth > rhs.depth }
+            return lhs.index < rhs.index
+        }
+        return renames + orderedMerges.map(\.assignment)
+    }
+
+    /// A local transcript row may be linked to a profile that the same batch
+    /// merges into another profile. Point that row at the final surviving UUID
+    /// so the saved Markdown never receives a dangling `db_id`.
+    static func remappingLocalTargets(
+        _ assignments: [HomeMeetingSpeakerAssignment],
+        after savedAssignments: [HomeMeetingSpeakerAssignment]
+    ) -> [HomeMeetingSpeakerAssignment]? {
+        guard let mergeTargets = mergeTargetsBySource(from: savedAssignments) else { return nil }
+        var remapped: [HomeMeetingSpeakerAssignment] = []
+        for assignment in assignments {
+            guard let targetID = assignment.targetProfileID else {
+                remapped.append(assignment)
+                continue
+            }
+            guard let resolvedTargetID = finalTarget(
+                from: targetID,
+                mergeTargets: mergeTargets
+            ) else { return nil }
+            remapped.append(HomeMeetingSpeakerAssignment(
+                identity: assignment.identity,
+                newName: assignment.newName,
+                targetProfileID: resolvedTargetID
+            ))
+        }
+        return remapped
+    }
+
+    private static func normalize(_ raw: String) -> String {
+        raw
+            .components(separatedBy: .newlines)
+            .joined(separator: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    private static func mergeTargetsBySource(
+        from assignments: [HomeMeetingSpeakerAssignment]
+    ) -> [UUID: UUID]? {
+        var result: [UUID: UUID] = [:]
+        for assignment in assignments {
+            guard let sourceID = assignment.identity.persistentSpeakerID,
+                  let targetID = assignment.targetProfileID,
+                  targetID != sourceID else { continue }
+            if let existing = result[sourceID], existing != targetID { return nil }
+            result[sourceID] = targetID
+        }
+        for sourceID in result.keys {
+            guard finalTarget(from: sourceID, mergeTargets: result) != nil else { return nil }
+        }
+        return result
+    }
+
+    private static func mergeDepth(
+        from sourceID: UUID,
+        mergeTargets: [UUID: UUID]
+    ) -> Int? {
+        var currentID = sourceID
+        var visited = Set<UUID>()
+        var depth = 0
+        while let targetID = mergeTargets[currentID] {
+            guard visited.insert(currentID).inserted else { return nil }
+            currentID = targetID
+            depth += 1
+        }
+        return depth
+    }
+
+    private static func finalTarget(
+        from sourceID: UUID,
+        mergeTargets: [UUID: UUID]
+    ) -> UUID? {
+        var currentID = sourceID
+        var visited = Set<UUID>()
+        while let targetID = mergeTargets[currentID] {
+            guard visited.insert(currentID).inserted else { return nil }
+            currentID = targetID
+        }
+        return currentID
+    }
 }
 
 struct HomeMeetingPreviewContent {

--- a/Sources/UI/Settings/QuietHomeLibrary.swift
+++ b/Sources/UI/Settings/QuietHomeLibrary.swift
@@ -238,11 +238,16 @@ struct QuietMeetingExpansion: View {
     /// the caller should treat an empty or unchanged value as a no-op (this
     /// view already skips the call in both of those cases).
     let onRename: (String) -> Void
-    let onRenameSpeaker: (HomeMeetingSpeakerIdentity, String) -> Void
+    let knownPeople: [SpeakerIdentityOption]
+    let onAssignSpeakers: (
+        [HomeMeetingSpeakerAssignment],
+        @escaping (Bool) -> Void
+    ) -> Void
     let menuItems: [HomeRowMenuItem]
 
     @ObservedObject private var playback = MeetingAudioPlayback.shared
     @State private var showsFullTranscript = false
+    @State private var showsSpeakerNamingSheet = false
     @State private var isEditingTitle = false
     @State private var editedTitle = ""
     @FocusState private var titleFieldIsFocused: Bool
@@ -329,6 +334,21 @@ struct QuietMeetingExpansion: View {
         )
         .padding(.vertical, 6)
         .accessibilityIdentifier("transcripted.home.expansion")
+        .sheet(isPresented: $showsSpeakerNamingSheet) {
+            if let content = preview?.content {
+                HomeMeetingSpeakerNamingSheet(
+                    content: content,
+                    knownPeople: knownPeople,
+                    onCancel: { showsSpeakerNamingSheet = false },
+                    onSave: { assignments, completion in
+                        onAssignSpeakers(assignments) { didSave in
+                            if didSave { showsSpeakerNamingSheet = false }
+                            completion(didSave)
+                        }
+                    }
+                )
+            }
+        }
     }
 
     @ViewBuilder
@@ -355,11 +375,31 @@ struct QuietMeetingExpansion: View {
     @ViewBuilder
     private func transcript(for content: HomeMeetingPreviewContent) -> some View {
         VStack(alignment: .leading, spacing: 9) {
-            Text("TRANSCRIPT")
-                .font(LibraryTokens.label)
-                .tracking(LibraryTokens.labelTracking)
-                .foregroundStyle(LibraryTokens.ink3)
-                .help("Transcribed on this Mac")
+            HStack(alignment: .firstTextBaseline) {
+                Text("TRANSCRIPT")
+                    .font(LibraryTokens.label)
+                    .tracking(LibraryTokens.labelTracking)
+                    .foregroundStyle(LibraryTokens.ink3)
+                    .help("Transcribed on this Mac")
+                Spacer()
+                if !content.transcriptLines.isEmpty {
+                    Button {
+                        showsSpeakerNamingSheet = true
+                    } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: "person.2")
+                                .font(.system(size: 10.5, weight: .medium))
+                            Text("Name speakers")
+                                .font(LibraryTokens.meta)
+                        }
+                        .foregroundStyle(LibraryTokens.ink2)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Assign or correct every speaker in this meeting")
+                    .accessibilityIdentifier("transcripted.home.expansion.name-speakers")
+                }
+            }
 
             if content.transcriptLines.isEmpty {
                 Text(content.fallbackText)
@@ -416,7 +456,10 @@ struct QuietMeetingExpansion: View {
             if !line.speaker.isEmpty {
                 QuietMeetingSpeakerLabel(
                     identity: line.identity,
-                    onRename: onRenameSpeaker
+                    knownPeople: knownPeople,
+                    onAssign: { assignment, completion in
+                        onAssignSpeakers([assignment], completion)
+                    }
                 )
             }
             Text(line.text)
@@ -530,76 +573,376 @@ struct QuietMeetingExpansion: View {
     }()
 }
 
-/// Prominent, editable speaker name used by every transcript line. Double-click
-/// is the fast path; the context menu and accessibility action expose the same
-/// rename behavior without requiring a gesture.
+/// Prominent speaker identity used by every transcript line. It is a real
+/// single-click button: the popover stages an edit and only writes on Save.
 private struct QuietMeetingSpeakerLabel: View {
     let identity: HomeMeetingSpeakerIdentity
-    let onRename: (HomeMeetingSpeakerIdentity, String) -> Void
+    let knownPeople: [SpeakerIdentityOption]
+    let onAssign: (HomeMeetingSpeakerAssignment, @escaping (Bool) -> Void) -> Void
 
-    @State private var isEditing = false
-    @State private var editedName = ""
-    @FocusState private var fieldIsFocused: Bool
+    @State private var showsPicker = false
+    @State private var isHovering = false
 
     private var canRename: Bool {
         !identity.displayName.isEmpty && identity.rawLabel != "Speaker"
     }
 
     var body: some View {
-        Group {
-            if isEditing {
-                TextField("Speaker name", text: $editedName)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 13, weight: .semibold))
-                    .focused($fieldIsFocused)
-                    .onSubmit { commit() }
-                    .onExitCommand { cancel() }
-                    .onAppear { fieldIsFocused = true }
-                    .onChange(of: fieldIsFocused) { _, focused in
-                        if !focused && isEditing { commit() }
-                    }
-                    .accessibilityIdentifier("transcripted.home.expansion.speaker.field")
-            } else {
+        Button {
+            guard canRename else { return }
+            showsPicker = true
+        } label: {
+            HStack(spacing: 4) {
                 Text(identity.displayName)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(speakerColor)
+                    .underline(isHovering || showsPicker, color: speakerColor.opacity(0.72))
                     .lineLimit(1)
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) { beginEditing() }
-                    .contextMenu {
-                        if canRename {
-                            Button("Rename Speaker…") { beginEditing() }
-                        }
-                    }
-                    .accessibilityAction(named: "Rename speaker") { beginEditing() }
-                    .help(canRename ? "Double-click to rename \(identity.displayName)" : "")
-                    .accessibilityIdentifier("transcripted.home.expansion.speaker")
+                if canRename {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(speakerColor.opacity(0.75))
+                        .opacity((isHovering || showsPicker) ? 1 : 0.34)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!canRename)
+        .onHover { isHovering = $0 }
+        .contextMenu {
+            if canRename {
+                Button("Rename Speaker…") { showsPicker = true }
             }
         }
+        .accessibilityLabel("Speaker: \(identity.displayName)")
+        .accessibilityHint(canRename ? "Assign or correct this person" : "")
+        .accessibilityAction(named: "Rename speaker") { showsPicker = true }
+        .help(canRename ? "Assign or correct \(identity.displayName)" : "")
+        .accessibilityIdentifier("transcripted.home.expansion.speaker.\(identity.stableID)")
         .frame(width: 116, alignment: .leading)
+        .popover(isPresented: $showsPicker, arrowEdge: .bottom) {
+            HomeMeetingSpeakerPicker(
+                identity: identity,
+                knownPeople: knownPeople.filter { $0.id != identity.persistentSpeakerID },
+                onCancel: { showsPicker = false },
+                onSave: { assignment, completion in
+                    onAssign(assignment) { didSave in
+                        if didSave { showsPicker = false }
+                        completion(didSave)
+                    }
+                }
+            )
+        }
     }
 
     private var speakerColor: Color {
         if identity.displayName == "You" { return LibraryTokens.accent }
-        return HomeMeetingSpeakerColor.color(for: identity.displayName)
+        return HomeMeetingSpeakerColor.color(for: identity.stableID)
+    }
+}
+
+private struct HomeMeetingSpeakerPicker: View {
+    let identity: HomeMeetingSpeakerIdentity
+    let knownPeople: [SpeakerIdentityOption]
+    let onCancel: () -> Void
+    let onSave: (HomeMeetingSpeakerAssignment, @escaping (Bool) -> Void) -> Void
+
+    @State private var nameDraft: String
+    @State private var selectedProfileID: UUID?
+    @State private var isSaving = false
+    @State private var saveFailed = false
+
+    init(
+        identity: HomeMeetingSpeakerIdentity,
+        knownPeople: [SpeakerIdentityOption],
+        onCancel: @escaping () -> Void,
+        onSave: @escaping (HomeMeetingSpeakerAssignment, @escaping (Bool) -> Void) -> Void
+    ) {
+        self.identity = identity
+        self.knownPeople = knownPeople
+        self.onCancel = onCancel
+        self.onSave = onSave
+        _nameDraft = State(initialValue: identity.displayName)
+        _selectedProfileID = State(initialValue: nil)
     }
 
-    private func beginEditing() {
-        guard canRename else { return }
-        editedName = identity.displayName
-        isEditing = true
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Who is this?")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(scopeMessage)
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(LibraryTokens.ink2)
+            }
+
+            SpeakerNameAutocompleteField(
+                text: $nameDraft,
+                placeholder: "Type a name",
+                options: knownPeople,
+                selectedOptionID: $selectedProfileID,
+                showAllWhenTextEquals: identity.displayName,
+                accessibilityIdentifier: "transcripted.home.speaker-picker.name",
+                autoFocus: true,
+                onSubmit: save,
+                onCancel: onCancel
+            )
+            .frame(height: 28)
+
+            if saveFailed {
+                Text("Couldn’t save that name. Nothing else was changed.")
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(LibraryTokens.attention)
+            }
+
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("transcripted.home.speaker-picker.cancel")
+                Button(isSaving ? "Saving…" : "Save", action: save)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(assignment == nil || isSaving)
+                    .accessibilityIdentifier("transcripted.home.speaker-picker.save")
+            }
+        }
+        .padding(16)
+        .frame(width: 340)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("transcripted.home.speaker-picker")
+        .onChange(of: nameDraft) { _, _ in saveFailed = false }
     }
 
-    private func commit() {
-        isEditing = false
-        let trimmed = editedName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed != identity.displayName else { return }
-        onRename(identity, trimmed)
+    private var assignment: HomeMeetingSpeakerAssignment? {
+        HomeMeetingSpeakerNamingPolicy.assignment(from: HomeMeetingSpeakerNamingDraft(
+            identity: identity,
+            sampleTexts: [],
+            name: nameDraft,
+            selectedProfileID: selectedProfileID
+        ))
     }
 
-    private func cancel() {
-        isEditing = false
-        editedName = identity.displayName
+    private var scopeMessage: String {
+        if identity.persistentSpeakerID != nil {
+            return selectedProfileID == nil
+                ? "Renames this saved person in linked meetings."
+                : "Uses this saved person in linked meetings."
+        }
+        return selectedProfileID == nil
+            ? "Updates this meeting only."
+            : "Links this voice to the saved person."
+    }
+
+    private func save() {
+        guard let assignment, !isSaving else { return }
+        isSaving = true
+        saveFailed = false
+        onSave(assignment) { didSave in
+            isSaving = false
+            saveFailed = !didSave
+        }
+    }
+}
+
+private struct HomeMeetingSpeakerNamingSheet: View {
+    let knownPeople: [SpeakerIdentityOption]
+    let onCancel: () -> Void
+    let onSave: ([HomeMeetingSpeakerAssignment], @escaping (Bool) -> Void) -> Void
+    private let initialDrafts: [HomeMeetingSpeakerNamingDraft]
+
+    @State private var drafts: [HomeMeetingSpeakerNamingDraft]
+    @State private var isSaving = false
+    @State private var saveFailed = false
+
+    init(
+        content: HomeMeetingPreviewContent,
+        knownPeople: [SpeakerIdentityOption],
+        onCancel: @escaping () -> Void,
+        onSave: @escaping ([HomeMeetingSpeakerAssignment], @escaping (Bool) -> Void) -> Void
+    ) {
+        let initialDrafts = HomeMeetingSpeakerNamingPolicy.drafts(from: content.transcriptLines)
+        self.knownPeople = knownPeople
+        self.onCancel = onCancel
+        self.onSave = onSave
+        self.initialDrafts = initialDrafts
+        _drafts = State(initialValue: initialDrafts)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Name speakers")
+                        .font(.system(size: 22, weight: .semibold))
+                    Text("Give each voice a name and we’ll relabel the whole transcript.")
+                        .font(LibraryTokens.body)
+                        .foregroundStyle(LibraryTokens.ink2)
+                }
+                Spacer()
+                Button(action: onCancel) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+                .help("Cancel")
+                .accessibilityIdentifier("transcripted.home.speaker-sheet.close")
+            }
+            .padding(20)
+
+            Divider().opacity(0.55)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    if hasLocalAndRemoteSpeakers {
+                        section("PEOPLE IN THE ROOM", channel: .mic)
+                        section("REMOTE PARTICIPANTS", channel: .system)
+                        section("OTHER SPEAKERS", channel: nil)
+                    } else {
+                        ForEach(drafts.indices, id: \.self) { index in
+                            speakerRow(at: index)
+                        }
+                    }
+                }
+                .padding(20)
+            }
+
+            Divider().opacity(0.55)
+
+            HStack(spacing: 10) {
+                if saveFailed {
+                    Text("One or more names couldn’t be saved. Try again.")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(LibraryTokens.attention)
+                }
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                    .accessibilityIdentifier("transcripted.home.speaker-sheet.cancel")
+                Button(isSaving ? "Saving…" : "Save names", action: save)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(assignments.isEmpty || isSaving)
+                    .accessibilityIdentifier("transcripted.home.speaker-sheet.save")
+            }
+            .padding(16)
+        }
+        .frame(minWidth: 620, idealWidth: 680, minHeight: 440, idealHeight: 560)
+        .background(LibraryTokens.contentBackground)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("transcripted.home.speaker-sheet")
+        .onAppear {
+            // SwiftUI can reuse sheet state across presentations. Always start
+            // from the latest persisted transcript, never an old cancelled or
+            // previously-saved draft.
+            drafts = initialDrafts
+            isSaving = false
+            saveFailed = false
+        }
+        .onChange(of: drafts) { _, _ in saveFailed = false }
+    }
+
+    @ViewBuilder
+    private func section(_ title: String, channel: HomeMeetingSpeakerChannel?) -> some View {
+        let indices = drafts.indices.filter { drafts[$0].identity.channel == channel }
+        if !indices.isEmpty {
+            Text(title)
+                .font(LibraryTokens.label)
+                .tracking(LibraryTokens.labelTracking)
+                .foregroundStyle(LibraryTokens.ink3)
+                .padding(.top, 2)
+            ForEach(indices, id: \.self) { index in
+                speakerRow(at: index)
+            }
+        }
+    }
+
+    private func speakerRow(at index: Int) -> some View {
+        HomeMeetingSpeakerNamingRow(
+            draft: $drafts[index],
+            knownPeople: knownPeople.filter { $0.id != drafts[index].identity.persistentSpeakerID }
+        )
+    }
+
+    private var hasLocalAndRemoteSpeakers: Bool {
+        drafts.contains { $0.identity.channel == .mic }
+            && drafts.contains { $0.identity.channel == .system }
+    }
+
+    private var assignments: [HomeMeetingSpeakerAssignment] {
+        HomeMeetingSpeakerNamingPolicy.assignments(from: drafts)
+    }
+
+    private func save() {
+        let assignments = assignments
+        guard !assignments.isEmpty, !isSaving else { return }
+        isSaving = true
+        saveFailed = false
+        onSave(assignments) { didSave in
+            isSaving = false
+            saveFailed = !didSave
+        }
+    }
+}
+
+private struct HomeMeetingSpeakerNamingRow: View {
+    @Binding var draft: HomeMeetingSpeakerNamingDraft
+    let knownPeople: [SpeakerIdentityOption]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 9) {
+                Circle()
+                    .fill(speakerColor)
+                    .frame(width: 8, height: 8)
+                Text(draft.identity.displayName)
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                Text(scopeLabel)
+                    .font(.system(size: 11))
+                    .foregroundStyle(LibraryTokens.ink3)
+            }
+
+            ForEach(draft.sampleTexts, id: \.self) { sample in
+                Text("“\(sample)”")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(LibraryTokens.ink2)
+                    .lineLimit(2)
+                    .padding(.leading, 17)
+            }
+
+            SpeakerNameAutocompleteField(
+                text: $draft.name,
+                placeholder: "Type a name",
+                options: knownPeople,
+                selectedOptionID: $draft.selectedProfileID,
+                showAllWhenTextEquals: draft.identity.displayName,
+                accessibilityIdentifier: "transcripted.home.speaker-sheet.row.\(draft.id).name",
+                onSubmit: {}
+            )
+            .frame(height: 30)
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: LibraryTokens.radiusRaised, style: .continuous)
+                .fill(LibraryTokens.raisedFill)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: LibraryTokens.radiusRaised, style: .continuous)
+                .stroke(LibraryTokens.raisedStroke, lineWidth: 1)
+        )
+        .accessibilityIdentifier("transcripted.home.speaker-sheet.row.\(draft.id)")
+    }
+
+    private var speakerColor: Color {
+        if draft.identity.displayName == "You" { return LibraryTokens.accent }
+        return HomeMeetingSpeakerColor.color(for: draft.identity.stableID)
+    }
+
+    private var scopeLabel: String {
+        draft.identity.persistentSpeakerID == nil ? "This meeting" : "Linked meetings"
     }
 }
 

--- a/Sources/UI/Settings/SpeakerNameAutocompleteField.swift
+++ b/Sources/UI/Settings/SpeakerNameAutocompleteField.swift
@@ -11,8 +11,18 @@ struct SpeakerNameAutocompleteField: NSViewRepresentable {
     @Binding var text: String
     var placeholder: String
     var options: [SpeakerIdentityOption]
+    /// Carries the exact saved-person UUID selected from the dropdown. Typing
+    /// clears it, so callers can distinguish a new name from choosing one of
+    /// two saved people who happen to share the same display name.
+    var selectedOptionID: Binding<UUID?>? = nil
+    /// When a picker opens prefilled with the current transcript label, its
+    /// disclosure tray should show every saved person instead of treating that
+    /// old label as an active search query.
+    var showAllWhenTextEquals: String? = nil
     var accessibilityIdentifier: String?
+    var autoFocus = false
     var onSubmit: () -> Void
+    var onCancel: (() -> Void)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
@@ -32,6 +42,12 @@ struct SpeakerNameAutocompleteField: NSViewRepresentable {
         }
         context.coordinator.rebuild(options: options)
         combo.numberOfVisibleItems = Self.visibleItemCount(for: options)
+        if autoFocus {
+            DispatchQueue.main.async {
+                guard combo.window != nil else { return }
+                combo.window?.makeFirstResponder(combo)
+            }
+        }
         return combo
     }
 
@@ -72,6 +88,11 @@ struct SpeakerNameAutocompleteField: NSViewRepresentable {
         private func visibleLabels(for query: String) -> [String] {
             let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return labels }
+            if let initial = parent.showAllWhenTextEquals,
+               SpeakerNameSelectionPolicy.normalizedSearchText(trimmed)
+                == SpeakerNameSelectionPolicy.normalizedSearchText(initial) {
+                return labels
+            }
             return SpeakerNameSelectionPolicy.sortedLabels(
                 matching: trimmed,
                 labels: labels,
@@ -112,6 +133,7 @@ struct SpeakerNameAutocompleteField: NSViewRepresentable {
         func controlTextDidChange(_ obj: Notification) {
             guard let combo = obj.object as? NSComboBox else { return }
             parent.text = combo.stringValue
+            parent.selectedOptionID?.wrappedValue = nil
             combo.reloadData()
         }
 
@@ -128,17 +150,19 @@ struct SpeakerNameAutocompleteField: NSViewRepresentable {
             let label = visible[index]
             // Map the (possibly decorated) dropdown label back to the plain
             // display name, matching what the naming sheet stores.
-            let resolved = SpeakerNameSelectionPolicy.option(
+            let selectedOption = SpeakerNameSelectionPolicy.option(
                 matching: label,
                 optionsByLabel: optionsByLabel,
                 displayName: { $0.displayName }
-            )?.displayName ?? label
+            )
+            let resolved = selectedOption?.displayName ?? label
             // Assign on the next tick so this lands *after* the combo commits its
             // own selected value, overriding the decorated label with the plain
             // name instead of being clobbered by it.
             DispatchQueue.main.async { [weak self] in
                 combo.stringValue = resolved
                 self?.parent.text = resolved
+                self?.parent.selectedOptionID?.wrappedValue = selectedOption?.id
             }
         }
 
@@ -151,6 +175,11 @@ struct SpeakerNameAutocompleteField: NSViewRepresentable {
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 parent.text = combo.stringValue
                 parent.onSubmit()
+                return true
+            }
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)),
+               let onCancel = parent.onCancel {
+                onCancel()
                 return true
             }
             return false

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -138,6 +138,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     @Published private(set) var skippedVoiceGroupIDs: Set<UUID> = []
 
     private let speakerDatabase: SpeakerDatabase
+    private let transcriptDirectory: URL
     private let preferredClipsDirectory: URL
     private let legacyClipsDirectory: URL
     private(set) var duplicateCandidates: [SpeakerDuplicateCandidate] = []
@@ -161,10 +162,12 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
 
     init(
         speakerDatabase: SpeakerDatabase,
+        transcriptDirectory: URL = TranscriptSaver.defaultSaveDirectory,
         preferredClipsDirectory: URL,
         legacyClipsDirectory: URL = CoreStoragePaths.default.speakerClips
     ) {
         self.speakerDatabase = speakerDatabase
+        self.transcriptDirectory = transcriptDirectory
         self.preferredClipsDirectory = preferredClipsDirectory
         self.legacyClipsDirectory = legacyClipsDirectory
         refresh()
@@ -381,6 +384,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
 
         let profileId = profile.id
         let speakerDatabase = self.speakerDatabase
+        let transcriptDirectory = self.transcriptDirectory
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -394,7 +398,8 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             do {
                 let outcome = try SpeakerIdentityMutationService.apply(
                     .rename(profileId: profileId, newName: trimmed),
-                    speakerDB: speakerDatabase
+                    speakerDB: speakerDatabase,
+                    directory: transcriptDirectory
                 )
                 didRename = outcome.succeeded
                 if !outcome.succeeded {
@@ -447,12 +452,20 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         }
     }
 
-    func merge(source: SpeakerProfile, into target: SpeakerProfile) {
-        guard source.id != target.id else { return }
+    func merge(
+        source: SpeakerProfile,
+        into target: SpeakerProfile,
+        completion: ((Bool) -> Void)? = nil
+    ) {
+        guard source.id != target.id else {
+            completion?(false)
+            return
+        }
 
         let sourceId = source.id
         let targetId = target.id
         let speakerDatabase = self.speakerDatabase
+        let transcriptDirectory = self.transcriptDirectory
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
 
@@ -465,10 +478,12 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             // throws, and only then runs clip promotion/deletion. Same-id merges are
             // rejected by the service itself now (MutationError.sameSourceAndTarget), so the
             // `source.id != target.id` guard above is defense in depth, not the only guard.
+            var didMerge = false
             do {
                 let outcome = try SpeakerIdentityMutationService.apply(
                     .merge(sourceId: sourceId, targetId: targetId),
                     speakerDB: speakerDatabase,
+                    directory: transcriptDirectory,
                     clipSideEffects: SpeakerIdentityMutationService.ClipSideEffects(
                         onMergeCommitted: { sourceId, targetId in
                             Self.promoteClipIfNeeded(
@@ -491,6 +506,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
                         "targetId": targetId.uuidString
                     ])
                 }
+                didMerge = outcome.succeeded
             } catch {
                 Self.reportMutationFailure(error, engine: "speakers", profileId: sourceId)
             }
@@ -501,6 +517,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             )
             DispatchQueue.main.async {
                 self?.applySnapshot(snapshot)
+                completion?(didMerge)
             }
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -703,10 +703,17 @@ struct TranscriptedSettingsView: View {
                             : nil) ?? HomeMeetingPreview(item: meeting, markdown: "")
                         renameMeetingPreview(preview, to: newTitle)
                     },
-                    onRenameSpeaker: { identity, newName in
+                    knownPeople: SpeakerNameSuggestionSource.options(
+                        from: speakerPeopleModel.profiles,
+                        excluding: nil
+                    ),
+                    onAssignSpeakers: { assignments, completion in
                         guard let preview = homeExpandedMeetingPreview,
-                              preview.id == meeting.id else { return }
-                        renameMeetingSpeaker(identity, in: preview, to: newName)
+                              preview.id == meeting.id else {
+                            completion(false)
+                            return
+                        }
+                        assignMeetingSpeakers(assignments, in: preview, completion: completion)
                     },
                     menuItems: meetingRowMenuItems(for: meeting)
                 )
@@ -1362,70 +1369,174 @@ struct TranscriptedSettingsView: View {
         }
     }
 
-    private func renameMeetingSpeaker(
-        _ identity: HomeMeetingSpeakerIdentity,
+    /// Applies the staged inline/batch picker result. Transcript-local rows are
+    /// rewritten together in one file write; saved identities continue through
+    /// the canonical transactional global rename/merge service.
+    private func assignMeetingSpeakers(
+        _ assignments: [HomeMeetingSpeakerAssignment],
         in preview: HomeMeetingPreview,
-        to rawName: String
+        completion: @escaping (Bool) -> Void
     ) {
-        trackSettingsAction("rename_meeting_speaker", page: .home)
+        guard !assignments.isEmpty else {
+            completion(true)
+            return
+        }
+        trackSettingsAction(
+            assignments.count == 1 ? "rename_meeting_speaker" : "name_meeting_speakers",
+            page: .home
+        )
 
-        if let persistentSpeakerID = identity.persistentSpeakerID {
-            guard let profile = speakerPeopleModel.profiles.first(where: { $0.id == persistentSpeakerID }) else {
-                speakerPeopleModel.refresh()
-                presentHomeActionFailure(
-                    title: "Could not rename speaker",
-                    message: "Transcripted couldn't find that saved speaker identity. Refresh the meeting and try again.",
-                    retry: {
-                        renameMeetingSpeaker(identity, in: preview, to: rawName)
-                    }
-                )
-                return
-            }
+        let localAssignments = assignments.filter { $0.identity.persistentSpeakerID == nil }
+        let savedAssignments = assignments.filter { $0.identity.persistentSpeakerID != nil }
+        guard let savedAssignmentsInCommitOrder =
+            HomeMeetingSpeakerNamingPolicy.savedAssignmentsInCommitOrder(savedAssignments),
+              let localAssignmentsAfterSavedMerges =
+            HomeMeetingSpeakerNamingPolicy.remappingLocalTargets(
+                localAssignments,
+                after: savedAssignmentsInCommitOrder
+            ) else {
+            completion(false)
+            return
+        }
+        let profileIDs = Set(speakerPeopleModel.profiles.map(\.id))
 
-            // Saved identities use the canonical transactional rename path so
-            // the people database and every linked transcript stay aligned.
-            speakerPeopleModel.rename(profile: profile, to: rawName) { didRename in
-                if didRename {
-                    reloadExpandedMeetingPreview(preview)
-                    refreshRecentCaptures(force: true)
-                } else {
-                    presentHomeActionFailure(
-                        title: "Could not rename speaker",
-                        message: "Transcripted couldn't update this saved speaker and its linked transcripts.",
-                        retry: {
-                            renameMeetingSpeaker(identity, in: preview, to: rawName)
-                        }
-                    )
-                }
-            }
+        // Validate the whole saved-person plan before the first mutation. This
+        // catches stale picker rows without leaving an avoidable partial batch.
+        let savedProfilesAreCurrent = savedAssignmentsInCommitOrder.allSatisfy { assignment in
+            guard let sourceID = assignment.identity.persistentSpeakerID,
+                  profileIDs.contains(sourceID) else { return false }
+            guard let targetID = assignment.targetProfileID,
+                  targetID != sourceID else { return true }
+            return profileIDs.contains(targetID)
+        }
+        let localTargetsAreCurrent = localAssignmentsAfterSavedMerges.allSatisfy {
+            $0.targetProfileID.map(profileIDs.contains) ?? true
+        }
+        guard savedProfilesAreCurrent, localTargetsAreCurrent else {
+            speakerPeopleModel.refresh()
+            completion(false)
             return
         }
 
-        // Older transcripts can lack a persistent speaker id. Keep that edit
-        // scoped to this file and exact source label, avoiding Mic/System bleed.
-        let transcriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [preview.transcriptURL])
-            ?? preview.transcriptURL
-        Task { @MainActor in
-            do {
-                _ = try await Task.detached(priority: .userInitiated) {
-                    try HomeMeetingSpeakerRename.rename(
-                        transcriptAt: transcriptURL,
-                        identity: identity,
-                        to: rawName
-                    )
-                }.value
-                reloadExpandedMeetingPreview(preview)
-                refreshRecentCaptures(force: true)
-            } catch {
-                presentHomeActionFailure(
-                    title: "Could not rename speaker",
-                    message: "Transcripted couldn't update this speaker in the saved transcript.",
-                    details: error.localizedDescription,
-                    retry: {
-                        renameMeetingSpeaker(identity, in: preview, to: rawName)
-                    }
+        var savedAssignmentCount = 0
+
+        func finish(_ didSave: Bool) {
+            // A late completion must not replace whichever meeting the user
+            // opened while the persistence work was running.
+            reloadExpandedMeetingPreview(preview)
+            refreshRecentCaptures(force: true)
+            completion(didSave)
+        }
+
+        func finishPartialFailure() {
+            // At least one canonical mutation committed, so the old drafts are
+            // no longer a safe retry surface. Close the sheet, reload persisted
+            // truth, and tell the user to review the remaining voices.
+            reloadExpandedMeetingPreview(preview)
+            refreshRecentCaptures(force: true)
+            completion(true)
+            presentHomeActionFailure(
+                title: "Some speaker names were saved",
+                message: "Transcripted saved part of this batch but couldn't finish it. Reopen Name speakers to review what's left.",
+                retryTitle: "Refresh meeting",
+                retry: { reloadExpandedMeetingPreview(preview) }
+            )
+        }
+
+        func applyLocalAssignments() {
+            guard !localAssignmentsAfterSavedMerges.isEmpty else {
+                finish(true)
+                return
+            }
+
+            // Saved mutations above may have renamed or merged a selected
+            // person. Read the canonical surviving name back from the refreshed
+            // model before linking a formerly-unlinked transcript row.
+            let resolvedLocalAssignments = localAssignmentsAfterSavedMerges.compactMap { assignment
+                -> HomeMeetingSpeakerAssignment? in
+                guard let targetID = assignment.targetProfileID else { return assignment }
+                guard let profile = speakerPeopleModel.profiles.first(where: { $0.id == targetID }),
+                      let canonicalName = profile.displayName?
+                        .trimmingCharacters(in: .whitespacesAndNewlines),
+                      !canonicalName.isEmpty else { return nil }
+                return HomeMeetingSpeakerAssignment(
+                    identity: assignment.identity,
+                    newName: canonicalName,
+                    targetProfileID: targetID
                 )
             }
+            guard resolvedLocalAssignments.count == localAssignmentsAfterSavedMerges.count else {
+                if savedAssignmentCount > 0 {
+                    finishPartialFailure()
+                } else {
+                    finish(false)
+                }
+                return
+            }
+
+            let transcriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [preview.transcriptURL])
+                ?? preview.transcriptURL
+            Task { @MainActor in
+                do {
+                    _ = try await Task.detached(priority: .userInitiated) {
+                        try HomeMeetingSpeakerRename.renameMany(
+                            transcriptAt: transcriptURL,
+                            assignments: resolvedLocalAssignments
+                        )
+                    }.value
+                    finish(true)
+                } catch {
+                    if savedAssignmentCount > 0 {
+                        finishPartialFailure()
+                    } else {
+                        finish(false)
+                    }
+                }
+            }
+        }
+
+        func applySavedAssignment(at index: Int) {
+            guard savedAssignmentsInCommitOrder.indices.contains(index) else {
+                applyLocalAssignments()
+                return
+            }
+            applySavedMeetingSpeakerAssignment(savedAssignmentsInCommitOrder[index]) { didSave in
+                guard didSave else {
+                    if savedAssignmentCount > 0 {
+                        finishPartialFailure()
+                    } else {
+                        finish(false)
+                    }
+                    return
+                }
+                savedAssignmentCount += 1
+                applySavedAssignment(at: index + 1)
+            }
+        }
+
+        applySavedAssignment(at: 0)
+    }
+
+    private func applySavedMeetingSpeakerAssignment(
+        _ assignment: HomeMeetingSpeakerAssignment,
+        completion: @escaping (Bool) -> Void
+    ) {
+        guard let sourceID = assignment.identity.persistentSpeakerID,
+              let source = speakerPeopleModel.profiles.first(where: { $0.id == sourceID }) else {
+            speakerPeopleModel.refresh()
+            completion(false)
+            return
+        }
+
+        if let targetID = assignment.targetProfileID, targetID != sourceID {
+            guard let target = speakerPeopleModel.profiles.first(where: { $0.id == targetID }) else {
+                speakerPeopleModel.refresh()
+                completion(false)
+                return
+            }
+            speakerPeopleModel.merge(source: source, into: target, completion: completion)
+        } else {
+            speakerPeopleModel.rename(profile: source, to: assignment.newName, completion: completion)
         }
     }
 
@@ -1575,6 +1686,7 @@ struct TranscriptedSettingsView: View {
         title: String,
         message: String,
         details: String? = nil,
+        retryTitle: String = HomeActionFailureCopy.retryTitle,
         retry: @escaping () -> Void
     ) {
         NSSound.beep()
@@ -1586,6 +1698,7 @@ struct TranscriptedSettingsView: View {
             homeDeleteFailure = HomeDeleteFailure(
                 title: title,
                 message: message,
+                retryTitle: retryTitle,
                 details: details,
                 retry: retry
             )

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -13,6 +13,7 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
             ?? SpeakerDatabase(path: SpeakerEmbedderFactory.activeSpeakerDBURL().path)
         let speakerPeopleModel = SpeakerPeopleSettingsViewModel(
             speakerDatabase: speakerDatabase,
+            transcriptDirectory: MeetingStoragePaths.transcriptsFolder,
             preferredClipsDirectory: MeetingStoragePaths.speakerClipsFolder
         )
         self.speakerPeopleModel = speakerPeopleModel

--- a/Sources/UI/Shared/HomeMeetingRename.swift
+++ b/Sources/UI/Shared/HomeMeetingRename.swift
@@ -11,6 +11,7 @@ struct HomeMeetingRenameResult: Equatable {
 enum HomeMeetingSpeakerRenameError: Error, Equatable, LocalizedError {
     case emptyName
     case speakerNotFound
+    case ambiguousSpeaker
     case readFailed
     case writeFailed
 
@@ -20,6 +21,8 @@ enum HomeMeetingSpeakerRenameError: Error, Equatable, LocalizedError {
             return "Enter a speaker name."
         case .speakerNotFound:
             return "That speaker label changed before the rename could be saved."
+        case .ambiguousSpeaker:
+            return "Two different voices use the same transcript label, so Transcripted left them unchanged."
         case .readFailed:
             return "The meeting transcript could not be read."
         case .writeFailed:
@@ -38,12 +41,42 @@ enum HomeMeetingSpeakerRename {
         transcriptAt url: URL,
         identity: HomeMeetingSpeakerIdentity,
         to rawName: String,
+        linkingTo targetProfileID: UUID? = nil,
         fileManager: FileManager = .default
     ) throws -> String {
+        let assignment = HomeMeetingSpeakerAssignment(
+            identity: identity,
+            newName: rawName,
+            targetProfileID: targetProfileID
+        )
+        return try renameMany(
+            transcriptAt: url,
+            assignments: [assignment],
+            fileManager: fileManager
+        ).first ?? rawName
+    }
+
+    /// Applies every transcript-local correction against one snapshot and
+    /// writes once. Placeholder tokens prevent cascading replacements when,
+    /// for example, Alex becomes Jordan while Jordan becomes Morgan.
+    @discardableResult
+    static func renameMany(
+        transcriptAt url: URL,
+        assignments: [HomeMeetingSpeakerAssignment],
+        fileManager: FileManager = .default
+    ) throws -> [String] {
         try MeetingTranscriptFileUpdateSerializer.sync {
-            guard let name = normalizedName(rawName) else {
-                throw HomeMeetingSpeakerRenameError.emptyName
+            let normalizedAssignments = try assignments.map { assignment -> HomeMeetingSpeakerAssignment in
+                guard let name = normalizedName(assignment.newName) else {
+                    throw HomeMeetingSpeakerRenameError.emptyName
+                }
+                return HomeMeetingSpeakerAssignment(
+                    identity: assignment.identity,
+                    newName: name,
+                    targetProfileID: assignment.targetProfileID
+                )
             }
+            guard !normalizedAssignments.isEmpty else { return [] }
 
             let raw: String
             do {
@@ -53,22 +86,51 @@ enum HomeMeetingSpeakerRename {
             }
 
             var lines = raw.components(separatedBy: "\n")
-            let metadataChanged = rewriteFrontmatterSpeaker(
-                in: &lines,
-                identity: identity,
-                newName: name
-            )
+            var metadataChangedByID: [String: Bool] = [:]
+            var replacements: [String: String] = [:]
 
-            var rewritten = lines.joined(separator: "\n")
-            let oldToken = "[\(identity.rawLabel)]"
-            let newToken = "[\(replacementRawLabel(for: identity, newName: name))]"
-            let bodyChanged = rewritten.contains(oldToken)
-            if bodyChanged {
-                rewritten = rewritten.replacingOccurrences(of: oldToken, with: newToken)
+            for assignment in normalizedAssignments {
+                let oldToken = "[\(assignment.identity.rawLabel)]"
+                let newRawLabel = replacementRawLabel(
+                    for: assignment.identity,
+                    newName: assignment.newName
+                )
+                let newToken = "[\(newRawLabel)]"
+                if let existing = replacements[oldToken], existing != newToken {
+                    throw HomeMeetingSpeakerRenameError.ambiguousSpeaker
+                }
+                replacements[oldToken] = newToken
+                metadataChangedByID[assignment.identity.stableID] = rewriteFrontmatterSpeaker(
+                    in: &lines,
+                    identity: assignment.identity,
+                    newName: assignment.newName,
+                    targetProfileID: assignment.targetProfileID
+                )
             }
 
-            guard metadataChanged || bodyChanged else {
-                throw HomeMeetingSpeakerRenameError.speakerNotFound
+            var rewritten = lines.joined(separator: "\n")
+            var placeholders: [(token: String, replacement: String)] = []
+            var bodyChangedTokens: Set<String> = []
+            for (offset, pair) in replacements.sorted(by: { $0.key < $1.key }).enumerated() {
+                guard rewritten.contains(pair.key) else { continue }
+                let placeholder = "[TRANSCRIPTED_SPEAKER_RENAME_\(offset)_\(UUID().uuidString)]"
+                rewritten = rewritten.replacingOccurrences(of: pair.key, with: placeholder)
+                placeholders.append((placeholder, pair.value))
+                bodyChangedTokens.insert(pair.key)
+            }
+            for placeholder in placeholders {
+                rewritten = rewritten.replacingOccurrences(
+                    of: placeholder.token,
+                    with: placeholder.replacement
+                )
+            }
+
+            for assignment in normalizedAssignments {
+                let oldToken = "[\(assignment.identity.rawLabel)]"
+                let metadataChanged = metadataChangedByID[assignment.identity.stableID] ?? false
+                guard metadataChanged || bodyChangedTokens.contains(oldToken) else {
+                    throw HomeMeetingSpeakerRenameError.speakerNotFound
+                }
             }
 
             do {
@@ -77,7 +139,7 @@ enum HomeMeetingSpeakerRename {
             } catch {
                 throw HomeMeetingSpeakerRenameError.writeFailed
             }
-            return name
+            return normalizedAssignments.map(\.newName)
         }
     }
 
@@ -111,7 +173,8 @@ enum HomeMeetingSpeakerRename {
     private static func rewriteFrontmatterSpeaker(
         in lines: inout [String],
         identity: HomeMeetingSpeakerIdentity,
-        newName: String
+        newName: String,
+        targetProfileID: UUID?
     ) -> Bool {
         guard let diarizerID = identity.diarizerSpeakerID else { return false }
 
@@ -142,12 +205,13 @@ enum HomeMeetingSpeakerRename {
             }
         }
 
-        var matches: [(nameIndex: Int, sourceIndex: Int?)] = []
+        var matches: [(nameIndex: Int, sourceIndex: Int?, dbIDIndex: Int?, endIndex: Int)] = []
         for (offset, start) in entryStarts.enumerated() {
             let end = offset + 1 < entryStarts.count ? entryStarts[offset + 1] : frontmatterEntryEnd(after: start, in: lines)
             var values: [String: String] = [:]
             var nameIndex: Int?
             var sourceIndex: Int?
+            var dbIDIndex: Int?
 
             for index in start..<end {
                 let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
@@ -159,6 +223,7 @@ enum HomeMeetingSpeakerRename {
                 values[key] = value
                 if key == "name" { nameIndex = index }
                 if key == "source" { sourceIndex = index }
+                if key == "db_id" { dbIDIndex = index }
             }
 
             let rowChannel = HomeMeetingSpeakerChannel(rawValue: values["channel"] ?? "system")
@@ -167,7 +232,7 @@ enum HomeMeetingSpeakerRename {
                   identity.channel == nil || rowChannel == identity.channel,
                   identity.persistentSpeakerID == nil || persistentID == identity.persistentSpeakerID,
                   let nameIndex else { continue }
-            matches.append((nameIndex, sourceIndex))
+            matches.append((nameIndex, sourceIndex, dbIDIndex, end))
         }
 
         guard matches.count == 1, let match = matches.first else { return false }
@@ -176,6 +241,18 @@ enum HomeMeetingSpeakerRename {
         if let sourceIndex = match.sourceIndex {
             let sourceIndent = lines[sourceIndex].prefix(while: { $0 == " " })
             lines[sourceIndex] = "\(sourceIndent)source: user_manual"
+        } else {
+            lines.insert("    source: user_manual", at: match.endIndex)
+        }
+        if let targetProfileID {
+            if let dbIDIndex = match.dbIDIndex {
+                let dbIndent = lines[dbIDIndex].prefix(while: { $0 == " " })
+                lines[dbIDIndex] = "\(dbIndent)db_id: \"\(targetProfileID.uuidString)\""
+            } else {
+                // Insert after the name. This remains inside the exact matched
+                // speaker row even when the row originally had no source/db id.
+                lines.insert("    db_id: \"\(targetProfileID.uuidString)\"", at: match.nameIndex + 1)
+            }
         }
         return true
     }

--- a/Tests/HomeMeetingPreviewFormatterTests.swift
+++ b/Tests/HomeMeetingPreviewFormatterTests.swift
@@ -76,6 +76,105 @@ func testHomeMeetingPreviewFormatter() {
             "The collapsed excerpt should follow a later active row"
         )
     }
+
+    runSuite("HomeMeetingSpeakerNamingPolicy groups voices and keeps saved-person identity") {
+        let lines = HomeMeetingPreviewContent.make(from: styledMeetingMarkdown()).transcriptLines
+        let drafts = HomeMeetingSpeakerNamingPolicy.drafts(from: lines)
+
+        assertEqual(drafts.count, 3, "Same visible name on different channels/voice ids must stay separate")
+        let micLinus = drafts.first {
+            $0.identity.channel == .mic && $0.identity.diarizerSpeakerID == "0"
+        }
+        assertEqual(micLinus?.sampleTexts.count, 2, "A voice should carry up to two first-seen quotes")
+
+        let selectedProfileID = UUID(uuidString: "22222222-2222-2222-2222-222222222222")!
+        guard var selectedDraft = drafts.first else {
+            assertionFailure("fixture should produce a speaker naming draft")
+            return
+        }
+        selectedDraft.name = "Alex"
+        selectedDraft.selectedProfileID = selectedProfileID
+        let selectedAssignment = HomeMeetingSpeakerNamingPolicy.assignment(from: selectedDraft)
+        assertEqual(
+            selectedAssignment?.targetProfileID,
+            selectedProfileID,
+            "Dropdown selection must retain its UUID instead of degrading to display-name matching"
+        )
+
+        selectedDraft.selectedProfileID = nil
+        selectedDraft.name = "  Jordan\nTest  "
+        assertEqual(
+            HomeMeetingSpeakerNamingPolicy.assignment(from: selectedDraft)?.newName,
+            "Jordan Test",
+            "Typed names should normalize whitespace before persistence"
+        )
+
+        selectedDraft.name = selectedDraft.identity.displayName
+        assertTrue(
+            HomeMeetingSpeakerNamingPolicy.assignment(from: selectedDraft) == nil,
+            "An unchanged typed name should not create a write"
+        )
+
+        let profileA = UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!
+        let profileB = UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!
+        let profileC = UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!
+        func savedIdentity(_ name: String, id: UUID, voice: String) -> HomeMeetingSpeakerIdentity {
+            HomeMeetingSpeakerIdentity(
+                displayName: name,
+                rawLabel: "System/\(name)",
+                channel: .system,
+                diarizerSpeakerID: voice,
+                persistentSpeakerID: id
+            )
+        }
+        let bIntoC = HomeMeetingSpeakerAssignment(
+            identity: savedIdentity("B", id: profileB, voice: "2"),
+            newName: "C",
+            targetProfileID: profileC
+        )
+        let aIntoB = HomeMeetingSpeakerAssignment(
+            identity: savedIdentity("A", id: profileA, voice: "1"),
+            newName: "B",
+            targetProfileID: profileB
+        )
+        let ordered = HomeMeetingSpeakerNamingPolicy.savedAssignmentsInCommitOrder([bIntoC, aIntoB])
+        assertEqual(
+            ordered?.compactMap(\.identity.persistentSpeakerID),
+            [profileA, profileB],
+            "Merge chains should commit leaf sources before a target profile is removed"
+        )
+
+        let localIdentity = HomeMeetingSpeakerIdentity(
+            displayName: "Speaker 9",
+            rawLabel: "System/Speaker 9",
+            channel: .system,
+            diarizerSpeakerID: "9",
+            persistentSpeakerID: nil
+        )
+        let localLink = HomeMeetingSpeakerAssignment(
+            identity: localIdentity,
+            newName: "A",
+            targetProfileID: profileA
+        )
+        assertEqual(
+            HomeMeetingSpeakerNamingPolicy.remappingLocalTargets(
+                [localLink],
+                after: [aIntoB, bIntoC]
+            )?.first?.targetProfileID,
+            profileC,
+            "A local row should link to the final surviving profile after a same-batch merge chain"
+        )
+
+        let cIntoA = HomeMeetingSpeakerAssignment(
+            identity: savedIdentity("C", id: profileC, voice: "3"),
+            newName: "A",
+            targetProfileID: profileA
+        )
+        assertTrue(
+            HomeMeetingSpeakerNamingPolicy.savedAssignmentsInCommitOrder([aIntoB, bIntoC, cIntoA]) == nil,
+            "Cyclic saved-person merges should fail before any profile is changed"
+        )
+    }
 }
 
 private func styledMeetingMarkdown() -> String {

--- a/Tests/HomeMeetingRenameTests.swift
+++ b/Tests/HomeMeetingRenameTests.swift
@@ -226,6 +226,110 @@ func testHomeMeetingRename() {
             }
         }
     }
+
+    runSuite("HomeMeetingSpeakerRename batches without cascading names") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Speaker Swap.md")
+            let markdown = """
+            ---
+            capture_type: meeting
+            speakers:
+              - id: "0"
+                channel: system
+                name: "Alex"
+                source: unknown
+              - id: "1"
+                channel: system
+                name: "Jordan"
+                source: unknown
+            ---
+
+            ## Transcript
+
+            **00:00** [System/Alex]
+            First voice.
+
+            **00:02** [System/Jordan]
+            Second voice.
+
+            **00:04** [System/Alex]
+            First voice again.
+            """
+            try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            let identities = HomeMeetingPreviewContent.make(from: markdown).transcriptLines.map(\.identity)
+            guard let alex = identities.first(where: { $0.displayName == "Alex" }),
+                  let jordan = identities.first(where: { $0.displayName == "Jordan" }) else {
+                assertionFailure("fixture should expose both identities")
+                return
+            }
+
+            do {
+                _ = try HomeMeetingSpeakerRename.renameMany(
+                    transcriptAt: transcriptURL,
+                    assignments: [
+                        HomeMeetingSpeakerAssignment(identity: alex, newName: "Jordan", targetProfileID: nil),
+                        HomeMeetingSpeakerAssignment(identity: jordan, newName: "Morgan", targetProfileID: nil),
+                    ]
+                )
+                let updated = try String(contentsOf: transcriptURL, encoding: .utf8)
+                assertEqual(
+                    updated.components(separatedBy: "[System/Jordan]").count - 1,
+                    2,
+                    "Alex rows should become Jordan without being renamed a second time"
+                )
+                assertEqual(
+                    updated.components(separatedBy: "[System/Morgan]").count - 1,
+                    1,
+                    "The original Jordan row alone should become Morgan"
+                )
+            } catch {
+                assertionFailure("batch rename should not throw: \(error)")
+            }
+        }
+    }
+
+    runSuite("HomeMeetingSpeakerRename links an unlinked row to the selected saved person") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Link Speaker.md")
+            let targetID = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+            let markdown = """
+            ---
+            capture_type: meeting
+            speakers:
+              - id: "7"
+                channel: system
+                name: "Speaker 7"
+                source: unknown
+            ---
+
+            ## Transcript
+
+            **00:00** [System/Speaker 7]
+            Hello from the remote speaker.
+            """
+            try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            guard let identity = HomeMeetingPreviewContent.make(from: markdown).transcriptLines.first?.identity else {
+                assertionFailure("fixture should expose an unlinked identity")
+                return
+            }
+
+            do {
+                _ = try HomeMeetingSpeakerRename.rename(
+                    transcriptAt: transcriptURL,
+                    identity: identity,
+                    to: "Alex",
+                    linkingTo: targetID
+                )
+                let updated = try String(contentsOf: transcriptURL, encoding: .utf8)
+                assertTrue(updated.contains("name: \"Alex\""), "selected name should update metadata")
+                assertTrue(updated.contains("db_id: \"\(targetID.uuidString)\""), "selected UUID should be linked")
+                assertTrue(updated.contains("source: user_manual"), "manual assignment should record its source")
+                assertTrue(updated.contains("[System/Alex]"), "visible transcript rows should update together")
+            } catch {
+                assertionFailure("link assignment should not throw: \(error)")
+            }
+        }
+    }
 }
 
 private func withTemporaryHomeMeetingRenameLibrary(_ body: (URL) throws -> Void) {

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -549,6 +549,43 @@ func testUIAutomationSurfaceContract() {
                 "\(identifier) should keep speaker review scriptable without using speaker names"
             )
         }
+        for identifier in [
+            "transcripted.home.expansion.name-speakers",
+            "transcripted.home.expansion.speaker.\\(identity.stableID)",
+            "transcripted.home.speaker-picker",
+            "transcripted.home.speaker-picker.name",
+            "transcripted.home.speaker-picker.cancel",
+            "transcripted.home.speaker-picker.save",
+            "transcripted.home.speaker-sheet",
+            "transcripted.home.speaker-sheet.row.\\(draft.id).name",
+            "transcripted.home.speaker-sheet.cancel",
+            "transcripted.home.speaker-sheet.save",
+        ] {
+            assertTrue(
+                contractSource("Sources/UI/Settings/QuietHomeLibrary.swift").contains(identifier),
+                "\(identifier) should keep meeting speaker correction scriptable without matching visible names"
+            )
+        }
+        assertTrue(
+            contractSource("Sources/UI/Settings/SpeakerNameAutocompleteField.swift").contains("selectedOptionID?.wrappedValue = selectedOption?.id")
+                && contractSource("Sources/UI/Settings/SpeakerNameAutocompleteField.swift").contains("selectedOptionID?.wrappedValue = nil"),
+            "meeting speaker autocomplete must preserve the selected saved-person UUID and clear it on typing"
+        )
+        assertTrue(
+            contractSource("Sources/UI/Settings/TranscriptedSettingsWindowController.swift").contains("transcriptDirectory: MeetingStoragePaths.transcriptsFolder")
+                && contractSource("Sources/UI/Settings/SpeakerPeopleSettingsSection.swift").contains("directory: transcriptDirectory"),
+            "saved-person rename/merge must scan the active capture library, including relocated libraries"
+        )
+        let meetingSpeakerAssignmentSource = contractSource("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        assertTrue(
+            meetingSpeakerAssignmentSource.contains("savedAssignmentsInCommitOrder(savedAssignments)")
+                && meetingSpeakerAssignmentSource.contains("remappingLocalTargets(")
+                && meetingSpeakerAssignmentSource.contains("let resolvedLocalAssignments = localAssignmentsAfterSavedMerges.compactMap")
+                && meetingSpeakerAssignmentSource.contains("applySavedAssignment(at: 0)")
+                && meetingSpeakerAssignmentSource.contains("finishPartialFailure()")
+                && meetingSpeakerAssignmentSource.contains("Reopen Name speakers to review what's left."),
+            "batch speaker naming must commit saved identities first, remap local links to surviving profiles, and close stale drafts after a partial save"
+        )
         assertTrue(
             contractSource("Sources/UI/Settings/SpeakerNamingSheet.swift").contains("static let minimum: CGFloat = 40")
                 && contractSource("Sources/UI/Settings/SpeakerNamingSheet.swift").contains("let btnH = SpeakerNamingHitTargets.minimum")


### PR DESCRIPTION
## Summary
- add a one-click “Who is this?” picker with exact saved-person selection
- add a batch “Name speakers” sheet with sample quotes and explicit Save names
- show clean prominent names, keep audio playback aligned with active transcript lines, and update every matching line
- preserve transcript-local vs linked-profile scope, relocated capture libraries, merge chains, and partial-failure recovery

## Verification
- `bash build.sh --no-open` — signed build and launch/performance smoke passed
- `bash run-tests.sh` — 12,160 passed, 0 failed
- focused formatter/policy — 26 passed
- focused rename persistence — 36 passed
- focused UI automation contracts — 265 passed
- Computer Use — inline picker, saved-person dropdown, Escape/cancel, batch sheet, clean re-open state, local rename, global linked rename, and relocated-library persistence passed on synthetic data

## Review
Independent full-diff review is clean. Two P1s were accepted and fixed before the clean rerun: stale drafts after a partial batch save, and local rows linking to a profile removed by a same-batch merge. No findings were rejected.