### PR TITLE
Fix stale meeting speaker renames

### DIFF
--- a/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
+++ b/Sources/UI/Settings/HomeMeetingPreviewFormatter.swift
@@ -35,6 +35,27 @@ struct HomeMeetingSpeakerAssignment: Equatable, Sendable {
     let identity: HomeMeetingSpeakerIdentity
     let newName: String
     let targetProfileID: UUID?
+    /// True only when a transcript references a profile that no longer exists.
+    /// Keeps stale-link repair explicit instead of inferring it from a missing
+    /// identity, which could otherwise unlink a profile added after preview load.
+    let removesPersistentSpeakerLink: Bool
+
+    init(
+        identity: HomeMeetingSpeakerIdentity,
+        newName: String,
+        targetProfileID: UUID?,
+        removesPersistentSpeakerLink: Bool = false
+    ) {
+        self.identity = identity
+        self.newName = newName
+        self.targetProfileID = targetProfileID
+        self.removesPersistentSpeakerLink = removesPersistentSpeakerLink
+    }
+}
+
+struct HomeMeetingSpeakerAssignmentPlan: Equatable, Sendable {
+    let localAssignments: [HomeMeetingSpeakerAssignment]
+    let savedAssignments: [HomeMeetingSpeakerAssignment]
 }
 
 struct HomeMeetingSpeakerNamingDraft: Identifiable, Equatable, Sendable {
@@ -102,6 +123,60 @@ enum HomeMeetingSpeakerNamingPolicy {
         drafts.compactMap(assignment(from:))
     }
 
+    /// Routes each edit through the strongest persistence path that still
+    /// exists. Older transcripts can retain a `db_id` after that profile was
+    /// merged or deleted. Those stale links must fall back to an exact,
+    /// transcript-local rewrite instead of making Save fail forever.
+    ///
+    /// A stale saved identity can cover more than one diarizer row in the
+    /// meeting, so expand it back to every matching row before clearing the
+    /// dead link. Selected target profiles still have to exist; otherwise the
+    /// whole plan fails before any file or database mutation begins.
+    static func assignmentPlan(
+        for assignments: [HomeMeetingSpeakerAssignment],
+        transcriptLines: [HomeMeetingTranscriptLine],
+        availableProfileIDs: Set<UUID>
+    ) -> HomeMeetingSpeakerAssignmentPlan? {
+        var localAssignments: [HomeMeetingSpeakerAssignment] = []
+        var savedAssignments: [HomeMeetingSpeakerAssignment] = []
+
+        for assignment in assignments {
+            if let targetProfileID = assignment.targetProfileID,
+               !availableProfileIDs.contains(targetProfileID) {
+                return nil
+            }
+
+            guard let sourceProfileID = assignment.identity.persistentSpeakerID else {
+                localAssignments.append(assignment)
+                continue
+            }
+            guard !availableProfileIDs.contains(sourceProfileID) else {
+                savedAssignments.append(assignment)
+                continue
+            }
+
+            let matchingIdentities = transcriptLines
+                .map(\.identity)
+                .filter { $0.persistentSpeakerID == sourceProfileID }
+            let distinctIdentities = uniqueLocalIdentities(
+                matchingIdentities.isEmpty ? [assignment.identity] : matchingIdentities
+            )
+            localAssignments.append(contentsOf: distinctIdentities.map { identity in
+                HomeMeetingSpeakerAssignment(
+                    identity: identity,
+                    newName: assignment.newName,
+                    targetProfileID: assignment.targetProfileID,
+                    removesPersistentSpeakerLink: true
+                )
+            })
+        }
+
+        return HomeMeetingSpeakerAssignmentPlan(
+            localAssignments: localAssignments,
+            savedAssignments: savedAssignments
+        )
+    }
+
     /// Returns a safe sequential order for saved-profile mutations. Renames
     /// happen first, then merge chains run from their leaves toward the final
     /// target (A -> B before B -> C). Cycles and duplicate source mutations
@@ -163,7 +238,8 @@ enum HomeMeetingSpeakerNamingPolicy {
             remapped.append(HomeMeetingSpeakerAssignment(
                 identity: assignment.identity,
                 newName: assignment.newName,
-                targetProfileID: resolvedTargetID
+                targetProfileID: resolvedTargetID,
+                removesPersistentSpeakerLink: assignment.removesPersistentSpeakerLink
             ))
         }
         return remapped
@@ -175,6 +251,20 @@ enum HomeMeetingSpeakerNamingPolicy {
             .joined(separator: " ")
             .split(whereSeparator: \.isWhitespace)
             .joined(separator: " ")
+    }
+
+    private static func uniqueLocalIdentities(
+        _ identities: [HomeMeetingSpeakerIdentity]
+    ) -> [HomeMeetingSpeakerIdentity] {
+        var seen = Set<String>()
+        return identities.filter { identity in
+            let key = [
+                identity.channel?.rawValue ?? "unknown",
+                identity.diarizerSpeakerID ?? "",
+                identity.rawLabel,
+            ].joined(separator: "|")
+            return seen.insert(key).inserted
+        }
     }
 
     private static func mergeTargetsBySource(

--- a/Sources/UI/Settings/QuietHomeLibrary.swift
+++ b/Sources/UI/Settings/QuietHomeLibrary.swift
@@ -239,6 +239,7 @@ struct QuietMeetingExpansion: View {
     /// view already skips the call in both of those cases).
     let onRename: (String) -> Void
     let knownPeople: [SpeakerIdentityOption]
+    let savedSpeakerIDs: Set<UUID>
     let onAssignSpeakers: (
         [HomeMeetingSpeakerAssignment],
         @escaping (Bool) -> Void
@@ -339,6 +340,7 @@ struct QuietMeetingExpansion: View {
                 HomeMeetingSpeakerNamingSheet(
                     content: content,
                     knownPeople: knownPeople,
+                    savedSpeakerIDs: savedSpeakerIDs,
                     onCancel: { showsSpeakerNamingSheet = false },
                     onSave: { assignments, completion in
                         onAssignSpeakers(assignments) { didSave in
@@ -457,6 +459,7 @@ struct QuietMeetingExpansion: View {
                 QuietMeetingSpeakerLabel(
                     identity: line.identity,
                     knownPeople: knownPeople,
+                    isSavedPerson: identityIsSaved(line.identity),
                     onAssign: { assignment, completion in
                         onAssignSpeakers([assignment], completion)
                     }
@@ -482,6 +485,10 @@ struct QuietMeetingExpansion: View {
             }
         }
         .animation(.easeOut(duration: 0.12), value: isActive)
+    }
+
+    private func identityIsSaved(_ identity: HomeMeetingSpeakerIdentity) -> Bool {
+        identity.persistentSpeakerID.map(savedSpeakerIDs.contains) ?? false
     }
 
     private func activeTranscriptLineIndices(
@@ -578,6 +585,7 @@ struct QuietMeetingExpansion: View {
 private struct QuietMeetingSpeakerLabel: View {
     let identity: HomeMeetingSpeakerIdentity
     let knownPeople: [SpeakerIdentityOption]
+    let isSavedPerson: Bool
     let onAssign: (HomeMeetingSpeakerAssignment, @escaping (Bool) -> Void) -> Void
 
     @State private var showsPicker = false
@@ -627,6 +635,7 @@ private struct QuietMeetingSpeakerLabel: View {
             HomeMeetingSpeakerPicker(
                 identity: identity,
                 knownPeople: knownPeople.filter { $0.id != identity.persistentSpeakerID },
+                isSavedPerson: isSavedPerson,
                 onCancel: { showsPicker = false },
                 onSave: { assignment, completion in
                     onAssign(assignment) { didSave in
@@ -647,6 +656,7 @@ private struct QuietMeetingSpeakerLabel: View {
 private struct HomeMeetingSpeakerPicker: View {
     let identity: HomeMeetingSpeakerIdentity
     let knownPeople: [SpeakerIdentityOption]
+    let isSavedPerson: Bool
     let onCancel: () -> Void
     let onSave: (HomeMeetingSpeakerAssignment, @escaping (Bool) -> Void) -> Void
 
@@ -658,11 +668,13 @@ private struct HomeMeetingSpeakerPicker: View {
     init(
         identity: HomeMeetingSpeakerIdentity,
         knownPeople: [SpeakerIdentityOption],
+        isSavedPerson: Bool,
         onCancel: @escaping () -> Void,
         onSave: @escaping (HomeMeetingSpeakerAssignment, @escaping (Bool) -> Void) -> Void
     ) {
         self.identity = identity
         self.knownPeople = knownPeople
+        self.isSavedPerson = isSavedPerson
         self.onCancel = onCancel
         self.onSave = onSave
         _nameDraft = State(initialValue: identity.displayName)
@@ -726,7 +738,7 @@ private struct HomeMeetingSpeakerPicker: View {
     }
 
     private var scopeMessage: String {
-        if identity.persistentSpeakerID != nil {
+        if isSavedPerson {
             return selectedProfileID == nil
                 ? "Renames this saved person in linked meetings."
                 : "Uses this saved person in linked meetings."
@@ -749,6 +761,7 @@ private struct HomeMeetingSpeakerPicker: View {
 
 private struct HomeMeetingSpeakerNamingSheet: View {
     let knownPeople: [SpeakerIdentityOption]
+    let savedSpeakerIDs: Set<UUID>
     let onCancel: () -> Void
     let onSave: ([HomeMeetingSpeakerAssignment], @escaping (Bool) -> Void) -> Void
     private let initialDrafts: [HomeMeetingSpeakerNamingDraft]
@@ -760,11 +773,13 @@ private struct HomeMeetingSpeakerNamingSheet: View {
     init(
         content: HomeMeetingPreviewContent,
         knownPeople: [SpeakerIdentityOption],
+        savedSpeakerIDs: Set<UUID>,
         onCancel: @escaping () -> Void,
         onSave: @escaping ([HomeMeetingSpeakerAssignment], @escaping (Bool) -> Void) -> Void
     ) {
         let initialDrafts = HomeMeetingSpeakerNamingPolicy.drafts(from: content.transcriptLines)
         self.knownPeople = knownPeople
+        self.savedSpeakerIDs = savedSpeakerIDs
         self.onCancel = onCancel
         self.onSave = onSave
         self.initialDrafts = initialDrafts
@@ -862,7 +877,9 @@ private struct HomeMeetingSpeakerNamingSheet: View {
     private func speakerRow(at index: Int) -> some View {
         HomeMeetingSpeakerNamingRow(
             draft: $drafts[index],
-            knownPeople: knownPeople.filter { $0.id != drafts[index].identity.persistentSpeakerID }
+            knownPeople: knownPeople.filter { $0.id != drafts[index].identity.persistentSpeakerID },
+            isSavedPerson: drafts[index].identity.persistentSpeakerID
+                .map(savedSpeakerIDs.contains) ?? false
         )
     }
 
@@ -890,6 +907,7 @@ private struct HomeMeetingSpeakerNamingSheet: View {
 private struct HomeMeetingSpeakerNamingRow: View {
     @Binding var draft: HomeMeetingSpeakerNamingDraft
     let knownPeople: [SpeakerIdentityOption]
+    let isSavedPerson: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -942,7 +960,7 @@ private struct HomeMeetingSpeakerNamingRow: View {
     }
 
     private var scopeLabel: String {
-        draft.identity.persistentSpeakerID == nil ? "This meeting" : "Linked meetings"
+        isSavedPerson ? "Linked meetings" : "This meeting"
     }
 }
 

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -249,6 +249,13 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         }
     }
 
+    /// Reads through to the canonical store when the async UI snapshot has
+    /// not loaded yet. Meeting rename validation must distinguish a genuinely
+    /// deleted profile from a merely-not-yet-rendered one.
+    func currentProfile(id: UUID) -> SpeakerProfile? {
+        speakerDatabase.getSpeaker(id: id)
+    }
+
     func clipURL(for speakerId: UUID) -> URL? {
         clipURLsByProfileID[speakerId]
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -707,6 +707,7 @@ struct TranscriptedSettingsView: View {
                         from: speakerPeopleModel.profiles,
                         excluding: nil
                     ),
+                    savedSpeakerIDs: Set(speakerPeopleModel.profiles.map(\.id)),
                     onAssignSpeakers: { assignments, completion in
                         guard let preview = homeExpandedMeetingPreview,
                               preview.id == meeting.id else {
@@ -1386,8 +1387,23 @@ struct TranscriptedSettingsView: View {
             page: .home
         )
 
-        let localAssignments = assignments.filter { $0.identity.persistentSpeakerID == nil }
-        let savedAssignments = assignments.filter { $0.identity.persistentSpeakerID != nil }
+        let referencedProfileIDs = Set(assignments.flatMap { assignment in
+            [assignment.identity.persistentSpeakerID, assignment.targetProfileID].compactMap { $0 }
+        })
+        let availableProfileIDs = Set(referencedProfileIDs.filter {
+            speakerPeopleModel.currentProfile(id: $0) != nil
+        })
+        guard let assignmentPlan = HomeMeetingSpeakerNamingPolicy.assignmentPlan(
+            for: assignments,
+            transcriptLines: preview.content.transcriptLines,
+            availableProfileIDs: availableProfileIDs
+        ) else {
+            speakerPeopleModel.refresh()
+            completion(false)
+            return
+        }
+        let localAssignments = assignmentPlan.localAssignments
+        let savedAssignments = assignmentPlan.savedAssignments
         guard let savedAssignmentsInCommitOrder =
             HomeMeetingSpeakerNamingPolicy.savedAssignmentsInCommitOrder(savedAssignments),
               let localAssignmentsAfterSavedMerges =
@@ -1398,7 +1414,7 @@ struct TranscriptedSettingsView: View {
             completion(false)
             return
         }
-        let profileIDs = Set(speakerPeopleModel.profiles.map(\.id))
+        let profileIDs = availableProfileIDs
 
         // Validate the whole saved-person plan before the first mutation. This
         // catches stale picker rows without leaving an avoidable partial batch.
@@ -1522,14 +1538,14 @@ struct TranscriptedSettingsView: View {
         completion: @escaping (Bool) -> Void
     ) {
         guard let sourceID = assignment.identity.persistentSpeakerID,
-              let source = speakerPeopleModel.profiles.first(where: { $0.id == sourceID }) else {
+              let source = speakerPeopleModel.currentProfile(id: sourceID) else {
             speakerPeopleModel.refresh()
             completion(false)
             return
         }
 
         if let targetID = assignment.targetProfileID, targetID != sourceID {
-            guard let target = speakerPeopleModel.profiles.first(where: { $0.id == targetID }) else {
+            guard let target = speakerPeopleModel.currentProfile(id: targetID) else {
                 speakerPeopleModel.refresh()
                 completion(false)
                 return

--- a/Sources/UI/Shared/HomeMeetingRename.swift
+++ b/Sources/UI/Shared/HomeMeetingRename.swift
@@ -73,7 +73,8 @@ enum HomeMeetingSpeakerRename {
                 return HomeMeetingSpeakerAssignment(
                     identity: assignment.identity,
                     newName: name,
-                    targetProfileID: assignment.targetProfileID
+                    targetProfileID: assignment.targetProfileID,
+                    removesPersistentSpeakerLink: assignment.removesPersistentSpeakerLink
                 )
             }
             guard !normalizedAssignments.isEmpty else { return [] }
@@ -104,7 +105,8 @@ enum HomeMeetingSpeakerRename {
                     in: &lines,
                     identity: assignment.identity,
                     newName: assignment.newName,
-                    targetProfileID: assignment.targetProfileID
+                    targetProfileID: assignment.targetProfileID,
+                    removesPersistentSpeakerLink: assignment.removesPersistentSpeakerLink
                 )
             }
 
@@ -174,7 +176,8 @@ enum HomeMeetingSpeakerRename {
         in lines: inout [String],
         identity: HomeMeetingSpeakerIdentity,
         newName: String,
-        targetProfileID: UUID?
+        targetProfileID: UUID?,
+        removesPersistentSpeakerLink: Bool
     ) -> Bool {
         guard let diarizerID = identity.diarizerSpeakerID else { return false }
 
@@ -253,6 +256,12 @@ enum HomeMeetingSpeakerRename {
                 // speaker row even when the row originally had no source/db id.
                 lines.insert("    db_id: \"\(targetProfileID.uuidString)\"", at: match.nameIndex + 1)
             }
+        } else if removesPersistentSpeakerLink,
+                  let dbIDIndex = match.dbIDIndex {
+            // A local assignment with an existing db_id is the stale-profile
+            // recovery path. Remove the dead link along with correcting the
+            // visible name so the next edit does not hit the same failure.
+            lines.remove(at: dbIDIndex)
         }
         return true
     }

--- a/Tests/HomeMeetingRenameTests.swift
+++ b/Tests/HomeMeetingRenameTests.swift
@@ -330,6 +330,80 @@ func testHomeMeetingRename() {
             }
         }
     }
+
+    runSuite("HomeMeetingSpeakerRename repairs a stale saved-person link locally") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Stale Speaker Link.md")
+            let staleProfileID = UUID(uuidString: "44444444-4444-4444-4444-444444444444")!
+            let markdown = """
+            ---
+            capture_type: meeting
+            speakers:
+              - id: "0"
+                channel: system
+                db_id: "\(staleProfileID.uuidString)"
+                name: "Speaker 1"
+                source: db_pending
+              - id: "1"
+                channel: system
+                db_id: "\(staleProfileID.uuidString)"
+                name: "Speaker 2"
+                source: db_pending
+            ---
+
+            ## Transcript
+
+            **00:00** [System/Speaker 1]
+            First sample.
+
+            **00:02** [System/Speaker 2]
+            Second sample.
+            """
+            try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            let lines = HomeMeetingPreviewContent.make(from: markdown).transcriptLines
+            guard let identity = lines.first?.identity else {
+                assertionFailure("fixture should expose a stale saved identity")
+                return
+            }
+            let assignment = HomeMeetingSpeakerAssignment(
+                identity: identity,
+                newName: "Patrick",
+                targetProfileID: nil
+            )
+
+            guard let plan = HomeMeetingSpeakerNamingPolicy.assignmentPlan(
+                for: [assignment],
+                transcriptLines: lines,
+                availableProfileIDs: []
+            ) else {
+                assertionFailure("a missing source profile should have a local recovery plan")
+                return
+            }
+            assertTrue(plan.savedAssignments.isEmpty, "a deleted profile must not use the global rename path")
+            assertEqual(plan.localAssignments.count, 2, "every row linked to the stale profile should be repaired")
+            assertTrue(
+                plan.localAssignments.allSatisfy { $0.removesPersistentSpeakerLink },
+                "local recovery assignments should explicitly clear the dead profile identity"
+            )
+
+            do {
+                _ = try HomeMeetingSpeakerRename.renameMany(
+                    transcriptAt: transcriptURL,
+                    assignments: plan.localAssignments
+                )
+                let updated = try String(contentsOf: transcriptURL, encoding: .utf8)
+                assertFalse(updated.contains(staleProfileID.uuidString), "the dead db_id should be removed")
+                assertEqual(
+                    updated.components(separatedBy: "name: \"Patrick\"").count - 1,
+                    2,
+                    "every metadata row for the stale person should receive the corrected name"
+                )
+                assertTrue(updated.contains("[System/Patrick]"), "visible transcript labels should be corrected")
+            } catch {
+                assertionFailure("stale speaker recovery should not throw: \(error)")
+            }
+        }
+    }
 }
 
 private func withTemporaryHomeMeetingRenameLibrary(_ body: (URL) throws -> Void) {


### PR DESCRIPTION
Fixes meeting speaker renames when a transcript still references a deleted speaker profile.

- falls back to a meeting-local rename instead of aborting
- repairs every matching transcript row and removes the dead database link
- keeps valid saved-speaker renames global
- makes the UI accurately say when the change only affects this meeting

Verification:
- build.sh --no-open
- run-tests.sh: 12,166 passed, 0 failed
- git diff --check
- independent full-diff review: no actionable findings

Manual UI/audio validation is intentionally left to the user on this Mac.