### PR TITLE
One scrolling settings page; drop two toggles; trim Storage and About

### DIFF
--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -27,7 +27,7 @@
 - `HotkeyPreferences.swift` — persisted shortcut mode, meeting shortcut compatibility, legacy Carbon hotkey migration helpers, right-Option toggle migration, display formatting, and validation
 - `LaunchAtLoginController.swift` — app-facing wrapper for enabling or disabling launch-at-login behavior, including the one-time post-onboarding default-enable (meeting detection is dead while the app is closed)
 - `LaunchAtLoginPreferences.swift` — persisted preference state around launch-at-login UX: the explicit user choice plus the applied-once default-enable marker and its pure policy
-- `MissedCallNudgePreferences.swift` — persisted (default-on) toggle for the post-call "that call wasn't recorded" nudge; written by the nudge's "Don't show again" action and the Settings General toggle
+- `MissedCallNudgePreferences.swift` — persisted (default-on) toggle for the post-call "that call wasn't recorded" nudge; written only by the nudge's "Don't show again" action (the Settings toggle was removed in the 2026-08 settings simplification)
 - `LocalSpeakerPreferences.swift` — persisted toggle for splitting the local mic channel into multiple named speakers during meeting review
 - `MeetingOverlayPillPreferences.swift` — persisted "keep controls visible" pin that opts the meeting pill out of resting to its compact capsule
 - `MicrophoneProcessingPreferences.swift` — persisted mic processing mode, toggling between raw/off input, default software AGC, and optional Apple voice processing (VPIO) for users who need the WebRTC-specific recovery path in meetings or dictation
@@ -37,7 +37,7 @@
 - `OnboardingDictationShortcutPolicy.swift` — first-run shortcut policy that keeps dictation setup copy aligned with trigger preferences
 - `PermissionsOnboardingPreferences.swift` — persisted completion and forced-rerun state for the first-run permissions onboarding flow
 - `PhysicalDictationTriggerPreferences.swift` — canonical physical key / modifier trigger bindings for push-to-talk, hands-free dictation, paste-last-dictation, and meeting shortcuts, including migration from older right-Option settings
-- `QuitConfirmationPreferences.swift` — default-on quit safety policy and copy for warning before active meeting recordings are stopped by app quit
+- `QuitConfirmationPreferences.swift` — always-on quit safety policy and copy for warning before active meeting recordings are stopped by app quit (the opt-out preference was removed by owner decision in the 2026-08 settings simplification)
 - `SingleInstanceGuard.swift` — local guard used to keep duplicate app instances from racing shared app state
 - `SpeakerNameSelectionPolicy.swift` — shared speaker-name matching, duplicate-label disambiguation, and owner-label policy used by people/review UI
 - `TranscriptedConstants.swift` — shared timing thresholds and app-wide behavior constants
@@ -63,7 +63,7 @@
 - `AgentMCPConnector` is the seam for connecting more agents. New agents should get a detect/isConnected/connect triple here instead of bespoke UI logic; never rewrite `~/.claude.json` directly — Claude Code's CLI owns that file.
 - `DockVisibilityPreferences` is the canonical storage layer for the General Dock toggle. Keep the key and notification stable so upgrades preserve the setting.
 - `ActivationPolicyController` is the canonical place for the app's force-quit visibility policy. Keep Dock/icon activation-policy switching out of recording controllers and UI views.
-- `QuitConfirmationPreferences` should default on. Quitting during a live meeting stops capture, so the opt-out belongs in Settings instead of being hidden in the alert.
+- Quit confirmation during meeting work is always on; there is no opt-out preference. Quitting during a live meeting stops capture, so the dialog is not optional.
 - `MicrophoneProcessingPreferences` is the canonical switch for mic cleanup mode. Default behavior is software AGC without playback ducking; Apple voice processing stays opt-in because it can duck other apps during recording, and can be enabled from Settings or the in-meeting boost prompt.
 - `AudioStoragePreferences` only stores the retention choice. Destructive cleanup behavior belongs in `Sources/Meeting/MeetingAudioStorageManager.swift` and should stay conservative: the Settings UI should ask before switching into a destructive 7-day or 30-day cleanup window.
 

--- a/Sources/Support/QuitConfirmationPreferences.swift
+++ b/Sources/Support/QuitConfirmationPreferences.swift
@@ -37,31 +37,13 @@ enum ActiveMeetingQuitConfirmationPolicy {
         saveAudioAndQuitTitle: "Save Audio & Quit"
     )
 
+    /// Quit confirmation during meeting work is always on — the old opt-out
+    /// preference (`confirm-quit-during-active-meeting-recording`) was removed
+    /// by owner decision so nobody can accidentally kill a live recording.
     static func shouldConfirmQuit(
-        preferenceEnabled: Bool,
         activeMeetingCapture: Bool,
         backgroundTranscriptionWork: Bool = false
     ) -> Bool {
-        preferenceEnabled && (activeMeetingCapture || backgroundTranscriptionWork)
-    }
-}
-
-enum QuitConfirmationPreferences {
-    static let confirmQuitDuringActiveMeetingRecordingKey = "confirm-quit-during-active-meeting-recording"
-
-    static func confirmQuitDuringActiveMeetingRecording(
-        userDefaults: UserDefaults = .standard
-    ) -> Bool {
-        guard userDefaults.object(forKey: confirmQuitDuringActiveMeetingRecordingKey) != nil else {
-            return true
-        }
-        return userDefaults.bool(forKey: confirmQuitDuringActiveMeetingRecordingKey)
-    }
-
-    static func setConfirmQuitDuringActiveMeetingRecording(
-        _ enabled: Bool,
-        userDefaults: UserDefaults = .standard
-    ) {
-        userDefaults.set(enabled, forKey: confirmQuitDuringActiveMeetingRecordingKey)
+        activeMeetingCapture || backgroundTranscriptionWork
     }
 }

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -720,7 +720,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         let activeCapture = appState.meetingSession.shouldConfirmQuitForActiveCapture
         let backgroundWork = appState.meetingSession.shouldConfirmQuitForBackgroundTranscription
         guard ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
-            preferenceEnabled: QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecording(),
             activeMeetingCapture: activeCapture,
             backgroundTranscriptionWork: backgroundWork
         ) else {

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -94,7 +94,7 @@ onboarding connect stage. Both keep one mental model:
 - `Settings/TranscriptedSettingsNavigationModel.swift` — observable navigation state for the current `TranscriptedSettingsPage` selection
 - `Settings/TranscriptedSettingsPage.swift` — enum of window pages (home, dictations, general, people, storage, connectAgent, about) with titles, SF Symbol names, and navigation shortcuts; the legacy model/shortcut/privacy/beta/support alias cases and their `consolidatedDestination` routing were deleted once no live caller produced them
 - `Settings/TranscriptedSettingsRows.swift` — reusable Settings rows for correction editing, model choices, and Auto Enter apps
-- `Settings/TranscriptedSettingsSidebar.swift` — sidebar section model: content-first primary rows (Home/Dictations/Speakers/Agent); settings pages render as a tab strip (General/Storage/About) in the content pane, reached from the sidebar gear
+- `Settings/TranscriptedSettingsSidebar.swift` — sidebar section model: content-first primary rows (Home/Dictations/Speakers/Agent); configuration is one combined scrolling settings page reached from the sidebar gear (no tab strip)
 - `Settings/TranscriptedSettingsView.swift` — main settings view; still owns every Home side effect (delete/rename/copy/retranscribe, the shared root alert, undo staging, analytics) even after the Home page view moved out, partly because several pieces are pinned in place by literal-source-text assertions in `Tests/UIAutomationSurfaceContractTests.swift`
 - `Settings/TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 - `Settings/Pages/` — standalone settings pages split out of `TranscriptedSettingsView` (About, Dictations, General, Home, People, Storage); model, shortcut, and privacy editors are injected into General disclosures by the shell. The former Beta and Support pages dissolved in settings redesign phase 1: Support's two rows (email support, send diagnostics) moved into About under a "Support" section, and the Beta page's Nemotron toggle was later removed along with the Nemotron model itself. `HomeSettingsPage.swift` is pure view assembly (header, scan-warning/activity rows, search field, day-grouped meeting list, expanded-row preview, inline failed-meeting rows) — it takes the meeting day sections and every row action as injected values/closures and holds no runtime logic
@@ -136,9 +136,9 @@ while `SpeakerNamingSheet` is where users confirm local-vs-remote speakers or
 collapse the local side back into a single "You" track.
 
 The main window is content-first: the sidebar leads with Meetings, Dictations,
-Speakers, and Agent; the sidebar gear opens a settings area in the content
-pane with a capsule tab strip (General/Storage/About — Beta and Support
-dissolved into General and About in settings redesign phase 1). Meetings
+Speakers, and Agent; the sidebar gear opens one combined scrolling settings
+page in the content pane (the General/Storage/About tab strip was removed —
+everything is found by scrolling). Meetings
 (the `.home` page case) is the meetings surface — a page title, stats line,
 failed-meeting recovery, and the day-grouped meetings list; Dictations is
 the separate dictation history. `HomeView` keeps recent

--- a/Sources/UI/Settings/CLAUDE.md
+++ b/Sources/UI/Settings/CLAUDE.md
@@ -26,12 +26,11 @@ settings-side agent connection flow.
   `meetingRowMenuItems`, `revealOwnFile`/`openOwnFile`) are pinned in place
   by literal-source-text assertions in `Tests/UIAutomationSurfaceContractTests.swift`.
 - `TranscriptedSettingsSidebar.swift` - sidebar sections and rows: a primary
-  content section (Home/Dictations/Speakers/Agent); the settings pages are
-  reached via the sidebar gear and an in-content tab strip (General, Storage,
-  About — the settings redesign phase 1 pass dissolved the Beta and Support
-  tabs, and the legacy `.models`/`.shortcuts`/`.privacy`/`.beta`/`.support`
-  alias cases were later deleted from `TranscriptedSettingsPage` once no live
-  caller produced them).
+  content section (Home/Dictations/Speakers/Agent); all configuration lives
+  on one combined scrolling settings page reached from the sidebar gear — the
+  old General/Storage/About tab strip was removed, and `.storage`/`.about`
+  (like the earlier `.models`/`.shortcuts`/`.privacy`/`.beta`/`.support`
+  aliases) were deleted from `TranscriptedSettingsPage`.
 - `TranscriptedSettingsGeneralControls.swift` - compact General-page rows,
   disclosure rows, headings, and info popovers.
 - `TranscriptedSettingsRows.swift` - small reusable rows used by Settings:

--- a/Sources/UI/Settings/Pages/AboutSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/AboutSettingsPage.swift
@@ -21,12 +21,9 @@ struct AboutSettingsPage: View {
     let onSendDiagnosticEvent: () -> Void
 
     var body: some View {
+        // Rendered as sections of the single combined settings page — no
+        // page intro of its own; the section labels carry the headings.
         VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "About",
-                summary: "Version and updates."
-            )
-
             versionGroup
             supportGroup
         }
@@ -42,7 +39,7 @@ struct AboutSettingsPage: View {
             VStack(alignment: .leading, spacing: 0) {
                 AboutInfoRow(
                     title: "Transcripted",
-                    detail: "Local-first dictation and meeting notes.",
+                    detail: "",
                     value: TranscriptedSupportActions.appVersionDescription
                 )
 
@@ -80,12 +77,6 @@ struct AboutSettingsPage: View {
                 }
                 .padding(.vertical, 10)
 
-                Text(automaticUpdatesDetail)
-                    .font(.caption)
-                    .foregroundStyle(LibraryTokens.ink3)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.top, 4)
-
                 HStack {
                     SettingsInlineActionButton(
                         title: aboutUpdateButtonTitle,
@@ -108,15 +99,10 @@ struct AboutSettingsPage: View {
             LibrarySectionLabel(text: "Support")
 
             VStack(alignment: .leading, spacing: 12) {
-                Text("Need help, found a bug, or want to send feedback? Email is the best way to reach the team building Transcripted.")
-                    .font(.caption)
-                    .foregroundStyle(LibraryTokens.ink2)
-                    .fixedSize(horizontal: false, vertical: true)
-
                 VStack(alignment: .leading, spacing: 0) {
                     AboutActionRow(
                         title: "Email support",
-                        detail: "Send feedback, ask for help, or tell us what felt broken. This opens a prefilled email to help@transcripted.app.",
+                        detail: "Opens a prefilled email to help@transcripted.app.",
                         buttonTitle: "Email support",
                         tone: .accent,
                         isEnabled: true,
@@ -127,8 +113,8 @@ struct AboutSettingsPage: View {
 
                     AboutActionRow(
                         title: "Send diagnostics",
-                        detail: "Had an error or something felt broken? Send a privacy-safe diagnostic event so we can investigate and try to fix it.",
-                        buttonTitle: "One-click send diagnostics",
+                        detail: "Sends a privacy-safe diagnostic event so we can investigate a problem.",
+                        buttonTitle: "Send diagnostics",
                         tone: .neutral,
                         status: diagnosticsActionStatus,
                         isEnabled: CrashReporter.isAvailable && crashReportingEnabled,
@@ -227,17 +213,6 @@ struct AboutSettingsPage: View {
         updateActionEnabled(sparkleUpdater.updateStatus)
     }
 
-    private var automaticUpdatesDetail: String {
-        let settings = sparkleUpdater.automaticUpdateSettings
-        if settings.automaticDownloadsEnabled {
-            return "Transcripted will download updates in the background. When one is ready, you only need to restart."
-        }
-        if settings.automaticChecksEnabled {
-            return "Transcripted will check in the background and show an update badge when one is ready."
-        }
-        return "Transcripted only checks for updates when you ask."
-    }
-
     /// The three real states behind the two coupled Sparkle booleans.
     private enum AutomaticUpdatePolicy: String, CaseIterable, Identifiable {
         case off
@@ -276,28 +251,28 @@ struct AboutSettingsPage: View {
                 switch newPolicy {
                 case .off:
                     if settings.automaticChecksEnabled {
-                        onTrackSettingsToggle("automatic_update_checks", false, .about)
+                        onTrackSettingsToggle("automatic_update_checks", false, .general)
                     }
                     if settings.automaticDownloadsEnabled {
-                        onTrackSettingsToggle("automatic_update_downloads", false, .about)
+                        onTrackSettingsToggle("automatic_update_downloads", false, .general)
                     }
                     // The controller forces downloads off when checks go off.
                     sparkleUpdater.setAutomaticallyChecksForUpdates(false)
                 case .notify:
                     if !settings.automaticChecksEnabled {
-                        onTrackSettingsToggle("automatic_update_checks", true, .about)
+                        onTrackSettingsToggle("automatic_update_checks", true, .general)
                     }
                     if settings.automaticDownloadsEnabled {
-                        onTrackSettingsToggle("automatic_update_downloads", false, .about)
+                        onTrackSettingsToggle("automatic_update_downloads", false, .general)
                     }
                     sparkleUpdater.setAutomaticallyChecksForUpdates(true)
                     sparkleUpdater.setAutomaticallyDownloadsUpdates(false)
                 case .download:
                     if !settings.automaticChecksEnabled {
-                        onTrackSettingsToggle("automatic_update_checks", true, .about)
+                        onTrackSettingsToggle("automatic_update_checks", true, .general)
                     }
                     if !settings.automaticDownloadsEnabled {
-                        onTrackSettingsToggle("automatic_update_downloads", true, .about)
+                        onTrackSettingsToggle("automatic_update_downloads", true, .general)
                     }
                     // The controller forces checks on when downloads go on.
                     sparkleUpdater.setAutomaticallyDownloadsUpdates(true)

--- a/Sources/UI/Settings/Pages/GeneralSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/GeneralSettingsPage.swift
@@ -29,9 +29,7 @@ struct GeneralSettingsPage<
     @Binding var uiSoundsEnabled: Bool
     @Binding var dictationCleanupEnabled: Bool
     @Binding var dictationOverlayMode: DictationOverlayPresentationMode
-    @Binding var confirmQuitDuringMeetingEnabled: Bool
     @Binding var autoDetectCallsEnabled: Bool
-    @Binding var missedCallNudgeEnabled: Bool
 
     let effectiveTranscriptionModelTitle: String
     let dictationShortcutsEnabled: Bool
@@ -66,8 +64,8 @@ struct GeneralSettingsPage<
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
-                title: "General",
-                summary: "Dictation, meetings, and app-wide behavior."
+                title: "Settings",
+                summary: "Everything in one place — scroll to find it."
             )
 
             dictationGroup
@@ -173,19 +171,6 @@ struct GeneralSettingsPage<
 
             VStack(alignment: .leading, spacing: 0) {
                 GeneralToggleRow(
-                    title: "Confirm meeting quits",
-                    isOn: $confirmQuitDuringMeetingEnabled,
-                    help: confirmQuitDuringMeetingEnabled
-                        ? "Ask before stopping a live meeting."
-                        : "Quit immediately and save recoverable audio.",
-                    info: GeneralInfo(
-                        title: "Confirm meeting quits",
-                        message: "When this is on, Transcripted asks before quitting during a live meeting so you do not stop a recording by accident."
-                    ),
-                    automationIdentifier: "transcripted.settings.general.confirm-meeting-quits"
-                )
-
-                GeneralToggleRow(
                     title: "Auto-detect calls",
                     isOn: $autoDetectCallsEnabled,
                     help: autoDetectCallsEnabled
@@ -196,19 +181,6 @@ struct GeneralSettingsPage<
                         message: "When this is on, Transcripted notices when an app or browser starts using your microphone, when a conferencing app starts playing call audio (even if you joined muted), or when your camera turns on while a call app is active, and offers to record it. It only checks local device activity on your Mac; nothing about the audio or video ever leaves your device."
                     ),
                     automationIdentifier: "transcripted.settings.general.auto-detect-calls"
-                )
-
-                GeneralToggleRow(
-                    title: "Missed-call reminders",
-                    isOn: $missedCallNudgeEnabled,
-                    help: missedCallNudgeEnabled
-                        ? "Mention when a long call ends without a recording."
-                        : "Stay quiet when calls end without a recording.",
-                    info: GeneralInfo(
-                        title: "Missed-call reminders",
-                        message: "When a detected call lasts ten minutes or more and ends without a Transcripted recording, a small reminder appears so you know the meeting was not captured. It never shows after you decline a recording prompt, and it appears at most a few times a day."
-                    ),
-                    automationIdentifier: "transcripted.settings.general.missed-call-reminders"
                 )
 
                 GeneralDisclosureRow(

--- a/Sources/UI/Settings/Pages/StorageSettingsPage.swift
+++ b/Sources/UI/Settings/Pages/StorageSettingsPage.swift
@@ -5,8 +5,6 @@ import SwiftUI
 /// here; persisted state and filesystem work route through injected callbacks.
 struct StorageSettingsPage<FailureDetailsButton: View>: View {
     let captureLibraryURL: URL
-    let meetingCapturesURL: URL
-    let dictationCapturesURL: URL
     let unavailableCaptureLibraryPath: String?
     let captureLibraryMigrationInProgress: Bool
     let captureLibraryMigrationStatus: String?
@@ -48,12 +46,9 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
     @State private var showSupportFolders = false
 
     var body: some View {
+        // Rendered as sections of the single combined settings page — no
+        // page intro of its own; the section labels carry the headings.
         VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "Storage",
-                summary: "Choose where saved Markdown files live."
-            )
-
             libraryGroup
             audioAndModelsGroup
             supportFoldersGroup
@@ -69,10 +64,6 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
 
             VStack(alignment: .leading, spacing: 12) {
                 StorageRow(title: "Capture library", url: captureLibraryURL)
-                Hairline()
-                StorageRow(title: "Meeting captures", url: meetingCapturesURL)
-                Hairline()
-                StorageRow(title: "Dictation captures", url: dictationCapturesURL)
 
                 if let unavailableCaptureLibraryPath {
                     HStack(alignment: .top, spacing: 8) {
@@ -117,9 +108,10 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                     failureDetailsButton(captureLibraryMigrationStatusDetails)
                 }
 
-                Text("Pick an Obsidian vault or any folder you want agents to read.")
+                Text("Meetings and dictations save here as Markdown. Pick any folder you want agents to read.")
                     .font(.caption)
                     .foregroundStyle(LibraryTokens.ink3)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .alert(
@@ -159,11 +151,6 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                     .font(.caption)
                     .foregroundStyle(LibraryTokens.ink2)
 
-                Text("Choosing 7 or 30 days asks before deleting old replay audio. Replay audio is compressed from WAV to a smaller M4A automatically after each transcript saves.")
-                    .font(.caption)
-                    .foregroundStyle(LibraryTokens.ink3)
-                    .fixedSize(horizontal: false, vertical: true)
-
                 Hairline()
 
                 if modelCacheLoading, modelCacheSnapshot == nil {
@@ -175,16 +162,11 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                     let includeWhisperInReclaimableCleanup = !effectiveTranscriptionModelIsWhisper
                     let reclaimableBytes = snapshot.reclaimableBytes(includeWhisper: includeWhisperInReclaimableCleanup)
                     ModelCacheMetricRow(
-                        title: "Known model and cache footprint",
-                        value: snapshot.formattedTotalKnownSize,
-                        detail: "FluidAudio models plus Transcripted's app cache."
-                    )
-                    ModelCacheMetricRow(
-                        title: "Reclaimable cache",
+                        title: "Reclaimable space",
                         value: snapshot.formattedReclaimableSize(includeWhisper: includeWhisperInReclaimableCleanup),
                         detail: includeWhisperInReclaimableCleanup
-                            ? "Known stale models plus optional Whisper files."
-                            : "Known stale models. Whisper is preserved while selected."
+                            ? "Old model files Transcripted no longer needs."
+                            : "Old model files. Whisper is kept while selected."
                     )
                     if reclaimableBytes > 0 {
                         SettingsInlineActionButton(
@@ -252,6 +234,12 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                                     .font(.caption)
                                     .foregroundStyle(LibraryTokens.ink2)
                             }
+
+                            SettingsInlineActionButton(title: modelCacheLoading ? "Scanning..." : "Refresh Storage Sizes") {
+                                onRefreshModelCacheSnapshot()
+                            }
+                            .disabled(modelCacheLoading)
+                            .help(modelCacheLoading ? "Storage sizes are being scanned." : "")
                         }
                         .padding(.top, 12)
                     }
@@ -268,12 +256,6 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
                         .font(.caption)
                         .foregroundStyle(LibraryTokens.ink2)
                 }
-
-                SettingsInlineActionButton(title: modelCacheLoading ? "Scanning..." : "Refresh Storage Sizes") {
-                    onRefreshModelCacheSnapshot()
-                }
-                .disabled(modelCacheLoading)
-                .help(modelCacheLoading ? "Storage sizes are being scanned." : "")
             }
         }
         .onAppear {
@@ -327,7 +309,7 @@ struct StorageSettingsPage<FailureDetailsButton: View>: View {
 
     private var supportFoldersGroup: some View {
         VStack(alignment: .leading, spacing: 8) {
-            LibrarySectionLabel(text: "Advanced")
+            LibrarySectionLabel(text: "Support Files")
 
             DisclosureGroup("Show support folders", isExpanded: $showSupportFolders) {
                 VStack(alignment: .leading, spacing: 12) {

--- a/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
+++ b/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
@@ -10,7 +10,7 @@ enum SettingsRecentCaptureRefreshPolicy {
         switch page {
         case .home, .dictations:
             return .homeDashboard
-        case .general, .people, .storage, .connectAgent, .about:
+        case .general, .people, .connectAgent:
             return .none
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -5,9 +5,7 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
     case dictations
     case general
     case people
-    case storage
     case connectAgent
-    case about
 
     var id: String { rawValue }
 
@@ -33,11 +31,9 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         switch self {
         case .home: return "Meetings"
         case .dictations: return "Dictations"
-        case .general: return "General"
+        case .general: return "Settings"
         case .people: return "Speakers"
-        case .storage: return "Storage"
         case .connectAgent: return "Agent"
-        case .about: return "About"
         }
     }
 
@@ -68,9 +64,7 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .dictations: return "mic.fill"
         case .general: return "gearshape.fill"
         case .people: return "person.2.fill"
-        case .storage: return "externaldrive.fill"
         case .connectAgent: return "sparkles"
-        case .about: return "info.circle.fill"
         }
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsSidebar.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsSidebar.swift
@@ -8,10 +8,10 @@ struct SettingsSidebarSection {
         pages: [.home, .dictations, .people, .connectAgent]
     )
 
-    /// Configuration rows, demoted behind the sidebar's Settings toggle.
+    /// Configuration lives on one combined scrolling page, reached from the
+    /// sidebar's Settings toggle. No tab strip.
     static let settingsSections = [
-        SettingsSidebarSection(pages: [.general, .storage]),
-        SettingsSidebarSection(pages: [.about])
+        SettingsSidebarSection(pages: [.general])
     ]
 
     static func isSettingsPage(_ page: TranscriptedSettingsPage) -> Bool {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -69,9 +69,7 @@ struct TranscriptedSettingsView: View {
     @State private var modelCacheCleanupStatus: String?
     @State private var meetingMicProcessingMode = MicrophoneProcessingPreferences.mode()
     @State private var splitLocalSpeakersEnabled = LocalSpeakerPreferences.isEnabled()
-    @State private var confirmQuitDuringMeetingEnabled = QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecording()
     @State private var autoDetectCallsEnabled = AutoCallDetectionPreferences.isEnabled()
-    @State private var missedCallNudgeEnabled = MissedCallNudgePreferences.isEnabled()
     @State private var audioRetentionWindow = AudioStoragePreferences.deleteAudioAfter()
     @StateObject private var homeViewModel = HomeViewModel()
     @State private var homeCopiedRowID: String?
@@ -289,7 +287,7 @@ struct TranscriptedSettingsView: View {
             if settingsFooterShowsUpdateBadge {
                 Button {
                     guard settingsFooterActionEnabled else { return }
-                    trackSettingsAction(settingsUpdateActionID, page: .about)
+                    trackSettingsAction(settingsUpdateActionID, page: .general)
                     sparkleUpdater.performUserUpdateAction(surface: "settings_footer")
                 } label: {
                     HStack(spacing: 5) {
@@ -367,9 +365,6 @@ struct TranscriptedSettingsView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 24) {
-                        if SettingsSidebarSection.isSettingsPage(navigation.selectedPage) {
-                            settingsTabStrip
-                        }
                         pageBody
                     }
                     .padding(.horizontal, 28)
@@ -406,33 +401,6 @@ struct TranscriptedSettingsView: View {
         }
     }
 
-    private var settingsTabStrip: some View {
-        HStack(spacing: 6) {
-            ForEach(SettingsSidebarSection.settingsSections.flatMap(\.pages)) { page in
-                let isSelected = navigation.selectedPage == page
-                Button {
-                    navigation.selectedPage = page
-                } label: {
-                    Text(page.title)
-                        .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                        .foregroundStyle(isSelected ? Color.white : Color.primary.opacity(0.75))
-                        .padding(.horizontal, 13)
-                        .padding(.vertical, 5)
-                        .background(
-                            Capsule(style: .continuous)
-                                .fill(isSelected ? Color.accentColor : Color.primary.opacity(0.055))
-                        )
-                        .contentShape(Capsule(style: .continuous))
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("transcripted.settings.tab.\(page.rawValue)")
-            }
-
-            Spacer(minLength: 0)
-        }
-        .padding(.top, 2)
-    }
-
     @ViewBuilder
     private var pageBody: some View {
         switch navigation.selectedPage {
@@ -441,14 +409,21 @@ struct TranscriptedSettingsView: View {
         case .dictations:
             dictationsPage
         case .general:
-            generalPage
+            settingsPage
         case .people:
             peoplePage
-        case .storage:
-            storagePage
         case .connectAgent:
             connectAgentPage
-        case .about:
+        }
+    }
+
+    /// The whole settings surface as one scrolling page: what used to be the
+    /// General / Storage / About tab strip now renders stacked, so everything
+    /// is findable by scrolling instead of tab-hunting.
+    private var settingsPage: some View {
+        VStack(alignment: .leading, spacing: 36) {
+            generalPage
+            storagePage
             aboutPage
         }
     }
@@ -1700,20 +1675,10 @@ struct TranscriptedSettingsView: View {
                 persist: { DictationOverlayPresentationPreferences.setMode($0) },
                 track: { _ in trackSettingsAction("change_dictation_overlay_mode", page: .general) }
             ),
-            confirmQuitDuringMeetingEnabled: persistedSettingsBinding(
-                $confirmQuitDuringMeetingEnabled,
-                persist: { QuitConfirmationPreferences.setConfirmQuitDuringActiveMeetingRecording($0) },
-                track: { trackSettingsToggle("meeting_quit_confirmation", enabled: $0, page: .general) }
-            ),
             autoDetectCallsEnabled: persistedSettingsBinding(
                 $autoDetectCallsEnabled,
                 persist: { AutoCallDetectionPreferences.setEnabled($0) },
                 track: { trackSettingsToggle("auto_call_detection", enabled: $0, page: .general) }
-            ),
-            missedCallNudgeEnabled: persistedSettingsBinding(
-                $missedCallNudgeEnabled,
-                persist: { MissedCallNudgePreferences.setEnabled($0) },
-                track: { trackSettingsToggle("missed_call_nudge", enabled: $0, page: .general) }
             ),
             effectiveTranscriptionModelTitle: effectiveTranscriptionModel.title,
             dictationShortcutsEnabled: dictationShortcutsEnabled,
@@ -2244,8 +2209,6 @@ struct TranscriptedSettingsView: View {
     private var storagePage: some View {
         StorageSettingsPage(
             captureLibraryURL: captureLibraryURL,
-            meetingCapturesURL: MeetingStoragePaths.transcriptsFolder,
-            dictationCapturesURL: DictationStoragePaths.transcriptsFolder,
             unavailableCaptureLibraryPath: unavailableCaptureLibraryPath,
             captureLibraryMigrationInProgress: captureLibraryMigrationInProgress,
             captureLibraryMigrationStatus: captureLibraryMigrationStatus,
@@ -2264,11 +2227,11 @@ struct TranscriptedSettingsView: View {
             logsFolder: logsFolder,
             recordingsFolder: recordingsFolder,
             onChooseCaptureLibrary: {
-                trackSettingsAction("choose_capture_library", page: .storage)
+                trackSettingsAction("choose_capture_library", page: .general)
                 chooseCaptureLibrary()
             },
             onResetCaptureLibrary: {
-                trackSettingsAction("reset_capture_library", page: .storage)
+                trackSettingsAction("reset_capture_library", page: .general)
                 resetCaptureLibraryToDefault()
             },
             onCopyCapturesThenSwitchLibrary: { choice in
@@ -2290,7 +2253,7 @@ struct TranscriptedSettingsView: View {
                 refreshModelCacheSnapshot()
             },
             onRefreshModelCacheSnapshot: {
-                trackSettingsAction("refresh_model_cache_storage", page: .storage)
+                trackSettingsAction("refresh_model_cache_storage", page: .general)
                 refreshModelCacheSnapshot()
             },
             onApplyAudioRetentionWindow: { window in
@@ -2314,17 +2277,17 @@ struct TranscriptedSettingsView: View {
             },
             updateActionEnabled: { status in updateActionEnabled(for: status) },
             onPerformUpdateAction: {
-                trackSettingsAction(settingsUpdateActionID, page: .about)
+                trackSettingsAction(settingsUpdateActionID, page: .general)
                 sparkleUpdater.performUserUpdateAction(surface: "settings_about")
             },
             diagnosticsActionStatus: diagnosticsActionStatus,
             crashReportingEnabled: crashReportingEnabled,
             onSubmitFeedback: {
-                trackSettingsAction("submit_feedback", page: .about)
+                trackSettingsAction("submit_feedback", page: .general)
                 actions.sendFeedback()
             },
             onSendDiagnosticEvent: {
-                trackSettingsAction("send_diagnostic_event", page: .about)
+                trackSettingsAction("send_diagnostic_event", page: .general)
                 sendDiagnosticEvent()
             }
         )
@@ -2480,7 +2443,6 @@ struct TranscriptedSettingsView: View {
         uiSoundsEnabled = UISoundPreferences.isEnabled()
         meetingMicProcessingMode = MicrophoneProcessingPreferences.mode()
         splitLocalSpeakersEnabled = LocalSpeakerPreferences.isEnabled()
-        missedCallNudgeEnabled = MissedCallNudgePreferences.isEnabled()
         dictationShortcutsEnabled = HotkeyPreferences.dictationShortcutsEnabled()
         refreshAutoEnterPreferences(includeCandidates: pageShowsAutoEnterSettings(navigation.selectedPage))
         crashReportingEnabled = CrashReportingPreferences.isEnabled()
@@ -2555,13 +2517,11 @@ struct TranscriptedSettingsView: View {
             return .localArtifactActions
         case .people:
             return .speakerReview
-        case .storage:
-            return .captureLibrary
         case .connectAgent:
             return .agentSetup
-        case .about:
-            return .updateSettings
         case .general:
+            // The combined settings page spans capture-library, update, and
+            // permission surfaces; no single discovery area fits it.
             return nil
         }
     }
@@ -2690,7 +2650,7 @@ struct TranscriptedSettingsView: View {
 
     private func applyAudioRetentionWindow(_ window: AudioRetentionWindow) {
         audioRetentionWindow = window
-        trackSettingsAction("audio_retention_changed", page: .storage)
+        trackSettingsAction("audio_retention_changed", page: .general)
         AudioStoragePreferences.setDeleteAudioAfter(window)
         Task.detached(priority: .utility) {
             let result = await MeetingAudioStorageManager.processExistingRetainedAudio(
@@ -3007,7 +2967,7 @@ struct TranscriptedSettingsView: View {
             "settings_capture_library_changed",
             properties: [
                 "location_type": isUsingDefaultCaptureLibrary ? "default" : "custom",
-                "page_id": TranscriptedSettingsPage.storage.analyticsValue,
+                "page_id": TranscriptedSettingsPage.general.analyticsValue,
             ]
         )
     }

--- a/Tests/QuitConfirmationPreferencesTests.swift
+++ b/Tests/QuitConfirmationPreferencesTests.swift
@@ -1,71 +1,25 @@
 import Foundation
 
 func testQuitConfirmationPreferences() {
-    runSuite("QuitConfirmationPreferences defaults to enabled") {
-        let (defaults, suiteName) = makeQuitConfirmationDefaults()
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        assertTrue(
-            QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecording(userDefaults: defaults),
-            "active meeting quit confirmation should protect new installs by default"
-        )
-    }
-
-    runSuite("QuitConfirmationPreferences persists disabled and enabled states") {
-        let (defaults, suiteName) = makeQuitConfirmationDefaults()
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        QuitConfirmationPreferences.setConfirmQuitDuringActiveMeetingRecording(false, userDefaults: defaults)
-        assertFalse(
-            QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecording(userDefaults: defaults),
-            "explicit opt-out should round-trip through injected defaults"
-        )
-
-        QuitConfirmationPreferences.setConfirmQuitDuringActiveMeetingRecording(true, userDefaults: defaults)
-        assertTrue(
-            QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecording(userDefaults: defaults),
-            "explicit opt-in should round-trip through injected defaults"
-        )
-    }
-
-    runSuite("QuitConfirmationPreferences uses a stable storage key") {
-        assertEqual(
-            QuitConfirmationPreferences.confirmQuitDuringActiveMeetingRecordingKey,
-            "confirm-quit-during-active-meeting-recording",
-            "storage key must stay stable across releases"
-        )
-    }
-
     runSuite("ActiveMeetingQuitConfirmationPolicy prompts for active and background meeting work") {
         assertTrue(
             ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
-                preferenceEnabled: true,
                 activeMeetingCapture: true
             ),
-            "default-on preference should prompt while a meeting is recording or finishing"
+            "quit confirmation should always prompt while a meeting is recording or finishing"
         )
         assertTrue(
             ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
-                preferenceEnabled: true,
                 activeMeetingCapture: false,
                 backgroundTranscriptionWork: true
             ),
-            "default-on preference should also prompt while meeting transcription or imports are queued"
+            "quit confirmation should also prompt while meeting transcription or imports are queued"
         )
         assertFalse(
             ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
-                preferenceEnabled: true,
                 activeMeetingCapture: false
             ),
             "idle quits should not show an extra dialog"
-        )
-        assertFalse(
-            ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit(
-                preferenceEnabled: false,
-                activeMeetingCapture: true,
-                backgroundTranscriptionWork: true
-            ),
-            "user opt-out should skip the dialog even during active or background meeting work"
         )
     }
 
@@ -118,11 +72,4 @@ func testQuitConfirmationPreferences() {
             "background-only quit should still describe preserved audio"
         )
     }
-}
-
-private func makeQuitConfirmationDefaults() -> (UserDefaults, String) {
-    let suiteName = "QuitConfirmationPreferencesTests-\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: suiteName)!
-    defaults.removePersistentDomain(forName: suiteName)
-    return (defaults, suiteName)
 }

--- a/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
+++ b/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
@@ -12,7 +12,7 @@ func testSettingsRecentCaptureRefreshPolicy() {
     }
 
     runSuite("SettingsRecentCaptureRefreshPolicy.mode — skips recent capture work on non-list pages") {
-        for page in [TranscriptedSettingsPage.general, .people, .storage, .connectAgent, .about] {
+        for page in [TranscriptedSettingsPage.general, .people, .connectAgent] {
             assertEqual(
                 SettingsRecentCaptureRefreshPolicy.mode(for: page),
                 .none,
@@ -90,7 +90,7 @@ func testSettingsRecentCaptureRefreshPolicy() {
     runSuite("SettingsRecentCaptureRefreshPolicy.shouldStartDashboardRefresh — force does not bypass page gating") {
         let now = Date(timeIntervalSinceReferenceDate: 20)
 
-        for page in [TranscriptedSettingsPage.general, .people, .storage, .connectAgent, .about] {
+        for page in [TranscriptedSettingsPage.general, .people, .connectAgent] {
             assertFalse(
                 SettingsRecentCaptureRefreshPolicy.shouldStartDashboardRefresh(
                     for: page,

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -238,9 +238,7 @@ func testUIAutomationSurfaceContract() {
             "case dictations",
             "case general",
             "case people",
-            "case storage",
             "case connectAgent",
-            "case about",
         ] {
             assertTrue(contractSource("Sources/UI/Settings/TranscriptedSettingsPage.swift").contains(pageCase), "\(pageCase) should stay in the settings navigation surface map")
         }
@@ -649,7 +647,6 @@ func testUIAutomationSurfaceContract() {
             "transcripted.settings.general.show-in-dock",
             "transcripted.settings.general.dictation-sounds",
             "transcripted.settings.general.cleanup-pasted-text",
-            "transcripted.settings.general.confirm-meeting-quits",
             "transcripted.settings.general.disclosure.transcription-model",
             "transcripted.settings.general.disclosure.keyboard-shortcuts",
             "transcripted.settings.general.disclosure.bluetooth-microphone",
@@ -799,7 +796,7 @@ func testUIAutomationSurfaceContract() {
             "transcripted.status-item.button",
             "transcripted.menubar.utility.open-transcripted",
             "transcripted.home.find.toggle",
-            "transcripted.settings.tab.general",
+            "transcripted.settings.page.storage",
             "transcripted.settings.sidebar.settings-toggle",
             "transcripted.settings.sidebar.dictations",
             "transcripted.onboarding.permissions.system-audio",

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/ImportedAudioNativeSmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/ImportedAudioNativeSmoke.swift
@@ -277,18 +277,8 @@ private final class ImportedAudioNativeSmokeRunner {
             return false
         }
 
-        guard waitUntil(timeout: timeout, condition: {
-            appInspector.snapshot(maxDepth: 12).contains { $0.identifier == "transcripted.settings.tab.general" }
-        }) else {
-            checks.append(.fail("settings-tabs", "Settings tabs are visible", target: "transcripted.settings.tab.general", detail: "Settings tab strip did not appear."))
-            return false
-        }
-
-        guard appInspector.performPressOrClick(identifier: "transcripted.settings.tab.general") else {
-            checks.append(.fail("settings-general", "General settings tab opens", target: "transcripted.settings.tab.general", detail: "Could not press the General settings tab."))
-            return false
-        }
-
+        // The settings area is one combined scrolling page — no tab strip to
+        // wait for or click; the import control appears directly.
         guard waitUntil(timeout: timeout, condition: {
             appInspector.snapshot(maxDepth: 12).contains { $0.identifier == "transcripted.settings.general.transcribe-audio-file" }
         }) else {

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
@@ -429,22 +429,25 @@ final class UIAutomationSmokeRunner {
             return builder.build()
         }
 
-        let settingsTabIDs = [
-            "transcripted.settings.tab.general",
-            "transcripted.settings.tab.storage",
-            "transcripted.settings.tab.about",
+        // The settings area is one combined scrolling page (the old
+        // General / Storage / About tab strip was removed): after the toggle,
+        // all three section identifiers must be present in a single snapshot.
+        let settingsSectionIDs = [
+            "transcripted.settings.page.general",
+            "transcripted.settings.page.storage",
+            "transcripted.settings.page.about",
         ]
 
-        guard waitUntil(timeout: timeout, description: "settings tabs", condition: {
+        guard waitUntil(timeout: timeout, description: "combined settings page", condition: {
             let ids = Set(appInspector.snapshot(maxDepth: 12).compactMap(\.identifier))
-            return settingsTabIDs.allSatisfy(ids.contains)
+            return settingsSectionIDs.allSatisfy(ids.contains)
         }) else {
             builder.add(.fail(
                 "settings-pages-toggle",
                 "Settings area opens from the sidebar toggle",
                 target: "Transcripted Settings",
-                detail: "Settings tab strip did not appear after pressing the toggle.",
-                observed: observedElements(for: settingsTabIDs, inspector: appInspector)
+                detail: "Combined settings page did not expose its General/Storage/About section identifiers.",
+                observed: observedElements(for: settingsSectionIDs, inspector: appInspector)
             ))
             return builder.build()
         }
@@ -453,91 +456,12 @@ final class UIAutomationSmokeRunner {
             "Settings area opens from the sidebar toggle",
             target: "transcripted.settings.sidebar.settings-toggle"
         ))
-
-        guard appInspector.performPressOrClick(identifier: "transcripted.settings.tab.general") else {
-            builder.add(.fail(
-                "settings-navigation",
-                "Settings tabs navigate to General",
-                target: "transcripted.settings.tab.general",
-                detail: "Could not press the General settings tab."
-            ))
-            return builder.build()
-        }
-
-        let generalIDs = [
-            "transcripted.settings.page.general",
-        ]
-
-        guard waitUntil(timeout: timeout, description: "General settings", condition: {
-            let ids = Set(appInspector.snapshot(maxDepth: 12).compactMap(\.identifier))
-            return generalIDs.allSatisfy(ids.contains)
-        }) else {
-            builder.add(.fail(
-                "settings-general",
-                "General settings page is visible",
-                target: "General",
-                detail: "General page did not expose its page identifier.",
-                observed: observedElements(for: generalIDs, inspector: appInspector)
-            ))
-            return builder.build()
-        }
-        builder.add(.pass(
-            "settings-navigation",
-            "Settings tabs navigate to General",
-            target: "transcripted.settings.tab.general"
-        ))
         builder.add(.pass(
             "settings-general",
-            "General settings page is visible",
-            target: "General",
-            observed: observedElements(for: generalIDs, inspector: appInspector)
+            "Combined settings page shows the General, Storage, and About sections",
+            target: "transcripted.settings.page.general",
+            observed: observedElements(for: settingsSectionIDs, inspector: appInspector)
         ))
-
-        let settingsPageChecks: [(id: String, title: String, triggerID: String, requiredIDs: [String])] = [
-            (
-                id: "settings-storage",
-                title: "Storage settings tab is reachable",
-                triggerID: "transcripted.settings.tab.storage",
-                requiredIDs: ["transcripted.settings.page.storage"]
-            ),
-            (
-                id: "settings-about",
-                title: "About settings tab is reachable",
-                triggerID: "transcripted.settings.tab.about",
-                requiredIDs: ["transcripted.settings.page.about"]
-            ),
-        ]
-
-        for check in settingsPageChecks {
-            guard appInspector.performPressOrClick(identifier: check.triggerID) else {
-                builder.add(.fail(
-                    check.id,
-                    check.title,
-                    target: check.triggerID,
-                    detail: "Could not open this settings tab."
-                ))
-                return builder.build()
-            }
-            guard waitUntil(timeout: timeout, description: check.title, condition: {
-                let ids = Set(appInspector.snapshot(maxDepth: 12).compactMap(\.identifier))
-                return check.requiredIDs.allSatisfy(ids.contains)
-            }) else {
-                builder.add(.fail(
-                    check.id,
-                    check.title,
-                    target: check.triggerID,
-                    detail: "Settings tab did not expose expected automation identifiers.",
-                    observed: observedElements(for: check.requiredIDs, inspector: appInspector)
-                ))
-                return builder.build()
-            }
-            builder.add(.pass(
-                check.id,
-                check.title,
-                target: check.triggerID,
-                observed: observedElements(for: check.requiredIDs, inspector: appInspector)
-            ))
-        }
 
         return builder.build()
     }


### PR DESCRIPTION
## Summary

Part 6 of the settings-simplification stack (stacked on #1677; owner-requested round two).

- **One scrolling settings page**: the General / Storage / About tab strip is gone — the sidebar gear opens a single combined page titled "Settings" where every section is found by scrolling. `.storage`/`.about` are deleted from `TranscriptedSettingsPage` (no live producers; analytics `page_id` consolidates to `general`); the Storage/About page files render as embedded sections without their own intros.
- **"Confirm meeting quits" is no longer optional**: quit confirmation during meeting work is always on. The opt-out preference and key are deleted; `ActiveMeetingQuitConfirmationPolicy.shouldConfirmQuit` drops `preferenceEnabled`. Users who previously opted out will see confirmations again — that is the point.
- **"Missed-call reminders" leaves Settings**: feature stays default-on; the nudge's own "Don't show again" action remains the opt-out (`MissedCallNudgePreferences` unchanged).
- **Storage slimmed**: one Capture-library row, no WAV→M4A blurb, no footprint metric, no double-confirmation caption; "Reclaimable space" + **Free Up Space** are the whole primary surface, with per-cache metrics/narrow removals/refresh under "Storage details"; support-folder reveals sit under "Support Files".
- **About trimmed**: intro, support blurb, and the automatic-updates explainer paragraph removed; action rows cut to one line each.

Tests updated in lockstep: `QuitConfirmationPreferencesTests` (always-on policy), refresh-policy + automation-contract pins, and both QA smokes (`UISmoke`, `ImportedAudioNativeSmoke`) now assert the combined page's three section identifiers instead of clicking tabs.

## Verification

```
export TRANSCRIPTED_DISABLE_FILE_LOGGER=1
bash build.sh --no-open                          # passed
bash run-tests.sh                                # 12064 tests, 0 failed
swift test --package-path Tools/TranscriptedQA   # passed
bash run-e2e-smoke.sh                            # passed
```

## Test plan

- [ ] Sidebar gear opens one scrolling page: Dictation → Meetings → App → Advanced → Capture Library → Audio & Models → Support Files → Version → Support
- [ ] No Confirm-meeting-quits or Missed-call-reminders toggles anywhere; quitting during a live meeting still prompts
- [ ] Storage shows one library row + Free Up Space; details disclosure holds the rest
- [ ] About reads terse; Automatic updates control works

🤖 Generated with [Claude Code](https://claude.com/claude-code)