### PR TITLE
Fix speaker finalization recovery

### DIFF
--- a/Sources/Meeting/MeetingArtifactRenamer.swift
+++ b/Sources/Meeting/MeetingArtifactRenamer.swift
@@ -3,6 +3,10 @@ import Foundation
 import TranscriptedCore
 #endif
 
+enum MeetingTranscriptFileUpdateError: Error {
+    case replacementInProgress
+}
+
 enum MeetingTranscriptFileUpdateSerializer {
     private static let fallbackQueueSpecific = DispatchSpecificKey<Void>()
     private static let fallbackQueue: DispatchQueue = {
@@ -19,6 +23,24 @@ enum MeetingTranscriptFileUpdateSerializer {
             return try update()
         }
         return try fallbackQueue.sync(execute: update)
+        #endif
+    }
+
+    static func sync<T>(
+        protecting transcriptURLs: [URL],
+        _ update: () throws -> T
+    ) throws -> T {
+        #if canImport(TranscriptedCore)
+        do {
+            return try TranscriptSaver.serializeTranscriptFileUpdate(
+                protecting: transcriptURLs,
+                update
+            )
+        } catch TranscriptFileUpdateError.replacementInProgress {
+            throw MeetingTranscriptFileUpdateError.replacementInProgress
+        }
+        #else
+        return try sync(update)
         #endif
     }
 }

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -22,8 +22,19 @@ enum MeetingTranscriptStyler {
     private static let formatterQueue = DispatchQueue(label: "Transcripted.MeetingTranscriptStyler.formatters")
 
     static func restyleTranscript(at url: URL) -> StyledMeetingTranscript {
-        MeetingTranscriptFileUpdateSerializer.sync {
-            styledTranscript(at: url, persistChanges: true)
+        do {
+            return try MeetingTranscriptFileUpdateSerializer.sync(protecting: [url]) {
+                styledTranscript(at: url, persistChanges: true)
+            }
+        } catch MeetingTranscriptFileUpdateError.replacementInProgress {
+            logFailure(
+                event: "meeting_transcript_restyle_replacement_conflict",
+                message: "Skipped transcript restyle during replacement retranscription",
+                context: ["file": url.lastPathComponent]
+            )
+            return styledTranscript(at: url, persistChanges: false)
+        } catch {
+            return styledTranscript(at: url, persistChanges: false)
         }
     }
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -629,6 +629,17 @@ public class TranscriptionTaskManager: ObservableObject {
             return
         }
 
+        if let replacementTranscriptURL {
+            guard TranscriptSaver.beginReplacingTranscript(at: replacementTranscriptURL) else {
+                publishFailure(
+                    displayMessage: "That meeting is already being re-transcribed.",
+                    diagnosticMessage: "Replacement transcript already in progress"
+                )
+                scheduleStatusReset(delay: 4)
+                return
+            }
+        }
+
         let taskId = UUID()
         activeCount += 1
         backgroundTaskCount += 1
@@ -646,6 +657,12 @@ public class TranscriptionTaskManager: ObservableObject {
         ])
 
         let asyncTask = Task {
+            defer {
+                if let replacementTranscriptURL {
+                    TranscriptSaver.finishReplacingTranscript(at: replacementTranscriptURL)
+                }
+            }
+
             do {
                 await MainActor.run {
                     self.publishNonFailureStatus(.transcribing(progress: 0.0))

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -629,15 +629,19 @@ public class TranscriptionTaskManager: ObservableObject {
             return
         }
 
+        let replacementReservation: ReplacementTranscriptReservationToken?
         if let replacementTranscriptURL {
-            guard TranscriptSaver.beginReplacingTranscript(at: replacementTranscriptURL) else {
+            guard let reservation = TranscriptSaver.beginReplacingTranscript(at: replacementTranscriptURL) else {
                 publishFailure(
-                    displayMessage: "That meeting is already being re-transcribed.",
-                    diagnosticMessage: "Replacement transcript already in progress"
+                    displayMessage: "That meeting moved or is already being re-transcribed. Refresh and try again.",
+                    diagnosticMessage: "Replacement transcript unavailable"
                 )
                 scheduleStatusReset(delay: 4)
                 return
             }
+            replacementReservation = reservation
+        } else {
+            replacementReservation = nil
         }
 
         let taskId = UUID()
@@ -657,9 +661,10 @@ public class TranscriptionTaskManager: ObservableObject {
         ])
 
         let asyncTask = Task {
+            var heldReplacementReservation = replacementReservation
             defer {
-                if let replacementTranscriptURL {
-                    TranscriptSaver.finishReplacingTranscript(at: replacementTranscriptURL)
+                if let heldReplacementReservation {
+                    TranscriptSaver.finishReplacingTranscript(heldReplacementReservation)
                 }
             }
 
@@ -681,6 +686,14 @@ public class TranscriptionTaskManager: ObservableObject {
                     targetTranscriptURL: replacementTranscriptURL,
                     archiveRecordingAudio: replacementTranscriptURL == nil
                 )
+
+                // The replacement file is fully committed. Release its writer
+                // barrier before publishing the save, because that publication
+                // intentionally starts the normal post-save restyle/rename path.
+                if let reservation = heldReplacementReservation {
+                    TranscriptSaver.finishReplacingTranscript(reservation)
+                    heldReplacementReservation = nil
+                }
 
                 await MainActor.run {
                     guard !self.finishCancelledTaskIfNeeded(taskId: taskId) else { return }

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater+Scanning.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater+Scanning.swift
@@ -171,26 +171,4 @@ extension TranscriptSaver {
         return nil
     }
 
-    static func extractTranscriptId(from url: URL) -> UUID? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
-        // read(upToCount:) (error-returning) instead of the legacy readData(ofLength:),
-        // which raises an uncatchable ObjC NSException on I/O failure and hard-crashes.
-        let header = try? handle.read(upToCount: 2048)
-        try? handle.close()
-        guard let header, let text = String(data: header, encoding: .utf8) else { return nil }
-        return extractTranscriptId(fromFrontmatter: text)
-    }
-
-    private static func extractTranscriptId(fromFrontmatter text: String) -> UUID? {
-        for line in text.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard trimmed.hasPrefix("transcript_id:") else { continue }
-            let value = trimmed
-                .dropFirst("transcript_id:".count)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            return UUID(uuidString: value)
-        }
-        return nil
-    }
 }

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -4,6 +4,25 @@ import Foundation
 
 extension TranscriptSaver {
 
+    public struct DeferredSpeakerNameUpdate: Sendable {
+        public let transcriptURL: URL
+        public let dbId: UUID
+        public let diarizerSpeakerId: String
+        public let channel: UtteranceChannel
+
+        public init(
+            transcriptURL: URL,
+            dbId: UUID,
+            diarizerSpeakerId: String,
+            channel: UtteranceChannel
+        ) {
+            self.transcriptURL = transcriptURL
+            self.dbId = dbId
+            self.diarizerSpeakerId = diarizerSpeakerId
+            self.channel = channel
+        }
+    }
+
     /// When a speaker is renamed in Settings, update ALL transcripts that reference them.
     /// Finds transcripts by searching YAML for the speaker's db_id, extracts the old name,
     /// and replaces it in both YAML frontmatter and transcript body.
@@ -36,14 +55,98 @@ extension TranscriptSaver {
         channel: UtteranceChannel,
         newName: String
     ) -> Bool {
-        serializeTranscriptFileUpdate {
-            _updateDeferredSpeakerNameImpl(
+        updateDeferredSpeakerNames(
+            [DeferredSpeakerNameUpdate(
                 transcriptURL: transcriptURL,
                 dbId: dbId,
                 diarizerSpeakerId: diarizerSpeakerId,
-                channel: channel,
-                newName: newName
-            )
+                channel: channel
+            )],
+            newName: newName
+        )
+    }
+
+    /// Update every saved occurrence of one queued voice as one file batch.
+    /// All replacement reservations and metadata matches are checked before
+    /// the first write, so a blocked meeting cannot leave sibling meetings
+    /// partially renamed while the speaker database remains unchanged.
+    @discardableResult
+    public static func updateDeferredSpeakerNames(
+        _ updates: [DeferredSpeakerNameUpdate],
+        newName: String
+    ) -> Bool {
+        guard !updates.isEmpty else { return true }
+
+        return serializeTranscriptFileUpdate {
+            let transcriptURLs = updates.map(\.transcriptURL)
+            guard !isReplacingAnyTranscript(at: transcriptURLs) else {
+                AppLogger.pipeline.warning(
+                    "Deferred speaker batch blocked during replacement retranscription",
+                    ["files": "\(Set(transcriptURLs.map(\.lastPathComponent)).count)"]
+                )
+                return false
+            }
+
+            struct StagedUpdate {
+                let url: URL
+                let original: String
+                var updated: String
+            }
+
+            var orderedPaths: [String] = []
+            var stagedByPath: [String: StagedUpdate] = [:]
+            for update in updates {
+                let path = update.transcriptURL.standardizedFileURL.path
+                var staged: StagedUpdate
+                if let existing = stagedByPath[path] {
+                    staged = existing
+                } else {
+                    guard let content = try? String(contentsOf: update.transcriptURL, encoding: .utf8) else {
+                        AppLogger.pipeline.error(
+                            "Failed to read deferred speaker transcript",
+                            ["path": update.transcriptURL.path]
+                        )
+                        return false
+                    }
+                    staged = StagedUpdate(
+                        url: update.transcriptURL,
+                        original: content,
+                        updated: content
+                    )
+                    orderedPaths.append(path)
+                }
+
+                guard applyDeferredSpeakerName(
+                    in: &staged.updated,
+                    update: update,
+                    newName: newName
+                ) else {
+                    return false
+                }
+                stagedByPath[path] = staged
+            }
+
+            var written: [(url: URL, original: String)] = []
+            for path in orderedPaths {
+                guard let staged = stagedByPath[path],
+                      FileManager.default.fileExists(atPath: staged.url.path) else {
+                    rollbackDeferredSpeakerUpdates(written)
+                    return false
+                }
+                do {
+                    try staged.updated.write(to: staged.url, atomically: true, encoding: .utf8)
+                    restrictTranscriptToOwnerOnly(staged.url)
+                    written.append((url: staged.url, original: staged.original))
+                } catch {
+                    AppLogger.pipeline.warning("Failed to update deferred speaker transcript", [
+                        "file": staged.url.lastPathComponent,
+                        "error": error.localizedDescription
+                    ])
+                    rollbackDeferredSpeakerUpdates(written)
+                    return false
+                }
+            }
+            return true
         }
     }
 
@@ -81,8 +184,18 @@ extension TranscriptSaver {
         let dbIdNeedle = "db_id: \"\(dbIdString)\""
         var updatedCount = 0
 
-        for fileURL in transcriptMarkdownFiles(under: directory) {
-            guard scanFrontmatter(at: fileURL, for: dbIdNeedle) != .notMatched else { continue }
+        let matchingFiles = transcriptMarkdownFiles(under: directory).filter {
+            scanFrontmatter(at: $0, for: dbIdNeedle) != .notMatched
+        }
+        guard !isReplacingAnyTranscript(at: matchingFiles) else {
+            AppLogger.pipeline.warning(
+                "Retroactive speaker update blocked during replacement retranscription",
+                ["dbId": dbIdString]
+            )
+            return
+        }
+
+        for fileURL in matchingFiles {
             guard var content = try? String(contentsOf: fileURL, encoding: .utf8),
                   content.contains(dbIdNeedle) else { continue }
 
@@ -115,46 +228,31 @@ extension TranscriptSaver {
         }
     }
 
-    private static func _updateDeferredSpeakerNameImpl(
-        transcriptURL: URL,
-        dbId: UUID,
-        diarizerSpeakerId: String,
-        channel: UtteranceChannel,
+    private static func applyDeferredSpeakerName(
+        in content: inout String,
+        update: DeferredSpeakerNameUpdate,
         newName: String
     ) -> Bool {
-        guard !isReplacingTranscript(at: transcriptURL) else {
-            AppLogger.pipeline.warning(
-                "Deferred speaker update blocked during replacement retranscription",
-                ["file": transcriptURL.lastPathComponent]
-            )
-            return false
-        }
-
-        guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
-            AppLogger.pipeline.error("Failed to read deferred speaker transcript", ["path": transcriptURL.path])
-            return false
-        }
-
         guard let oldName = currentSpeakerName(
             in: content,
-            diarizerSpeakerId: diarizerSpeakerId,
-            channel: channel,
-            matchingDbId: dbId
+            diarizerSpeakerId: update.diarizerSpeakerId,
+            channel: update.channel,
+            matchingDbId: update.dbId
         ) else {
             AppLogger.pipeline.warning("Deferred speaker metadata no longer matches queued row", [
-                "path": transcriptURL.lastPathComponent,
-                "dbId": dbId.uuidString,
-                "diarizerSpeakerId": diarizerSpeakerId,
-                "channel": channel.rawValue
+                "path": update.transcriptURL.lastPathComponent,
+                "dbId": update.dbId.uuidString,
+                "diarizerSpeakerId": update.diarizerSpeakerId,
+                "channel": update.channel.rawValue
             ])
             return false
         }
 
         writeFrontmatterSpeakerMetadata(
             in: &content,
-            diarizerSpeakerId: diarizerSpeakerId,
-            channel: channel,
-            persistentSpeakerId: dbId,
+            diarizerSpeakerId: update.diarizerSpeakerId,
+            channel: update.channel,
+            persistentSpeakerId: update.dbId,
             name: newName,
             source: NameSource.userManual
         )
@@ -162,20 +260,25 @@ extension TranscriptSaver {
             in: &content,
             oldName: oldName,
             newName: newName,
-            channel: channel
+            channel: update.channel
         )
         content = SpeakerBreakdownConsolidator.consolidate(content)
+        return true
+    }
 
-        do {
-            try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
-            restrictTranscriptToOwnerOnly(transcriptURL)
-            return true
-        } catch {
-            AppLogger.pipeline.warning("Failed to update deferred speaker transcript", [
-                "file": transcriptURL.lastPathComponent,
-                "error": error.localizedDescription
-            ])
-            return false
+    private static func rollbackDeferredSpeakerUpdates(
+        _ updates: [(url: URL, original: String)]
+    ) {
+        for update in updates.reversed() {
+            do {
+                try update.original.write(to: update.url, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(update.url)
+            } catch {
+                AppLogger.pipeline.error("Failed to roll back deferred speaker transcript", [
+                    "file": update.url.lastPathComponent,
+                    "error": error.localizedDescription
+                ])
+            }
         }
     }
 
@@ -190,8 +293,18 @@ extension TranscriptSaver {
         let sourceIdNeedle = "db_id: \"\(sourceIdString)\""
         var updatedCount = 0
 
-        for fileURL in transcriptMarkdownFiles(under: directory) {
-            guard scanFrontmatter(at: fileURL, for: sourceIdNeedle) != .notMatched else { continue }
+        let matchingFiles = transcriptMarkdownFiles(under: directory).filter {
+            scanFrontmatter(at: $0, for: sourceIdNeedle) != .notMatched
+        }
+        guard !isReplacingAnyTranscript(at: matchingFiles) else {
+            AppLogger.pipeline.warning(
+                "Retroactive speaker merge blocked during replacement retranscription",
+                ["sourceDbId": sourceIdString]
+            )
+            return
+        }
+
+        for fileURL in matchingFiles {
             guard var content = try? String(contentsOf: fileURL, encoding: .utf8),
                   content.contains(sourceIdNeedle) else { continue }
 
@@ -231,7 +344,7 @@ extension TranscriptSaver {
     //
     // File scanning (transcriptMarkdownFiles, scanFrontmatter), frontmatter row
     // parsing (FrontmatterSpeakerRow, parseFrontmatterSpeakerRows), and YAML value
-    // extraction (extractYAMLQuotedString, extractTranscriptId) live in
+    // extraction (extractYAMLQuotedString) live in
     // RetroactiveSpeakerUpdater+Scanning.swift (audit 2026-07-08 wave 2).
 
     /// Rename one person (by db_id) inside a single transcript without bleeding into

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -795,35 +795,30 @@ extension TranscriptSaver {
     }
 
     /// Resolve a transcript URL that may have been renamed by MeetingTranscriptStyler.
-    /// Uses the stable transcript_id written at initial save time.
+    /// Uses the canonical stable-identity resolver shared with recovery flows.
     static func resolveTranscriptURL(_ url: URL, transcriptId: UUID) -> URL? {
-        if FileManager.default.fileExists(atPath: url.path),
-           extractTranscriptId(from: url) == transcriptId {
+        if let frontmatter = try? TranscriptFrontmatter.readValues(from: url),
+           TranscriptFrontmatter.captureID(in: frontmatter) == transcriptId {
             return url
         }
 
-        AppLogger.pipeline.info("Transcript not at expected path, scanning for stable transcript id", [
-            "expected": url.lastPathComponent,
-            "transcriptId": transcriptId.uuidString
-        ])
-
         let dir = url.deletingLastPathComponent()
-        guard let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
-            .filter({ $0.pathExtension == "md" }) else {
+        guard let resolvedURL = existingTranscriptURL(in: dir, transcriptId: transcriptId) else {
+            AppLogger.pipeline.error("Failed to resolve transcript by stable id", [
+                "expected": url.lastPathComponent,
+                "transcriptId": transcriptId.uuidString
+            ])
             return nil
         }
 
-        for file in files {
-            guard extractTranscriptId(from: file) == transcriptId else { continue }
-            AppLogger.pipeline.info("Resolved renamed transcript", ["from": url.lastPathComponent, "to": file.lastPathComponent])
-            return dir.appendingPathComponent(file.lastPathComponent)
+        let logicalResolvedURL = dir.appendingPathComponent(resolvedURL.lastPathComponent)
+        if logicalResolvedURL.standardizedFileURL != url.standardizedFileURL {
+            AppLogger.pipeline.info("Resolved renamed transcript", [
+                "from": url.lastPathComponent,
+                "to": logicalResolvedURL.lastPathComponent
+            ])
         }
-
-        AppLogger.pipeline.error("Failed to resolve transcript by stable id", [
-            "expected": url.lastPathComponent,
-            "transcriptId": transcriptId.uuidString
-        ])
-        return nil
+        return logicalResolvedURL
     }
 
     /// Replace all occurrences of a speaker name throughout a transcript's YAML and body.
@@ -1013,8 +1008,7 @@ extension TranscriptSaver {
         }.count
     }
 
-    // extractYAMLQuotedString / extractTranscriptId(from:) / extractTranscriptId(fromFrontmatter:)
-    // moved to RetroactiveSpeakerUpdater+Scanning.swift. (audit 2026-07-08 wave 2)
+    // extractYAMLQuotedString moved to RetroactiveSpeakerUpdater+Scanning.swift.
 
     private static func updateFrontmatterSpeakerMetadata(
         in content: inout String,

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -4,6 +4,17 @@ import Foundation
 
 extension TranscriptSaver {
 
+    public enum DeferredSpeakerNameUpdateError: Error, LocalizedError, Equatable {
+        case transcriptRestoreFailed(fileCount: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .transcriptRestoreFailed(let count):
+                return "Could not restore \(count) transcript(s) after the speaker update failed."
+            }
+        }
+    }
+
     public struct DeferredSpeakerNameUpdate: Sendable {
         public let transcriptURL: URL
         public let dbId: UUID
@@ -55,7 +66,7 @@ extension TranscriptSaver {
         channel: UtteranceChannel,
         newName: String
     ) -> Bool {
-        updateDeferredSpeakerNames(
+        (try? updateDeferredSpeakerNames(
             [DeferredSpeakerNameUpdate(
                 transcriptURL: transcriptURL,
                 dbId: dbId,
@@ -63,7 +74,7 @@ extension TranscriptSaver {
                 channel: channel
             )],
             newName: newName
-        )
+        )) ?? false
     }
 
     /// Update every saved occurrence of one queued voice as one file batch.
@@ -74,10 +85,10 @@ extension TranscriptSaver {
     public static func updateDeferredSpeakerNames(
         _ updates: [DeferredSpeakerNameUpdate],
         newName: String
-    ) -> Bool {
+    ) throws -> Bool {
         guard !updates.isEmpty else { return true }
 
-        return serializeTranscriptFileUpdate {
+        return try serializeTranscriptFileUpdate {
             let transcriptURLs = updates.map(\.transcriptURL)
             guard !isReplacingAnyTranscript(at: transcriptURLs) else {
                 AppLogger.pipeline.warning(
@@ -130,7 +141,7 @@ extension TranscriptSaver {
             for path in orderedPaths {
                 guard let staged = stagedByPath[path],
                       FileManager.default.fileExists(atPath: staged.url.path) else {
-                    rollbackDeferredSpeakerUpdates(written)
+                    try restoreDeferredSpeakerUpdatesOrThrow(written)
                     return false
                 }
                 do {
@@ -142,7 +153,7 @@ extension TranscriptSaver {
                         "file": staged.url.lastPathComponent,
                         "error": error.localizedDescription
                     ])
-                    rollbackDeferredSpeakerUpdates(written)
+                    try restoreDeferredSpeakerUpdatesOrThrow(written)
                     return false
                 }
             }
@@ -266,19 +277,39 @@ extension TranscriptSaver {
         return true
     }
 
-    private static func rollbackDeferredSpeakerUpdates(
+    /// Restore every file already written by a deferred batch. A failure is
+    /// retried once and then surfaced, so callers cannot mistake a partial
+    /// on-disk update for an ordinary clean rejection.
+    static func restoreDeferredSpeakerUpdatesOrThrow(
         _ updates: [(url: URL, original: String)]
-    ) {
-        for update in updates.reversed() {
-            do {
-                try update.original.write(to: update.url, atomically: true, encoding: .utf8)
-                restrictTranscriptToOwnerOnly(update.url)
-            } catch {
-                AppLogger.pipeline.error("Failed to roll back deferred speaker transcript", [
-                    "file": update.url.lastPathComponent,
-                    "error": error.localizedDescription
-                ])
-            }
+    ) throws {
+        var stillFailing = updates.reversed().filter { !attemptDeferredSpeakerRestore($0) }
+        guard !stillFailing.isEmpty else { return }
+
+        stillFailing = stillFailing.filter { !attemptDeferredSpeakerRestore($0) }
+        guard stillFailing.isEmpty else {
+            AppLogger.pipeline.error("Deferred speaker rollback failed after retry", [
+                "fileCount": "\(stillFailing.count)"
+            ])
+            throw DeferredSpeakerNameUpdateError.transcriptRestoreFailed(
+                fileCount: stillFailing.count
+            )
+        }
+    }
+
+    private static func attemptDeferredSpeakerRestore(
+        _ update: (url: URL, original: String)
+    ) -> Bool {
+        do {
+            try update.original.write(to: update.url, atomically: true, encoding: .utf8)
+            restrictTranscriptToOwnerOnly(update.url)
+            return true
+        } catch {
+            AppLogger.pipeline.error("Failed to roll back deferred speaker transcript", [
+                "file": update.url.lastPathComponent,
+                "error": error.localizedDescription
+            ])
+            return false
         }
     }
 

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -122,6 +122,14 @@ extension TranscriptSaver {
         channel: UtteranceChannel,
         newName: String
     ) -> Bool {
+        guard !isReplacingTranscript(at: transcriptURL) else {
+            AppLogger.pipeline.warning(
+                "Deferred speaker update blocked during replacement retranscription",
+                ["file": transcriptURL.lastPathComponent]
+            )
+            return false
+        }
+
         guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
             AppLogger.pipeline.error("Failed to read deferred speaker transcript", ["path": transcriptURL.path])
             return false

--- a/Sources/TranscriptedCore/Speaker/SpeakerIdentityMutationService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerIdentityMutationService.swift
@@ -171,6 +171,9 @@ public enum SpeakerIdentityMutationService {
         directory: URL
     ) throws -> Outcome {
         let planned = try planAffectedTranscripts(matchingDbId: profileId, directory: directory)
+        guard !replacementBlocksMutation(planned, operation: "rename") else {
+            return failure()
+        }
 
         let rewrites: [PlannedRewrite] = planned.compactMap { entry in
             var content = entry.content
@@ -243,6 +246,9 @@ public enum SpeakerIdentityMutationService {
             ?? "Speaker \(targetId.uuidString.prefix(8))"
 
         let planned = try planAffectedTranscripts(matchingDbId: sourceId, directory: directory)
+        guard !replacementBlocksMutation(planned, operation: "merge") else {
+            return failure()
+        }
         let sourceIdNeedle = "db_id: \"\(sourceId.uuidString)\""
         let targetIdReplacement = "db_id: \"\(targetId.uuidString)\""
 
@@ -301,6 +307,9 @@ public enum SpeakerIdentityMutationService {
         clipSideEffects: ClipSideEffects
     ) throws -> Outcome {
         let planned = try planAffectedTranscripts(matchingDbId: profileId, directory: directory)
+        guard !replacementBlocksMutation(planned, operation: "discard") else {
+            return failure()
+        }
 
         let rewrites: [PlannedRewrite] = planned.compactMap { entry in
             var content = entry.content
@@ -348,6 +357,20 @@ public enum SpeakerIdentityMutationService {
     private struct PlannedTranscript {
         let url: URL
         let content: String
+    }
+
+    private static func replacementBlocksMutation(
+        _ planned: [PlannedTranscript],
+        operation: String
+    ) -> Bool {
+        let urls = planned.map(\.url)
+        guard TranscriptSaver.isReplacingAnyTranscript(at: urls) else { return false }
+
+        AppLogger.speakers.warning("Speaker identity mutation blocked during replacement retranscription", [
+            "operation": operation,
+            "files": "\(urls.count)"
+        ])
+        return true
     }
 
     // Not private: SpeakerIdentityMutationServiceTests exercises restoreOrThrow directly

--- a/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
@@ -84,7 +84,11 @@ public enum TranscriptFrontmatter {
 
         let readLimit = maximumFrontmatterByteLimit
         let chunkSize = max(1, min(byteLimit, previewByteLimit))
+        let openingDelimiter = Data("---\n".utf8)
+        let closingDelimiter = Data("\n---\n".utf8)
         var data = Data()
+        var didValidateOpeningDelimiter = false
+        var nextClosingDelimiterSearchOffset = openingDelimiter.count
 
         while data.count < readLimit {
             let remaining = readLimit - data.count
@@ -94,11 +98,28 @@ public enum TranscriptFrontmatter {
             }
             data.append(chunk)
 
-            let raw = String(decoding: data, as: UTF8.self)
-            guard raw.hasPrefix("---\n") else { return nil }
-            if let document = document(in: raw) {
-                return document
+            if !didValidateOpeningDelimiter, data.count >= openingDelimiter.count {
+                guard data.starts(with: openingDelimiter) else { return nil }
+                didValidateOpeningDelimiter = true
             }
+            guard didValidateOpeningDelimiter else { continue }
+
+            let searchStart = min(nextClosingDelimiterSearchOffset, data.count)
+            if data.range(
+                of: closingDelimiter,
+                in: searchStart..<data.endIndex
+            ) != nil {
+                // Decode once, after the complete delimiter is present. Besides
+                // preserving UTF-8 split across chunks, this avoids repeatedly
+                // decoding and parsing the whole growing prefix.
+                let raw = String(decoding: data, as: UTF8.self)
+                return document(in: raw)
+            }
+
+            nextClosingDelimiterSearchOffset = max(
+                openingDelimiter.count,
+                data.count - (closingDelimiter.count - 1)
+            )
         }
 
         return nil

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -1,8 +1,37 @@
 import Foundation
 
+private final class ReplacementTranscriptReservations: @unchecked Sendable {
+    private let lock = NSLock()
+    private var paths: Set<String> = []
+
+    func reserve(_ url: URL) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return paths.insert(key(for: url)).inserted
+    }
+
+    func release(_ url: URL) {
+        lock.lock()
+        paths.remove(key(for: url))
+        lock.unlock()
+    }
+
+    func contains(_ url: URL) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return paths.contains(key(for: url))
+    }
+
+    private func key(for url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}
+
 /// Handles automatic saving of transcripts to the filesystem
 public class TranscriptSaver {
     private static let fileUpdateQueueSpecific = DispatchSpecificKey<Void>()
+    private static let stableIdentityReadChunkSize = 2 * 1024
+    private static let replacementReservations = ReplacementTranscriptReservations()
 
     /// Default save location for the standalone Transcripted app.
     /// Falls back to `CoreStoragePaths.default.transcripts` unless the user has set a
@@ -58,6 +87,28 @@ public class TranscriptSaver {
         return try fileUpdateQueue.sync(execute: update)
     }
 
+    /// Reserve one saved transcript for in-place replacement. The reservation is
+    /// established under the same serializer as speaker edits, so an edit either
+    /// finishes before replacement starts or fails closed while it is active.
+    @discardableResult
+    static func beginReplacingTranscript(at url: URL) -> Bool {
+        serializeTranscriptFileUpdate {
+            replacementReservations.reserve(url)
+        }
+    }
+
+    static func finishReplacingTranscript(at url: URL) {
+        serializeTranscriptFileUpdate {
+            replacementReservations.release(url)
+        }
+    }
+
+    static func isReplacingTranscript(at url: URL) -> Bool {
+        serializeTranscriptFileUpdate {
+            replacementReservations.contains(url)
+        }
+    }
+
     /// Finds an already-written transcript by its stable frontmatter identity.
     /// Recovery uses this to make a crash immediately after the atomic Markdown
     /// write idempotent instead of producing a second timestamp-suffixed file.
@@ -95,7 +146,10 @@ public class TranscriptSaver {
             guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
                   values.isRegularFile == true,
                   values.isSymbolicLink != true,
-                  let frontmatter = try? TranscriptFrontmatter.readValues(from: url),
+                  let frontmatter = try? TranscriptFrontmatter.readValues(
+                    from: url,
+                    byteLimit: stableIdentityReadChunkSize
+                  ),
                   let transcriptId = TranscriptFrontmatter.captureID(in: frontmatter),
                   transcriptIds.contains(transcriptId),
                   matches[transcriptId] == nil

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -1,29 +1,60 @@
 import Foundation
 
-private final class ReplacementTranscriptReservations: @unchecked Sendable {
-    private let lock = NSLock()
-    private var paths: Set<String> = []
+struct ReplacementTranscriptReservationToken: Hashable, Sendable {
+    fileprivate let id: UUID
+}
 
-    func reserve(_ url: URL) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return paths.insert(key(for: url)).inserted
+private final class ReplacementTranscriptReservations: @unchecked Sendable {
+    private struct Entry {
+        let path: String
+        let transcriptId: UUID?
     }
 
-    func release(_ url: URL) {
+    private let lock = NSLock()
+    private var entries: [ReplacementTranscriptReservationToken: Entry] = [:]
+
+    func reserve(_ url: URL, transcriptId: UUID?) -> ReplacementTranscriptReservationToken? {
         lock.lock()
-        paths.remove(key(for: url))
+        defer { lock.unlock() }
+
+        let path = key(for: url)
+        guard !entries.values.contains(where: {
+            $0.path == path || (transcriptId != nil && $0.transcriptId == transcriptId)
+        }) else {
+            return nil
+        }
+
+        let token = ReplacementTranscriptReservationToken(id: UUID())
+        entries[token] = Entry(path: path, transcriptId: transcriptId)
+        return token
+    }
+
+    func release(_ token: ReplacementTranscriptReservationToken) {
+        lock.lock()
+        entries.removeValue(forKey: token)
         lock.unlock()
     }
 
-    func contains(_ url: URL) -> Bool {
+    func contains(_ url: URL, transcriptId: UUID?) -> Bool {
         lock.lock()
         defer { lock.unlock() }
-        return paths.contains(key(for: url))
+
+        let path = key(for: url)
+        return entries.values.contains {
+            $0.path == path || (transcriptId != nil && $0.transcriptId == transcriptId)
+        }
     }
 
     private func key(for url: URL) -> String {
         url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}
+
+public enum TranscriptFileUpdateError: Error, LocalizedError, Equatable {
+    case replacementInProgress
+
+    public var errorDescription: String? {
+        "That meeting is being re-transcribed. Try again when it finishes."
     }
 }
 
@@ -87,26 +118,69 @@ public class TranscriptSaver {
         return try fileUpdateQueue.sync(execute: update)
     }
 
+    /// Run a user-initiated transcript mutation only when none of its targets
+    /// is owned by an in-place replacement. Identity matching keeps the barrier
+    /// intact if a path alias or rename changes the target's visible URL.
+    public static func serializeTranscriptFileUpdate<T>(
+        protecting transcriptURLs: [URL],
+        _ update: () throws -> T
+    ) throws -> T {
+        try serializeTranscriptFileUpdate {
+            guard !isReplacingAnyTranscript(at: transcriptURLs) else {
+                throw TranscriptFileUpdateError.replacementInProgress
+            }
+            return try update()
+        }
+    }
+
     /// Reserve one saved transcript for in-place replacement. The reservation is
     /// established under the same serializer as speaker edits, so an edit either
     /// finishes before replacement starts or fails closed while it is active.
     @discardableResult
-    static func beginReplacingTranscript(at url: URL) -> Bool {
+    static func beginReplacingTranscript(at url: URL) -> ReplacementTranscriptReservationToken? {
         serializeTranscriptFileUpdate {
-            replacementReservations.reserve(url)
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            return replacementReservations.reserve(
+                url,
+                transcriptId: stableTranscriptIdentity(at: url)
+            )
         }
     }
 
-    static func finishReplacingTranscript(at url: URL) {
+    static func finishReplacingTranscript(_ token: ReplacementTranscriptReservationToken) {
         serializeTranscriptFileUpdate {
-            replacementReservations.release(url)
+            replacementReservations.release(token)
         }
     }
 
     static func isReplacingTranscript(at url: URL) -> Bool {
         serializeTranscriptFileUpdate {
-            replacementReservations.contains(url)
+            replacementReservations.contains(
+                url,
+                transcriptId: stableTranscriptIdentity(at: url)
+            )
         }
+    }
+
+    static func isReplacingAnyTranscript(at urls: [URL]) -> Bool {
+        serializeTranscriptFileUpdate {
+            urls.contains { url in
+                replacementReservations.contains(
+                    url,
+                    transcriptId: stableTranscriptIdentity(at: url)
+                )
+            }
+        }
+    }
+
+    private static func stableTranscriptIdentity(at url: URL) -> UUID? {
+        guard let values = try? TranscriptFrontmatter.readValues(
+            from: url,
+            byteLimit: stableIdentityReadChunkSize
+        ) else {
+            return nil
+        }
+        return TranscriptFrontmatter.captureID(in: values)
     }
 
     /// Finds an already-written transcript by its stable frontmatter identity.

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -299,17 +299,17 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            var allTranscriptUpdatesSucceeded = true
-            for reviewItem in matchingReviewItems {
-                let didUpdate = TranscriptSaver.updateDeferredSpeakerName(
-                    transcriptURL: reviewItem.transcriptURL,
-                    dbId: speakerId,
-                    diarizerSpeakerId: reviewItem.diarizerSpeakerId,
-                    channel: reviewItem.channel,
-                    newName: trimmed
-                )
-                allTranscriptUpdatesSucceeded = allTranscriptUpdatesSucceeded && didUpdate
-            }
+            let allTranscriptUpdatesSucceeded = TranscriptSaver.updateDeferredSpeakerNames(
+                matchingReviewItems.map { reviewItem in
+                    TranscriptSaver.DeferredSpeakerNameUpdate(
+                        transcriptURL: reviewItem.transcriptURL,
+                        dbId: speakerId,
+                        diarizerSpeakerId: reviewItem.diarizerSpeakerId,
+                        channel: reviewItem.channel
+                    )
+                },
+                newName: trimmed
+            )
 
             if allTranscriptUpdatesSucceeded {
                 speakerDatabase.setDisplayName(id: speakerId, name: trimmed, source: NameSource.userManual)

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -299,17 +299,26 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let allTranscriptUpdatesSucceeded = TranscriptSaver.updateDeferredSpeakerNames(
-                matchingReviewItems.map { reviewItem in
-                    TranscriptSaver.DeferredSpeakerNameUpdate(
-                        transcriptURL: reviewItem.transcriptURL,
-                        dbId: speakerId,
-                        diarizerSpeakerId: reviewItem.diarizerSpeakerId,
-                        channel: reviewItem.channel
-                    )
-                },
-                newName: trimmed
-            )
+            let allTranscriptUpdatesSucceeded: Bool
+            do {
+                allTranscriptUpdatesSucceeded = try TranscriptSaver.updateDeferredSpeakerNames(
+                    matchingReviewItems.map { reviewItem in
+                        TranscriptSaver.DeferredSpeakerNameUpdate(
+                            transcriptURL: reviewItem.transcriptURL,
+                            dbId: speakerId,
+                            diarizerSpeakerId: reviewItem.diarizerSpeakerId,
+                            channel: reviewItem.channel
+                        )
+                    },
+                    newName: trimmed
+                )
+            } catch {
+                AppLogger.speakers.error("Deferred speaker batch left an unrestored transcript", [
+                    "profileId": speakerId.uuidString,
+                    "error": error.localizedDescription
+                ])
+                allTranscriptUpdatesSucceeded = false
+            }
 
             if allTranscriptUpdatesSucceeded {
                 speakerDatabase.setDisplayName(id: speakerId, name: trimmed, source: NameSource.userManual)

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -776,11 +776,6 @@ struct TranscriptedSettingsView: View {
     }
 
     private func handleRetranscribeMeeting(_ item: RecentMeetingItem) {
-        guard !hasSpeakerReviewWork(for: item) else {
-            openHomeSpeakerReview(actionName: "open_speaker_review_before_retranscribe")
-            return
-        }
-
         guard let input = item.audio?.retranscriptionInput else {
             presentHomeActionFailure(
                 title: "Could not re-transcribe meeting",
@@ -1088,8 +1083,7 @@ struct TranscriptedSettingsView: View {
                             title: "Re-transcribe with speaker ID",
                             symbolName: "person.2.fill",
                             isEnabled: RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
-                                globalUnavailableReason: savedMeetingRetranscriptionUnavailableReason,
-                                hasSpeakerReviewWork: hasPendingSpeakerReview
+                                globalUnavailableReason: savedMeetingRetranscriptionUnavailableReason
                             )
                         ) {
                             handleRetranscribeMeeting(item)

--- a/Sources/UI/Shared/HomeMeetingRename.swift
+++ b/Sources/UI/Shared/HomeMeetingRename.swift
@@ -14,6 +14,7 @@ enum HomeMeetingSpeakerRenameError: Error, Equatable, LocalizedError {
     case ambiguousSpeaker
     case readFailed
     case writeFailed
+    case retranscriptionInProgress
 
     var errorDescription: String? {
         switch self {
@@ -27,6 +28,8 @@ enum HomeMeetingSpeakerRenameError: Error, Equatable, LocalizedError {
             return "The meeting transcript could not be read."
         case .writeFailed:
             return "The meeting transcript could not be updated."
+        case .retranscriptionInProgress:
+            return "That meeting is being re-transcribed. Try again when it finishes."
         }
     }
 }
@@ -65,83 +68,87 @@ enum HomeMeetingSpeakerRename {
         assignments: [HomeMeetingSpeakerAssignment],
         fileManager: FileManager = .default
     ) throws -> [String] {
-        try MeetingTranscriptFileUpdateSerializer.sync {
-            let normalizedAssignments = try assignments.map { assignment -> HomeMeetingSpeakerAssignment in
-                guard let name = normalizedName(assignment.newName) else {
-                    throw HomeMeetingSpeakerRenameError.emptyName
+        do {
+            return try MeetingTranscriptFileUpdateSerializer.sync(protecting: [url]) {
+                let normalizedAssignments = try assignments.map { assignment -> HomeMeetingSpeakerAssignment in
+                    guard let name = normalizedName(assignment.newName) else {
+                        throw HomeMeetingSpeakerRenameError.emptyName
+                    }
+                    return HomeMeetingSpeakerAssignment(
+                        identity: assignment.identity,
+                        newName: name,
+                        targetProfileID: assignment.targetProfileID,
+                        removesPersistentSpeakerLink: assignment.removesPersistentSpeakerLink
+                    )
                 }
-                return HomeMeetingSpeakerAssignment(
-                    identity: assignment.identity,
-                    newName: name,
-                    targetProfileID: assignment.targetProfileID,
-                    removesPersistentSpeakerLink: assignment.removesPersistentSpeakerLink
-                )
-            }
-            guard !normalizedAssignments.isEmpty else { return [] }
+                guard !normalizedAssignments.isEmpty else { return [] }
 
-            let raw: String
-            do {
-                raw = try String(contentsOf: url, encoding: .utf8)
-            } catch {
-                throw HomeMeetingSpeakerRenameError.readFailed
-            }
-
-            var lines = raw.components(separatedBy: "\n")
-            var metadataChangedByID: [String: Bool] = [:]
-            var replacements: [String: String] = [:]
-
-            for assignment in normalizedAssignments {
-                let oldToken = "[\(assignment.identity.rawLabel)]"
-                let newRawLabel = replacementRawLabel(
-                    for: assignment.identity,
-                    newName: assignment.newName
-                )
-                let newToken = "[\(newRawLabel)]"
-                if let existing = replacements[oldToken], existing != newToken {
-                    throw HomeMeetingSpeakerRenameError.ambiguousSpeaker
+                let raw: String
+                do {
+                    raw = try String(contentsOf: url, encoding: .utf8)
+                } catch {
+                    throw HomeMeetingSpeakerRenameError.readFailed
                 }
-                replacements[oldToken] = newToken
-                metadataChangedByID[assignment.identity.stableID] = rewriteFrontmatterSpeaker(
-                    in: &lines,
-                    identity: assignment.identity,
-                    newName: assignment.newName,
-                    targetProfileID: assignment.targetProfileID,
-                    removesPersistentSpeakerLink: assignment.removesPersistentSpeakerLink
-                )
-            }
 
-            var rewritten = lines.joined(separator: "\n")
-            var placeholders: [(token: String, replacement: String)] = []
-            var bodyChangedTokens: Set<String> = []
-            for (offset, pair) in replacements.sorted(by: { $0.key < $1.key }).enumerated() {
-                guard rewritten.contains(pair.key) else { continue }
-                let placeholder = "[TRANSCRIPTED_SPEAKER_RENAME_\(offset)_\(UUID().uuidString)]"
-                rewritten = rewritten.replacingOccurrences(of: pair.key, with: placeholder)
-                placeholders.append((placeholder, pair.value))
-                bodyChangedTokens.insert(pair.key)
-            }
-            for placeholder in placeholders {
-                rewritten = rewritten.replacingOccurrences(
-                    of: placeholder.token,
-                    with: placeholder.replacement
-                )
-            }
+                var lines = raw.components(separatedBy: "\n")
+                var metadataChangedByID: [String: Bool] = [:]
+                var replacements: [String: String] = [:]
 
-            for assignment in normalizedAssignments {
-                let oldToken = "[\(assignment.identity.rawLabel)]"
-                let metadataChanged = metadataChangedByID[assignment.identity.stableID] ?? false
-                guard metadataChanged || bodyChangedTokens.contains(oldToken) else {
-                    throw HomeMeetingSpeakerRenameError.speakerNotFound
+                for assignment in normalizedAssignments {
+                    let oldToken = "[\(assignment.identity.rawLabel)]"
+                    let newRawLabel = replacementRawLabel(
+                        for: assignment.identity,
+                        newName: assignment.newName
+                    )
+                    let newToken = "[\(newRawLabel)]"
+                    if let existing = replacements[oldToken], existing != newToken {
+                        throw HomeMeetingSpeakerRenameError.ambiguousSpeaker
+                    }
+                    replacements[oldToken] = newToken
+                    metadataChangedByID[assignment.identity.stableID] = rewriteFrontmatterSpeaker(
+                        in: &lines,
+                        identity: assignment.identity,
+                        newName: assignment.newName,
+                        targetProfileID: assignment.targetProfileID,
+                        removesPersistentSpeakerLink: assignment.removesPersistentSpeakerLink
+                    )
                 }
-            }
 
-            do {
-                try rewritten.write(to: url, atomically: true, encoding: .utf8)
-                fileManager.restrictFileToOwnerOnly(at: url)
-            } catch {
-                throw HomeMeetingSpeakerRenameError.writeFailed
+                var rewritten = lines.joined(separator: "\n")
+                var placeholders: [(token: String, replacement: String)] = []
+                var bodyChangedTokens: Set<String> = []
+                for (offset, pair) in replacements.sorted(by: { $0.key < $1.key }).enumerated() {
+                    guard rewritten.contains(pair.key) else { continue }
+                    let placeholder = "[TRANSCRIPTED_SPEAKER_RENAME_\(offset)_\(UUID().uuidString)]"
+                    rewritten = rewritten.replacingOccurrences(of: pair.key, with: placeholder)
+                    placeholders.append((placeholder, pair.value))
+                    bodyChangedTokens.insert(pair.key)
+                }
+                for placeholder in placeholders {
+                    rewritten = rewritten.replacingOccurrences(
+                        of: placeholder.token,
+                        with: placeholder.replacement
+                    )
+                }
+
+                for assignment in normalizedAssignments {
+                    let oldToken = "[\(assignment.identity.rawLabel)]"
+                    let metadataChanged = metadataChangedByID[assignment.identity.stableID] ?? false
+                    guard metadataChanged || bodyChangedTokens.contains(oldToken) else {
+                        throw HomeMeetingSpeakerRenameError.speakerNotFound
+                    }
+                }
+
+                do {
+                    try rewritten.write(to: url, atomically: true, encoding: .utf8)
+                    fileManager.restrictFileToOwnerOnly(at: url)
+                } catch {
+                    throw HomeMeetingSpeakerRenameError.writeFailed
+                }
+                return normalizedAssignments.map(\.newName)
             }
-            return normalizedAssignments.map(\.newName)
+        } catch MeetingTranscriptFileUpdateError.replacementInProgress {
+            throw HomeMeetingSpeakerRenameError.retranscriptionInProgress
         }
     }
 
@@ -297,6 +304,7 @@ enum HomeMeetingRenameError: Error, Equatable {
     case notOwnedMeeting
     case readFailed
     case writeFailed
+    case retranscriptionInProgress
 }
 
 /// Renames a saved meeting from the Home preview's editable title.
@@ -316,8 +324,12 @@ enum HomeMeetingRename {
         to rawTitle: String,
         fileManager: FileManager = .default
     ) throws -> HomeMeetingRenameResult {
-        try MeetingTranscriptFileUpdateSerializer.sync {
-            try renameSerialized(transcriptAt: url, to: rawTitle, fileManager: fileManager)
+        do {
+            return try MeetingTranscriptFileUpdateSerializer.sync(protecting: [url]) {
+                try renameSerialized(transcriptAt: url, to: rawTitle, fileManager: fileManager)
+            }
+        } catch MeetingTranscriptFileUpdateError.replacementInProgress {
+            throw HomeMeetingRenameError.retranscriptionInProgress
         }
     }
 

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -154,11 +154,8 @@ enum RecentMeetingSpeakerStatus: Equatable, Sendable {
 }
 
 enum RecentMeetingRetranscriptionMenuActionPolicy {
-    static func isEnabled(
-        globalUnavailableReason: String?,
-        hasSpeakerReviewWork: Bool
-    ) -> Bool {
-        globalUnavailableReason == nil && !hasSpeakerReviewWork
+    static func isEnabled(globalUnavailableReason: String?) -> Bool {
+        globalUnavailableReason == nil
     }
 }
 

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -145,27 +145,18 @@ func testRecentCaptureScanners() async {
         )
     }
 
-    runSuite("RecentMeetingRetranscriptionMenuActionPolicy blocks rows with pending speaker review") {
+    runSuite("RecentMeetingRetranscriptionMenuActionPolicy keeps persisted-review recovery available") {
         assertFalse(
             RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
-                globalUnavailableReason: nil,
-                hasSpeakerReviewWork: true
-            ),
-            "The row menu should not re-transcribe the same meeting while speaker review is still pending"
-        )
-        assertFalse(
-            RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
-                globalUnavailableReason: "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.",
-                hasSpeakerReviewWork: false
+                globalUnavailableReason: "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio."
             ),
             "Global meeting work should still disable the row menu re-transcribe action"
         )
         assertTrue(
             RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
-                globalUnavailableReason: nil,
-                hasSpeakerReviewWork: false
+                globalUnavailableReason: nil
             ),
-            "Reviewed saved meetings should remain re-transcribable from the row menu"
+            "Persisted review metadata should not strand retained-audio recovery after finalization fails"
         )
     }
 
@@ -1425,7 +1416,7 @@ func testRecentCaptureLoader() async {
         }
     }
 
-    await runSuite("RecentMeetingsScanner preserves retained audio and speaker review metadata") {
+    await runSuite("RecentMeetingsScanner keeps retained audio recoverable with pending speaker review") {
         await withTemporaryRecentCaptureLibrary { captureRoot in
             let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
             let transcriptURL = meetingsRoot.appendingPathComponent("audio-review.md", isDirectory: false)
@@ -1452,6 +1443,14 @@ func testRecentCaptureLoader() async {
             assertEqual(meetings.map(\.title), ["Synthetic Audio Row"], "scanner should keep the valid meeting row")
             assertEqual(meetings.first?.audio?.urls.map(\.lastPathComponent), ["system_audio.wav", "microphone.wav"], "scanner should attach retained meeting audio")
             assertEqual(meetings.first?.speakerStatus, .needsReview(1), "scanner should keep speaker review metadata from the transcript")
+            assertTrue(
+                meetings.first?.audio?.retranscriptionInput != nil,
+                "pending speaker review should keep retained system audio available for replacement transcription"
+            )
+            assertTrue(
+                RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(globalUnavailableReason: nil),
+                "a stranded review row should keep its re-transcription action enabled when no live work is active"
+            )
         }
     }
 

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
@@ -354,6 +354,41 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path), "cancellation must keep retained source audio")
     }
 
+    func testSavedAudioReplacementReservesTranscriptUntilCancellationFinishes() async throws {
+        let speech = BlockingMetadataStubSpeechToTextEngine(transcript: "Replacement transcript.")
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments(duration: 2.5))
+        )
+        let transcriptsDirectory = tempDirectory.appendingPathComponent("transcripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptsDirectory, withIntermediateDirectories: true)
+        let originalTranscriptURL = transcriptsDirectory.appendingPathComponent("Saved_Meeting.md")
+        try "old transcript".write(to: originalTranscriptURL, atomically: true, encoding: .utf8)
+        let savedAudioDirectory = tempDirectory.appendingPathComponent("saved-meeting-audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: savedAudioDirectory, withIntermediateDirectories: true)
+        let systemURL = savedAudioDirectory.appendingPathComponent("system_audio.wav")
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.startSavedAudioRetranscription(
+            micURL: nil,
+            systemURL: systemURL,
+            outputFolder: transcriptsDirectory,
+            meetingTitle: "Saved Meeting",
+            replacementTranscriptURL: originalTranscriptURL
+        )
+
+        try await waitUntil { speech.didStart }
+        XCTAssertTrue(TranscriptSaver.isReplacingTranscript(at: originalTranscriptURL))
+
+        manager.cancelAll()
+        try await waitUntil {
+            !TranscriptSaver.isReplacingTranscript(at: originalTranscriptURL)
+        }
+
+        XCTAssertTrue(manager.activeTasks.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+    }
+
     func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileAfterSuccess() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "Imported meeting artifact."),

--- a/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
@@ -26,22 +26,6 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         super.tearDown()
     }
 
-    // Regression: extractTranscriptId(from:) used the legacy readData(ofLength:),
-    // which raises an uncatchable ObjC NSException on I/O failure and hard-crashes
-    // the app (same crash family as the 1.1.48 telemetry-flush crash). Reading a
-    // directory fd fails with EISDIR — with read(upToCount:) that surfaces as a
-    // Swift error we swallow and return nil, instead of terminating the process.
-    func testExtractTranscriptIdDoesNotCrashOnUnreadableHandle() throws {
-        let directoryURL = temporaryDirectory.appendingPathComponent("a-directory", isDirectory: true)
-        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-
-        // Opening a directory read-only succeeds; the first read fails with EISDIR.
-        // If this line NSException-crashes, the whole test process aborts.
-        let result = TranscriptSaver.extractTranscriptId(from: directoryURL)
-
-        XCTAssertNil(result, "an unreadable handle should yield nil, not a crash")
-    }
-
     func testRetroactivelyUpdateSpeakerRenamesEscapedQuotes() throws {
         let speakerId = UUID()
         let transcriptURL = temporaryDirectory.appendingPathComponent("quoted.md")
@@ -1097,6 +1081,52 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         let resolved = TranscriptSaver.resolveTranscriptURL(originalURL, transcriptId: transcriptId)
 
         XCTAssertEqual(resolved, renamedURL)
+    }
+
+    func testResolveTranscriptURLFindsCaptureIdOnlyTranscript() throws {
+        let transcriptId = UUID()
+        let originalURL = tempDirectory.appendingPathComponent("Call_2026-04-10_15-01-23.md")
+        let renamedURL = tempDirectory.appendingPathComponent("Legacy Capture Identity.md")
+
+        try """
+        ---
+        capture_id: \(transcriptId.uuidString)
+        capture_type: meeting
+        ---
+
+        [00:01] [System/Speaker 1] Thanks for joining.
+        """.write(to: renamedURL, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            TranscriptSaver.resolveTranscriptURL(originalURL, transcriptId: transcriptId),
+            renamedURL
+        )
+    }
+
+    func testResolveTranscriptURLHandlesUnicodeSplitAtLegacyProbeBoundary() throws {
+        let transcriptId = UUID()
+        let originalURL = tempDirectory.appendingPathComponent("Call_2026-04-10_15-01-23.md")
+        let renamedURL = tempDirectory.appendingPathComponent("Long Unicode Meeting.md")
+        let frontmatter = """
+        ---
+        transcript_id: \(transcriptId.uuidString)
+        capture_id: \(transcriptId.uuidString)
+        capture_type: meeting
+        ---
+
+        """
+        let legacyProbeBoundary = 2_048
+        let paddingByteCount = legacyProbeBoundary - 1 - frontmatter.utf8.count
+        XCTAssertGreaterThan(paddingByteCount, 0)
+        let content = frontmatter + String(repeating: "a", count: paddingByteCount) + "é"
+        let legacyProbe = Data(content.utf8).prefix(legacyProbeBoundary)
+        XCTAssertNil(String(data: legacyProbe, encoding: .utf8))
+        try content.write(to: renamedURL, atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(
+            TranscriptSaver.resolveTranscriptURL(originalURL, transcriptId: transcriptId),
+            renamedURL
+        )
     }
 
     func testResolveTranscriptURLFailsWhenStableIdDoesNotMatchAnySibling() throws {

--- a/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
@@ -330,6 +330,44 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         XCTAssertFalse(updated.contains("[Mic/Taylor]"))
     }
 
+    func testUpdateDeferredSpeakerNameFailsClosedDuringReplacementRetranscription() throws {
+        let speakerId = UUID()
+        let transcriptURL = temporaryDirectory.appendingPathComponent("replacement-in-progress.md")
+        let original = pendingSystemMarkdown(
+            speakerId: speakerId,
+            diarizerSpeakerId: "1",
+            speakerName: "Speaker 1",
+            sample: "original saved meeting"
+        )
+        try original.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(TranscriptSaver.beginReplacingTranscript(at: transcriptURL))
+        defer { TranscriptSaver.finishReplacingTranscript(at: transcriptURL) }
+        XCTAssertTrue(TranscriptSaver.isReplacingTranscript(at: transcriptURL))
+        XCTAssertFalse(
+            TranscriptSaver.updateDeferredSpeakerName(
+                transcriptURL: transcriptURL,
+                dbId: speakerId,
+                diarizerSpeakerId: "1",
+                channel: .system,
+                newName: "Taylor"
+            )
+        )
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), original)
+
+        TranscriptSaver.finishReplacingTranscript(at: transcriptURL)
+        XCTAssertFalse(TranscriptSaver.isReplacingTranscript(at: transcriptURL))
+        XCTAssertTrue(
+            TranscriptSaver.updateDeferredSpeakerName(
+                transcriptURL: transcriptURL,
+                dbId: speakerId,
+                diarizerSpeakerId: "1",
+                channel: .system,
+                newName: "Taylor"
+            )
+        )
+    }
+
     func testUpdateDeferredSpeakerNameCanRenameSameProfileAcrossSavedCalls() throws {
         let speakerId = UUID()
         let firstURL = temporaryDirectory.appendingPathComponent("first-call.md")

--- a/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
@@ -414,7 +414,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         try secondOriginal.write(to: secondURL, atomically: true, encoding: .utf8)
         let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: secondURL))
 
-        let didUpdate = TranscriptSaver.updateDeferredSpeakerNames(
+        let didUpdate = try TranscriptSaver.updateDeferredSpeakerNames(
             [
                 .init(
                     transcriptURL: firstURL,
@@ -436,6 +436,23 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: firstURL, encoding: .utf8), firstOriginal)
         XCTAssertEqual(try String(contentsOf: secondURL, encoding: .utf8), secondOriginal)
         TranscriptSaver.finishReplacingTranscript(reservation)
+    }
+
+    func testDeferredSpeakerBatchSurfacesRollbackFailureAfterRetry() {
+        let ghostURL = temporaryDirectory
+            .appendingPathComponent("does-not-exist", isDirectory: true)
+            .appendingPathComponent("ghost.md")
+
+        XCTAssertThrowsError(
+            try TranscriptSaver.restoreDeferredSpeakerUpdatesOrThrow([
+                (url: ghostURL, original: "original")
+            ])
+        ) { error in
+            guard case TranscriptSaver.DeferredSpeakerNameUpdateError.transcriptRestoreFailed(let fileCount) = error else {
+                return XCTFail("expected transcriptRestoreFailed, got \(error)")
+            }
+            XCTAssertEqual(fileCount, 1)
+        }
     }
 
     func testUpdateDeferredSpeakerNameCanRenameSameProfileAcrossSavedCalls() throws {

--- a/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
@@ -341,8 +341,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         )
         try original.write(to: transcriptURL, atomically: true, encoding: .utf8)
 
-        XCTAssertTrue(TranscriptSaver.beginReplacingTranscript(at: transcriptURL))
-        defer { TranscriptSaver.finishReplacingTranscript(at: transcriptURL) }
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: transcriptURL))
         XCTAssertTrue(TranscriptSaver.isReplacingTranscript(at: transcriptURL))
         XCTAssertFalse(
             TranscriptSaver.updateDeferredSpeakerName(
@@ -355,7 +354,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         )
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), original)
 
-        TranscriptSaver.finishReplacingTranscript(at: transcriptURL)
+        TranscriptSaver.finishReplacingTranscript(reservation)
         XCTAssertFalse(TranscriptSaver.isReplacingTranscript(at: transcriptURL))
         XCTAssertTrue(
             TranscriptSaver.updateDeferredSpeakerName(
@@ -366,6 +365,77 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
                 newName: "Taylor"
             )
         )
+    }
+
+    func testReplacementReservationFollowsStableIdentityAcrossRename() throws {
+        let transcriptId = UUID()
+        let originalURL = temporaryDirectory.appendingPathComponent("before-rename.md")
+        let renamedURL = temporaryDirectory.appendingPathComponent("after-rename.md")
+        try """
+        ---
+        capture_id: "\(transcriptId.uuidString)"
+        capture_type: meeting
+        ---
+
+        Original meeting.
+        """.write(to: originalURL, atomically: true, encoding: .utf8)
+
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: originalURL))
+        try FileManager.default.moveItem(at: originalURL, to: renamedURL)
+
+        XCTAssertTrue(TranscriptSaver.isReplacingTranscript(at: renamedURL))
+        XCTAssertThrowsError(
+            try TranscriptSaver.serializeTranscriptFileUpdate(protecting: [renamedURL]) {}
+        ) { error in
+            XCTAssertEqual(error as? TranscriptFileUpdateError, .replacementInProgress)
+        }
+
+        TranscriptSaver.finishReplacingTranscript(reservation)
+        XCTAssertFalse(TranscriptSaver.isReplacingTranscript(at: renamedURL))
+    }
+
+    func testDeferredSpeakerBatchPreflightsEveryReplacementBeforeWriting() throws {
+        let speakerId = UUID()
+        let firstURL = temporaryDirectory.appendingPathComponent("first-pending-call.md")
+        let secondURL = temporaryDirectory.appendingPathComponent("second-pending-call.md")
+        let firstOriginal = pendingSystemMarkdown(
+            speakerId: speakerId,
+            diarizerSpeakerId: "1",
+            speakerName: "Speaker 1",
+            sample: "first call"
+        )
+        let secondOriginal = pendingSystemMarkdown(
+            speakerId: speakerId,
+            diarizerSpeakerId: "2",
+            speakerName: "Speaker 2",
+            sample: "second call"
+        )
+        try firstOriginal.write(to: firstURL, atomically: true, encoding: .utf8)
+        try secondOriginal.write(to: secondURL, atomically: true, encoding: .utf8)
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: secondURL))
+
+        let didUpdate = TranscriptSaver.updateDeferredSpeakerNames(
+            [
+                .init(
+                    transcriptURL: firstURL,
+                    dbId: speakerId,
+                    diarizerSpeakerId: "1",
+                    channel: .system
+                ),
+                .init(
+                    transcriptURL: secondURL,
+                    dbId: speakerId,
+                    diarizerSpeakerId: "2",
+                    channel: .system
+                )
+            ],
+            newName: "Taylor"
+        )
+
+        XCTAssertFalse(didUpdate)
+        XCTAssertEqual(try String(contentsOf: firstURL, encoding: .utf8), firstOriginal)
+        XCTAssertEqual(try String(contentsOf: secondURL, encoding: .utf8), secondOriginal)
+        TranscriptSaver.finishReplacingTranscript(reservation)
     }
 
     func testUpdateDeferredSpeakerNameCanRenameSameProfileAcrossSavedCalls() throws {

--- a/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerIdentityMutationServiceTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerIdentityMutationServiceTests.swift
@@ -98,6 +98,31 @@ final class SpeakerIdentityMutationServiceTests: XCTestCase {
         XCTAssertFalse(updated.contains("Speaker 0"))
     }
 
+    func testRenameFailsClosedWhileAnyAffectedTranscriptIsBeingReplaced() throws {
+        let speaker = speakerDatabase.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.1, count: 256),
+            existingId: nil
+        )
+        speakerDatabase.setDisplayName(id: speaker.id, name: "Speaker 0", source: NameSource.userManual)
+        let firstURL = try writeTranscript(named: "first.md", speakerId: speaker.id, speakerName: "Speaker 0")
+        let secondURL = try writeTranscript(named: "second.md", speakerId: speaker.id, speakerName: "Speaker 0")
+        let firstOriginal = try String(contentsOf: firstURL, encoding: .utf8)
+        let secondOriginal = try String(contentsOf: secondURL, encoding: .utf8)
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: secondURL))
+
+        let outcome = try SpeakerIdentityMutationService.apply(
+            .rename(profileId: speaker.id, newName: "Jamie"),
+            speakerDB: speakerDatabase,
+            directory: temporaryDirectory
+        )
+
+        XCTAssertFalse(outcome.succeeded)
+        XCTAssertEqual(speakerDatabase.getSpeaker(id: speaker.id)?.displayName, "Speaker 0")
+        XCTAssertEqual(try String(contentsOf: firstURL, encoding: .utf8), firstOriginal)
+        XCTAssertEqual(try String(contentsOf: secondURL, encoding: .utf8), secondOriginal)
+        TranscriptSaver.finishReplacingTranscript(reservation)
+    }
+
     /// Pins the new atomicity: when one of several affected transcripts can't be written,
     /// the database must never be mutated, and every transcript already rewritten in this
     /// call must be restored to its pre-mutation snapshot. Neither of the two DB-first

--- a/Tests/TranscriptedCoreTests/StorageTests/TranscriptFrontmatterTests.swift
+++ b/Tests/TranscriptedCoreTests/StorageTests/TranscriptFrontmatterTests.swift
@@ -95,7 +95,9 @@ final class TranscriptFrontmatterTests: XCTestCase {
         """
         try raw.write(to: url, atomically: true, encoding: .utf8)
 
-        let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: url))
+        let values = try XCTUnwrap(
+            try TranscriptFrontmatter.readValues(from: url, byteLimit: 2 * 1024)
+        )
 
         XCTAssertEqual(values["title"], "Large Meeting")
         XCTAssertEqual(values["duration"], "42:17")
@@ -126,7 +128,9 @@ final class TranscriptFrontmatterTests: XCTestCase {
         """
         try raw.write(to: url, atomically: true, encoding: .utf8)
 
-        let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: url))
+        let values = try XCTUnwrap(
+            try TranscriptFrontmatter.readValues(from: url, byteLimit: 2 * 1024)
+        )
 
         XCTAssertEqual(values["capture_type"], "meeting")
         XCTAssertEqual(values["title"], "Long Meeting")


### PR DESCRIPTION
## Summary
- resolve renamed saved meeting transcripts through canonical frontmatter identity (`transcript_id` plus legacy `capture_id`)
- keep retained-audio re-transcription available after persisted speaker finalization/review failure while live work still blocks it
- protect replacement transcripts by stable identity across title, restyle, and speaker mutations
- batch deferred speaker updates and surface incomplete rollback instead of reporting a clean failure

## Root cause
Speaker finalization used a bespoke 2 KB UTF-8 probe that could miss a renamed transcript. Persisted `db_pending` review metadata was also treated like live work, so retained audio could not be used for recovery after finalization failed.

## Validation
- `bash run-tests.sh` (12,126 passed)
- `bash build-deps.sh --force`
- `bash run-integration-smoke.sh`
- `swift test` (1,034 passed, 13 skipped, 0 failures)
- focused `RetroactiveSpeakerUpdaterTests` (43 passed)
- compile-only app source build reached the intentionally disabled local signing boundary
- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`
- hosted CI green: app build, package tests, integration smoke, tools tests, checks, and repo hygiene

## Review
- initial Codex and thermonuclear findings were accepted and fixed: stable identity reservations, writer barriers, grouped batch atomicity, linear frontmatter parsing, and rollback escalation
- final Codex review: no actionable P0-P3 findings
- final thermonuclear review: MERGE, no actionable P0-P3 findings

## Proof boundary
Deterministic recovery and gating behavior are covered. Local signing/launch was excluded because the login-keychain password prompt is unresolved, while hosted app-build CI passed. A real imported-audio UI recovery click and hardware routes remain manual/UNKNOWN. No release was performed.

Addresses #1681