### PR TITLE
Unfreeze the UI during saved-audio retranscription, gate hardware smokes

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -46,6 +46,16 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      run_hardware_smokes:
+        description: >-
+          Run the real mic / system-audio smokes on a self-hosted Apple Silicon
+          runner labelled [self-hosted, macOS, ARM64]. Requires Microphone and
+          System Audio Recording TCC grants for the runner agent. Leave false to
+          only print the manual commands.
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -284,12 +294,33 @@ jobs:
   # release checklist item — never as part of pull_request, so they can never
   # block a normal PR.
   #
-  # This job is workflow_dispatch-only. With no self-hosted runner wired up yet
-  # it just echoes the commands an operator should run on a real Mac; replace
-  # the echo step with `runs-on: [self-hosted, macOS, ARM64]` and the real
-  # smoke invocations once such a runner exists.
+  # Both jobs below are workflow_dispatch-only and mutually exclusive on the
+  # `run_hardware_smokes` input: true runs the real smokes on a self-hosted
+  # runner, false prints the manual commands. Neither can block a PR.
   hardware-smokes:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.run_hardware_smokes
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build dependencies
+        run: bash build-deps.sh
+
+      - name: Live capture smoke
+        run: bash run-live-capture-smoke.sh
+
+      - name: Slow paste-back smoke
+        run: bash run-slow-pasteback-smoke.sh
+
+  # Fallback for when no self-hosted runner is registered yet: prints the exact
+  # commands an operator should run by hand on an Apple Silicon Mac. Flip
+  # `run_hardware_smokes` to true once a runner exists and `hardware-smokes`
+  # above replaces this with a real gate.
+  hardware-smokes-manual-instructions:
+    if: github.event_name == 'workflow_dispatch' && !inputs.run_hardware_smokes
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -304,3 +335,9 @@ jobs:
           echo "  bash run-live-capture-smoke.sh"
           echo "  bash run-slow-pasteback-smoke.sh"
           echo "They are intentionally excluded from the PR gate."
+          echo
+          echo "To automate: register a self-hosted runner labelled"
+          echo "  [self-hosted, macOS, ARM64]"
+          echo "grant its agent Microphone + System Audio Recording in System"
+          echo "Settings > Privacy & Security, then re-dispatch this workflow"
+          echo "with run_hardware_smokes = true."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,18 +166,39 @@ Treat as reference, not current runtime truth:
 
 ## Hotspots
 
-Files still over 1500 lines after the 2026-07 god-file splits (measured with `wc -l`). These are dense, high-blast-radius files — read the whole file and the relevant subsystem `CLAUDE.md` before editing; do not casually append another responsibility to any of them:
+Files over 1500 lines. These are dense, high-blast-radius files — read the whole file and the relevant subsystem `CLAUDE.md` before editing; do not casually append another responsibility to any of them.
 
-- `Sources/UI/Settings/TranscriptedSettingsView.swift` (~4.8k) — settings shell, navigation, state, and page routing for every settings surface; General, Storage, and Beta presentation now live under `Sources/UI/Settings/Pages/`, while the shell keeps their bindings and runtime work
-- `Sources/Meeting/MeetingSessionController.swift` (~3.1k) — the meeting state machine; failed-meeting and queue bookkeeping were split into `FailedMeetingStore.swift`/`TranscriptionQueueCoordinator.swift`, but permission gating, capture start/stop, and transcript-save handoff still live here
-- `Sources/Speech/ParakeetEngine.swift` (~2.8k) — the dictation STT engine; device recovery and model lifecycle already moved to `ParakeetDeviceRecovery.swift`/`ParakeetModelLifecycle.swift`, this file is still the public-API owner and `@MainActor` home for recording state
-- `Sources/UI/Overlay/MeetingOverlayController.swift` (~2.7k) — the non-activating meeting-prompt/recording panel controller; touches capture state, live-transcript drawer, and prompt UI all at once
-- `Sources/UI/Settings/HomeView.swift` (~2.4k) — the Home canvas (greeting, stats, capture lists, preview/feedback sheets); most small formatting/policy helpers already live in sibling files (`HomePresentation.swift`, `HomeCanvasGreeting.swift`, etc.), this is the view assembly itself
-- `Sources/UI/Overlay/DictationSessionController.swift` (~2.2k) — dictation session orchestration; the engine-facing half (recovery wait loop, model-warmup wait loop, STTRouter control-flow decisions) moved to `Sources/Speech/DictationSession.swift`, but the giant `stopDictationAndPaste` stop/transcribe/paste/persist/telemetry path and `installSessionTimeout` stay here — several existing tests assert on their literal source text as a behavior contract, and both interleave overlay/paste-back concerns too tightly to split safely in one pass
-- `Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift` (~1.7k) — the MCP server's SQLite index; schema DDL already split into `TranscriptIndex+Schema.swift`, this file is still the query/reconcile surface
-- `Tests/TranscriptedCoreTests/SpeakerTests/Support/SpeakerNamingSimulationRunner.swift` (~1.7k) — test-only offline speaker-naming simulation harness
-- `Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift` (~1.7k) — the single-flight transcription queue/orchestrator
-- `Sources/UI/Settings/SpeakerPeopleSettingsSection.swift` (~1.6k) — the speakers settings surface (voice-to-name queue, duplicate suggestions, searchable list)
+Regenerate this list rather than editing sizes by hand — hand-typed counts go stale
+and then mislead about which files are actually risky:
+
+```bash
+find Sources Tools/*/Sources -name '*.swift' -not -path '*/.build/*' | xargs wc -l | awk '$1>1500 && $2!="total"' | sort -rn
+```
+
+Production code only — large test files are a separate concern and are listed after the
+table. Sizes below were measured 2026-08-11 and match that command exactly:
+
+- `Sources/Meeting/MeetingSessionController.swift` (3431) — the meeting state machine; failed-meeting and queue bookkeeping were split into `FailedMeetingStore.swift`/`TranscriptionQueueCoordinator.swift`, but permission gating, capture start/stop, and transcript-save handoff still live here
+- `Sources/UI/Settings/TranscriptedSettingsView.swift` (3228) — settings shell, navigation, state, and page routing for every settings surface; the extracted pages live under `Sources/UI/Settings/Pages/`, while the shell keeps their bindings, runtime work, and every Home side effect. Note it is partly pinned in place by literal-source-text assertions in `Tests/UIAutomationSurfaceContractTests.swift` — budget for rewriting those before refactoring it
+- `Sources/Speech/ParakeetEngine.swift` (3124) — the dictation STT engine; device recovery and model lifecycle already moved to `ParakeetDeviceRecovery.swift`/`ParakeetModelLifecycle.swift`, this file is still the public-API owner and `@MainActor` home for recording state
+- `Sources/TranscriptedCore/Audio/Audio.swift` (2517) — **the riskiest file in the repo.** Mic + system capture, CoreAudio real-time callbacks, tap lifecycle, and the recording-session generation token. The real-time safety rules in "Threading rules" are not advisory here; a violation is a crash or silent audio corruption, and no CI job exercises this path (see `hardware-smokes` in `.github/workflows/swift-ci.yml` — it needs a self-hosted Apple Silicon runner)
+- `Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift` (2513) — the single-flight transcription queue/orchestrator, plus the failed-queue retention paths. A *transcription failure* must archive audio into the failed queue before deleting scratch. The early reject gates are the deliberate exception — the sub-2s live-capture gate (commented and pinned by `testStartTranscriptionRejectsTooShortLiveAudioWithoutQueueingRetry`) and the imported-audio gates, which are safe to delete outright because that scratch is a copy and the user's original import still exists
+- `Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift` (2211) — the packaged-app release smoke; release-gating, so a break here blocks shipping rather than breaking the app
+- `Sources/UI/Overlay/DictationSessionController.swift` (2195) — dictation session orchestration; the engine-facing half (recovery wait loop, model-warmup wait loop, STTRouter control-flow decisions) moved to `Sources/Speech/DictationSession.swift`, but the giant `stopDictationAndPaste` stop/transcribe/paste/persist/telemetry path and `installSessionTimeout` stay here — several existing tests assert on their literal source text as a behavior contract, and both interleave overlay/paste-back concerns too tightly to split safely in one pass
+- `Sources/UI/Settings/SpeakerPeopleSettingsSection.swift` (1954) — the speakers settings surface (voice-to-name queue, duplicate suggestions, searchable list)
+- `Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift` (1783) — the MCP server's SQLite index; schema DDL already split into `TranscriptIndex+Schema.swift`, this file is still the query/reconcile surface
+- `Sources/TranscriptedApp.swift` (1764) — app entry, menubar wiring, popover/overlay setup, detected-meeting prompts, activation-policy switching
+- `Sources/UI/Settings/HomeView.swift` (1545) — the Home canvas (greeting, stats, capture lists, preview/feedback sheets); most small formatting/policy helpers already live in sibling files (`HomePresentation.swift`, `HomeCanvasGreeting.swift`, etc.), this is the view assembly itself
+
+`Sources/UI/Overlay/MeetingOverlayController.swift` dropped off this list (1129 lines after its split).
+
+Large test files, for reference (swap `Tools/*/Sources` for `Tests` in the command above):
+`SpeakerNamingCoordinatorTests.swift` (3655), `ClaudeDesktopIntegrationInstallerTests.swift`
+(2218), `RetroactiveSpeakerUpdaterTests.swift` (2175), `ClipboardRestoringTextPasterTests.swift`
+(1838), `AnalyticsEventPolicyTests.swift` (1757), `RecentCaptureScannersTests.swift` (1702),
+`SpeakerNamingSimulationRunner.swift` (1687, a test-only simulation harness). These are big but
+mostly real behavioral tests against temp-directory fixtures — size here is not a warning sign
+the way it is above.
 
 ## Response voice
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -268,6 +268,22 @@ public class TranscriptionTaskManager: ObservableObject {
                 "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? "none"
             ])
 
+            // Deliberate: this gate deletes live-capture scratch outright instead of
+            // archiving it into the failed queue the way the transcription failure paths
+            // below do — do not "fix" it to retain the audio.
+            // `testStartTranscriptionRejectsTooShortLiveAudioWithoutQueueingRetry` pins
+            // both halves (scratch removed, failed queue left empty).
+            //
+            // This gate means the whole capture *file* is under 2s, which in practice is
+            // an accidental hotkey bump. `recordingTooShort` is non-retryable, so a failed
+            // row here would be a dead entry the user can only dismiss — junk in the
+            // failed-meetings list for every mis-trigger.
+            //
+            // The same-named error thrown deeper (`PipelineError.recordingTooShort` in
+            // TranscriptionPipeline) IS retained by the catch block, and that is not an
+            // inconsistency: it fires on decoded *sample* count after a full-length
+            // recording turned out to be empty, which is a real capture failure worth
+            // keeping. Same name, different situation.
             if let micURL {
                 removeRecordingFile(micURL, label: "short mic recording")
             }
@@ -629,21 +645,6 @@ public class TranscriptionTaskManager: ObservableObject {
             return
         }
 
-        let replacementReservation: ReplacementTranscriptReservationToken?
-        if let replacementTranscriptURL {
-            guard let reservation = TranscriptSaver.beginReplacingTranscript(at: replacementTranscriptURL) else {
-                publishFailure(
-                    displayMessage: "That meeting moved or is already being re-transcribed. Refresh and try again.",
-                    diagnosticMessage: "Replacement transcript unavailable"
-                )
-                scheduleStatusReset(delay: 4)
-                return
-            }
-            replacementReservation = reservation
-        } else {
-            replacementReservation = nil
-        }
-
         let taskId = UUID()
         activeCount += 1
         backgroundTaskCount += 1
@@ -661,11 +662,45 @@ public class TranscriptionTaskManager: ObservableObject {
         ])
 
         let asyncTask = Task {
-            var heldReplacementReservation = replacementReservation
+            // Reserve off the main actor. `beginReplacingTranscript` blocks on the shared
+            // transcript-file serializer, which a library-wide speaker rename can hold for
+            // as long as it takes to rewrite every referencing transcript. Taking that wait
+            // on the main actor froze the whole UI until the rename finished. The reservation
+            // still lands before any transcript write, so the replacement-vs-speaker-edit
+            // barrier is unchanged — only the thread that waits for it moved.
+            //
+            // Deliberate trade-off: reserving later means a speaker edit submitted in the
+            // meantime can now win the queue where the old synchronous call would have
+            // beaten it. That is safe — the serializer admits one side or the other, never
+            // an interleaved write — and it fails closed with the "already being
+            // re-transcribed" message below. A responsive window plus a retryable error
+            // beats a frozen window, so do not "fix" this by reserving on the main actor.
+            var heldReplacementReservation: ReplacementTranscriptReservationToken?
             defer {
                 if let heldReplacementReservation {
                     TranscriptSaver.finishReplacingTranscript(heldReplacementReservation)
                 }
+            }
+
+            if let replacementTranscriptURL {
+                let reservation = await Task.detached(priority: .userInitiated) {
+                    TranscriptSaver.beginReplacingTranscript(at: replacementTranscriptURL)
+                }.value
+
+                guard let reservation else {
+                    // Cancellation is checked first, same as the success and catch exits
+                    // below: a cancel landing while the reservation was in flight must
+                    // resolve as a cancel, not as a misleading "meeting moved" failure.
+                    guard !self.finishCancelledTaskIfNeeded(taskId: taskId) else { return }
+                    self.publishFailure(
+                        displayMessage: "That meeting moved or is already being re-transcribed. Refresh and try again.",
+                        diagnosticMessage: "Replacement transcript unavailable"
+                    )
+                    self.handleTaskCompletion(taskId: taskId)
+                    self.scheduleStatusReset(delay: 4)
+                    return
+                }
+                heldReplacementReservation = reservation
             }
 
             do {

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
@@ -389,6 +389,62 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
     }
 
+    /// The replacement reservation is taken inside the task (off the MainActor, so a
+    /// long-running speaker rename holding the shared transcript-file serializer cannot
+    /// freeze the UI). This covers the resulting failure branch: the reservation is
+    /// attempted after the task is already registered, so it has to unwind that
+    /// registration itself rather than returning before any bookkeeping happened.
+    func testSavedAudioRetranscriptionUnwindsCleanlyWhenReplacementTargetIsMissing() async throws {
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Should never run."),
+            diarization: MetadataStubDiarizationEngine(segments: singleSpeakerSegments(duration: 2.5))
+        )
+        let transcriptsDirectory = tempDirectory.appendingPathComponent("transcripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptsDirectory, withIntermediateDirectories: true)
+        let savedAudioDirectory = tempDirectory.appendingPathComponent("saved-meeting-audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: savedAudioDirectory, withIntermediateDirectories: true)
+        let systemURL = savedAudioDirectory.appendingPathComponent("system_audio.wav")
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        // Never created: beginReplacingTranscript refuses to reserve a file that is not
+        // there, which is the "that meeting moved" case the user-facing copy describes.
+        let missingTranscriptURL = transcriptsDirectory.appendingPathComponent("Moved_Meeting.md")
+
+        manager.startSavedAudioRetranscription(
+            micURL: nil,
+            systemURL: systemURL,
+            outputFolder: transcriptsDirectory,
+            meetingTitle: "Moved Meeting",
+            replacementTranscriptURL: missingTranscriptURL
+        )
+
+        try await waitUntil {
+            manager.lastFailureDiagnosticMessage == "Replacement transcript unavailable"
+        }
+
+        // The task registered before the reservation was attempted, so all three counters
+        // have to come back down or the app keeps thinking work is in flight (which also
+        // blocks quit and rejects the user's next retranscription as "already running").
+        try await waitUntil {
+            manager.activeTasks.isEmpty && manager.activeCount == 0 && manager.backgroundTaskCount == 0
+        }
+        XCTAssertTrue(manager.activeTasks.isEmpty)
+        XCTAssertEqual(manager.activeCount, 0)
+        XCTAssertEqual(manager.backgroundTaskCount, 0)
+
+        // A failed reservation must not leave the target reserved, or every later speaker
+        // rename touching that transcript would fail closed forever.
+        XCTAssertFalse(TranscriptSaver.isReplacingTranscript(at: missingTranscriptURL))
+
+        // Retained user audio is never scratch — it survives the rejection untouched.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+
+        guard case .failed(let message) = manager.displayStatus else {
+            return XCTFail("Expected a missing replacement target to publish a failed status")
+        }
+        XCTAssertEqual(message, "That meeting moved or is already being re-transcribed. Refresh and try again.")
+    }
+
     func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileAfterSuccess() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "Imported meeting artifact."),


### PR DESCRIPTION
## Why

Three findings from a reliability + maintainability audit of the repo (12 audit agents across data-loss, concurrency, recent churn, over-engineering, test quality, and repo process; every finding adversarially verified).

The load-bearing one: hitting **Retry** on a saved meeting while a **Speakers rename/merge** was still running beachballed the entire app until the rename finished. The other two close gaps in the safety net rather than fixing user-visible bugs.

## Product Impact

- Affects: `meetings` / `agent artifacts` / `docs only`
- Lane: `meeting reliability` / `agent workflow`
- Why this matters: the freeze is reachable from two ordinary UI actions colliding, and gets worse the bigger your speaker library gets. Separately, the real mic + ScreenCaptureKit capture path — the thing this app exists to do — had **no automated gate at all**, so a broken tap could ship with fully green CI and only surface as an empty recording, which for a local-only app is unrecoverable.

## What changed

- **Take the replacement-transcript reservation off the main actor.** `TranscriptSaver.beginReplacingTranscript` blocks on the shared transcript-file serializer (`fileUpdateQueue.sync`), which a library-wide speaker rename holds for as long as it takes to rewrite every referencing transcript. The reservation now happens inside the task via `Task.detached`. It still lands before any transcript write, so the replacement-vs-speaker-edit barrier is unchanged — only the waiting thread moved.
  - Reserving later means a rename submitted in the meantime can win the queue. That fails closed with the existing *"already being re-transcribed"* message. A responsive window plus a retryable error beats a frozen window; there's a comment saying so, to stop someone "fixing" it back onto the main actor.
  - The new failure branch checks `finishCancelledTaskIfNeeded` first, matching its two sibling exits, so a cancel landing mid-reservation resolves as a cancel instead of a misleading *"meeting moved"* banner.
- **Give the hardware smokes somewhere to run.** `hardware-smokes` was an echo step on `ubuntu-latest`. It now runs `run-live-capture-smoke.sh` + `run-slow-pasteback-smoke.sh` on a `[self-hosted, macOS, ARM64]` runner behind a `run_hardware_smokes` dispatch input, with the instruction echo kept as the toggle-off fallback.
- **Refresh the stale `CLAUDE.md` hotspot table.** It was wrong in both directions — `MeetingOverlayController` listed at ~2.7k had already been split to 1129, while `TranscriptionTaskManager` had grown past its listed ~1.7k. `Audio.swift` (2517 lines, the CoreAudio real-time path) was missing entirely, so the doc telling agents which files are dangerous omitted the most dangerous one. Sizes now match an embedded regeneration command exactly.
- **Document the sub-2s "recording too short" gate.** See *Notes* — this one is a deliberate non-change.
- **New test** `testSavedAudioRetranscriptionUnwindsCleanlyWhenReplacementTargetIsMissing` covering the reservation-failure unwind, the three counters returning to zero, and the target not being left reserved forever.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` — 12,126 passed, 0 failed
- [x] Performance budget passed (bundle gate via `build.sh`)
- [x] `bash run-integration-smoke.sh`
- [x] `swift test` — **1,035** passed, 0 failed (1,034 before; +1 is the new test)
- [x] `bash run-e2e-smoke.sh`
- [ ] Manual check: **not done — the live capture path still needs a real Mac.** That is exactly the gap this PR wires up but cannot close on its own.

Independently reviewed twice before this PR:

- **Codex CLI: PASS**, zero P1 / zero P2. Two P3 doc-accuracy nits, both fixed here (an overstated "every other give-up path archives first" claim, and a line count that went stale mid-edit).
- **4-lens agent review** (concurrency / data-loss / CI / docs), each lens adversarially verified. Concurrency caught the missing `finishCancelledTaskIfNeeded` guard — fixed. Docs caught two wrong numbers in the table — fixed. Both lenses flagged the untested branch — test added. CI lens passed clean, confirming `inputs.run_hardware_smokes` is a real typed boolean and that neither hardware job has a `needs` edge into `build-and-test`.

## Risk Review

- [x] Privacy / local-first behavior reviewed — no payload or telemetry shape changes
- [x] Storage path or migration impact reviewed — none; no path or format changes
- [x] Public-facing copy stays concrete and matches current product scope — no user-facing copy changed
- [x] Release/update impact reviewed — none; no version, appcast, or cask changes
- [ ] Agent PRs link the issue/workpad and stay draft until human review — no issue; opened from an interactive session
- [x] UI changes include sanitized `.agent-review/visuals/` evidence — n/a, no visual changes
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

**Reviewer, please look hardest at the reservation move.** It touches the same machinery as `73e28c0b` / `85b22a6f` / `8784e457`, and the failure mode if it's wrong is transcript corruption rather than a beachball. The claim to check: the reservation still precedes every transcript write, and the serializer admits one side or the other but never an interleave.

## Notes

**One audit finding was rejected, on purpose.** The sub-2s *"recording too short"* gate hard-deletes scratch audio while the same-named error thrown deeper is retained, which reads like an inconsistency. I changed it, and `testStartTranscriptionRejectsTooShortLiveAudioWithoutQueueingRetry` failed — it pins both halves deliberately. The two aren't the same situation: the gate means the whole *file* is under 2s (an accidental hotkey bump), while the deeper error fires on decoded *sample* count after a full-length recording came back empty. Retaining the first would put a dead, non-retryable row in the failed-meetings list for every mis-trigger. Reverted, and the reasoning is now a comment naming the test, so the next reviewer doesn't re-litigate it.

**Outstanding, needs hardware:** register a self-hosted runner labelled `[self-hosted, macOS, ARM64]` and grant its agent Microphone + System Audio Recording. Until then the capture path stays untested by CI and `run-live-capture-smoke.sh` remains a manual step.

**Done outside this diff:** deleted 374 merged remote branches (550 → 175; `main`, `legacy/transcripted-standalone`, and all 63 tags intact) and enabled auto-delete-on-merge so it stops accumulating.

## Agent handoff

`COORD_DONE: GREEN | this PR | reservation off main actor + hardware-smokes runner wiring + hotspot table refresh + 1 new test | deleted 374 merged branches, enabled auto-delete-on-merge | decision needed: provision a self-hosted Apple Silicon runner | build.sh, run-tests.sh (12126), swift test (1035), integration smoke, e2e smoke, agent-preflight, codex review PASS, 4-lens agent review | smallest next action: register the Mac runner and dispatch with run_hardware_smokes=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
