### PR TITLE
Protect meeting artifact recovery

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -40,6 +40,8 @@
 - `MeetingSystemAudioStatusCopy.swift` — Foundation-pure system-audio status copy mapping for fast tests
 - `MeetingSystemAudioStatusCopy+SystemAudioStatus.swift` — app-build bridge from `TranscriptedCore.SystemAudioStatus` into the copy mapping
 - `MeetingTranscriptStyler.swift` — restyles saved transcripts and renames files after save
+- `MeetingArtifactRecoveryStore.swift` — journals transcript/audio renames before either artifact moves, blocks unresolved retries across launches, and clears records only after the pair is coherent again
+- `MeetingArtifactRenameTransaction.swift` — executes the journaled transcript/audio rename, rollback, and forward-recovery state machine
 - `MeetingArtifactRenamer.swift` — shared rename mechanics for a saved meeting's Markdown, retained `audio/<stem>_audio/` directory, and legacy `<stem>.summary.md` sidecar (hygiene for artifacts left by the removed local AI summarizer); builds the canonical `YYYY-MM-dd <title>` stem. Used by both the post-save restyle and the Home title-edit flow so naming and sidecar bookkeeping cannot drift
 - `MeetingWarmupStatusPolicy.swift` — centralizes the user-facing warmup progress, copy, visibility, and ready/failure state for dictation + meeting model startup across overlay, menubar, and settings surfaces
 

--- a/Sources/Meeting/MeetingArtifactRecoveryStore.swift
+++ b/Sources/Meeting/MeetingArtifactRecoveryStore.swift
@@ -1,0 +1,395 @@
+import Foundation
+import CryptoKit
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
+
+extension Notification.Name {
+    static let meetingArtifactRecoveryJournalUnavailable = Notification.Name(
+        "Transcripted.meetingArtifactRecoveryJournalUnavailable"
+    )
+}
+
+enum MeetingArtifactRecoveryStoreError: Error {
+    case pending(MeetingArtifactRecoveryNotice)
+    case invalidRecord
+}
+
+struct MeetingArtifactRecoveryTransaction {
+    fileprivate let record: MeetingArtifactRecoveryStore.Record
+    let notice: MeetingArtifactRecoveryNotice
+}
+
+enum MeetingArtifactRecoveryAlert: Equatable {
+    case artifacts([MeetingArtifactRecoveryNotice])
+    case journalUnavailable(URL)
+}
+
+/// Durable transaction journal for transcript/audio renames. A record is written
+/// before either artifact moves and is removed only after the pair is coherent.
+/// Unresolved records block later rename/restyle attempts across app launches.
+enum MeetingArtifactRecoveryStore {
+    fileprivate struct Record: Codable, Equatable {
+        let version: Int
+        let transactionID: UUID
+        let captureID: UUID?
+        let transcriptDigest: String
+        let sourceTranscriptPath: String
+        let targetTranscriptPath: String
+        let hadSourceAudio: Bool
+
+        var notice: MeetingArtifactRecoveryNotice {
+            MeetingArtifactRecoveryNotice(
+                sourceTranscriptURL: URL(fileURLWithPath: sourceTranscriptPath),
+                targetTranscriptURL: URL(fileURLWithPath: targetTranscriptPath)
+            )
+        }
+    }
+
+    private static let currentVersion = 1
+    private static let directoryName = "meeting_artifact_recovery"
+    private static let lock = NSLock()
+
+    static var defaultDirectory: URL {
+        MeetingStoragePaths.stateFolder.appendingPathComponent(directoryName, isDirectory: true)
+    }
+
+    static func notifyUnavailable(directory: URL? = nil) {
+        NotificationCenter.default.post(
+            name: .meetingArtifactRecoveryJournalUnavailable,
+            object: (directory ?? defaultDirectory).standardizedFileURL
+        )
+    }
+
+    static func prepare(
+        sourceTranscriptURL: URL,
+        targetTranscriptURL: URL,
+        hadSourceAudio: Bool,
+        directory: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> MeetingArtifactRecoveryTransaction {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let directory = directory ?? defaultDirectory
+        let captureID = captureID(
+            sourceTranscriptURL: sourceTranscriptURL,
+            targetTranscriptURL: targetTranscriptURL
+        )
+        let sourcePath = sourceTranscriptURL.standardizedFileURL.path
+        let targetPath = targetTranscriptURL.standardizedFileURL.path
+        let transcriptDigest = try digest(of: sourceTranscriptURL)
+
+        fileManager.ensurePrivateDirectory(at: directory, context: "meeting artifact recovery")
+        for (recordURL, existing) in try records(in: directory, fileManager: fileManager) where matches(
+            existing,
+            captureID: captureID,
+            transcriptPaths: [sourcePath, targetPath]
+        ) {
+            if isResolved(existing, fileManager: fileManager) {
+                try? fileManager.removeItem(at: recordURL)
+            } else {
+                throw MeetingArtifactRecoveryStoreError.pending(existing.notice)
+            }
+        }
+
+        let record = Record(
+            version: currentVersion,
+            transactionID: UUID(),
+            captureID: captureID,
+            transcriptDigest: transcriptDigest,
+            sourceTranscriptPath: sourcePath,
+            targetTranscriptPath: targetPath,
+            hadSourceAudio: hadSourceAudio
+        )
+        let recordURL = recordURL(transactionID: record.transactionID, directory: directory)
+        try writeRecord(record, to: recordURL, fileManager: fileManager)
+        return MeetingArtifactRecoveryTransaction(record: record, notice: record.notice)
+    }
+
+    static func finish(
+        _ transaction: MeetingArtifactRecoveryTransaction,
+        directory: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let directory = directory ?? defaultDirectory
+        let url = recordURL(transactionID: transaction.record.transactionID, directory: directory)
+        guard let current = try? readRecord(at: url), current == transaction.record else { return }
+        try? fileManager.removeItem(at: url)
+    }
+
+    static func pendingNotice(
+        for transcriptURL: URL,
+        directory: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> MeetingArtifactRecoveryNotice? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let captureID = captureID(
+            sourceTranscriptURL: transcriptURL,
+            targetTranscriptURL: transcriptURL
+        )
+        let transcriptPath = transcriptURL.standardizedFileURL.path
+        let directory = directory ?? defaultDirectory
+        for (url, storedRecord) in try records(in: directory, fileManager: fileManager) where matches(
+            storedRecord,
+            captureID: captureID,
+            transcriptPaths: [transcriptPath]
+        ) {
+            let record = try rebaseIfNeeded(
+                storedRecord,
+                around: transcriptURL,
+                recordURL: url,
+                fileManager: fileManager
+            )
+            if isResolved(record, fileManager: fileManager) {
+                try? fileManager.removeItem(at: url)
+                continue
+            }
+            return record.notice
+        }
+        return nil
+    }
+
+    static func pendingNotices(
+        directory: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> [MeetingArtifactRecoveryNotice] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let shouldRebaseToActiveLibrary = directory == nil
+        let directory = directory ?? defaultDirectory
+        var notices: [MeetingArtifactRecoveryNotice] = []
+        for (url, storedRecord) in try records(in: directory, fileManager: fileManager) {
+            let record = shouldRebaseToActiveLibrary
+                ? try rebaseToActiveLibraryIfNeeded(
+                    storedRecord,
+                    recordURL: url,
+                    fileManager: fileManager
+                )
+                : storedRecord
+            if isResolved(record, fileManager: fileManager) {
+                try? fileManager.removeItem(at: url)
+            } else {
+                notices.append(record.notice)
+            }
+        }
+        return notices.sorted {
+            $0.sourceTranscriptURL.path < $1.sourceTranscriptURL.path
+        }
+    }
+
+    static func transcriptBelongsToTransaction(
+        at url: URL,
+        transaction: MeetingArtifactRecoveryTransaction,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        transcriptMatchesPreparedContent(
+            at: url,
+            record: transaction.record,
+            fileManager: fileManager
+        )
+    }
+
+    private static func captureID(
+        sourceTranscriptURL: URL,
+        targetTranscriptURL: URL
+    ) -> UUID? {
+        for url in [sourceTranscriptURL, targetTranscriptURL] {
+            guard let values = try? TranscriptFrontmatter.readValues(from: url),
+                  let captureID = TranscriptFrontmatter.captureID(in: values) else { continue }
+            return captureID
+        }
+        return nil
+    }
+
+    private static func recordURL(transactionID: UUID, directory: URL) -> URL {
+        directory.appendingPathComponent("\(transactionID.uuidString).json", isDirectory: false)
+    }
+
+    private static func records(
+        in directory: URL,
+        fileManager: FileManager
+    ) throws -> [(URL, Record)] {
+        guard fileManager.fileExists(atPath: directory.path) else { return [] }
+        let urls = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        return try urls
+            .filter { $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .map { url in
+                (url, try readRecord(at: url))
+            }
+    }
+
+    private static func matches(
+        _ record: Record,
+        captureID: UUID?,
+        transcriptPaths: Set<String>
+    ) -> Bool {
+        if let captureID, record.captureID == captureID {
+            return true
+        }
+        return transcriptPaths.contains(record.sourceTranscriptPath)
+            || transcriptPaths.contains(record.targetTranscriptPath)
+    }
+
+    private static func rebaseIfNeeded(
+        _ record: Record,
+        around transcriptURL: URL,
+        recordURL: URL,
+        fileManager: FileManager
+    ) throws -> Record {
+        let currentDirectory = transcriptURL.deletingLastPathComponent().standardizedFileURL
+        let recordedDirectory = record.notice.sourceTranscriptURL
+            .deletingLastPathComponent()
+            .standardizedFileURL
+        guard currentDirectory != recordedDirectory,
+              transcriptBelongs(at: transcriptURL, to: record, fileManager: fileManager) else {
+            return record
+        }
+
+        let rebased = Record(
+            version: record.version,
+            transactionID: record.transactionID,
+            captureID: record.captureID,
+            transcriptDigest: record.transcriptDigest,
+            sourceTranscriptPath: currentDirectory
+                .appendingPathComponent(record.notice.sourceTranscriptURL.lastPathComponent)
+                .path,
+            targetTranscriptPath: currentDirectory
+                .appendingPathComponent(record.notice.targetTranscriptURL.lastPathComponent)
+                .path,
+            hadSourceAudio: record.hadSourceAudio
+        )
+        try writeRecord(rebased, to: recordURL, fileManager: fileManager)
+        return rebased
+    }
+
+    private static func rebaseToActiveLibraryIfNeeded(
+        _ record: Record,
+        recordURL: URL,
+        fileManager: FileManager
+    ) throws -> Record {
+        let activeDirectory = MeetingStoragePaths.transcriptsFolder.standardizedFileURL
+        let candidateURLs = [
+            activeDirectory.appendingPathComponent(record.notice.sourceTranscriptURL.lastPathComponent),
+            activeDirectory.appendingPathComponent(record.notice.targetTranscriptURL.lastPathComponent),
+        ]
+        guard let matchingURL = candidateURLs.first(where: {
+            transcriptBelongs(at: $0, to: record, fileManager: fileManager)
+        }) else { return record }
+        return try rebaseIfNeeded(
+            record,
+            around: matchingURL,
+            recordURL: recordURL,
+            fileManager: fileManager
+        )
+    }
+
+    private static func readRecord(at url: URL) throws -> Record {
+        let record = try JSONDecoder().decode(Record.self, from: Data(contentsOf: url))
+        guard record.version == currentVersion else {
+            throw MeetingArtifactRecoveryStoreError.invalidRecord
+        }
+        return record
+    }
+
+    private static func digest(of url: URL) throws -> String {
+        SHA256.hash(data: try Data(contentsOf: url))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    private static func transcriptBelongs(
+        at url: URL,
+        to record: Record,
+        fileManager: FileManager
+    ) -> Bool {
+        guard fileManager.fileExists(atPath: url.path) else { return false }
+        if let expectedCaptureID = record.captureID {
+            guard let values = try? TranscriptFrontmatter.readValues(from: url),
+                  let actualCaptureID = TranscriptFrontmatter.captureID(in: values) else { return false }
+            return actualCaptureID == expectedCaptureID
+        }
+        return (try? digest(of: url)) == record.transcriptDigest
+    }
+
+    private static func transcriptMatchesPreparedContent(
+        at url: URL,
+        record: Record,
+        fileManager: FileManager
+    ) -> Bool {
+        guard fileManager.fileExists(atPath: url.path),
+              (try? digest(of: url)) == record.transcriptDigest else { return false }
+        guard let expectedCaptureID = record.captureID else { return true }
+        guard let values = try? TranscriptFrontmatter.readValues(from: url),
+              let actualCaptureID = TranscriptFrontmatter.captureID(in: values) else { return false }
+        return actualCaptureID == expectedCaptureID
+    }
+
+    private static func writeRecord(
+        _ record: Record,
+        to url: URL,
+        fileManager: FileManager
+    ) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(record).write(to: url, options: [.atomic])
+        fileManager.restrictFileToOwnerOnly(at: url)
+
+        // The journal must reach stable storage before either artifact moves.
+        // Atomic replacement prevents torn JSON; synchronize establishes the
+        // write-before-move ordering for process and machine failures.
+        let handle = try FileHandle(forWritingTo: url)
+        do {
+            try handle.synchronize()
+            try handle.close()
+        } catch {
+            try? handle.close()
+            throw error
+        }
+    }
+
+    private static func isResolved(_ record: Record, fileManager: FileManager) -> Bool {
+        let notice = record.notice
+        let sourceTranscriptExists = transcriptBelongs(
+            at: notice.sourceTranscriptURL,
+            to: record,
+            fileManager: fileManager
+        )
+        let targetTranscriptExists = transcriptMatchesPreparedContent(
+            at: notice.targetTranscriptURL,
+            record: record,
+            fileManager: fileManager
+        )
+        if !record.hadSourceAudio {
+            return (sourceTranscriptExists && !targetTranscriptExists)
+                || (!sourceTranscriptExists && targetTranscriptExists)
+        }
+
+        let sourceAudioExists = fileManager.fileExists(
+            atPath: MeetingArtifactRenamer.audioDirectoryURL(for: notice.sourceTranscriptURL).path
+        )
+        let targetAudioExists = fileManager.fileExists(
+            atPath: MeetingArtifactRenamer.audioDirectoryURL(for: notice.targetTranscriptURL).path
+        )
+        let sourcePairIsCoherent = sourceTranscriptExists
+            && sourceAudioExists
+            && !targetTranscriptExists
+            && !targetAudioExists
+        let targetPairIsCoherent = !sourceTranscriptExists
+            && !sourceAudioExists
+            && targetTranscriptExists
+            && targetAudioExists
+        return sourcePairIsCoherent || targetPairIsCoherent
+    }
+}

--- a/Sources/Meeting/MeetingArtifactRenameTransaction.swift
+++ b/Sources/Meeting/MeetingArtifactRenameTransaction.swift
@@ -1,0 +1,299 @@
+import Foundation
+
+/// Executes the failure-sensitive part of a saved-meeting rename. Keeping the
+/// transaction here leaves `MeetingArtifactRenamer` responsible for naming and
+/// sidecar policy while this type owns journal, rollback, and forward recovery.
+struct MeetingArtifactRenameTransaction {
+    let sourceTranscriptURL: URL
+    let targetTranscriptURL: URL
+    let displayTitle: String?
+    let fileManager: FileManager
+    let moveItem: (URL, URL) throws -> Void
+    let copyItem: (URL, URL) throws -> Void
+    let removeItem: (URL) throws -> Void
+    let recoveryStoreDirectory: URL?
+    let logFailure: (_ event: String, _ context: [String: String]) -> Void
+
+    func execute() throws -> URL {
+        let sourceAudioURL = MeetingArtifactRenamer.audioDirectoryURL(for: sourceTranscriptURL)
+        let targetAudioURL = MeetingArtifactRenamer.audioDirectoryURL(for: targetTranscriptURL)
+        let hadSourceAudio = fileManager.fileExists(atPath: sourceAudioURL.path)
+        let recoveryTransaction: MeetingArtifactRecoveryTransaction
+        do {
+            recoveryTransaction = try MeetingArtifactRecoveryStore.prepare(
+                sourceTranscriptURL: sourceTranscriptURL,
+                targetTranscriptURL: targetTranscriptURL,
+                hadSourceAudio: hadSourceAudio,
+                directory: recoveryStoreDirectory,
+                fileManager: fileManager
+            )
+        } catch MeetingArtifactRecoveryStoreError.pending(let notice) {
+            throw MeetingArtifactRenameError.recoveryPending(notice)
+        } catch {
+            logFailure(
+                "meeting_artifact_recovery_journal_write_failed",
+                ["errorType": "\(type(of: error))"]
+            )
+            MeetingArtifactRecoveryStore.notifyUnavailable(directory: recoveryStoreDirectory)
+            throw error
+        }
+
+        if hadSourceAudio {
+            do {
+                try moveItem(sourceAudioURL, targetAudioURL)
+            } catch {
+                let audioLocation = restoreAudioToSource(
+                    hadSourceAudio: hadSourceAudio,
+                    sourceURL: sourceAudioURL,
+                    targetURL: targetAudioURL
+                )
+                logFailure(
+                    "meeting_audio_directory_rename_failed",
+                    [
+                        "sourceExists": "\(fileManager.fileExists(atPath: sourceAudioURL.path))",
+                        "targetExists": "\(fileManager.fileExists(atPath: targetAudioURL.path))",
+                        "audioLocation": audioLocation.rawValue,
+                        "errorType": "\(type(of: error))"
+                    ]
+                )
+                if audioLocation.isRetrySafe {
+                    finish(recoveryTransaction)
+                }
+                throw MeetingArtifactRenameError.audioMoveFailed(
+                    audioLocation: audioLocation,
+                    targetTranscriptURL: targetTranscriptURL
+                )
+            }
+        }
+
+        do {
+            try moveItem(sourceTranscriptURL, targetTranscriptURL)
+        } catch {
+            if fileManager.fileExists(atPath: targetTranscriptURL.path),
+               MeetingArtifactRecoveryStore.transcriptBelongsToTransaction(
+                   at: targetTranscriptURL,
+                   transaction: recoveryTransaction,
+                   fileManager: fileManager
+               ),
+               !hadSourceAudio || fileManager.fileExists(atPath: targetAudioURL.path) {
+                if fileManager.fileExists(atPath: sourceTranscriptURL.path) {
+                    do {
+                        try removeItem(sourceTranscriptURL)
+                    } catch let cleanupError {
+                        logFailure(
+                            "meeting_transcript_rename_source_cleanup_failed",
+                            [
+                                "sourceExists": "\(fileManager.fileExists(atPath: sourceTranscriptURL.path))",
+                                "targetExists": "true",
+                                "errorType": "\(type(of: cleanupError))"
+                            ]
+                        )
+                        throw MeetingArtifactRenameError.recoveryPending(
+                            recoveryTransaction.notice
+                        )
+                    }
+                }
+                logFailure(
+                    "meeting_transcript_rename_reconciled",
+                    [
+                        "sourceExists": "\(fileManager.fileExists(atPath: sourceTranscriptURL.path))",
+                        "targetExists": "true",
+                        "errorType": "\(type(of: error))"
+                    ]
+                )
+                finishSuccessfulRename(recoveryTransaction)
+                return targetTranscriptURL
+            }
+
+            var audioLocation = restoreAudioToSource(
+                hadSourceAudio: hadSourceAudio,
+                sourceURL: sourceAudioURL,
+                targetURL: targetAudioURL
+            )
+
+            if audioLocation == .atTarget,
+               recoverTranscriptForward(
+                   from: sourceTranscriptURL,
+                   to: targetTranscriptURL
+               ) {
+                finishSuccessfulRename(recoveryTransaction)
+                return targetTranscriptURL
+            }
+
+            audioLocation = resolveAudioLocation(
+                hadSourceAudio: hadSourceAudio,
+                sourceURL: sourceAudioURL,
+                targetURL: targetAudioURL
+            )
+            logFailure(
+                "meeting_transcript_rename_failed",
+                [
+                    "sourceExists": "\(fileManager.fileExists(atPath: sourceTranscriptURL.path))",
+                    "targetExists": "\(fileManager.fileExists(atPath: targetTranscriptURL.path))",
+                    "audioLocation": audioLocation.rawValue,
+                    "errorType": "\(type(of: error))"
+                ]
+            )
+            if audioLocation.isRetrySafe {
+                finish(recoveryTransaction)
+            }
+            throw MeetingArtifactRenameError.transcriptMoveFailed(
+                audioLocation: audioLocation,
+                targetTranscriptURL: targetTranscriptURL
+            )
+        }
+
+        finishSuccessfulRename(recoveryTransaction)
+        return targetTranscriptURL
+    }
+
+    private func finishSuccessfulRename(_ transaction: MeetingArtifactRecoveryTransaction) {
+        MeetingArtifactRenamer.renameSummarySidecarIfNeeded(
+            from: sourceTranscriptURL,
+            to: targetTranscriptURL,
+            displayTitle: displayTitle,
+            fileManager: fileManager,
+            logFailure: logFailure
+        )
+        finish(transaction)
+    }
+
+    private func finish(_ transaction: MeetingArtifactRecoveryTransaction) {
+        MeetingArtifactRecoveryStore.finish(
+            transaction,
+            directory: recoveryStoreDirectory,
+            fileManager: fileManager
+        )
+    }
+
+    private func restoreAudioToSource(
+        hadSourceAudio: Bool,
+        sourceURL: URL,
+        targetURL: URL
+    ) -> MeetingArtifactAudioLocation {
+        guard hadSourceAudio else { return .notPresent }
+        var restoredByCopy = false
+
+        if !fileManager.fileExists(atPath: sourceURL.path),
+           fileManager.fileExists(atPath: targetURL.path) {
+            do {
+                try moveItem(targetURL, sourceURL)
+            } catch let rollbackError {
+                logFailure(
+                    "meeting_audio_directory_rename_rollback_failed",
+                    [
+                        "sourceExists": "\(fileManager.fileExists(atPath: sourceURL.path))",
+                        "targetExists": "\(fileManager.fileExists(atPath: targetURL.path))",
+                        "errorType": "\(type(of: rollbackError))"
+                    ]
+                )
+
+                if !fileManager.fileExists(atPath: sourceURL.path),
+                   fileManager.fileExists(atPath: targetURL.path) {
+                    let temporaryRecoveryURL = sourceURL
+                        .deletingLastPathComponent()
+                        .appendingPathComponent(
+                            ".\(sourceURL.lastPathComponent).recovery-\(UUID().uuidString)",
+                            isDirectory: true
+                        )
+                    do {
+                        try copyItem(targetURL, temporaryRecoveryURL)
+                        guard !fileManager.fileExists(atPath: sourceURL.path) else {
+                            try? fileManager.removeItem(at: temporaryRecoveryURL)
+                            return resolveAudioLocation(
+                                hadSourceAudio: hadSourceAudio,
+                                sourceURL: sourceURL,
+                                targetURL: targetURL
+                            )
+                        }
+                        try moveItem(temporaryRecoveryURL, sourceURL)
+                        restoredByCopy = true
+                    } catch let recoveryError {
+                        try? fileManager.removeItem(at: temporaryRecoveryURL)
+                        logFailure(
+                            "meeting_audio_directory_rename_recovery_failed",
+                            [
+                                "sourceExists": "\(fileManager.fileExists(atPath: sourceURL.path))",
+                                "targetExists": "\(fileManager.fileExists(atPath: targetURL.path))",
+                                "errorType": "\(type(of: recoveryError))"
+                            ]
+                        )
+                    }
+                }
+            }
+        }
+
+        if restoredByCopy,
+           fileManager.fileExists(atPath: sourceURL.path),
+           fileManager.fileExists(atPath: targetURL.path) {
+            do {
+                try removeItem(targetURL)
+            } catch let cleanupError {
+                logFailure(
+                    "meeting_audio_directory_rename_cleanup_failed",
+                    [
+                        "sourceExists": "true",
+                        "targetExists": "\(fileManager.fileExists(atPath: targetURL.path))",
+                        "errorType": "\(type(of: cleanupError))"
+                    ]
+                )
+            }
+        }
+
+        return resolveAudioLocation(
+            hadSourceAudio: hadSourceAudio,
+            sourceURL: sourceURL,
+            targetURL: targetURL
+        )
+    }
+
+    private func recoverTranscriptForward(from sourceURL: URL, to targetURL: URL) -> Bool {
+        do {
+            try copyItem(sourceURL, targetURL)
+            fileManager.restrictFileToOwnerOnly(at: targetURL)
+        } catch let recoveryError {
+            logFailure(
+                "meeting_transcript_rename_recovery_failed",
+                [
+                    "sourceExists": "\(fileManager.fileExists(atPath: sourceURL.path))",
+                    "targetExists": "\(fileManager.fileExists(atPath: targetURL.path))",
+                    "errorType": "\(type(of: recoveryError))"
+                ]
+            )
+            return false
+        }
+
+        if fileManager.fileExists(atPath: sourceURL.path) {
+            do {
+                try removeItem(sourceURL)
+            } catch let cleanupError {
+                logFailure(
+                    "meeting_transcript_rename_source_cleanup_failed",
+                    [
+                        "sourceExists": "\(fileManager.fileExists(atPath: sourceURL.path))",
+                        "targetExists": "\(fileManager.fileExists(atPath: targetURL.path))",
+                        "errorType": "\(type(of: cleanupError))"
+                    ]
+                )
+                return false
+            }
+        }
+        return fileManager.fileExists(atPath: targetURL.path)
+    }
+
+    private func resolveAudioLocation(
+        hadSourceAudio: Bool,
+        sourceURL: URL,
+        targetURL: URL
+    ) -> MeetingArtifactAudioLocation {
+        guard hadSourceAudio else { return .notPresent }
+        let sourceExists = fileManager.fileExists(atPath: sourceURL.path)
+        let targetExists = fileManager.fileExists(atPath: targetURL.path)
+        switch (sourceExists, targetExists) {
+        case (true, false): return .atSource
+        case (true, true): return .duplicated
+        case (false, true): return .atTarget
+        case (false, false): return .missing
+        }
+    }
+}

--- a/Sources/Meeting/MeetingArtifactRenamer.swift
+++ b/Sources/Meeting/MeetingArtifactRenamer.swift
@@ -7,6 +7,58 @@ enum MeetingTranscriptFileUpdateError: Error {
     case replacementInProgress
 }
 
+enum MeetingArtifactAudioLocation: String, Equatable {
+    case notPresent
+    case atSource
+    case duplicated
+    case atTarget
+    case missing
+
+    var isRetrySafe: Bool {
+        self == .notPresent || self == .atSource
+    }
+}
+
+struct MeetingArtifactRecoveryNotice: Equatable {
+    let sourceTranscriptURL: URL
+    let targetTranscriptURL: URL
+}
+
+enum MeetingArtifactRenameError: Error, Equatable {
+    case audioMoveFailed(audioLocation: MeetingArtifactAudioLocation, targetTranscriptURL: URL)
+    case transcriptMoveFailed(audioLocation: MeetingArtifactAudioLocation, targetTranscriptURL: URL)
+    case recoveryPending(MeetingArtifactRecoveryNotice)
+
+    var audioLocation: MeetingArtifactAudioLocation? {
+        switch self {
+        case .audioMoveFailed(let audioLocation, _),
+             .transcriptMoveFailed(let audioLocation, _):
+            return audioLocation
+        case .recoveryPending:
+            return nil
+        }
+    }
+
+    var targetTranscriptURL: URL {
+        switch self {
+        case .audioMoveFailed(_, let targetTranscriptURL),
+             .transcriptMoveFailed(_, let targetTranscriptURL):
+            return targetTranscriptURL
+        case .recoveryPending(let notice):
+            return notice.targetTranscriptURL
+        }
+    }
+
+    func recoveryNotice(sourceTranscriptURL: URL) -> MeetingArtifactRecoveryNotice? {
+        if case .recoveryPending(let notice) = self { return notice }
+        guard let audioLocation, !audioLocation.isRetrySafe else { return nil }
+        return MeetingArtifactRecoveryNotice(
+            sourceTranscriptURL: sourceTranscriptURL,
+            targetTranscriptURL: targetTranscriptURL
+        )
+    }
+}
+
 enum MeetingTranscriptFileUpdateSerializer {
     private static let fallbackQueueSpecific = DispatchSpecificKey<Void>()
     private static let fallbackQueue: DispatchQueue = {
@@ -103,16 +155,39 @@ enum MeetingArtifactRenamer {
     /// Move the transcript and its sibling artifacts so the Markdown stem becomes
     /// `preferredStem`. Returns the final transcript URL.
     ///
-    /// Fails closed: a no-op when the stem already matches, and on any move error the
-    /// original URL is returned unchanged so callers never lose track of the file.
+    /// Fails closed: a no-op when the stem already matches. Any core transcript/audio
+    /// move failure is thrown so callers cannot mistake a partial rename for success.
     @discardableResult
     static func rename(
         transcriptAt url: URL,
         toStem preferredStem: String,
         displayTitle: String? = nil,
         fileManager: FileManager = .default,
-        logFailure: (_ event: String, _ context: [String: String]) -> Void = { _, _ in }
-    ) -> URL {
+        moveItem: ((URL, URL) throws -> Void)? = nil,
+        copyItem: ((URL, URL) throws -> Void)? = nil,
+        removeItem: ((URL) throws -> Void)? = nil,
+        recoveryStoreDirectory: URL? = nil,
+        logFailure: @escaping (_ event: String, _ context: [String: String]) -> Void = { _, _ in }
+    ) throws -> URL {
+        do {
+            if let pendingNotice = try MeetingArtifactRecoveryStore.pendingNotice(
+                for: url,
+                directory: recoveryStoreDirectory,
+                fileManager: fileManager
+            ) {
+                throw MeetingArtifactRenameError.recoveryPending(pendingNotice)
+            }
+        } catch let error as MeetingArtifactRenameError {
+            throw error
+        } catch {
+            logFailure(
+                "meeting_artifact_recovery_journal_read_failed",
+                ["errorType": "\(type(of: error))"]
+            )
+            MeetingArtifactRecoveryStore.notifyUnavailable(directory: recoveryStoreDirectory)
+            throw error
+        }
+
         let targetURL = uniqueTranscriptURL(
             in: url.deletingLastPathComponent(),
             preferredStem: preferredStem,
@@ -122,34 +197,26 @@ enum MeetingArtifactRenamer {
 
         guard targetURL != url else { return url }
 
-        do {
-            try fileManager.moveItem(at: url, to: targetURL)
-        } catch {
-            logFailure(
-                "meeting_transcript_rename_failed",
-                [
-                    "sourceExists": "\(fileManager.fileExists(atPath: url.path))",
-                    "targetExists": "\(fileManager.fileExists(atPath: targetURL.path))",
-                    "errorType": "\(type(of: error))"
-                ]
-            )
-            return url
+        let moveItem = moveItem ?? { sourceURL, targetURL in
+            try fileManager.moveItem(at: sourceURL, to: targetURL)
         }
-
-        renameAudioDirectoryIfNeeded(
-            from: audioDirectoryURL(for: url),
-            to: audioDirectoryURL(for: targetURL),
-            fileManager: fileManager,
-            logFailure: logFailure
-        )
-        renameSummarySidecarIfNeeded(
-            from: url,
-            to: targetURL,
+        let copyItem = copyItem ?? { sourceURL, targetURL in
+            try fileManager.copyItem(at: sourceURL, to: targetURL)
+        }
+        let removeItem = removeItem ?? { targetURL in
+            try fileManager.removeItem(at: targetURL)
+        }
+        return try MeetingArtifactRenameTransaction(
+            sourceTranscriptURL: url,
+            targetTranscriptURL: targetURL,
             displayTitle: displayTitle,
             fileManager: fileManager,
+            moveItem: moveItem,
+            copyItem: copyItem,
+            removeItem: removeItem,
+            recoveryStoreDirectory: recoveryStoreDirectory,
             logFailure: logFailure
-        )
-        return targetURL
+        ).execute()
     }
 
     static func uniqueTranscriptURL(
@@ -179,47 +246,6 @@ enum MeetingArtifactRenamer {
         return directory.appendingPathComponent("\(preferredStem) \(UUID().uuidString)").appendingPathExtension("md")
     }
 
-    private static func renameAudioDirectoryIfNeeded(
-        from sourceURL: URL,
-        to targetURL: URL,
-        fileManager: FileManager,
-        logFailure: (_ event: String, _ context: [String: String]) -> Void
-    ) {
-        guard sourceURL != targetURL, fileManager.fileExists(atPath: sourceURL.path) else { return }
-
-        let finalURL = uniqueAudioDirectoryURL(preferredURL: targetURL, fileManager: fileManager)
-
-        do {
-            try fileManager.moveItem(at: sourceURL, to: finalURL)
-        } catch {
-            logFailure(
-                "meeting_audio_directory_rename_failed",
-                [
-                    "sourceExists": "\(fileManager.fileExists(atPath: sourceURL.path))",
-                    "targetExists": "\(fileManager.fileExists(atPath: finalURL.path))",
-                    "errorType": "\(type(of: error))"
-                ]
-            )
-        }
-    }
-
-    private static func uniqueAudioDirectoryURL(preferredURL: URL, fileManager: FileManager) -> URL {
-        guard fileManager.fileExists(atPath: preferredURL.path) else { return preferredURL }
-
-        let directory = preferredURL.deletingLastPathComponent()
-        let stem = preferredURL.lastPathComponent
-        var suffix = 2
-
-        while suffix <= 999 {
-            let candidate = directory.appendingPathComponent("\(stem) \(suffix)", isDirectory: true)
-            if !fileManager.fileExists(atPath: candidate.path) {
-                return candidate
-            }
-            suffix += 1
-        }
-        return directory.appendingPathComponent("\(stem) \(UUID().uuidString)", isDirectory: true)
-    }
-
     // MARK: - Legacy summary sidecar hygiene
 
     /// `<stem>.summary.md` next to the transcript. Matches the sidecar name the
@@ -238,7 +264,7 @@ enum MeetingArtifactRenamer {
     /// frontmatter at the new filename. Only an owned summary (`capture_type:
     /// meeting_summary` pointing back at the source transcript) is touched;
     /// anything else is left in place.
-    private static func renameSummarySidecarIfNeeded(
+    static func renameSummarySidecarIfNeeded(
         from sourceTranscriptURL: URL,
         to targetTranscriptURL: URL,
         displayTitle: String?,

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -148,6 +148,7 @@ final class MeetingSessionController: ObservableObject {
     @Published private(set) var isMicBoostPromptVisible = false
     @Published private(set) var audioRouteWarning: CaptureRouteStabilizationOutcome?
     @Published private(set) var systemAudioDegradationWarning: MeetingSystemAudioDegradationWarning?
+    @Published private(set) var artifactRecoveryAlert: MeetingArtifactRecoveryAlert?
 
     @Published private(set) var failedMeetings: [FailedMeetingItem] = []
     @Published private(set) var warmupStatus: ModelWarmupStatus = .ready {
@@ -215,9 +216,39 @@ final class MeetingSessionController: ObservableObject {
     var activeQueuedTranscriptionJobID: UUID?
     var activeStoppedAudioRecovery: DictationStoppedAudioRecovery?
     private var stoppedAudioRecoveryRetryRegistry = DictationStoppedAudioRecoveryRetryRegistry()
+    private var acknowledgedArtifactRecoveryJournalDirectories: Set<String> = []
 
     var shouldConfirmQuitForActiveCapture: Bool {
         isCaptureSessionActive
+    }
+
+    func clearArtifactRecoveryAlert(_ alert: MeetingArtifactRecoveryAlert) {
+        guard artifactRecoveryAlert == alert else { return }
+        if case .journalUnavailable(let directory) = alert {
+            acknowledgedArtifactRecoveryJournalDirectories.insert(directory.standardizedFileURL.path)
+        }
+        artifactRecoveryAlert = nil
+    }
+
+    private func reportArtifactRecoveryJournalUnavailable(_ directory: URL) {
+        let directory = directory.standardizedFileURL
+        guard !acknowledgedArtifactRecoveryJournalDirectories.contains(directory.path) else { return }
+        let alert = MeetingArtifactRecoveryAlert.journalUnavailable(directory)
+        guard artifactRecoveryAlert != alert else { return }
+        artifactRecoveryAlert = alert
+    }
+
+    private func addArtifactRecoveryNotice(_ notice: MeetingArtifactRecoveryNotice) {
+        switch artifactRecoveryAlert {
+        case nil:
+            artifactRecoveryAlert = .artifacts([notice])
+        case .some(.artifacts(var notices)):
+            guard !notices.contains(notice) else { return }
+            notices.append(notice)
+            artifactRecoveryAlert = .artifacts(notices)
+        case .some(.journalUnavailable):
+            break
+        }
     }
 
     var shouldConfirmQuitForBackgroundTranscription: Bool {
@@ -499,6 +530,14 @@ final class MeetingSessionController: ObservableObject {
         // reference. `failedMeetingStore` initializes lazily when
         // `wireSubscriptions()` first needs it.
         self.transcriptionQueue = TranscriptionQueueCoordinator(controller: self)
+        do {
+            let notices = try MeetingArtifactRecoveryStore.pendingNotices()
+            self.artifactRecoveryAlert = notices.isEmpty ? nil : .artifacts(notices)
+        } catch {
+            self.artifactRecoveryAlert = .journalUnavailable(
+                MeetingArtifactRecoveryStore.defaultDirectory
+            )
+        }
 
         capture.onUnexpectedRecordingComplete = { [weak self] result in
             Task { @MainActor [weak self] in
@@ -2273,6 +2312,14 @@ final class MeetingSessionController: ObservableObject {
     // MARK: - Subscriptions
 
     private func wireSubscriptions() {
+        NotificationCenter.default.publisher(for: .meetingArtifactRecoveryJournalUnavailable)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let directory = notification.object as? URL else { return }
+                self?.reportArtifactRecoveryJournalUnavailable(directory)
+            }
+            .store(in: &cancellables)
+
         capture.$isRecording
             .sink { [weak self] captureIsRecording in
                 guard let self else { return }
@@ -2476,13 +2523,26 @@ final class MeetingSessionController: ObservableObject {
             // meeting, not just the heavy local-summary beta opt-in. Runs after
             // restyle (the body is now in canonical styled form) on this chained
             // background task, and is idempotent + frontmatter-only.
-            MeetingQuickSummaryWriter.ensureQuickSummary(at: styled.url)
+            if !styled.artifactPostProcessingBlocked {
+                MeetingQuickSummaryWriter.ensureQuickSummary(at: styled.url)
+            }
             return styled
         }
         savedTranscriptRestyleTask = restyle
 
         Task { @MainActor [weak self] in
             let styled = await restyle.value
+            if let recoveryNotice = styled.artifactRecoveryNotice {
+                self?.addArtifactRecoveryNotice(recoveryNotice)
+                CaptureLibraryChangeBroadcaster.shared.noteArtifactsChanged(
+                    transcriptURLs: [
+                        recoveryNotice.sourceTranscriptURL,
+                        recoveryNotice.targetTranscriptURL
+                    ]
+                )
+                return
+            }
+            guard !styled.artifactPostProcessingBlocked else { return }
             let transcriptURL = styled.url
             // The restyle may have renamed the transcript + its audio/<stem>_audio
             // directory. Tell Home so any cached URLs for the old stem re-resolve.

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -6,6 +6,27 @@ import TranscriptedCore
 struct StyledMeetingTranscript {
     let url: URL
     let title: String
+    let artifactRecoveryNotice: MeetingArtifactRecoveryNotice?
+    let artifactPostProcessingBlocked: Bool
+
+    init(
+        url: URL,
+        title: String,
+        artifactRecoveryNotice: MeetingArtifactRecoveryNotice? = nil,
+        artifactPostProcessingBlocked: Bool = false
+    ) {
+        self.url = url
+        self.title = title
+        self.artifactRecoveryNotice = artifactRecoveryNotice
+        self.artifactPostProcessingBlocked = artifactPostProcessingBlocked
+    }
+}
+
+private struct MeetingArtifactRenameOutcome {
+    let url: URL
+    let recoveryNotice: MeetingArtifactRecoveryNotice?
+    let shouldPersistStyling: Bool
+    let postProcessingBlocked: Bool
 }
 
 enum MeetingTranscriptStyler {
@@ -21,10 +42,17 @@ enum MeetingTranscriptStyler {
 
     private static let formatterQueue = DispatchQueue(label: "Transcripted.MeetingTranscriptStyler.formatters")
 
-    static func restyleTranscript(at url: URL) -> StyledMeetingTranscript {
+    static func restyleTranscript(
+        at url: URL,
+        recoveryStoreDirectory: URL? = nil
+    ) -> StyledMeetingTranscript {
         do {
             return try MeetingTranscriptFileUpdateSerializer.sync(protecting: [url]) {
-                styledTranscript(at: url, persistChanges: true)
+                styledTranscript(
+                    at: url,
+                    persistChanges: true,
+                    recoveryStoreDirectory: recoveryStoreDirectory
+                )
             }
         } catch MeetingTranscriptFileUpdateError.replacementInProgress {
             logFailure(
@@ -32,10 +60,20 @@ enum MeetingTranscriptStyler {
                 message: "Skipped transcript restyle during replacement retranscription",
                 context: ["file": url.lastPathComponent]
             )
-            return styledTranscript(at: url, persistChanges: false)
+            return blockedRestyleResult(at: url)
         } catch {
-            return styledTranscript(at: url, persistChanges: false)
+            return blockedRestyleResult(at: url)
         }
+    }
+
+    static func blockedRestyleResult(at url: URL) -> StyledMeetingTranscript {
+        let styled = styledTranscript(at: url, persistChanges: false)
+        return StyledMeetingTranscript(
+            url: styled.url,
+            title: styled.title,
+            artifactRecoveryNotice: styled.artifactRecoveryNotice,
+            artifactPostProcessingBlocked: true
+        )
     }
 
     static func displayTranscript(at url: URL) -> StyledMeetingTranscript {
@@ -70,7 +108,11 @@ enum MeetingTranscriptStyler {
         return StyledMeetingTranscript(url: url, title: buildTitle(for: document))
     }
 
-    private static func styledTranscript(at url: URL, persistChanges: Bool) -> StyledMeetingTranscript {
+    private static func styledTranscript(
+        at url: URL,
+        persistChanges: Bool,
+        recoveryStoreDirectory: URL? = nil
+    ) -> StyledMeetingTranscript {
         if !persistChanges, let title = frontmatterTitle(at: url) {
             return StyledMeetingTranscript(url: url, title: title)
         }
@@ -131,9 +173,15 @@ enum MeetingTranscriptStyler {
         let renderedFrontmatter = renderFrontmatter(lines: document.frontmatterLines, title: title)
         let body = renderBody(document: document, title: title)
         let updated = renderedFrontmatter + "\n\n" + body + "\n"
-        let finalURL = renameTranscriptArtifactsIfNeeded(at: url, title: title, recordedAt: document.recordedAt)
+        let renameOutcome = renameTranscriptArtifactsIfNeeded(
+            at: url,
+            title: title,
+            recordedAt: document.recordedAt,
+            recoveryStoreDirectory: recoveryStoreDirectory
+        )
+        let finalURL = renameOutcome.url
 
-        if updated != raw {
+        if renameOutcome.shouldPersistStyling, updated != raw {
             do {
                 try updated.write(to: finalURL, atomically: true, encoding: .utf8)
                 FileManager.default.restrictFileToOwnerOnly(at: finalURL)
@@ -149,7 +197,12 @@ enum MeetingTranscriptStyler {
             }
         }
 
-        return StyledMeetingTranscript(url: finalURL, title: title)
+        return StyledMeetingTranscript(
+            url: finalURL,
+            title: title,
+            artifactRecoveryNotice: renameOutcome.recoveryNotice,
+            artifactPostProcessingBlocked: renameOutcome.postProcessingBlocked
+        )
     }
 
     static func transcriptBody(at url: URL) -> String? {
@@ -511,20 +564,56 @@ enum MeetingTranscriptStyler {
         return formatter.string(from: TimeInterval(seconds)) ?? fallback
     }
 
-    private static func renameTranscriptArtifactsIfNeeded(at url: URL, title: String, recordedAt: Date) -> URL {
+    private static func renameTranscriptArtifactsIfNeeded(
+        at url: URL,
+        title: String,
+        recordedAt: Date,
+        recoveryStoreDirectory: URL?
+    ) -> MeetingArtifactRenameOutcome {
         let preferredStem = MeetingArtifactRenamer.fileStem(
             date: recordedAt,
             title: title,
             fallback: url.deletingPathExtension().lastPathComponent
         )
-        return MeetingArtifactRenamer.rename(
-            transcriptAt: url,
-            toStem: preferredStem,
-            displayTitle: title,
-            logFailure: { event, context in
-                logFailure(event: event, message: "Failed to rename styled transcript artifact", context: context)
+        do {
+            let finalURL = try MeetingArtifactRenamer.rename(
+                transcriptAt: url,
+                toStem: preferredStem,
+                displayTitle: title,
+                recoveryStoreDirectory: recoveryStoreDirectory,
+                logFailure: { event, context in
+                    logFailure(event: event, message: "Failed to rename styled transcript artifact", context: context)
+                }
+            )
+            return MeetingArtifactRenameOutcome(
+                url: finalURL,
+                recoveryNotice: nil,
+                shouldPersistStyling: true,
+                postProcessingBlocked: false
+            )
+        } catch let error as MeetingArtifactRenameError {
+            let recoveryNotice = error.recoveryNotice(sourceTranscriptURL: url)
+            if recoveryNotice != nil {
+                logFailure(
+                    event: "meeting_transcript_artifact_recovery_required",
+                    message: "Transcript artifacts need manual recovery after restyle",
+                    context: ["audioLocation": error.audioLocation?.rawValue ?? "pending"]
+                )
             }
-        )
+            return MeetingArtifactRenameOutcome(
+                url: url,
+                recoveryNotice: recoveryNotice,
+                shouldPersistStyling: false,
+                postProcessingBlocked: recoveryNotice != nil
+            )
+        } catch {
+            return MeetingArtifactRenameOutcome(
+                url: url,
+                recoveryNotice: nil,
+                shouldPersistStyling: false,
+                postProcessingBlocked: true
+            )
+        }
     }
 
     private static func fallbackTitle(for url: URL) -> String {

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -98,9 +98,8 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
         window.contentView = contentView
         window.isReleasedWhenClosed = false
         window.level = .modalPanel
-        // A normal titled review window should behave like other Mac app
-        // windows in screenshots and screen sharing.
-        window.sharingType = .readOnly
+        // Speaker review can contain transcript excerpts and real names.
+        window.sharingType = .none
 
         super.init(window: window)
         window.delegate = self

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -161,6 +161,9 @@ struct TranscriptedSettingsView: View {
             }
         }
         .task(id: navigation.presentationID) {
+            if let alert = meetingSession.artifactRecoveryAlert {
+                handleMeetingArtifactRecoveryAlert(alert)
+            }
             refreshState()
             trackSettingsPageViewed(
                 navigation.selectedPage,
@@ -195,6 +198,10 @@ struct TranscriptedSettingsView: View {
         .onChange(of: meetingSession.savedMeetingReplacementCommitCount) { _, _ in
             refreshRecentCaptures(force: true)
             speakerPeopleModel.refresh()
+        }
+        .onReceive(meetingSession.$artifactRecoveryAlert) { alert in
+            guard let alert else { return }
+            handleMeetingArtifactRecoveryAlert(alert)
         }
         .onReceive(NotificationCenter.default.publisher(for: .dictationTranscriptDidSave)) { _ in
             refreshRecentCaptures(force: true)
@@ -1283,6 +1290,9 @@ struct TranscriptedSettingsView: View {
                 refreshRecentCaptures(force: true)
             } catch HomeMeetingRenameError.emptyTitle {
                 // Empty title is treated as a cancelled edit — leave everything untouched.
+            } catch HomeMeetingRenameError.artifactRecoveryRequired(let notice) {
+                refreshRecentCaptures(force: true)
+                presentMeetingArtifactRecovery([notice])
             } catch {
                 refreshRecentCaptures(force: true)
                 presentHomeDeleteFailure(
@@ -1629,6 +1639,64 @@ struct TranscriptedSettingsView: View {
             message: HomeActionFailureCopy.message(forFailureTitle: title),
             details: error.localizedDescription,
             retry: retry
+        )
+    }
+
+    private func handleMeetingArtifactRecoveryAlert(_ alert: MeetingArtifactRecoveryAlert) {
+        // Consume before opening the modal so the explicit startup path and the
+        // publisher path cannot present the same recovery state twice.
+        meetingSession.clearArtifactRecoveryAlert(alert)
+        switch alert {
+        case .artifacts(let notices):
+            presentMeetingArtifactRecovery(notices)
+        case .journalUnavailable(let directory):
+            presentMeetingArtifactJournalRecovery(directory)
+        }
+    }
+
+    private func presentMeetingArtifactRecovery(_ notices: [MeetingArtifactRecoveryNotice]) {
+        let candidateURLs = notices.flatMap { notice in
+            [
+                notice.sourceTranscriptURL,
+                notice.targetTranscriptURL,
+                MeetingArtifactRenamer.audioDirectoryURL(for: notice.sourceTranscriptURL),
+                MeetingArtifactRenamer.audioDirectoryURL(for: notice.targetTranscriptURL),
+            ]
+        }
+        let uniqueCandidateURLs = candidateURLs.reduce(into: [URL]()) { result, url in
+            guard !result.contains(where: { $0.standardizedFileURL == url.standardizedFileURL }) else {
+                return
+            }
+            result.append(url)
+        }
+        let count = notices.count
+        presentHomeActionFailure(
+            title: count == 1 ? "Meeting files need attention" : "\(count) meetings need attention",
+            message: count == 1
+                ? "Transcripted could not safely keep this meeting's transcript and audio together. Keep the highlighted items and avoid renaming this meeting again."
+                : "Transcripted could not safely keep these meetings' transcripts and audio together. Keep the highlighted items and avoid renaming these meetings again.",
+            retryTitle: "Show files",
+            retry: {
+                let existingURLs = uniqueCandidateURLs.filter {
+                    FileManager.default.fileExists(atPath: $0.path)
+                }
+                let fallbackURL = notices.first?.sourceTranscriptURL.deletingLastPathComponent()
+                    ?? MeetingStoragePaths.transcriptsFolder
+                NSWorkspace.shared.activateFileViewerSelecting(
+                    existingURLs.isEmpty ? [fallbackURL] : existingURLs
+                )
+            }
+        )
+    }
+
+    private func presentMeetingArtifactJournalRecovery(_ directory: URL) {
+        presentHomeActionFailure(
+            title: "Meeting recovery needs attention",
+            message: "Transcripted could not read a meeting recovery record, so it left your transcript and audio files unchanged. Avoid renaming saved meetings until this is resolved.",
+            retryTitle: "Show files",
+            retry: {
+                NSWorkspace.shared.activateFileViewerSelecting([directory])
+            }
         )
     }
 

--- a/Sources/UI/Shared/HomeMeetingRename.swift
+++ b/Sources/UI/Shared/HomeMeetingRename.swift
@@ -297,14 +297,35 @@ enum HomeMeetingSpeakerRename {
     }
 }
 
-enum HomeMeetingRenameError: Error, Equatable {
+enum HomeMeetingRenameError: Error, Equatable, LocalizedError {
     /// The new title was empty after normalization — callers should treat this as a cancel.
     case emptyTitle
     /// The transcript is not an app-owned meeting, so its filename is not ours to rewrite.
     case notOwnedMeeting
     case readFailed
     case writeFailed
+    case artifactRenameFailed
+    case artifactRecoveryRequired(MeetingArtifactRecoveryNotice)
     case retranscriptionInProgress
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyTitle:
+            return "Enter a meeting title."
+        case .notOwnedMeeting:
+            return "This meeting is not managed by Transcripted."
+        case .readFailed:
+            return "The meeting transcript could not be read."
+        case .writeFailed:
+            return "The meeting transcript could not be updated."
+        case .artifactRenameFailed:
+            return "The meeting files could not be renamed together. The title was left unchanged; try again."
+        case .artifactRecoveryRequired:
+            return "The meeting title was left unchanged, but its retained audio needs attention."
+        case .retranscriptionInProgress:
+            return "That meeting is being re-transcribed. Try again when it finishes."
+        }
+    }
 }
 
 /// Renames a saved meeting from the Home preview's editable title.
@@ -322,11 +343,23 @@ enum HomeMeetingRename {
     static func rename(
         transcriptAt url: URL,
         to rawTitle: String,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        moveItem: ((URL, URL) throws -> Void)? = nil,
+        copyItem: ((URL, URL) throws -> Void)? = nil,
+        removeItem: ((URL) throws -> Void)? = nil,
+        recoveryStoreDirectory: URL? = nil
     ) throws -> HomeMeetingRenameResult {
         do {
             return try MeetingTranscriptFileUpdateSerializer.sync(protecting: [url]) {
-                try renameSerialized(transcriptAt: url, to: rawTitle, fileManager: fileManager)
+                try renameSerialized(
+                    transcriptAt: url,
+                    to: rawTitle,
+                    fileManager: fileManager,
+                    moveItem: moveItem,
+                    copyItem: copyItem,
+                    removeItem: removeItem,
+                    recoveryStoreDirectory: recoveryStoreDirectory
+                )
             }
         } catch MeetingTranscriptFileUpdateError.replacementInProgress {
             throw HomeMeetingRenameError.retranscriptionInProgress
@@ -336,7 +369,11 @@ enum HomeMeetingRename {
     private static func renameSerialized(
         transcriptAt url: URL,
         to rawTitle: String,
-        fileManager: FileManager
+        fileManager: FileManager,
+        moveItem: ((URL, URL) throws -> Void)?,
+        copyItem: ((URL, URL) throws -> Void)?,
+        removeItem: ((URL) throws -> Void)?,
+        recoveryStoreDirectory: URL?
     ) throws -> HomeMeetingRenameResult {
         guard let normalizedTitle = MeetingRecordingTitlePolicy.normalized(rawTitle) else {
             throw HomeMeetingRenameError.emptyTitle
@@ -372,12 +409,42 @@ enum HomeMeetingRename {
             title: normalizedTitle,
             fallback: url.deletingPathExtension().lastPathComponent
         )
-        let finalURL = MeetingArtifactRenamer.rename(
-            transcriptAt: url,
-            toStem: preferredStem,
-            displayTitle: normalizedTitle,
-            fileManager: fileManager
-        )
+        let finalURL: URL
+        do {
+            finalURL = try MeetingArtifactRenamer.rename(
+                transcriptAt: url,
+                toStem: preferredStem,
+                displayTitle: normalizedTitle,
+                fileManager: fileManager,
+                moveItem: moveItem,
+                copyItem: copyItem,
+                removeItem: removeItem,
+                recoveryStoreDirectory: recoveryStoreDirectory
+            )
+        } catch let artifactError as MeetingArtifactRenameError {
+            if rewritten != raw {
+                do {
+                    try raw.write(to: url, atomically: true, encoding: .utf8)
+                    fileManager.restrictFileToOwnerOnly(at: url)
+                } catch {
+                    throw HomeMeetingRenameError.writeFailed
+                }
+            }
+            if let recoveryNotice = artifactError.recoveryNotice(sourceTranscriptURL: url) {
+                throw HomeMeetingRenameError.artifactRecoveryRequired(recoveryNotice)
+            }
+            throw HomeMeetingRenameError.artifactRenameFailed
+        } catch {
+            if rewritten != raw {
+                do {
+                    try raw.write(to: url, atomically: true, encoding: .utf8)
+                    fileManager.restrictFileToOwnerOnly(at: url)
+                } catch {
+                    throw HomeMeetingRenameError.writeFailed
+                }
+            }
+            throw HomeMeetingRenameError.artifactRenameFailed
+        }
 
         return HomeMeetingRenameResult(transcriptURL: finalURL, title: normalizedTitle)
     }

--- a/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
+++ b/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
@@ -149,9 +149,44 @@ enum MeetingAudioArchiveResolver {
 
     static func attachment(
         forTranscript transcriptURL: URL,
+        recoveryStoreDirectory: URL? = nil,
         fileManager: FileManager = .default
     ) -> MeetingAudioAttachment? {
-        let directoryURL = archiveDirectory(forTranscript: transcriptURL)
+        if let attachment = attachment(
+            in: archiveDirectory(forTranscript: transcriptURL),
+            fileManager: fileManager
+        ) {
+            return attachment
+        }
+
+        let notice: MeetingArtifactRecoveryNotice?
+        do {
+            notice = try MeetingArtifactRecoveryStore.pendingNotice(
+                for: transcriptURL,
+                directory: recoveryStoreDirectory,
+                fileManager: fileManager
+            )
+        } catch {
+            MeetingArtifactRecoveryStore.notifyUnavailable(directory: recoveryStoreDirectory)
+            return nil
+        }
+        guard let notice else { return nil }
+        for candidateURL in [notice.sourceTranscriptURL, notice.targetTranscriptURL]
+            where candidateURL.standardizedFileURL != transcriptURL.standardizedFileURL {
+            if let attachment = attachment(
+                in: archiveDirectory(forTranscript: candidateURL),
+                fileManager: fileManager
+            ) {
+                return attachment
+            }
+        }
+        return nil
+    }
+
+    private static func attachment(
+        in directoryURL: URL,
+        fileManager: FileManager
+    ) -> MeetingAudioAttachment? {
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory),
               isDirectory.boolValue else {

--- a/Tests/HomeMeetingRenameTests.swift
+++ b/Tests/HomeMeetingRenameTests.swift
@@ -10,7 +10,11 @@ func testHomeMeetingRename() {
             try writeRenameSummary(summaryURL, sourceTranscript: transcriptURL.lastPathComponent)
 
             do {
-                let result = try HomeMeetingRename.rename(transcriptAt: transcriptURL, to: "  Launch planning  ")
+                let result = try HomeMeetingRename.rename(
+                    transcriptAt: transcriptURL,
+                    to: "  Launch planning  ",
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot)
+                )
 
                 assertEqual(result.title, "Launch planning", "title should be trimmed/normalized")
                 assertEqual(
@@ -45,6 +49,411 @@ func testHomeMeetingRename() {
                 assertionFailure("rename should not throw: \(error)")
             }
         }
+    }
+
+    runSuite("MeetingArtifactRenamer leaves the meeting together when audio cannot move") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            let audioDirectory = try writeRenameAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+            var loggedEvents: [String] = []
+
+            do {
+                _ = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == audioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 1)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot),
+                    logFailure: { event, _ in loggedEvents.append(event) }
+                )
+                assertionFailure("a failed audio move should throw")
+            } catch let error as MeetingArtifactRenameError {
+                assertEqual(
+                    error,
+                    .audioMoveFailed(audioLocation: .atSource, targetTranscriptURL: targetURL),
+                    "the failure should preserve the safe audio location"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertTrue(FileManager.default.fileExists(atPath: transcriptURL.path), "the transcript should not move alone")
+            assertTrue(FileManager.default.fileExists(atPath: audioDirectory.path), "retained audio should stay beside the transcript")
+            assertFalse(FileManager.default.fileExists(atPath: targetURL.path), "the target transcript should not be created")
+            assertFalse(FileManager.default.fileExists(atPath: targetAudioDirectory.path), "the target audio directory should not be created")
+            assertTrue(loggedEvents.contains("meeting_audio_directory_rename_failed"), "the failed audio move should be observable")
+        }
+    }
+
+    runSuite("MeetingArtifactRenamer rolls audio back when the transcript cannot move") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            let audioDirectory = try writeRenameAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+            var rejectedTranscriptMove = false
+            var transcriptFailureContext: [String: String] = [:]
+
+            do {
+                _ = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL, !rejectedTranscriptMove {
+                            rejectedTranscriptMove = true
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 2)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot),
+                    logFailure: { event, context in
+                        if event == "meeting_transcript_rename_failed" {
+                            transcriptFailureContext = context
+                        }
+                    }
+                )
+                assertionFailure("a failed transcript move should throw")
+            } catch let error as MeetingArtifactRenameError {
+                assertEqual(
+                    error,
+                    .transcriptMoveFailed(audioLocation: .atSource, targetTranscriptURL: targetURL),
+                    "the failure should report restored audio"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertTrue(FileManager.default.fileExists(atPath: transcriptURL.path), "the original transcript should remain")
+            assertTrue(FileManager.default.fileExists(atPath: audioDirectory.path), "retained audio should be rolled back")
+            assertFalse(FileManager.default.fileExists(atPath: targetURL.path), "the target transcript should not exist")
+            assertFalse(FileManager.default.fileExists(atPath: targetAudioDirectory.path), "rolled-back audio should not remain at the target")
+            assertEqual(transcriptFailureContext["audioLocation"], "atSource", "the failure event should prove audio was restored")
+        }
+    }
+
+    runSuite("MeetingArtifactRenamer copies audio back when rollback movement fails") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            let audioDirectory = try writeRenameAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+
+            do {
+                _ = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL || sourceURL == targetAudioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 3)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot)
+                )
+                assertionFailure("a failed transcript move should throw")
+            } catch let error as MeetingArtifactRenameError {
+                assertEqual(
+                    error,
+                    .transcriptMoveFailed(audioLocation: .atSource, targetTranscriptURL: targetURL),
+                    "copy recovery should report restored audio"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertTrue(FileManager.default.fileExists(atPath: transcriptURL.path), "the original transcript should remain")
+            assertTrue(FileManager.default.fileExists(atPath: audioDirectory.path), "copy recovery should restore retained audio")
+            assertFalse(FileManager.default.fileExists(atPath: targetURL.path), "the target transcript should not exist")
+            assertFalse(FileManager.default.fileExists(atPath: targetAudioDirectory.path), "the recovered target audio should be cleaned up")
+        }
+    }
+
+    runSuite("MeetingArtifactRenamer reports when audio recovery also fails") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            _ = try writeRenameAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+            var loggedEvents: [String] = []
+
+            do {
+                _ = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL || sourceURL == targetAudioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 4)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    copyItem: { _, _ in
+                        throw NSError(domain: "MeetingArtifactRenamerTests", code: 5)
+                    },
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot),
+                    logFailure: { event, _ in loggedEvents.append(event) }
+                )
+                assertionFailure("an unrecovered transcript move should throw")
+            } catch let error as MeetingArtifactRenameError {
+                assertEqual(
+                    error,
+                    .transcriptMoveFailed(audioLocation: .atTarget, targetTranscriptURL: targetURL),
+                    "the unrecovered location should be explicit"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertTrue(FileManager.default.fileExists(atPath: transcriptURL.path), "the original transcript should remain")
+            assertTrue(FileManager.default.fileExists(atPath: targetAudioDirectory.path), "unrecovered audio should remain available at its moved path")
+            assertTrue(loggedEvents.contains("meeting_audio_directory_rename_recovery_failed"), "the failed recovery should be observable")
+        }
+    }
+
+    runSuite("MeetingArtifactRenamer completes forward when audio cannot return") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            _ = try writeRenameAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+
+            do {
+                let result = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL || sourceURL == targetAudioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 6)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    copyItem: { sourceURL, targetURL in
+                        if sourceURL == targetAudioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 7)
+                        }
+                        try FileManager.default.copyItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot)
+                )
+                assertEqual(result, targetURL, "the transcript should complete forward beside stranded audio")
+            } catch {
+                assertionFailure("forward recovery should succeed: \(error)")
+            }
+
+            assertFalse(FileManager.default.fileExists(atPath: transcriptURL.path), "forward recovery should retire the original transcript")
+            assertTrue(FileManager.default.fileExists(atPath: targetURL.path), "the recovered transcript should use the target stem")
+            assertTrue(FileManager.default.fileExists(atPath: targetAudioDirectory.path), "retained audio should remain beside the recovered transcript")
+        }
+    }
+
+    runSuite("MeetingArtifactRenamer marks duplicate audio as unsafe to retry") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            let audioDirectory = try writeRenameAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+
+            do {
+                _ = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL || sourceURL == targetAudioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 8)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    removeItem: { targetURL in
+                        if targetURL == targetAudioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 9)
+                        }
+                        try FileManager.default.removeItem(at: targetURL)
+                    },
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot)
+                )
+                assertionFailure("duplicate target audio should remain an explicit failure")
+            } catch let error as MeetingArtifactRenameError {
+                assertEqual(
+                    error,
+                    .transcriptMoveFailed(audioLocation: .duplicated, targetTranscriptURL: targetURL),
+                    "cleanup failure should be distinct from a safe rollback"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertTrue(FileManager.default.fileExists(atPath: transcriptURL.path), "the original transcript should remain")
+            assertTrue(FileManager.default.fileExists(atPath: audioDirectory.path), "the original audio should remain usable")
+            assertTrue(FileManager.default.fileExists(atPath: targetAudioDirectory.path), "the duplicate target should remain visible for recovery")
+        }
+    }
+
+    runSuite("HomeMeetingRename restores the title when artifact movement fails") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            let original = try String(contentsOf: transcriptURL, encoding: .utf8)
+            let audioDirectory = try writeRenameAudio(for: transcriptURL)
+
+            do {
+                _ = try HomeMeetingRename.rename(
+                    transcriptAt: transcriptURL,
+                    to: "Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == audioDirectory {
+                            throw NSError(domain: "HomeMeetingRenameTests", code: 1)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot)
+                )
+                assertionFailure("the Home rename should surface the artifact failure")
+            } catch let error as HomeMeetingRenameError {
+                assertEqual(error, .artifactRenameFailed, "the caller should receive a user-facing rename failure")
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            let restored = try String(contentsOf: transcriptURL, encoding: .utf8)
+            assertEqual(restored, original, "the original title and heading should be restored")
+            assertTrue(FileManager.default.fileExists(atPath: audioDirectory.path), "retained audio should remain at the original path")
+        }
+    }
+
+    runSuite("HomeMeetingRename blocks blind retry when audio remains at the target") {
+        withTemporaryHomeMeetingRenameLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeRenameMeeting(title: "Quick notes", transcriptURL: transcriptURL)
+            let original = try String(contentsOf: transcriptURL, encoding: .utf8)
+            _ = try writeRenameAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+            let sourceAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: transcriptURL)
+            let recoveryStoreDirectory = renameRecoveryStoreDirectory(for: meetingsRoot)
+            let expectedNotice = MeetingArtifactRecoveryNotice(
+                sourceTranscriptURL: transcriptURL,
+                targetTranscriptURL: targetURL
+            )
+
+            do {
+                _ = try HomeMeetingRename.rename(
+                    transcriptAt: transcriptURL,
+                    to: "Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL || sourceURL == targetAudioDirectory {
+                            throw NSError(domain: "HomeMeetingRenameTests", code: 2)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    copyItem: { _, _ in
+                        throw NSError(domain: "HomeMeetingRenameTests", code: 3)
+                    },
+                    recoveryStoreDirectory: recoveryStoreDirectory
+                )
+                assertionFailure("the Home rename should surface the recovery location")
+            } catch let error as HomeMeetingRenameError {
+                assertEqual(
+                    error,
+                    .artifactRecoveryRequired(expectedNotice),
+                    "the caller should block blind retry and preserve the audio location"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            let restored = try String(contentsOf: transcriptURL, encoding: .utf8)
+            assertEqual(restored, original, "the title should be restored before asking for recovery")
+            assertTrue(FileManager.default.fileExists(atPath: targetAudioDirectory.path), "the recovery location should remain inspectable")
+
+            let persistedNotice = try MeetingArtifactRecoveryStore.pendingNotice(
+                for: transcriptURL,
+                directory: recoveryStoreDirectory
+            )
+            assertEqual(persistedNotice, expectedNotice, "the unsafe transaction should survive a relaunch")
+            assertEqual(
+                try MeetingArtifactRecoveryStore.pendingNotices(directory: recoveryStoreDirectory),
+                [expectedNotice],
+                "launch scanning should surface the same recovery action"
+            )
+
+            var attemptedArtifactMove = false
+            do {
+                _ = try HomeMeetingRename.rename(
+                    transcriptAt: transcriptURL,
+                    to: "A different title",
+                    moveItem: { sourceURL, targetURL in
+                        attemptedArtifactMove = true
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: recoveryStoreDirectory
+                )
+                assertionFailure("a later rename should remain blocked until the artifacts are coherent")
+            } catch let error as HomeMeetingRenameError {
+                assertEqual(
+                    error,
+                    .artifactRecoveryRequired(expectedNotice),
+                    "a persisted recovery record should block a suffix-producing retry"
+                )
+            } catch {
+                assertionFailure("unexpected retry error: \(error)")
+            }
+            assertFalse(attemptedArtifactMove, "the durable recovery guard should run before any new artifact move")
+            assertEqual(
+                try String(contentsOf: transcriptURL, encoding: .utf8),
+                original,
+                "a blocked retry should restore the original title"
+            )
+
+            try FileManager.default.moveItem(at: targetAudioDirectory, to: sourceAudioDirectory)
+            assertNil(
+                try MeetingArtifactRecoveryStore.pendingNotice(
+                    for: transcriptURL,
+                    directory: recoveryStoreDirectory
+                ),
+                "a coherent source pair should automatically clear the journal"
+            )
+            assertTrue(
+                try MeetingArtifactRecoveryStore.pendingNotices(directory: recoveryStoreDirectory).isEmpty,
+                "resolved recovery records should not reappear on the next launch"
+            )
+        }
+    }
+
+    runSuite("MeetingArtifactRenameError emits recovery notices only for unsafe locations") {
+        let sourceURL = URL(fileURLWithPath: "/tmp/source.md")
+        let targetURL = URL(fileURLWithPath: "/tmp/target.md")
+        let safeError = MeetingArtifactRenameError.transcriptMoveFailed(
+            audioLocation: .atSource,
+            targetTranscriptURL: targetURL
+        )
+        let unsafeError = MeetingArtifactRenameError.transcriptMoveFailed(
+            audioLocation: .duplicated,
+            targetTranscriptURL: targetURL
+        )
+
+        assertNil(
+            safeError.recoveryNotice(sourceTranscriptURL: sourceURL),
+            "safe rollback should retain the normal retry path"
+        )
+        assertEqual(
+            unsafeError.recoveryNotice(sourceTranscriptURL: sourceURL),
+            MeetingArtifactRecoveryNotice(
+                sourceTranscriptURL: sourceURL,
+                targetTranscriptURL: targetURL
+            ),
+            "unsafe placement should preserve both transcript locations"
+        )
     }
 
     runSuite("HomeMeetingRename rejects an empty title as a cancelled edit") {
@@ -89,7 +498,11 @@ func testHomeMeetingRename() {
             try writeRenameMeeting(title: "Launch planning", transcriptURL: blockerURL)
 
             do {
-                let result = try HomeMeetingRename.rename(transcriptAt: transcriptURL, to: "Launch planning")
+                let result = try HomeMeetingRename.rename(
+                    transcriptAt: transcriptURL,
+                    to: "Launch planning",
+                    recoveryStoreDirectory: renameRecoveryStoreDirectory(for: meetingsRoot)
+                )
                 assertEqual(
                     result.transcriptURL.lastPathComponent,
                     "2026-06-05 Launch planning 2.md",
@@ -420,6 +833,12 @@ private func withTemporaryHomeMeetingRenameLibrary(_ body: (URL) throws -> Void)
         assertionFailure("temporary rename fixture failed: \(error)")
     }
     try? fm.removeItem(at: root)
+}
+
+private func renameRecoveryStoreDirectory(for meetingsRoot: URL) -> URL {
+    meetingsRoot
+        .deletingLastPathComponent()
+        .appendingPathComponent("meeting-artifact-recovery", isDirectory: true)
 }
 
 private func writeRenameMeeting(

--- a/Tests/MeetingArtifactRecoveryStoreTests.swift
+++ b/Tests/MeetingArtifactRecoveryStoreTests.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+func testMeetingArtifactRecoveryStore() {
+    runSuite("MeetingArtifactRenamer never claims a foreign target transcript") {
+        withTemporaryMeetingArtifactRecoveryLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeArtifactRecoveryMeeting(transcriptURL)
+            let original = try Data(contentsOf: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            guard let values = try TranscriptFrontmatter.readValues(from: transcriptURL),
+                  let captureID = TranscriptFrontmatter.captureID(in: values) else {
+                assertionFailure("fixture should include a capture ID")
+                return
+            }
+            let foreign = Data("""
+            ---
+            capture_id: "\(captureID.uuidString)"
+            transcript_id: "\(captureID.uuidString)"
+            capture_type: meeting
+            title: "Stale duplicate"
+            ---
+
+            # Stale duplicate
+            """.utf8)
+
+            do {
+                _ = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL {
+                            try foreign.write(to: targetURL)
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 10)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: artifactRecoveryStoreDirectory(for: meetingsRoot)
+                )
+                assertionFailure("a target collision should not be reconciled as our transcript")
+            } catch let error as MeetingArtifactRenameError {
+                assertEqual(
+                    error,
+                    .transcriptMoveFailed(audioLocation: .notPresent, targetTranscriptURL: targetURL),
+                    "a foreign target should remain a normal move failure"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertEqual(try Data(contentsOf: transcriptURL), original, "the owned transcript should remain untouched")
+            assertEqual(try Data(contentsOf: targetURL), foreign, "a foreign target must never be deleted or adopted")
+        }
+    }
+
+    runSuite("MeetingArtifactRenamer keeps the complete audio copy when fallback copying is partial") {
+        withTemporaryMeetingArtifactRecoveryLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeArtifactRecoveryMeeting(transcriptURL)
+            let sourceAudioDirectory = try writeArtifactRecoveryAudio(for: transcriptURL)
+            let targetURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetURL)
+            let recoveryStoreDirectory = artifactRecoveryStoreDirectory(for: meetingsRoot)
+
+            do {
+                _ = try MeetingArtifactRenamer.rename(
+                    transcriptAt: transcriptURL,
+                    toStem: "2026-06-05 Launch planning",
+                    moveItem: { sourceURL, targetURL in
+                        if sourceURL == transcriptURL || sourceURL == targetAudioDirectory {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 11)
+                        }
+                        try FileManager.default.moveItem(at: sourceURL, to: targetURL)
+                    },
+                    copyItem: { sourceURL, targetURL in
+                        if sourceURL == targetAudioDirectory {
+                            try FileManager.default.createDirectory(at: targetURL, withIntermediateDirectories: true)
+                            try Data("partial".utf8).write(to: targetURL.appendingPathComponent("system_audio.wav"))
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 12)
+                        }
+                        if sourceURL == transcriptURL {
+                            throw NSError(domain: "MeetingArtifactRenamerTests", code: 13)
+                        }
+                        try FileManager.default.copyItem(at: sourceURL, to: targetURL)
+                    },
+                    recoveryStoreDirectory: recoveryStoreDirectory
+                )
+                assertionFailure("partial copy recovery should remain pending")
+            } catch let error as MeetingArtifactRenameError {
+                assertEqual(
+                    error,
+                    .transcriptMoveFailed(audioLocation: .atTarget, targetTranscriptURL: targetURL),
+                    "the complete target must remain the recovery source"
+                )
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertFalse(FileManager.default.fileExists(atPath: sourceAudioDirectory.path), "a partial source copy must be removed")
+            assertEqual(
+                try Data(contentsOf: targetAudioDirectory.appendingPathComponent("system_audio.wav")),
+                Data("system".utf8),
+                "the complete system-audio file must remain at the target"
+            )
+            assertEqual(
+                try Data(contentsOf: targetAudioDirectory.appendingPathComponent("microphone.wav")),
+                Data("mic".utf8),
+                "the complete microphone file must remain at the target"
+            )
+            assertEqual(
+                try MeetingArtifactRecoveryStore.pendingNotice(
+                    for: transcriptURL,
+                    directory: recoveryStoreDirectory
+                ),
+                MeetingArtifactRecoveryNotice(
+                    sourceTranscriptURL: transcriptURL,
+                    targetTranscriptURL: targetURL
+                ),
+                "the surviving target audio should stay journaled for recovery"
+            )
+        }
+    }
+
+    runSuite("MeetingArtifactRecoveryStore fails closed on a damaged journal") {
+        withTemporaryMeetingArtifactRecoveryLibrary { meetingsRoot in
+            let transcriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            try writeArtifactRecoveryMeeting(transcriptURL)
+            let original = try String(contentsOf: transcriptURL, encoding: .utf8)
+            let sourceAudioDirectory = try writeArtifactRecoveryAudio(for: transcriptURL)
+            let recoveryStoreDirectory = artifactRecoveryStoreDirectory(for: meetingsRoot)
+            try FileManager.default.createDirectory(at: recoveryStoreDirectory, withIntermediateDirectories: true)
+            try Data("not-json".utf8).write(
+                to: recoveryStoreDirectory.appendingPathComponent("damaged.json")
+            )
+            var reportedDirectory: URL?
+            let observer = NotificationCenter.default.addObserver(
+                forName: .meetingArtifactRecoveryJournalUnavailable,
+                object: nil,
+                queue: nil
+            ) { notification in
+                reportedDirectory = notification.object as? URL
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            do {
+                _ = try HomeMeetingRename.rename(
+                    transcriptAt: transcriptURL,
+                    to: "Launch planning",
+                    recoveryStoreDirectory: recoveryStoreDirectory
+                )
+                assertionFailure("a damaged journal should block artifact movement")
+            } catch let error as HomeMeetingRenameError {
+                assertEqual(error, .artifactRenameFailed, "journal damage should fail closed")
+            } catch {
+                assertionFailure("unexpected error: \(error)")
+            }
+
+            assertEqual(
+                try String(contentsOf: transcriptURL, encoding: .utf8),
+                original,
+                "the title should be restored when journal validation fails"
+            )
+            assertTrue(FileManager.default.fileExists(atPath: sourceAudioDirectory.path), "retained audio should not move")
+            assertEqual(
+                reportedDirectory,
+                recoveryStoreDirectory.standardizedFileURL,
+                "a rename blocked by journal damage should surface the recovery directory"
+            )
+            do {
+                _ = try MeetingArtifactRecoveryStore.pendingNotices(directory: recoveryStoreDirectory)
+                assertionFailure("launch scanning should also report journal damage")
+            } catch {
+                // Expected: unreadable journals stay blocking instead of being skipped.
+            }
+        }
+    }
+
+    runSuite("MeetingArtifactRecoveryStore follows a relocated capture library") {
+        withTemporaryMeetingArtifactRecoveryLibrary { meetingsRoot in
+            let sourceTranscriptURL = meetingsRoot.appendingPathComponent("Call_2026-06-05_18-39-20.md")
+            let targetTranscriptURL = meetingsRoot.appendingPathComponent("2026-06-05 Launch planning.md")
+            try writeArtifactRecoveryMeeting(sourceTranscriptURL)
+            let sourceAudioDirectory = try writeArtifactRecoveryAudio(for: sourceTranscriptURL)
+            let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: targetTranscriptURL)
+            let recoveryStoreDirectory = artifactRecoveryStoreDirectory(for: meetingsRoot)
+            _ = try MeetingArtifactRecoveryStore.prepare(
+                sourceTranscriptURL: sourceTranscriptURL,
+                targetTranscriptURL: targetTranscriptURL,
+                hadSourceAudio: true,
+                directory: recoveryStoreDirectory
+            )
+            try FileManager.default.moveItem(at: sourceAudioDirectory, to: targetAudioDirectory)
+
+            let relocatedRoot = meetingsRoot
+                .deletingLastPathComponent()
+                .appendingPathComponent("relocated-meetings", isDirectory: true)
+            try FileManager.default.createDirectory(at: relocatedRoot, withIntermediateDirectories: true)
+            let relocatedSourceURL = relocatedRoot.appendingPathComponent(sourceTranscriptURL.lastPathComponent)
+            let relocatedTargetURL = relocatedRoot.appendingPathComponent(targetTranscriptURL.lastPathComponent)
+            try FileManager.default.copyItem(at: sourceTranscriptURL, to: relocatedSourceURL)
+            try FileManager.default.createDirectory(
+                at: MeetingAudioArchiveResolver.archiveDirectory(forTranscript: relocatedTargetURL)
+                    .deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.copyItem(
+                at: targetAudioDirectory,
+                to: MeetingAudioArchiveResolver.archiveDirectory(forTranscript: relocatedTargetURL)
+            )
+
+            assertEqual(
+                try MeetingArtifactRecoveryStore.pendingNotice(
+                    for: relocatedSourceURL,
+                    directory: recoveryStoreDirectory
+                ),
+                MeetingArtifactRecoveryNotice(
+                    sourceTranscriptURL: relocatedSourceURL,
+                    targetTranscriptURL: relocatedTargetURL
+                ),
+                "capture-ID matching should rebase recovery paths to the active library"
+            )
+        }
+    }
+}
+
+private func withTemporaryMeetingArtifactRecoveryLibrary(_ body: (URL) throws -> Void) {
+    let fileManager = FileManager.default
+    let root = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        .appendingPathComponent("build/meeting-artifact-recovery-tests", isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let meetingsRoot = root.appendingPathComponent("meetings", isDirectory: true)
+    do {
+        try fileManager.createDirectory(at: meetingsRoot, withIntermediateDirectories: true)
+        try body(meetingsRoot)
+    } catch {
+        assertionFailure("temporary recovery fixture failed: \(error)")
+    }
+    try? fileManager.removeItem(at: root)
+}
+
+private func artifactRecoveryStoreDirectory(for meetingsRoot: URL) -> URL {
+    meetingsRoot
+        .deletingLastPathComponent()
+        .appendingPathComponent("meeting-artifact-recovery", isDirectory: true)
+}
+
+private func writeArtifactRecoveryMeeting(_ transcriptURL: URL) throws {
+    let id = UUID().uuidString
+    let markdown = """
+    ---
+    capture_id: "\(id)"
+    transcript_id: "\(id)"
+    capture_type: meeting
+    title: "Quick notes"
+    date: "2026-06-05"
+    time: "18:39:20"
+    ---
+
+    # Quick notes
+
+    ## Transcript
+
+    **00:01** [Mic/You]
+    Synthetic test.
+    """
+    try markdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+}
+
+@discardableResult
+private func writeArtifactRecoveryAudio(for transcriptURL: URL) throws -> URL {
+    let audioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: transcriptURL)
+    try FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+    try Data("system".utf8).write(to: audioDirectory.appendingPathComponent("system_audio.wav"))
+    try Data("mic".utf8).write(to: audioDirectory.appendingPathComponent("microphone.wav"))
+    return audioDirectory
+}

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -16,9 +16,103 @@ func testMeetingAudioArchiveResolver() {
         testResolverUsesPlaybackMixForPlaybackOnlyArchive()
         testResolverPrefersPlaybackMix()
         testResolverFallsBackToPlaybackMixWhenSplitSidecarsAreIncomplete()
+        testResolverKeepsRetranscriptionAvailableDuringArtifactRecovery()
+        testResolverSurfacesUnreadableRecoveryJournal()
         testResolverReturnsNilWhenAudioIsMissing()
         testRetranscriptionInputMapsLiveSplitStreams()
         testRetranscriptionInputMapsSingleRecording()
+    }
+}
+
+private func testResolverSurfacesUnreadableRecoveryJournal() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Journal Failure.md")
+    let recoveryStoreDirectory = directory.appendingPathComponent("recovery", isDirectory: true)
+    try? FileManager.default.createDirectory(at: recoveryStoreDirectory, withIntermediateDirectories: true)
+    try? Data("not-json".utf8).write(
+        to: recoveryStoreDirectory.appendingPathComponent("broken.json")
+    )
+
+    var reportedDirectory: URL?
+    let observer = NotificationCenter.default.addObserver(
+        forName: .meetingArtifactRecoveryJournalUnavailable,
+        object: nil,
+        queue: nil
+    ) { notification in
+        reportedDirectory = notification.object as? URL
+    }
+    defer { NotificationCenter.default.removeObserver(observer) }
+
+    let attachment = MeetingAudioArchiveResolver.attachment(
+        forTranscript: transcriptURL,
+        recoveryStoreDirectory: recoveryStoreDirectory
+    )
+
+    assertNil(attachment, "an unreadable recovery journal must fail closed")
+    assertEqual(
+        reportedDirectory?.standardizedFileURL,
+        recoveryStoreDirectory.standardizedFileURL,
+        "an unreadable recovery journal should surface a recovery alert instead of looking like ordinary missing audio"
+    )
+}
+
+private func testResolverKeepsRetranscriptionAvailableDuringArtifactRecovery() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let captureID = UUID()
+    let sourceTranscriptURL = directory.appendingPathComponent("Imported Meeting.md")
+    let targetTranscriptURL = directory.appendingPathComponent("2026-08-11 Imported Meeting.md")
+    let recoveryStoreDirectory = directory.appendingPathComponent("recovery", isDirectory: true)
+    let transcript = """
+    ---
+    capture_id: "\(captureID.uuidString)"
+    transcript_id: "\(captureID.uuidString)"
+    capture_type: meeting
+    title: "Imported Meeting"
+    ---
+
+    # Imported Meeting
+    """
+
+    do {
+        try transcript.write(to: sourceTranscriptURL, atomically: true, encoding: .utf8)
+        let sourceAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(
+            forTranscript: sourceTranscriptURL
+        )
+        let targetAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(
+            forTranscript: targetTranscriptURL
+        )
+        try FileManager.default.createDirectory(at: sourceAudioDirectory, withIntermediateDirectories: true)
+        try Data("imported".utf8).write(
+            to: sourceAudioDirectory.appendingPathComponent("recording.m4a")
+        )
+        _ = try MeetingArtifactRecoveryStore.prepare(
+            sourceTranscriptURL: sourceTranscriptURL,
+            targetTranscriptURL: targetTranscriptURL,
+            hadSourceAudio: true,
+            directory: recoveryStoreDirectory
+        )
+        try FileManager.default.moveItem(at: sourceAudioDirectory, to: targetAudioDirectory)
+
+        let attachment = MeetingAudioArchiveResolver.attachment(
+            forTranscript: sourceTranscriptURL,
+            recoveryStoreDirectory: recoveryStoreDirectory
+        )
+        assertEqual(
+            attachment?.directoryURL,
+            targetAudioDirectory,
+            "recovery should resolve retained audio at the journaled target stem"
+        )
+        assertEqual(
+            attachment?.retranscriptionInput?.systemURL.lastPathComponent,
+            "recording.m4a",
+            "re-transcription should stay available while transcript and audio stems recover"
+        )
+    } catch {
+        assertionFailure("recovery audio fixture should succeed: \(error)")
     }
 }
 

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -13,6 +13,8 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerPreviewRejectsPlainMarkdown()
         testMeetingTranscriptStylerSkipsNonMeetingFrontmatter()
         testMeetingTranscriptStylerRenamesRetainedAudioDirectory()
+        testMeetingTranscriptStylerBlocksPostProcessingWhenRecoveryJournalIsUnavailable()
+        testMeetingTranscriptStylerBlockedFallbackStopsPostProcessing()
         testMeetingTranscriptStylerAvoidsAudioDirectoryCollisions()
         testMeetingTranscriptStylerPreservesObsidianSpeakerLinks()
         testMeetingTranscriptStylerPreservesLegacyTrailingSections()
@@ -26,6 +28,55 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerLeavesLegacyFilesWithoutFormatVersion()
         testMeetingTranscriptStylerPreservesSystemOnlyRecordingNote()
     }
+}
+
+private func testMeetingTranscriptStylerBlockedFallbackStopsPostProcessing() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleMeetingTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+    let styled = MeetingTranscriptStyler.blockedRestyleResult(at: transcriptURL)
+
+    assertTrue(
+        styled.artifactPostProcessingBlocked,
+        "active replacement should block quick-summary and retained-audio post-processing"
+    )
+    assertEqual(styled.url, transcriptURL, "active replacement should preserve the owned transcript path")
+}
+
+private func testMeetingTranscriptStylerBlocksPostProcessingWhenRecoveryJournalIsUnavailable() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    let recoveryStoreDirectory = directory.appendingPathComponent("recovery", isDirectory: true)
+    let raw = sampleMeetingTranscript()
+    try? raw.write(to: transcriptURL, atomically: true, encoding: .utf8)
+    try? FileManager.default.createDirectory(at: recoveryStoreDirectory, withIntermediateDirectories: true)
+    try? Data("not-json".utf8).write(
+        to: recoveryStoreDirectory.appendingPathComponent("damaged.json")
+    )
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(
+        at: transcriptURL,
+        recoveryStoreDirectory: recoveryStoreDirectory
+    )
+
+    assertTrue(
+        styled.artifactPostProcessingBlocked,
+        "journal failure should block quick-summary and retained-audio post-processing"
+    )
+    assertNil(
+        styled.artifactRecoveryNotice,
+        "an unreadable journal should surface through the journal alert instead of inventing an artifact location"
+    )
+    assertEqual(styled.url, transcriptURL, "journal failure should keep the original transcript path")
+    assertEqual(
+        try? String(contentsOf: transcriptURL, encoding: .utf8),
+        raw,
+        "journal failure should leave transcript contents unchanged"
+    )
 }
 
 private func testMeetingTranscriptStylerPreservesSystemOnlyRecordingNote() {

--- a/Tests/OverlayScreenSharePrivacyTests.swift
+++ b/Tests/OverlayScreenSharePrivacyTests.swift
@@ -1,11 +1,12 @@
 // OverlayScreenSharePrivacyTests.swift
 // Guards that transient Transcripted overlays stay excluded from screen capture
-// / screen sharing, while normal titled app windows stay capturable.
+// / screen sharing, while non-sensitive titled app windows stay capturable.
 //
 // AppKit windows and panels default to `NSWindow.SharingType.readOnly`, which
 // ScreenCaptureKit and Screenshot window capture can use. That is the right
 // choice for normal windows, where users expect standard macOS screenshots to
-// work. Only live/transient overlays opt out with `sharingType = .none`.
+// work. Live/transient overlays and transcript-bearing review windows opt out
+// with `sharingType = .none`.
 
 import AppKit
 import Foundation
@@ -79,6 +80,7 @@ func testOverlayScreenSharePrivacy() async {
         let capturePill = overlayPrivacySource("Sources/UI/Overlay/CapturePillController.swift")
         let panelSource = overlayPrivacySource("Sources/UI/Overlay/MeetingOverlayPanel.swift")
         let pasteFeedback = overlayPrivacySource("Sources/UI/MenuBar/PasteLastDictationFeedback.swift")
+        let speakerNaming = overlayPrivacySource("Sources/UI/Settings/SpeakerNamingSheet.swift")
         let inits: [(name: String, body: String)] = [
             (
                 "FloatingOverlayPanel",
@@ -120,6 +122,14 @@ func testOverlayScreenSharePrivacy() async {
                     to: "override var canBecomeKey"
                 )
             ),
+            (
+                "NamingWindowController",
+                overlayPrivacySlice(
+                    speakerNaming,
+                    from: "let window = NSWindow(",
+                    to: "super.init(window: window)"
+                )
+            ),
         ]
 
         for entry in inits {
@@ -130,10 +140,9 @@ func testOverlayScreenSharePrivacy() async {
         }
     }
 
-    runSuite("normal titled Transcripted windows stay capturable") {
+    runSuite("non-sensitive titled Transcripted windows stay capturable") {
         let onboardingWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedOnboardingWindowController.swift")
         let settingsWindow = overlayPrivacySource("Sources/UI/Settings/TranscriptedSettingsWindowController.swift")
-        let speakerNaming = overlayPrivacySource("Sources/UI/Settings/SpeakerNamingSheet.swift")
 
         let inits: [(name: String, body: String)] = [
             (
@@ -148,14 +157,6 @@ func testOverlayScreenSharePrivacy() async {
                 "TranscriptedSettingsWindowController",
                 overlayPrivacySlice(
                     settingsWindow,
-                    from: "let window = NSWindow(",
-                    to: "super.init(window: window)"
-                )
-            ),
-            (
-                "NamingWindowController",
-                overlayPrivacySlice(
-                    speakerNaming,
                     from: "let window = NSWindow(",
                     to: "super.init(window: window)"
                 )

--- a/scripts/dev/benchmark-home-recent-captures.sh
+++ b/scripts/dev/benchmark-home-recent-captures.sh
@@ -15,6 +15,8 @@ swiftc \
   "$ROOT_DIR/Sources/Dictation/DictationTranscriptWriter.swift" \
   "$ROOT_DIR/Sources/TranscriptedCore/Utilities/DateFormattingHelper.swift" \
   "$ROOT_DIR/Sources/Dictation/DictationTranscriptStore.swift" \
+  "$ROOT_DIR/Sources/Meeting/MeetingArtifactRecoveryStore.swift" \
+  "$ROOT_DIR/Sources/Meeting/MeetingArtifactRenameTransaction.swift" \
   "$ROOT_DIR/Sources/Meeting/MeetingArtifactRenamer.swift" \
   "$ROOT_DIR/Sources/Meeting/MeetingStoragePaths.swift" \
   "$ROOT_DIR/Sources/Meeting/MeetingTranscriptStyler.swift" \

--- a/scripts/entrypoints/lib/shared-smoke-sources.sh
+++ b/scripts/entrypoints/lib/shared-smoke-sources.sh
@@ -50,6 +50,8 @@ SHARED_TEST_STORAGE_SOURCES=(
     "Sources/Dictation/DictationTranscriptWriter.swift"
     "Sources/Dictation/DictationTranscriptStore.swift"
     "Sources/Meeting/MeetingStoragePaths.swift"
+    "Sources/Meeting/MeetingArtifactRecoveryStore.swift"
+    "Sources/Meeting/MeetingArtifactRenameTransaction.swift"
     "Sources/Meeting/MeetingTranscriptStyler.swift"
     "Sources/Meeting/MeetingArtifactRenamer.swift"
     "Sources/Observability/ObservabilityTextRedactor.swift"


### PR DESCRIPTION
## Summary
- journal transcript/audio renames before either artifact moves, with bounded rollback, forward recovery, relocation handling, and fail-closed retry protection
- keep retained audio playback and Re-transcribe with speaker ID available when speaker finalization leaves split artifacts
- surface recovery at launch and runtime, preserve speaker-window screen-share privacy, and stop summary/audio post-processing while recovery or replacement owns the files
- add focused recovery, resolver, restyle, rename, privacy, and benchmark coverage

Addresses #1681 without auto-closing it.

## Verification
- `bash scripts/ops/transcripted-qa-bench.sh --mode full`: PASS, 15 checks; one documented non-blocking warning from validation of existing local artifacts (`/tmp/transcripted-qa-bench/qa-20260811-181416/qa-report.md`)
- `bash run-tests.sh`: 12,192 passed, 0 failed
- `swift test`: 1,034 passed, 13 fixture/eval skips, 0 failed
- `bash build-deps.sh --force`: PASS; pinned dependencies and TranscriptedCore symbol placement verified
- `bash run-integration-smoke.sh`: PASS
- Developer ID `bash build.sh --no-open`: signature valid; launch smoke within budget
- `python3 scripts/ops/privacy-leak-sweep.py`: PASS
- Home recent-captures benchmark compiles and runs with the new sources

## Review
Independent thermonuclear review is clean after addressing startup alert delivery, journal error surfacing, source-list drift, transaction decomposition, downstream artifact freezes, and replacement ownership. One earlier claim that `@Published` does not replay current state was rejected after a direct Combine subscription emitted the current value; an explicit initial alert-consumption path was added anyway so correctness does not depend on that behavior.