### PR TITLE
Honour the local-speaker preference when retranscribing saved audio

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2231,7 +2231,7 @@ final class MeetingSessionController: ObservableObject {
             systemURL: systemAudioURL,
             outputFolder: MeetingStoragePaths.transcriptsFolder,
             meetingTitle: title,
-            splitLocalSpeakers: true,
+            splitLocalSpeakers: LocalSpeakerPreferences.isEnabled(),
             replacementTranscriptURL: transcriptURL,
             recordingDate: recordingDate,
             onReplacementTranscriptCommitted: { [weak self] committedTranscriptURL in

--- a/Tests/RetranscribeLocalSpeakerPreferenceContractTests.swift
+++ b/Tests/RetranscribeLocalSpeakerPreferenceContractTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+func testRetranscribeLocalSpeakerPreferenceContract() {
+    runSuite("Meeting transcription entry points resolve splitLocalSpeakers from the preference") {
+        let controller = readSourceFixture("Sources/Meeting/MeetingSessionController.swift")
+        let coordinator = readSourceFixture("Sources/Meeting/TranscriptionQueueCoordinator.swift")
+
+        guard let retranscribeStart = controller.range(of: "func retranscribeSavedMeeting("),
+              let retranscribeEnd = controller.range(
+                  of: "private func handleReplacementTranscriptCommitted(",
+                  range: retranscribeStart.upperBound..<controller.endIndex
+              ) else {
+            assertTrue(false, "test should find retranscribeSavedMeeting")
+            return
+        }
+        let retranscribe = String(controller[retranscribeStart.lowerBound..<retranscribeEnd.lowerBound])
+
+        assertTrue(
+            retranscribe.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
+            "saved-audio retranscription should honour the People-in-the-room preference"
+        )
+        assertTrue(
+            !retranscribe.contains("splitLocalSpeakers: true"),
+            "saved-audio retranscription should not hard-code local speaker splitting"
+        )
+        assertTrue(
+            coordinator.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
+            "live capture transcription should keep reading the preference"
+        )
+    }
+}


### PR DESCRIPTION
Fixes saved-audio retranscription ignoring the "People in the room" setting: `MeetingSessionController` hard-coded `splitLocalSpeakers: true`, so the local-speaker review opened even for users who had the setting off. The live capture path already reads the preference; this makes retranscription agree.

Verification:
- build.sh --no-open
- run-tests.sh: 12,207 passed, 0 failed
- run-integration-smoke.sh