### PR TITLE
Recover saved meetings stuck in speaker review

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2178,9 +2178,24 @@ final class MeetingSessionController: ObservableObject {
             reportUnrelatedFailure("Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.", reason: "retranscribe_blocked_background_work")
             return false
         }
-        guard !isSpeakerReviewPending else {
-            reportUnrelatedFailure("Finish the speaker review window before re-transcribing saved audio.", reason: "retranscribe_blocked_speaker_review")
-            return false
+        let shouldSupersedeSpeakerReview: Bool
+        let resolvedReplacementTranscriptURL: URL?
+        let speakerReviewReplacementCandidate: TranscriptionTaskManager.SpeakerNamingReplacementCandidate?
+        if isSpeakerReviewPending {
+            guard let transcriptURL,
+                  let candidate = taskManager.speakerNamingReplacementCandidate(
+                    at: transcriptURL
+                  ) else {
+                reportUnrelatedFailure("Finish the speaker review window before re-transcribing saved audio.", reason: "retranscribe_blocked_speaker_review")
+                return false
+            }
+            shouldSupersedeSpeakerReview = true
+            resolvedReplacementTranscriptURL = candidate.transcriptURL
+            speakerReviewReplacementCandidate = candidate
+        } else {
+            shouldSupersedeSpeakerReview = false
+            resolvedReplacementTranscriptURL = transcriptURL
+            speakerReviewReplacementCandidate = nil
         }
 
         DiagnosticsTrail.record(
@@ -2232,13 +2247,21 @@ final class MeetingSessionController: ObservableObject {
             outputFolder: MeetingStoragePaths.transcriptsFolder,
             meetingTitle: title,
             splitLocalSpeakers: true,
-            replacementTranscriptURL: transcriptURL,
+            replacementTranscriptURL: resolvedReplacementTranscriptURL,
+            supersedingSpeakerReview: shouldSupersedeSpeakerReview
+                ? speakerReviewReplacementCandidate
+                : nil,
             recordingDate: recordingDate,
             onReplacementTranscriptCommitted: { [weak self] committedTranscriptURL in
                 self?.handleReplacementTranscriptCommitted(for: committedTranscriptURL)
             }
         )
         return true
+    }
+
+    func canRecoverSavedMeetingDuringSpeakerReview(at transcriptURL: URL) -> Bool {
+        !isSpeakerReviewPending
+            || taskManager.hasSpeakerNamingReviewForReplacement(at: transcriptURL)
     }
 
     private func handleReplacementTranscriptCommitted(for transcriptURL: URL) {

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -222,7 +222,31 @@ public struct SpeakerIdentityOption: Identifiable, Hashable {
 }
 
 /// Request to show the speaker naming UI after transcription completes
+public final class SpeakerNamingRequestLease: @unchecked Sendable {
+    public let id: UUID
+    private let lock = NSLock()
+    private var superseded = false
+
+    public init(id: UUID = UUID()) {
+        self.id = id
+    }
+
+    func supersede() {
+        lock.lock()
+        superseded = true
+        lock.unlock()
+    }
+
+    var isCurrent: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !superseded
+    }
+}
+
 public struct SpeakerNamingRequest {
+    public var requestId: UUID { lease.id }
+    let lease: SpeakerNamingRequestLease
     public let speakers: [SpeakerNamingEntry]
     public let knownPeople: [SpeakerIdentityOption]
     /// Named, mature, undisputed profiles at request time — the sheet's
@@ -239,6 +263,8 @@ public struct SpeakerNamingRequest {
     public let onComplete: ([SpeakerNameUpdate]) -> Void
 
     public init(
+        requestId: UUID = UUID(),
+        lease: SpeakerNamingRequestLease? = nil,
         speakers: [SpeakerNamingEntry],
         knownPeople: [SpeakerIdentityOption] = [],
         recognizedPeopleCount: Int = 0,
@@ -253,6 +279,7 @@ public struct SpeakerNamingRequest {
         importedRecoverySession: (any ImportedTranscriptionRecoverySession)? = nil,
         onComplete: @escaping ([SpeakerNameUpdate]) -> Void
     ) {
+        self.lease = lease ?? SpeakerNamingRequestLease(id: requestId)
         self.speakers = speakers
         self.knownPeople = knownPeople
         self.recognizedPeopleCount = recognizedPeopleCount

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -728,12 +728,16 @@ extension TranscriptionTaskManager {
             }.count
 
             let capturedEntries = namingEntries
+            let namingRequestId = UUID()
+            let namingRequestLease = SpeakerNamingRequestLease(id: namingRequestId)
             try await rollback.checkCancellation()
             await MainActor.run {
                 let importedRecoverySession = self.importedRecoverySession(
                     taskId: taskId
                 )
                 self.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+                    requestId: namingRequestId,
+                    lease: namingRequestLease,
                     speakers: capturedEntries,
                     knownPeople: knownPeople,
                     recognizedPeopleCount: recognizedPeopleCount,
@@ -751,6 +755,8 @@ extension TranscriptionTaskManager {
                             updates: updates,
                             transcriptURL: savedURL,
                             transcriptId: transcriptId,
+                            requestId: namingRequestId,
+                            requestLease: namingRequestLease,
                             transcriptionResult: result,
                             micURL: micURL,
                             systemURL: systemURL,
@@ -772,7 +778,10 @@ extension TranscriptionTaskManager {
             // handed off to a request object that can outlive this function.
             let manager = self
             rollback.register {
-                await manager.cancelSpeakerNamingRequest(transcriptId: transcriptId)
+                await manager.cancelSpeakerNamingRequest(
+                    transcriptId: transcriptId,
+                    requestId: namingRequestId
+                )
                 AppLogger.pipeline.info("Rollback: cancelled queued speaker naming request", [
                     "transcriptId": transcriptId.uuidString
                 ])

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -612,6 +612,7 @@ public class TranscriptionTaskManager: ObservableObject {
         meetingTitle: String? = nil,
         splitLocalSpeakers: Bool = false,
         replacementTranscriptURL: URL? = nil,
+        supersedingSpeakerReview: SpeakerNamingReplacementCandidate? = nil,
         recordingDate: Date? = nil,
         onReplacementTranscriptCommitted: (@MainActor @Sendable (URL) -> Void)? = nil
     ) {
@@ -701,6 +702,24 @@ public class TranscriptionTaskManager: ObservableObject {
                     return
                 }
                 heldReplacementReservation = reservation
+            }
+
+            // Keep the existing review and its samples until the audio has
+            // passed validation and the replacement writer owns the transcript.
+            // A newer same-transcript review must win rather than being revoked
+            // through the stale candidate captured before model preparation.
+            if let supersedingSpeakerReview,
+               !self.supersedeSpeakerNamingReviewForReplacement(supersedingSpeakerReview),
+               self.hasPendingSpeakerNamingReview(
+                transcriptId: supersedingSpeakerReview.transcriptId
+               ) {
+                self.publishFailure(
+                    displayMessage: "The speaker review changed while re-transcription was getting ready. Try again.",
+                    diagnosticMessage: "Speaker review replacement owner changed"
+                )
+                self.handleTaskCompletion(taskId: taskId)
+                self.scheduleStatusReset(delay: 4)
+                return
             }
 
             do {

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -3,6 +3,12 @@ import Foundation
 // MARK: - Speaker Naming Flow Coordination
 
 extension TranscriptionTaskManager {
+    public struct SpeakerNamingReplacementCandidate: Sendable {
+        public let transcriptURL: URL
+        public let transcriptId: UUID
+        public let requestId: UUID
+    }
+
 
     private struct PlannedNamingChanges {
         let resolvedUpdates: [SpeakerNameUpdate]
@@ -42,6 +48,8 @@ extension TranscriptionTaskManager {
         updates: [SpeakerNameUpdate],
         transcriptURL: URL,
         transcriptId: UUID,
+        requestId: UUID? = nil,
+        requestLease: SpeakerNamingRequestLease? = nil,
         transcriptionResult: TranscriptionResult,
         micURL: URL?,
         systemURL: URL,
@@ -93,6 +101,17 @@ extension TranscriptionTaskManager {
                 clipsBySpeakerId: clipsBySpeakerId,
                 speakerDB: speakerDB
             ) else {
+                guard requestLease?.isCurrent != false else {
+                    self?.cleanupNamingArtifacts(
+                        clips: clips,
+                        micURL: micURL,
+                        systemURL: systemURL,
+                        shouldRemoveMicAudio: removeMicAudio && sourceFailedTranscriptionId == nil,
+                        shouldRemoveSystemAudio: removeSystemAudio && sourceFailedTranscriptionId == nil,
+                        importedRecoverySession: importedRecoverySession
+                    )
+                    return
+                }
                 self?.cleanupNamingArtifacts(
                     clips: clips,
                     micURL: micURL,
@@ -113,7 +132,10 @@ extension TranscriptionTaskManager {
                         systemURL: systemURL,
                         sourceFailedTranscriptionId: sourceFailedTranscriptionId
                     )
-                    self.clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
+                    self.clearCompletedSpeakerNamingRequest(
+                        transcriptId: transcriptId,
+                        requestId: requestId
+                    )
                 }
                 return
             }
@@ -128,23 +150,34 @@ extension TranscriptionTaskManager {
             // Resolve and mutate under the same serializer used by transcript styling/title
             // renames. Otherwise the styler can move the canonical file after resolution but
             // before the first speaker rewrite, leaving finalization pointed at a stale path.
-            let finalization = TranscriptSaver.serializeTranscriptFileUpdate {
-                guard let resolvedURL = TranscriptSaver.resolveTranscriptURL(
-                    transcriptURL,
+            let finalization: (didFinalize: Bool, resolvedURL: URL)
+            do {
+                finalization = try TranscriptSaver.serializeTranscriptFileUpdate(
+                    protecting: transcriptURL,
                     transcriptId: transcriptId
-                ) else {
-                    return (didFinalize: false, resolvedURL: transcriptURL)
-                }
-                guard let originalTranscriptData = try? Data(contentsOf: resolvedURL) else {
-                    AppLogger.speakers.error("Speaker naming could not snapshot the transcript before update")
-                    return (didFinalize: false, resolvedURL: resolvedURL)
-                }
+                ) {
+                    guard requestLease?.isCurrent != false else {
+                        AppLogger.speakers.info("Skipped superseded speaker naming finalization", [
+                            "transcriptId": transcriptId.uuidString
+                        ])
+                        return (didFinalize: false, resolvedURL: transcriptURL)
+                    }
+                    guard let resolvedURL = TranscriptSaver.resolveTranscriptURL(
+                        transcriptURL,
+                        transcriptId: transcriptId
+                    ) else {
+                        return (didFinalize: false, resolvedURL: transcriptURL)
+                    }
+                    guard let originalTranscriptData = try? Data(contentsOf: resolvedURL) else {
+                        AppLogger.speakers.error("Speaker naming could not snapshot the transcript before update")
+                        return (didFinalize: false, resolvedURL: resolvedURL)
+                    }
 
-                var didFinalize = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
-                    transcriptURL: resolvedURL,
-                    updates: transcriptUpdates,
-                    transcriptionResult: transcriptionResult
-                )
+                    var didFinalize = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
+                        transcriptURL: resolvedURL,
+                        updates: transcriptUpdates,
+                        transcriptionResult: transcriptionResult
+                    )
 
                 if didFinalize, let deferredReviewPlan {
                     didFinalize = TranscriptSaver.markSpeakerReviewDeferred(
@@ -196,10 +229,37 @@ extension TranscriptionTaskManager {
                     }
                 }
 
-                return (didFinalize: didFinalize, resolvedURL: resolvedURL)
+                    return (didFinalize: didFinalize, resolvedURL: resolvedURL)
+                }
+            } catch TranscriptFileUpdateError.replacementInProgress {
+                AppLogger.speakers.warning("Speaker naming finalization superseded by replacement retranscription", [
+                    "transcriptId": transcriptId.uuidString
+                ])
+                finalization = (didFinalize: false, resolvedURL: transcriptURL)
+            } catch {
+                AppLogger.speakers.error("Speaker naming finalization serialization failed", [
+                    "error": error.localizedDescription
+                ])
+                finalization = (didFinalize: false, resolvedURL: transcriptURL)
             }
             let didFinalizeTranscript = finalization.didFinalize
             let resolvedURL = finalization.resolvedURL
+
+            // Replacement recovery explicitly revoked this owner. Its stale
+            // worker may clean only its own temporary artifacts; it must not
+            // publish failure state, touch retry metadata, or clear the fresh
+            // same-transcript request that replacement will enqueue.
+            if requestLease?.isCurrent == false {
+                self?.cleanupNamingArtifacts(
+                    clips: clips,
+                    micURL: micURL,
+                    systemURL: systemURL,
+                    shouldRemoveMicAudio: removeMicAudio && sourceFailedTranscriptionId == nil,
+                    shouldRemoveSystemAudio: removeSystemAudio && sourceFailedTranscriptionId == nil,
+                    importedRecoverySession: importedRecoverySession
+                )
+                return
+            }
 
             if didFinalizeTranscript {
                 speakerDB.recordMatchOutcomes(Self.plannedMatchOutcomes(
@@ -285,7 +345,10 @@ extension TranscriptionTaskManager {
                 case .transcriptFinalizationFailed:
                     break
                 }
-                self.clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
+                self.clearCompletedSpeakerNamingRequest(
+                    transcriptId: transcriptId,
+                    requestId: requestId
+                )
             }
         }
     }
@@ -377,22 +440,81 @@ extension TranscriptionTaskManager {
         cleanupSpeakerClips(request.speakers)
     }
 
-    func clearCompletedSpeakerNamingRequest(transcriptId: UUID) {
-        if speakerNamingRequest?.transcriptId == transcriptId {
+    func clearCompletedSpeakerNamingRequest(transcriptId: UUID, requestId: UUID? = nil) {
+        if speakerNamingRequest?.transcriptId == transcriptId,
+           requestId == nil || speakerNamingRequest?.requestId == requestId {
             speakerNamingRequest = nil
         }
-        pendingSpeakerNamingRequests.removeAll { $0.transcriptId == transcriptId }
+        pendingSpeakerNamingRequests.removeAll {
+            $0.transcriptId == transcriptId && (requestId == nil || $0.requestId == requestId)
+        }
         promoteNextSpeakerNamingRequestIfNeeded()
     }
 
-    func cancelSpeakerNamingRequest(transcriptId: UUID) {
+    /// Resolve the exact review owner and current canonical transcript before
+    /// preparing retained-audio replacement. The request ID prevents a newer
+    /// same-transcript review from being cancelled after model preparation.
+    public func speakerNamingReplacementCandidate(
+        at transcriptURL: URL
+    ) -> SpeakerNamingReplacementCandidate? {
+        let requests = [speakerNamingRequest].compactMap { $0 } + pendingSpeakerNamingRequests
+        let request: SpeakerNamingRequest?
+        if let values = try? TranscriptFrontmatter.readValues(from: transcriptURL),
+           let transcriptId = TranscriptFrontmatter.captureID(in: values) {
+            request = requests.first { $0.transcriptId == transcriptId }
+        } else {
+            let standardizedURL = transcriptURL.standardizedFileURL
+            request = requests.first {
+                $0.transcriptURL.standardizedFileURL == standardizedURL
+            }
+        }
+        guard let request,
+              let resolvedURL = TranscriptSaver.resolveTranscriptURL(
+                transcriptURL,
+                transcriptId: request.transcriptId
+              ) else {
+            return nil
+        }
+        return SpeakerNamingReplacementCandidate(
+            transcriptURL: resolvedURL,
+            transcriptId: request.transcriptId,
+            requestId: request.requestId
+        )
+    }
+
+    /// Revoke only the review owner captured before model preparation.
+    @discardableResult
+    public func supersedeSpeakerNamingReviewForReplacement(
+        _ candidate: SpeakerNamingReplacementCandidate
+    ) -> Bool {
+        let requests = [speakerNamingRequest].compactMap { $0 } + pendingSpeakerNamingRequests
+        guard requests.contains(where: {
+            $0.transcriptId == candidate.transcriptId && $0.requestId == candidate.requestId
+        }) else {
+            return false
+        }
+        cancelSpeakerNamingRequest(
+            transcriptId: candidate.transcriptId,
+            requestId: candidate.requestId
+        )
+        return true
+    }
+
+    public func hasSpeakerNamingReviewForReplacement(at transcriptURL: URL) -> Bool {
+        speakerNamingReplacementCandidate(at: transcriptURL) != nil
+    }
+
+    func cancelSpeakerNamingRequest(transcriptId: UUID, requestId: UUID? = nil) {
         var cancelledRequests: [SpeakerNamingRequest] = []
-        if let request = speakerNamingRequest, request.transcriptId == transcriptId {
+        if let request = speakerNamingRequest,
+           request.transcriptId == transcriptId,
+           requestId == nil || request.requestId == requestId {
             cancelledRequests.append(request)
             speakerNamingRequest = nil
         }
         pendingSpeakerNamingRequests.removeAll { request in
-            if request.transcriptId == transcriptId {
+            if request.transcriptId == transcriptId,
+               requestId == nil || request.requestId == requestId {
                 cancelledRequests.append(request)
                 return true
             }
@@ -400,6 +522,7 @@ extension TranscriptionTaskManager {
         }
 
         for request in cancelledRequests {
+            request.lease.supersede()
             cleanupSpeakerNamingRequest(request)
         }
         promoteNextSpeakerNamingRequestIfNeeded()

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -133,16 +133,35 @@ public class TranscriptSaver {
         }
     }
 
+    /// Run a transcript mutation only when the stable transcript generation is
+    /// not owned by an in-place replacement. The explicit identity keeps this
+    /// barrier intact when the caller still holds the pre-rename URL.
+    static func serializeTranscriptFileUpdate<T>(
+        protecting transcriptURL: URL,
+        transcriptId: UUID,
+        _ update: () throws -> T
+    ) throws -> T {
+        try serializeTranscriptFileUpdate {
+            guard !replacementReservations.contains(transcriptURL, transcriptId: transcriptId) else {
+                throw TranscriptFileUpdateError.replacementInProgress
+            }
+            return try update()
+        }
+    }
+
     /// Reserve one saved transcript for in-place replacement. The reservation is
     /// established under the same serializer as speaker edits, so an edit either
     /// finishes before replacement starts or fails closed while it is active.
     @discardableResult
-    static func beginReplacingTranscript(at url: URL) -> ReplacementTranscriptReservationToken? {
+    static func beginReplacingTranscript(
+        at url: URL,
+        transcriptId: UUID? = nil
+    ) -> ReplacementTranscriptReservationToken? {
         serializeTranscriptFileUpdate {
             guard FileManager.default.fileExists(atPath: url.path) else { return nil }
             return replacementReservations.reserve(
                 url,
-                transcriptId: stableTranscriptIdentity(at: url)
+                transcriptId: transcriptId ?? stableTranscriptIdentity(at: url)
             )
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1090,7 +1090,7 @@ struct TranscriptedSettingsView: View {
                             title: "Re-transcribe with speaker ID",
                             symbolName: "person.2.fill",
                             isEnabled: RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
-                                globalUnavailableReason: savedMeetingRetranscriptionUnavailableReason
+                                globalUnavailableReason: savedMeetingRetranscriptionUnavailableReason(for: item)
                             )
                         ) {
                             handleRetranscribeMeeting(item)
@@ -1878,13 +1878,16 @@ struct TranscriptedSettingsView: View {
         return nil
     }
 
-    private var savedMeetingRetranscriptionUnavailableReason: String? {
+    private func savedMeetingRetranscriptionUnavailableReason(for item: RecentMeetingItem) -> String? {
         SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
             isDictationActive: sttRouter.isRecording || sttRouter.isTranscribing,
             isMeetingRecording: meetingSession.isRecording,
             isPreparingModels: meetingSession.state == .loadingModels,
             hasMeetingWork: meetingSession.hasRuntimeDiagnosticsWork,
-            isSpeakerReviewPending: meetingSession.isSpeakerReviewPending
+            isSpeakerReviewPending: meetingSession.isSpeakerReviewPending,
+            isTargetSpeakerReview: meetingSession.canRecoverSavedMeetingDuringSpeakerReview(
+                at: item.transcriptURL
+            )
         )
     }
 

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -165,7 +165,8 @@ enum SavedMeetingRetranscriptionAvailabilityPolicy {
         isMeetingRecording: Bool,
         isPreparingModels: Bool,
         hasMeetingWork: Bool,
-        isSpeakerReviewPending: Bool
+        isSpeakerReviewPending: Bool,
+        isTargetSpeakerReview: Bool
     ) -> String? {
         if isDictationActive {
             return "Wait for the current dictation to finish before re-transcribing saved audio."
@@ -179,7 +180,7 @@ enum SavedMeetingRetranscriptionAvailabilityPolicy {
         if hasMeetingWork {
             return "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio."
         }
-        if isSpeakerReviewPending {
+        if isSpeakerReviewPending && !isTargetSpeakerReview {
             return "Finish the speaker review window before re-transcribing saved audio."
         }
         return nil

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -203,7 +203,8 @@ func testRecentCaptureScanners() async {
                 isMeetingRecording: false,
                 isPreparingModels: true,
                 hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                isSpeakerReviewPending: false,
+                isTargetSpeakerReview: false
             ),
             "Preparing models...",
             "saved-meeting re-transcription should not accept duplicate clicks while model prep is in flight"
@@ -217,7 +218,8 @@ func testRecentCaptureScanners() async {
                 isMeetingRecording: false,
                 isPreparingModels: false,
                 hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                isSpeakerReviewPending: false,
+                isTargetSpeakerReview: false
             ),
             "Wait for the current dictation to finish before re-transcribing saved audio.",
             "saved-meeting re-transcription should not race an active dictation"
@@ -228,7 +230,8 @@ func testRecentCaptureScanners() async {
                 isMeetingRecording: true,
                 isPreparingModels: false,
                 hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                isSpeakerReviewPending: false,
+                isTargetSpeakerReview: false
             ),
             "Stop the current recording before re-transcribing saved audio.",
             "saved-meeting re-transcription should not start while a meeting is recording"
@@ -239,7 +242,8 @@ func testRecentCaptureScanners() async {
                 isMeetingRecording: false,
                 isPreparingModels: false,
                 hasMeetingWork: true,
-                isSpeakerReviewPending: false
+                isSpeakerReviewPending: false,
+                isTargetSpeakerReview: false
             ),
             "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.",
             "saved-meeting re-transcription should stay single-flight with background meeting work"
@@ -250,10 +254,25 @@ func testRecentCaptureScanners() async {
                 isMeetingRecording: false,
                 isPreparingModels: false,
                 hasMeetingWork: false,
-                isSpeakerReviewPending: true
+                isSpeakerReviewPending: true,
+                isTargetSpeakerReview: false
             ),
             "Finish the speaker review window before re-transcribing saved audio.",
             "saved-meeting re-transcription should wait until speaker review is resolved"
+        )
+    }
+
+    runSuite("SavedMeetingRetranscriptionAvailabilityPolicy recovers the matching pending review") {
+        assertNil(
+            SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
+                isDictationActive: false,
+                isMeetingRecording: false,
+                isPreparingModels: false,
+                hasMeetingWork: false,
+                isSpeakerReviewPending: true,
+                isTargetSpeakerReview: true
+            ),
+            "a saved meeting with retained audio should escape its own broken speaker review"
         )
     }
 
@@ -264,7 +283,8 @@ func testRecentCaptureScanners() async {
                 isMeetingRecording: false,
                 isPreparingModels: false,
                 hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                isSpeakerReviewPending: false,
+                isTargetSpeakerReview: false
             ),
             "idle saved meetings with retained audio should stay re-transcribable"
         )

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
@@ -915,6 +915,65 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertEqual(message, "That saved audio is too short to transcribe again.")
     }
 
+    func testTooShortReplacementKeepsMatchingSpeakerReviewAndSamples() throws {
+        let manager = makeManager()
+        let transcriptId = UUID()
+        let transcriptURL = tempDirectory.appendingPathComponent("saved-meeting.md")
+        let systemURL = tempDirectory.appendingPathComponent("system_audio.wav")
+        let clipURL = tempDirectory.appendingPathComponent("speaker_sample.wav")
+        try """
+        ---
+        transcript_id: "\(transcriptId.uuidString)"
+        ---
+
+        Sanitized transcript body.
+        """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        try writeMonoWAV(to: systemURL, duration: 1.0)
+        try Data([1]).write(to: clipURL)
+
+        let review = SpeakerNamingRequest(
+            speakers: [
+                SpeakerNamingEntry(
+                    id: UUID(),
+                    diarizerSpeakerId: "1",
+                    channel: .system,
+                    clipURL: clipURL,
+                    sampleText: "Sanitized sample",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: nil,
+                    matchedProfileSnapshot: nil
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: nil,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        )
+        manager.speakerNamingRequest = review
+        let candidate = try XCTUnwrap(
+            manager.speakerNamingReplacementCandidate(at: transcriptURL)
+        )
+
+        manager.startSavedAudioRetranscription(
+            micURL: nil,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            replacementTranscriptURL: transcriptURL,
+            supersedingSpeakerReview: candidate
+        )
+
+        XCTAssertEqual(manager.speakerNamingRequest?.requestId, review.requestId)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: clipURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertEqual(manager.activeCount, 0)
+        XCTAssertEqual(manager.lastFailureDiagnosticMessage, "Recording too short")
+    }
+
     func testSavedAudioRetranscriptionUsesSavedAudioFailureCopyAfterPipelineFailure() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "ignored")

--- a/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/RetroactiveSpeakerUpdaterTests.swift
@@ -394,6 +394,33 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         XCTAssertFalse(TranscriptSaver.isReplacingTranscript(at: renamedURL))
     }
 
+    func testSpeakerFinalizationBarrierUsesStableIdWhenExpectedPathIsGone() throws {
+        let transcriptId = UUID()
+        let expectedURL = temporaryDirectory.appendingPathComponent("Call_2026-08-10_09-03-55.md")
+        let renamedURL = temporaryDirectory.appendingPathComponent("Imported Meeting.md")
+        try """
+        ---
+        capture_id: "\(transcriptId.uuidString)"
+        transcript_id: "\(transcriptId.uuidString)"
+        capture_type: meeting
+        ---
+        """.write(to: renamedURL, atomically: true, encoding: .utf8)
+
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(
+            at: renamedURL,
+            transcriptId: transcriptId
+        ))
+        XCTAssertThrowsError(
+            try TranscriptSaver.serializeTranscriptFileUpdate(
+                protecting: expectedURL,
+                transcriptId: transcriptId
+            ) {}
+        ) { error in
+            XCTAssertEqual(error as? TranscriptFileUpdateError, .replacementInProgress)
+        }
+        TranscriptSaver.finishReplacingTranscript(reservation)
+    }
+
     func testDeferredSpeakerBatchPreflightsEveryReplacementBeforeWriting() throws {
         let speakerId = UUID()
         let firstURL = temporaryDirectory.appendingPathComponent("first-pending-call.md")
@@ -1313,8 +1340,8 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         )
     }
 
-    func testResolveTranscriptURLHandlesUnicodeSplitAtLegacyProbeBoundary() throws {
-        let transcriptId = UUID()
+    func testIssue1681StableIdResolutionSurvivesUnicodeSplitAtLegacyProbeBoundary() throws {
+        let transcriptId = try XCTUnwrap(UUID(uuidString: "13D4DF54-AEC5-434D-8E44-C375E2F87473"))
         let originalURL = tempDirectory.appendingPathComponent("Call_2026-04-10_15-01-23.md")
         let renamedURL = tempDirectory.appendingPathComponent("Long Unicode Meeting.md")
         let frontmatter = """

--- a/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingCoordinatorTests.swift
@@ -63,6 +63,235 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testReplacementSupersedesOnlyMatchingReviewAndRetainsSourceAudio() throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let unrelatedTranscriptId = UUID()
+        let expectedTranscriptURL = harness.paths.transcripts
+            .appendingPathComponent("Call_2026-08-10_09-03-55.md")
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("Imported Meeting.md")
+        let retainedSystemURL = harness.paths.audioCaptures.appendingPathComponent("retained-system.wav")
+        let clipURL = harness.paths.speakerClips.appendingPathComponent("speaker.wav")
+        try """
+        ---
+        capture_id: "\(transcriptId.uuidString)"
+        transcript_id: "\(transcriptId.uuidString)"
+        capture_type: meeting
+        ---
+
+        Sanitized transcript body.
+        """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        try Data([1]).write(to: retainedSystemURL)
+        try Data([2]).write(to: clipURL)
+
+        let matchingRequest = SpeakerNamingRequest(
+            speakers: [
+                SpeakerNamingEntry(
+                    id: UUID(),
+                    diarizerSpeakerId: "1",
+                    channel: .system,
+                    clipURL: clipURL,
+                    sampleText: "Sanitized sample",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: nil,
+                    matchedProfileSnapshot: nil
+                )
+            ],
+            transcriptURL: expectedTranscriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: retainedSystemURL,
+            micAudioURL: nil,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        )
+        let unrelatedRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: harness.paths.transcripts.appendingPathComponent("Other.md"),
+            transcriptId: unrelatedTranscriptId,
+            systemAudioURL: retainedSystemURL,
+            micAudioURL: nil,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        )
+        harness.manager.speakerNamingRequest = matchingRequest
+        harness.manager.pendingSpeakerNamingRequests = [unrelatedRequest]
+
+        let candidate = try XCTUnwrap(
+            harness.manager.speakerNamingReplacementCandidate(at: expectedTranscriptURL)
+        )
+        XCTAssertEqual(candidate.transcriptURL, transcriptURL)
+        XCTAssertTrue(harness.manager.supersedeSpeakerNamingReviewForReplacement(candidate))
+        XCTAssertEqual(harness.manager.speakerNamingRequest?.requestId, unrelatedRequest.requestId)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: retainedSystemURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path))
+    }
+
+    @MainActor
+    func testReplacementCandidateCannotCancelNewerSameTranscriptReview() throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("Meeting.md")
+        let retainedSystemURL = harness.paths.audioCaptures.appendingPathComponent("retained.wav")
+        try """
+        ---
+        transcript_id: "\(transcriptId.uuidString)"
+        ---
+
+        Sanitized transcript body.
+        """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let oldRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: retainedSystemURL,
+            micAudioURL: nil,
+            onComplete: { _ in }
+        )
+        harness.manager.speakerNamingRequest = oldRequest
+        let candidate = try XCTUnwrap(
+            harness.manager.speakerNamingReplacementCandidate(at: transcriptURL)
+        )
+
+        let freshRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: retainedSystemURL,
+            micAudioURL: nil,
+            onComplete: { _ in }
+        )
+        harness.manager.speakerNamingRequest = freshRequest
+
+        XCTAssertFalse(harness.manager.supersedeSpeakerNamingReviewForReplacement(candidate))
+        XCTAssertEqual(harness.manager.speakerNamingRequest?.requestId, freshRequest.requestId)
+    }
+
+    @MainActor
+    func testStaleCompletionCannotClearFreshReviewForSameTranscript() throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let oldRequestId = UUID()
+        let freshRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: harness.paths.transcripts.appendingPathComponent("replacement.md"),
+            transcriptId: transcriptId,
+            systemAudioURL: harness.paths.audioCaptures.appendingPathComponent("retained.wav"),
+            micAudioURL: nil,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        )
+        harness.manager.speakerNamingRequest = freshRequest
+
+        harness.manager.clearCompletedSpeakerNamingRequest(
+            transcriptId: transcriptId,
+            requestId: oldRequestId
+        )
+
+        XCTAssertEqual(harness.manager.speakerNamingRequest?.requestId, freshRequest.requestId)
+    }
+
+    @MainActor
+    func testSupersededFinalizerCannotRewriteReplacementTranscriptOrIdentity() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let oldLease = SpeakerNamingRequestLease()
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.25, count: 256),
+            existingId: nil
+        ).id
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("replacement.md")
+        let clipURL = harness.paths.speakerClips.appendingPathComponent("old-speaker.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("retained.wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "System",
+                label: "Speaker 1",
+                text: "Fresh replacement content."
+            )
+        ]
+        let original = sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: [
+                BreakdownEntry(name: "Speaker 1", utterances: 1, wordCount: 3, duration: "00:03")
+            ]
+        )
+        try original.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        try Data([1]).write(to: clipURL)
+        try Data([2]).write(to: systemURL)
+
+        let freshRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: nil,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        )
+        harness.manager.speakerNamingRequest = freshRequest
+        oldLease.supersede()
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Stale Name",
+                    previousName: nil,
+                    action: .named
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            requestId: oldLease.id,
+            requestLease: oldLease,
+            transcriptionResult: sampleTranscriptionResult(speakers: speakers, utterances: utterances),
+            micURL: nil,
+            systemURL: systemURL,
+            shouldRemoveTemporaryAudio: false,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    channel: .system,
+                    clipURL: clipURL,
+                    sampleText: "Old sample",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: nil,
+                    matchedProfileSnapshot: nil
+                )
+            ]
+        )
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), original)
+        XCTAssertNil(harness.speakerDB.getSpeaker(id: persistentSpeakerId)?.displayName)
+        XCTAssertEqual(harness.manager.speakerNamingRequest?.requestId, freshRequest.requestId)
+        if case .failed = harness.manager.displayStatus {
+            XCTFail("superseded speaker finalization must not publish a stale failure")
+        }
+    }
+
+    @MainActor
     func testCleanupPendingNamingDoesNotDeleteOutOfSandboxFiles() throws {
         let harness = try makeHarness()
         let externalClipURL = tempDirectory.appendingPathComponent("outside-clip.wav")


### PR DESCRIPTION
Fixes #1681.

Supersedes #1693. That draft allowed same-ID request and stale-finalizer races; this branch replaces it with exact review-owner fencing.

## What failed

The sanitized evidence proves the meeting Markdown, retained system audio, and speaker clips were saved before speaker-naming finalization failed to resolve stable ID `13D4DF54-AEC5-434D-8E44-C375E2F87473`. It does **not** prove the exact filesystem trigger because the sanitized Markdown is shorter than the historical UTF-8 prefix boundary. The deterministic reproduction therefore reconstructs the stale expected-path / renamed canonical transcript condition with the evidence ID and a UTF-8 boundary case.

## Recovery

- Re-transcription stays available when the pending speaker review belongs to that exact saved meeting.
- The matching transcript is resolved by stable frontmatter identity, never filename, display name, or newest-file fallback.
- Retained audio and the old speaker review stay intact through model preparation, audio validation, and transcript reservation.
- Recovery revokes only the exact captured review request. A newer same-ID review or unrelated review wins and blocks the stale recovery attempt.
- Superseded finalizers cannot rewrite the replacement transcript, mutate speaker identity, publish stale retry/failure state, or clear a fresh review.
- Transcript finalization and replacement share the stable-ID reservation barrier.

## Automated proof on `4ad639c9`

Green:

- `bash build-deps.sh --force`
- `bash build.sh --no-open` — signed app, 1305.9 ms launch smoke
- `bash run-integration-smoke.sh`
- `swift test` — full TranscriptedCore package suite passed
- focused package recovery regressions, including stale-path resolution, exact-owner supersession, stale finalizer isolation, retained audio, and short-audio rejection
- `bash run-tests.sh --filter RecentCaptureScanners` — 134/134
- `codex review --base origin/main` — clean after fixing both reported races

Not green:

- `bash run-tests.sh` completed with **12,190/12,195**, five failures. Re-running the binary/wrapper to isolate names aborts or exits before printing failure lines. The changed RecentCapture suite passes alone. This is still a red required gate until the five failures are identified; do not merge on this receipt alone.

## Manual proof still required

Automated tests do **not** prove the real 94-minute system-only import, installed-app UI state, retained-audio discovery, or live speaker-sample playback.

Before merge, dogfood an affected or disposable retained-audio meeting and verify:

1. Speaker samples are disabled/pending while re-transcription is enabled only for the matching meeting.
2. Starting recovery preserves the old review until the replacement actually owns the transcript.
3. Short/missing/corrupt audio leaves the original review, sample clips, Markdown, and retained audio intact.
4. Successful recovery produces one Markdown row with the same stable ID, preserves retained audio, and creates playable fresh samples.
5. Naming/saving writes the correct speaker identities without a duplicate meeting.
6. An old review completion racing replacement cannot overwrite the new transcript or speaker database.

This PR is draft because the full fast-test gate and live affected-artifact proof remain open.
