### PR TITLE
Fix saved meeting speaker recovery races

### DIFF
--- a/Sources/Meeting/MeetingCaptureHealthTelemetry.swift
+++ b/Sources/Meeting/MeetingCaptureHealthTelemetry.swift
@@ -70,6 +70,7 @@ enum MeetingCaptureHealthTelemetry {
             uniquingKeysWith: { _, new in new }
         )
         context["mic_file_available"] = boolString(input.micFileAvailable)
+        context["system_failed"] = boolString(input.systemFailed)
         return context
     }
 

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2178,11 +2178,6 @@ final class MeetingSessionController: ObservableObject {
             reportUnrelatedFailure("Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.", reason: "retranscribe_blocked_background_work")
             return false
         }
-        guard !isSpeakerReviewPending else {
-            reportUnrelatedFailure("Finish the speaker review window before re-transcribing saved audio.", reason: "retranscribe_blocked_speaker_review")
-            return false
-        }
-
         DiagnosticsTrail.record(
             engine: "meeting",
             event: "meeting_saved_audio_retranscription_requested",
@@ -2231,7 +2226,7 @@ final class MeetingSessionController: ObservableObject {
             systemURL: systemAudioURL,
             outputFolder: MeetingStoragePaths.transcriptsFolder,
             meetingTitle: title,
-            splitLocalSpeakers: true,
+            splitLocalSpeakers: LocalSpeakerPreferences.isEnabled(),
             replacementTranscriptURL: transcriptURL,
             recordingDate: recordingDate,
             onReplacementTranscriptCommitted: { [weak self] committedTranscriptURL in

--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -43,6 +43,7 @@ struct SentryEventPolicy: Equatable {
 
     private static let allowedDiagnosticTagKeys: Set<String> = [
         "attenuation_kind",
+        "buffer_success_bucket",
         "capture_quality",
         "captured_input_volume_changed",
         "captured_input_volume_dropped",
@@ -97,6 +98,7 @@ struct SentryEventPolicy: Equatable {
         "stt_model",
         "stop_timed_out",
         "system_file_available",
+        "system_failed",
         "system_stream_present",
         "system_status",
         "trigger",

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -496,6 +496,7 @@ extension Audio {
                         strongSelf.error = SystemAudioCaptureFailureCopy.message(for: error)
                         strongSelf.systemAudioFileURL = nil
                         strongSelf.systemAudioFailed = true
+                        strongSelf.systemAudioStatus = .failed
                     }
                 }
             }

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -223,6 +223,10 @@ public struct SpeakerIdentityOption: Identifiable, Hashable {
 
 /// Request to show the speaker naming UI after transcription completes
 public struct SpeakerNamingRequest {
+    /// Unique ownership token for this exact review generation. Replacement
+    /// retranscription preserves the transcript UUID, so transcript identity
+    /// alone cannot distinguish a stale sheet from the fresh review.
+    public let id: UUID
     public let speakers: [SpeakerNamingEntry]
     public let knownPeople: [SpeakerIdentityOption]
     /// Named, mature, undisputed profiles at request time — the sheet's
@@ -239,6 +243,7 @@ public struct SpeakerNamingRequest {
     public let onComplete: ([SpeakerNameUpdate]) -> Void
 
     public init(
+        id: UUID = UUID(),
         speakers: [SpeakerNamingEntry],
         knownPeople: [SpeakerIdentityOption] = [],
         recognizedPeopleCount: Int = 0,
@@ -253,6 +258,7 @@ public struct SpeakerNamingRequest {
         importedRecoverySession: (any ImportedTranscriptionRecoverySession)? = nil,
         onComplete: @escaping ([SpeakerNameUpdate]) -> Void
     ) {
+        self.id = id
         self.speakers = speakers
         self.knownPeople = knownPeople
         self.recognizedPeopleCount = recognizedPeopleCount

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -728,12 +728,14 @@ extension TranscriptionTaskManager {
             }.count
 
             let capturedEntries = namingEntries
+            let speakerNamingRequestId = UUID()
             try await rollback.checkCancellation()
             await MainActor.run {
                 let importedRecoverySession = self.importedRecoverySession(
                     taskId: taskId
                 )
                 self.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+                    id: speakerNamingRequestId,
                     speakers: capturedEntries,
                     knownPeople: knownPeople,
                     recognizedPeopleCount: recognizedPeopleCount,
@@ -759,7 +761,8 @@ extension TranscriptionTaskManager {
                             shouldRemoveSystemAudio: shouldRemoveSystemScratchAudio,
                             sourceFailedTranscriptionId: sourceFailedTranscriptionId,
                             clips: capturedEntries,
-                            importedRecoverySession: importedRecoverySession
+                            importedRecoverySession: importedRecoverySession,
+                            requestId: speakerNamingRequestId
                         )
                     }
                 ))
@@ -772,7 +775,10 @@ extension TranscriptionTaskManager {
             // handed off to a request object that can outlive this function.
             let manager = self
             rollback.register {
-                await manager.cancelSpeakerNamingRequest(transcriptId: transcriptId)
+                await manager.cancelSpeakerNamingRequest(
+                    transcriptId: transcriptId,
+                    requestId: speakerNamingRequestId
+                )
                 AppLogger.pipeline.info("Rollback: cancelled queued speaker naming request", [
                     "transcriptId": transcriptId.uuidString
                 ])

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -137,6 +137,8 @@ public class TranscriptionTaskManager: ObservableObject {
     /// `TaskLifecycleState` for the combination analysis.
     private var tasks: [UUID: TaskLifecycleState] = [:]
     var pendingSpeakerNamingRequests: [SpeakerNamingRequest] = []
+    var deferredSpeakerNamingRequests: [UUID: SpeakerNamingRequest] = [:]
+    let speakerNamingRequestOwnership = SpeakerNamingRequestOwnership()
     public let transcription: Transcription
 
     public let failedTranscriptionManager: FailedTranscriptionManager
@@ -676,6 +678,7 @@ public class TranscriptionTaskManager: ObservableObject {
             // re-transcribed" message below. A responsive window plus a retryable error
             // beats a frozen window, so do not "fix" this by reserving on the main actor.
             var heldReplacementReservation: ReplacementTranscriptReservationToken?
+            var priorSpeakerReviewRequestIds: [UUID: Set<UUID>] = [:]
             defer {
                 if let heldReplacementReservation {
                     TranscriptSaver.finishReplacingTranscript(heldReplacementReservation)
@@ -701,6 +704,17 @@ public class TranscriptionTaskManager: ObservableObject {
                     return
                 }
                 heldReplacementReservation = reservation
+                if let replacementTranscriptId = TranscriptSaver.transcriptIdentity(
+                    at: replacementTranscriptURL
+                ) {
+                    priorSpeakerReviewRequestIds[replacementTranscriptId] =
+                        speakerNamingRequestIds(transcriptId: replacementTranscriptId)
+                } else {
+                    priorSpeakerReviewRequestIds = speakerNamingRequestIds(
+                        transcriptURL: replacementTranscriptURL
+                    )
+                }
+
             }
 
             do {
@@ -721,6 +735,20 @@ public class TranscriptionTaskManager: ObservableObject {
                     targetTranscriptURL: replacementTranscriptURL,
                     archiveRecordingAudio: replacementTranscriptURL == nil
                 )
+
+                if replacementTranscriptURL != nil {
+                    // Retire only review generations that existed before the
+                    // successful replacement. A fresh request enqueued by this
+                    // pipeline has a different ID and stays active. On failure or
+                    // cancellation this line is never reached, so the old review
+                    // remains recoverable.
+                    for (transcriptId, requestIds) in priorSpeakerReviewRequestIds {
+                        supersedeSpeakerNamingRequests(
+                            transcriptId: transcriptId,
+                            requestIds: requestIds
+                        )
+                    }
+                }
 
                 // The replacement file is fully committed. Release its writer
                 // barrier before publishing the save, because that publication

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -1,5 +1,71 @@
 import Foundation
 
+/// Tracks which review generation owns each stable transcript identity.
+///
+/// Callers deliberately consult and mutate this registry while holding
+/// `TranscriptSaver`'s file-update serializer. That makes ownership changes
+/// atomic with transcript replacement/finalization ordering: a stale callback
+/// either finishes before supersession (and is then overwritten by the new
+/// transcript) or observes that it no longer owns the file and does nothing.
+final class SpeakerNamingRequestOwnership: @unchecked Sendable {
+    private struct Entry {
+        let requestId: UUID
+        let transcriptURL: URL
+    }
+
+    private let lock = NSLock()
+    private var entriesByTranscriptId: [UUID: [Entry]] = [:]
+
+    func install(requestId: UUID, transcriptId: UUID, transcriptURL: URL) {
+        lock.lock()
+        var entries = entriesByTranscriptId[transcriptId, default: []]
+        entries.removeAll { $0.requestId == requestId }
+        entries.append(Entry(
+            requestId: requestId,
+            transcriptURL: transcriptURL.standardizedFileURL
+        ))
+        entriesByTranscriptId[transcriptId] = entries
+        lock.unlock()
+    }
+
+    func isCurrent(requestId: UUID, transcriptId: UUID) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return entriesByTranscriptId[transcriptId]?.last?.requestId == requestId
+    }
+
+    func requestId(transcriptId: UUID) -> UUID? {
+        lock.lock()
+        defer { lock.unlock() }
+        return entriesByTranscriptId[transcriptId]?.last?.requestId
+    }
+
+    func requests(transcriptURL: URL) -> [UUID: Set<UUID>] {
+        let targetURL = transcriptURL.standardizedFileURL
+        lock.lock()
+        defer { lock.unlock() }
+        return entriesByTranscriptId.compactMapValues { entries in
+            let requestIds = Set(entries.compactMap { entry in
+                entry.transcriptURL == targetURL ? entry.requestId : nil
+            })
+            return requestIds.isEmpty ? nil : requestIds
+        }
+    }
+
+    func invalidate(transcriptId: UUID, requestId: UUID? = nil) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let requestId {
+            entriesByTranscriptId[transcriptId]?.removeAll { $0.requestId == requestId }
+            if entriesByTranscriptId[transcriptId]?.isEmpty == true {
+                entriesByTranscriptId.removeValue(forKey: transcriptId)
+            }
+        } else {
+            entriesByTranscriptId.removeValue(forKey: transcriptId)
+        }
+    }
+}
+
 // MARK: - Speaker Naming Flow Coordination
 
 extension TranscriptionTaskManager {
@@ -19,6 +85,7 @@ extension TranscriptionTaskManager {
         case completed
         case transcriptFinalizationFailed
         case metadataPublicationFailed
+        case superseded
     }
 
     private enum PlannedSpeakerMutation {
@@ -50,7 +117,8 @@ extension TranscriptionTaskManager {
         shouldRemoveSystemAudio: Bool? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
         clips: [SpeakerNamingEntry],
-        importedRecoverySession: (any ImportedTranscriptionRecoverySession)? = nil
+        importedRecoverySession: (any ImportedTranscriptionRecoverySession)? = nil,
+        requestId: UUID? = nil
     ) {
         let removeMicAudio = shouldRemoveMicAudio ?? shouldRemoveTemporaryAudio
         let removeSystemAudio = shouldRemoveSystemAudio ?? shouldRemoveTemporaryAudio
@@ -88,12 +156,30 @@ extension TranscriptionTaskManager {
         let newlyCreatedMicProfileIds = transcriptionResult.newlyCreatedMicProfileIds
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
+            guard let self else { return }
+            let requestIsCurrent = {
+                guard let requestId else { return true }
+                return TranscriptSaver.serializeTranscriptFileUpdate {
+                    self.speakerNamingRequestOwnership.isCurrent(
+                        requestId: requestId,
+                        transcriptId: transcriptId
+                    )
+                }
+            }
+            guard requestIsCurrent() else {
+                AppLogger.pipeline.info("Ignored superseded speaker naming callback", [
+                    "transcriptId": transcriptId.uuidString
+                ])
+                return
+            }
+
             guard let plannedChanges = Self.planNamingUpdates(
                 regularUpdates,
                 clipsBySpeakerId: clipsBySpeakerId,
                 speakerDB: speakerDB
             ) else {
-                self?.cleanupNamingArtifacts(
+                guard requestIsCurrent() else { return }
+                self.cleanupNamingArtifacts(
                     clips: clips,
                     micURL: micURL,
                     systemURL: systemURL,
@@ -103,7 +189,6 @@ extension TranscriptionTaskManager {
                 )
 
                 Task { @MainActor in
-                    guard let self else { return }
                     _ = self.finishNamingFlow(
                         didFinalizeTranscript: false,
                         updatesCount: updates.count,
@@ -111,9 +196,13 @@ extension TranscriptionTaskManager {
                         resolvedURL: transcriptURL,
                         micURL: micURL,
                         systemURL: systemURL,
-                        sourceFailedTranscriptionId: sourceFailedTranscriptionId
+                        sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+                        requestId: requestId
                     )
-                    self.clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
+                    self.clearCompletedSpeakerNamingRequest(
+                        transcriptId: transcriptId,
+                        requestId: requestId
+                    )
                 }
                 return
             }
@@ -129,15 +218,46 @@ extension TranscriptionTaskManager {
             // renames. Otherwise the styler can move the canonical file after resolution but
             // before the first speaker rewrite, leaving finalization pointed at a stale path.
             let finalization = TranscriptSaver.serializeTranscriptFileUpdate {
+                if let requestId,
+                   !self.speakerNamingRequestOwnership.isCurrent(
+                    requestId: requestId,
+                    transcriptId: transcriptId
+                   ) {
+                    return (
+                        didFinalize: false,
+                        resolvedURL: transcriptURL,
+                        superseded: true,
+                        replacementInProgress: false
+                    )
+                }
+                guard !TranscriptSaver.isReplacingTranscript(at: transcriptURL),
+                      !TranscriptSaver.isReplacingTranscript(transcriptId: transcriptId) else {
+                    return (
+                        didFinalize: false,
+                        resolvedURL: transcriptURL,
+                        superseded: false,
+                        replacementInProgress: true
+                    )
+                }
                 guard let resolvedURL = TranscriptSaver.resolveTranscriptURL(
                     transcriptURL,
                     transcriptId: transcriptId
                 ) else {
-                    return (didFinalize: false, resolvedURL: transcriptURL)
+                    return (
+                        didFinalize: false,
+                        resolvedURL: transcriptURL,
+                        superseded: false,
+                        replacementInProgress: false
+                    )
                 }
                 guard let originalTranscriptData = try? Data(contentsOf: resolvedURL) else {
                     AppLogger.speakers.error("Speaker naming could not snapshot the transcript before update")
-                    return (didFinalize: false, resolvedURL: resolvedURL)
+                    return (
+                        didFinalize: false,
+                        resolvedURL: resolvedURL,
+                        superseded: false,
+                        replacementInProgress: false
+                    )
                 }
 
                 var didFinalize = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
@@ -196,7 +316,24 @@ extension TranscriptionTaskManager {
                     }
                 }
 
-                return (didFinalize: didFinalize, resolvedURL: resolvedURL)
+                return (
+                    didFinalize: didFinalize,
+                    resolvedURL: resolvedURL,
+                    superseded: false,
+                    replacementInProgress: false
+                )
+            }
+            guard !finalization.superseded else {
+                AppLogger.pipeline.info("Stopped stale speaker finalization after supersession", [
+                    "transcriptId": transcriptId.uuidString
+                ])
+                return
+            }
+            guard !finalization.replacementInProgress else {
+                AppLogger.pipeline.info("Deferred speaker finalization while replacement is committing", [
+                    "transcriptId": transcriptId.uuidString
+                ])
+                return
             }
             let didFinalizeTranscript = finalization.didFinalize
             let resolvedURL = finalization.resolvedURL
@@ -240,7 +377,7 @@ extension TranscriptionTaskManager {
 
             if !didFinalizeTranscript {
                 let shouldKeepAudioForFailedRetry = sourceFailedTranscriptionId != nil
-                self?.cleanupNamingArtifacts(
+                self.cleanupNamingArtifacts(
                     clips: clips,
                     micURL: micURL,
                     systemURL: systemURL,
@@ -251,7 +388,6 @@ extension TranscriptionTaskManager {
             }
 
             Task { @MainActor in
-                guard let self else { return }
                 let outcome = self.finishNamingFlow(
                     didFinalizeTranscript: didFinalizeTranscript,
                     updatesCount: updates.count,
@@ -260,7 +396,8 @@ extension TranscriptionTaskManager {
                     micURL: micURL,
                     systemURL: systemURL,
                     sourceFailedTranscriptionId: sourceFailedTranscriptionId,
-                    shouldDeleteSourceFailedAudio: shouldRemoveTemporaryAudio
+                    shouldDeleteSourceFailedAudio: shouldRemoveTemporaryAudio,
+                    requestId: requestId
                 )
                 switch outcome {
                 case .completed:
@@ -284,8 +421,13 @@ extension TranscriptionTaskManager {
                     )
                 case .transcriptFinalizationFailed:
                     break
+                case .superseded:
+                    return
                 }
-                self.clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
+                self.clearCompletedSpeakerNamingRequest(
+                    transcriptId: transcriptId,
+                    requestId: requestId
+                )
             }
         }
     }
@@ -293,26 +435,66 @@ extension TranscriptionTaskManager {
     /// Clean up any tasks stuck in pendingNaming state.
     /// Called from applicationWillTerminate to prevent orphaned audio files.
     public func cleanupPendingNaming() {
-        let requests = [speakerNamingRequest].compactMap { $0 } + pendingSpeakerNamingRequests
+        let requests = [speakerNamingRequest].compactMap { $0 }
+            + pendingSpeakerNamingRequests
+            + Array(deferredSpeakerNamingRequests.values)
         guard !requests.isEmpty else { return }
 
+        TranscriptSaver.serializeTranscriptFileUpdate {
+            for request in requests {
+                speakerNamingRequestOwnership.invalidate(
+                    transcriptId: request.transcriptId,
+                    requestId: request.id
+                )
+            }
+        }
         for request in requests {
             cleanupSpeakerNamingRequest(request)
         }
         speakerNamingRequest = nil
         pendingSpeakerNamingRequests.removeAll()
+        deferredSpeakerNamingRequests.removeAll()
         AppLogger.pipeline.info("Cleaned up pending naming on shutdown", [
             "count": "\(requests.count)"
         ])
     }
 
     func enqueueSpeakerNamingRequest(_ request: SpeakerNamingRequest) {
-        if speakerNamingRequest?.transcriptId == request.transcriptId
-            || pendingSpeakerNamingRequests.contains(where: { $0.transcriptId == request.transcriptId }) {
-            AppLogger.pipeline.warning("Ignoring duplicate speaker naming request", [
+        let duplicateRequests = [speakerNamingRequest].compactMap { $0 }
+            .filter { $0.transcriptId == request.transcriptId }
+            + pendingSpeakerNamingRequests.filter { $0.transcriptId == request.transcriptId }
+            + deferredSpeakerNamingRequests.values.filter {
+                $0.transcriptId == request.transcriptId
+            }
+        if !duplicateRequests.isEmpty {
+            let isReplacementGeneration = TranscriptSaver.hasReplacementReservation(
+                at: request.transcriptURL
+            ) || TranscriptSaver.hasReplacementReservation(
+                transcriptId: request.transcriptId
+            )
+            guard isReplacementGeneration else {
+                AppLogger.pipeline.warning("Ignoring duplicate speaker naming request", [
+                    "transcriptId": request.transcriptId.uuidString
+                ])
+                return
+            }
+
+            // Keep the previous generation until the replacement task commits.
+            // This request becomes the current owner immediately, so an old
+            // callback cannot edit the replacement file. If the task rolls back,
+            // removing this request reveals the prior owner and review.
+        }
+
+        speakerNamingRequestOwnership.install(
+            requestId: request.id,
+            transcriptId: request.transcriptId,
+            transcriptURL: request.transcriptURL
+        )
+
+        if !duplicateRequests.isEmpty {
+            AppLogger.pipeline.info("Superseded speaker review with replacement generation", [
                 "transcriptId": request.transcriptId.uuidString
             ])
-            return
         }
 
         guard speakerNamingRequest != nil else {
@@ -330,6 +512,7 @@ extension TranscriptionTaskManager {
     public func deferPendingSpeakerNamingReview(reason: String) -> Bool {
         guard let request = speakerNamingRequest else { return false }
         speakerNamingRequest = nil
+        deferredSpeakerNamingRequests[request.id] = request
 
         AppLogger.pipeline.info("Deferring pending speaker review", [
             "reason": reason,
@@ -362,8 +545,12 @@ extension TranscriptionTaskManager {
             }
     }
 
-    private func cleanupSpeakerNamingRequest(_ request: SpeakerNamingRequest) {
-        if request.shouldRemoveMicAudioOnCleanup || request.shouldRemoveSystemAudioOnCleanup {
+    private func cleanupSpeakerNamingRequest(
+        _ request: SpeakerNamingRequest,
+        preservingSourceAudio: Bool = false
+    ) {
+        if !preservingSourceAudio
+            && (request.shouldRemoveMicAudioOnCleanup || request.shouldRemoveSystemAudioOnCleanup) {
             if request.importedRecoverySession?.prepareForScratchCleanup() != false {
                 let removedMic = !request.shouldRemoveMicAudioOnCleanup
                     || removeManagedCleanupFile(request.micAudioURL, label: "pending mic audio")
@@ -377,30 +564,124 @@ extension TranscriptionTaskManager {
         cleanupSpeakerClips(request.speakers)
     }
 
-    func clearCompletedSpeakerNamingRequest(transcriptId: UUID) {
-        if speakerNamingRequest?.transcriptId == transcriptId {
+    func clearCompletedSpeakerNamingRequest(
+        transcriptId: UUID,
+        requestId: UUID? = nil
+    ) {
+        TranscriptSaver.serializeTranscriptFileUpdate {
+            speakerNamingRequestOwnership.invalidate(
+                transcriptId: transcriptId,
+                requestId: requestId
+            )
+        }
+        if speakerNamingRequest?.transcriptId == transcriptId
+            && (requestId == nil || speakerNamingRequest?.id == requestId) {
             speakerNamingRequest = nil
         }
-        pendingSpeakerNamingRequests.removeAll { $0.transcriptId == transcriptId }
+        pendingSpeakerNamingRequests.removeAll {
+            $0.transcriptId == transcriptId && (requestId == nil || $0.id == requestId)
+        }
+        if let requestId {
+            deferredSpeakerNamingRequests.removeValue(forKey: requestId)
+        } else {
+            deferredSpeakerNamingRequests = deferredSpeakerNamingRequests.filter {
+                $0.value.transcriptId != transcriptId
+            }
+        }
         promoteNextSpeakerNamingRequestIfNeeded()
     }
 
     func cancelSpeakerNamingRequest(transcriptId: UUID) {
-        var cancelledRequests: [SpeakerNamingRequest] = []
-        if let request = speakerNamingRequest, request.transcriptId == transcriptId {
-            cancelledRequests.append(request)
+        removeSpeakerNamingRequests(
+            transcriptId: transcriptId,
+            requestIds: nil,
+            preservingSourceAudio: false
+        )
+    }
+
+    func cancelSpeakerNamingRequest(transcriptId: UUID, requestId: UUID) {
+        removeSpeakerNamingRequests(
+            transcriptId: transcriptId,
+            requestIds: [requestId],
+            preservingSourceAudio: false
+        )
+    }
+
+    func speakerNamingRequestIds(transcriptId: UUID) -> Set<UUID> {
+        var requestIds = Set(([speakerNamingRequest].compactMap { $0 } + pendingSpeakerNamingRequests)
+            .filter { $0.transcriptId == transcriptId }
+            .map(\.id))
+        if let ownedRequestId = speakerNamingRequestOwnership.requestId(transcriptId: transcriptId) {
+            requestIds.insert(ownedRequestId)
+        }
+        return requestIds
+    }
+
+    func speakerNamingRequestIds(transcriptURL: URL) -> [UUID: Set<UUID>] {
+        let targetURL = transcriptURL.standardizedFileURL
+        let matching = ([speakerNamingRequest].compactMap { $0 } + pendingSpeakerNamingRequests)
+            .filter { $0.transcriptURL.standardizedFileURL == targetURL }
+        var requestIds = Dictionary(grouping: matching, by: \.transcriptId)
+            .mapValues { Set($0.map(\.id)) }
+        for (transcriptId, ownedRequestIds) in speakerNamingRequestOwnership.requests(
+            transcriptURL: transcriptURL
+        ) {
+            requestIds[transcriptId, default: []].formUnion(ownedRequestIds)
+        }
+        return requestIds
+    }
+
+    func supersedeSpeakerNamingRequests(
+        transcriptId: UUID,
+        requestIds: Set<UUID>
+    ) {
+        guard !requestIds.isEmpty else { return }
+        removeSpeakerNamingRequests(
+            transcriptId: transcriptId,
+            requestIds: requestIds,
+            preservingSourceAudio: true
+        )
+    }
+
+    private func removeSpeakerNamingRequests(
+        transcriptId: UUID,
+        requestIds: Set<UUID>?,
+        preservingSourceAudio: Bool
+    ) {
+        let matchesTarget: (SpeakerNamingRequest) -> Bool = { request in
+            request.transcriptId == transcriptId
+                && (requestIds.map { $0.contains(request.id) } ?? true)
+        }
+        let cancelledRequests = [speakerNamingRequest].compactMap { $0 }
+            .filter(matchesTarget)
+            + pendingSpeakerNamingRequests.filter(matchesTarget)
+            + deferredSpeakerNamingRequests.values.filter(matchesTarget)
+
+        TranscriptSaver.serializeTranscriptFileUpdate {
+            if let requestIds {
+                for requestId in requestIds {
+                    speakerNamingRequestOwnership.invalidate(
+                        transcriptId: transcriptId,
+                        requestId: requestId
+                    )
+                }
+            } else {
+                speakerNamingRequestOwnership.invalidate(transcriptId: transcriptId)
+            }
+        }
+        if let activeRequest = speakerNamingRequest,
+           matchesTarget(activeRequest) {
             speakerNamingRequest = nil
         }
-        pendingSpeakerNamingRequests.removeAll { request in
-            if request.transcriptId == transcriptId {
-                cancelledRequests.append(request)
-                return true
-            }
-            return false
+        pendingSpeakerNamingRequests.removeAll(where: matchesTarget)
+        deferredSpeakerNamingRequests = deferredSpeakerNamingRequests.filter {
+            !matchesTarget($0.value)
         }
-
         for request in cancelledRequests {
-            cleanupSpeakerNamingRequest(request)
+            cleanupSpeakerNamingRequest(
+                request,
+                preservingSourceAudio: preservingSourceAudio
+            )
         }
         promoteNextSpeakerNamingRequestIfNeeded()
     }
@@ -917,26 +1198,48 @@ extension TranscriptionTaskManager {
         micURL: URL?,
         systemURL: URL,
         sourceFailedTranscriptionId: UUID? = nil,
-        shouldDeleteSourceFailedAudio: Bool = true
+        shouldDeleteSourceFailedAudio: Bool = true,
+        requestId: UUID? = nil
     ) -> NamingFlowFinishOutcome {
         if didFinalizeTranscript {
             // A title/style rename can queue behind transcript finalization and move the file
             // before this MainActor handoff runs. Resolve and consume metadata in one serialized
             // transaction so UI bookkeeping never publishes the stale pre-rename URL.
-            let metadataPublication: (resolvedURL: URL, didAlreadyPublish: Bool)? =
-                TranscriptSaver.serializeTranscriptFileUpdate {
+            let publicationAttempt = TranscriptSaver.serializeTranscriptFileUpdate {
+                    if let requestId,
+                       !speakerNamingRequestOwnership.isCurrent(
+                        requestId: requestId,
+                        transcriptId: transcriptId
+                       ) {
+                        return (
+                            metadata: Optional<(resolvedURL: URL, didAlreadyPublish: Bool)>.none,
+                            superseded: true
+                        )
+                    }
                     guard let currentURL = TranscriptSaver.resolveTranscriptURL(
                         resolvedURL,
                         transcriptId: transcriptId
                     ) else {
-                        return nil
+                        return (
+                            metadata: Optional<(resolvedURL: URL, didAlreadyPublish: Bool)>.none,
+                            superseded: false
+                        )
                     }
 
                     let didAlreadyPublish = lastSavedTranscriptId == transcriptId
                         || lastSavedTranscriptURL == currentURL
                     populateSavedMetadata(from: currentURL)
-                    return (resolvedURL: currentURL, didAlreadyPublish: didAlreadyPublish)
+                    return (
+                        metadata: Optional.some((
+                            resolvedURL: currentURL,
+                            didAlreadyPublish: didAlreadyPublish
+                        )),
+                        superseded: false
+                    )
                 }
+
+            guard !publicationAttempt.superseded else { return .superseded }
+            let metadataPublication = publicationAttempt.metadata
 
             guard let metadataPublication else {
                 AppLogger.pipeline.error("Speaker naming metadata publication failed", [

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -166,7 +166,20 @@ extension TranscriptionTaskManager {
                     )
                 }
             }
-            guard requestIsCurrent() else {
+            let replacementIsInProgress = {
+                TranscriptSaver.hasReplacementReservation(at: transcriptURL)
+                    || TranscriptSaver.hasReplacementReservation(transcriptId: transcriptId)
+            }
+            let waitForCurrentRequestAfterReplacement = {
+                while !requestIsCurrent() && replacementIsInProgress() {
+                    // The review UI has already consumed this one-shot callback.
+                    // A replacement failure can restore this generation, so keep
+                    // it alive until ownership reaches a permanent outcome.
+                    Thread.sleep(forTimeInterval: 0.1)
+                }
+                return requestIsCurrent()
+            }
+            guard waitForCurrentRequestAfterReplacement() else {
                 AppLogger.pipeline.info("Ignored superseded speaker naming callback", [
                     "transcriptId": transcriptId.uuidString
                 ])
@@ -224,11 +237,16 @@ extension TranscriptionTaskManager {
                         requestId: requestId,
                         transcriptId: transcriptId
                        ) {
+                        let replacementInProgress = TranscriptSaver.hasReplacementReservation(
+                            at: transcriptURL
+                        ) || TranscriptSaver.hasReplacementReservation(
+                            transcriptId: transcriptId
+                        )
                         return (
                             didFinalize: false,
                             resolvedURL: transcriptURL,
-                            superseded: true,
-                            replacementInProgress: false
+                            superseded: !replacementInProgress,
+                            replacementInProgress: replacementInProgress
                         )
                     }
                     guard !TranscriptSaver.isReplacingTranscript(at: transcriptURL),
@@ -334,7 +352,7 @@ extension TranscriptionTaskManager {
                 // retry only the serialized file-finalization step; speaker DB
                 // mutations above are intentionally not repeated.
                 Thread.sleep(forTimeInterval: 0.1)
-                guard requestIsCurrent() else { return }
+                guard waitForCurrentRequestAfterReplacement() else { return }
                 finalization = finalizeTranscript()
             }
             guard !finalization.superseded else {

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -217,48 +217,49 @@ extension TranscriptionTaskManager {
             // Resolve and mutate under the same serializer used by transcript styling/title
             // renames. Otherwise the styler can move the canonical file after resolution but
             // before the first speaker rewrite, leaving finalization pointed at a stale path.
-            let finalization = TranscriptSaver.serializeTranscriptFileUpdate {
-                if let requestId,
-                   !self.speakerNamingRequestOwnership.isCurrent(
-                    requestId: requestId,
-                    transcriptId: transcriptId
-                   ) {
-                    return (
-                        didFinalize: false,
-                        resolvedURL: transcriptURL,
-                        superseded: true,
-                        replacementInProgress: false
-                    )
-                }
-                guard !TranscriptSaver.isReplacingTranscript(at: transcriptURL),
-                      !TranscriptSaver.isReplacingTranscript(transcriptId: transcriptId) else {
-                    return (
-                        didFinalize: false,
-                        resolvedURL: transcriptURL,
-                        superseded: false,
-                        replacementInProgress: true
-                    )
-                }
-                guard let resolvedURL = TranscriptSaver.resolveTranscriptURL(
-                    transcriptURL,
-                    transcriptId: transcriptId
-                ) else {
-                    return (
-                        didFinalize: false,
-                        resolvedURL: transcriptURL,
-                        superseded: false,
-                        replacementInProgress: false
-                    )
-                }
-                guard let originalTranscriptData = try? Data(contentsOf: resolvedURL) else {
-                    AppLogger.speakers.error("Speaker naming could not snapshot the transcript before update")
-                    return (
-                        didFinalize: false,
-                        resolvedURL: resolvedURL,
-                        superseded: false,
-                        replacementInProgress: false
-                    )
-                }
+            let finalizeTranscript = {
+                TranscriptSaver.serializeTranscriptFileUpdate {
+                    if let requestId,
+                       !self.speakerNamingRequestOwnership.isCurrent(
+                        requestId: requestId,
+                        transcriptId: transcriptId
+                       ) {
+                        return (
+                            didFinalize: false,
+                            resolvedURL: transcriptURL,
+                            superseded: true,
+                            replacementInProgress: false
+                        )
+                    }
+                    guard !TranscriptSaver.isReplacingTranscript(at: transcriptURL),
+                          !TranscriptSaver.isReplacingTranscript(transcriptId: transcriptId) else {
+                        return (
+                            didFinalize: false,
+                            resolvedURL: transcriptURL,
+                            superseded: false,
+                            replacementInProgress: true
+                        )
+                    }
+                    guard let resolvedURL = TranscriptSaver.resolveTranscriptURL(
+                        transcriptURL,
+                        transcriptId: transcriptId
+                    ) else {
+                        return (
+                            didFinalize: false,
+                            resolvedURL: transcriptURL,
+                            superseded: false,
+                            replacementInProgress: false
+                        )
+                    }
+                    guard let originalTranscriptData = try? Data(contentsOf: resolvedURL) else {
+                        AppLogger.speakers.error("Speaker naming could not snapshot the transcript before update")
+                        return (
+                            didFinalize: false,
+                            resolvedURL: resolvedURL,
+                            superseded: false,
+                            replacementInProgress: false
+                        )
+                    }
 
                 var didFinalize = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
                     transcriptURL: resolvedURL,
@@ -316,21 +317,28 @@ extension TranscriptionTaskManager {
                     }
                 }
 
-                return (
-                    didFinalize: didFinalize,
-                    resolvedURL: resolvedURL,
-                    superseded: false,
-                    replacementInProgress: false
-                )
+                    return (
+                        didFinalize: didFinalize,
+                        resolvedURL: resolvedURL,
+                        superseded: false,
+                        replacementInProgress: false
+                    )
+                }
+            }
+            var finalization = finalizeTranscript()
+            while finalization.replacementInProgress {
+                // A replacement reservation can span model preparation and a
+                // full transcription. The review sheet has already handed us
+                // its one completion callback, so returning here would strand
+                // an invisible request forever. Wait off the main actor and
+                // retry only the serialized file-finalization step; speaker DB
+                // mutations above are intentionally not repeated.
+                Thread.sleep(forTimeInterval: 0.1)
+                guard requestIsCurrent() else { return }
+                finalization = finalizeTranscript()
             }
             guard !finalization.superseded else {
                 AppLogger.pipeline.info("Stopped stale speaker finalization after supersession", [
-                    "transcriptId": transcriptId.uuidString
-                ])
-                return
-            }
-            guard !finalization.replacementInProgress else {
-                AppLogger.pipeline.info("Deferred speaker finalization while replacement is committing", [
                     "transcriptId": transcriptId.uuidString
                 ])
                 return
@@ -639,7 +647,7 @@ extension TranscriptionTaskManager {
         removeSpeakerNamingRequests(
             transcriptId: transcriptId,
             requestIds: requestIds,
-            preservingSourceAudio: true
+            preservingSourceAudio: false
         )
     }
 

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -45,6 +45,12 @@ private final class ReplacementTranscriptReservations: @unchecked Sendable {
         }
     }
 
+    func contains(transcriptId: UUID) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries.values.contains { $0.transcriptId == transcriptId }
+    }
+
     private func key(for url: URL) -> String {
         url.standardizedFileURL.resolvingSymlinksInPath().path
     }
@@ -142,7 +148,7 @@ public class TranscriptSaver {
             guard FileManager.default.fileExists(atPath: url.path) else { return nil }
             return replacementReservations.reserve(
                 url,
-                transcriptId: stableTranscriptIdentity(at: url)
+                transcriptId: transcriptIdentity(at: url)
             )
         }
     }
@@ -157,9 +163,26 @@ public class TranscriptSaver {
         serializeTranscriptFileUpdate {
             replacementReservations.contains(
                 url,
-                transcriptId: stableTranscriptIdentity(at: url)
+                transcriptId: transcriptIdentity(at: url)
             )
         }
+    }
+
+    static func isReplacingTranscript(transcriptId: UUID) -> Bool {
+        serializeTranscriptFileUpdate {
+            replacementReservations.contains(transcriptId: transcriptId)
+        }
+    }
+
+    /// Non-blocking reservation probes for MainActor request routing. The
+    /// reservation registry has its own lock; callers that need to make a file
+    /// mutation decision still use the serialized APIs above.
+    static func hasReplacementReservation(at url: URL) -> Bool {
+        replacementReservations.contains(url, transcriptId: nil)
+    }
+
+    static func hasReplacementReservation(transcriptId: UUID) -> Bool {
+        replacementReservations.contains(transcriptId: transcriptId)
     }
 
     static func isReplacingAnyTranscript(at urls: [URL]) -> Bool {
@@ -167,13 +190,13 @@ public class TranscriptSaver {
             urls.contains { url in
                 replacementReservations.contains(
                     url,
-                    transcriptId: stableTranscriptIdentity(at: url)
+                    transcriptId: transcriptIdentity(at: url)
                 )
             }
         }
     }
 
-    private static func stableTranscriptIdentity(at url: URL) -> UUID? {
+    static func transcriptIdentity(at url: URL) -> UUID? {
         guard let values = try? TranscriptFrontmatter.readValues(
             from: url,
             byteLimit: stableIdentityReadChunkSize

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1883,8 +1883,7 @@ struct TranscriptedSettingsView: View {
             isDictationActive: sttRouter.isRecording || sttRouter.isTranscribing,
             isMeetingRecording: meetingSession.isRecording,
             isPreparingModels: meetingSession.state == .loadingModels,
-            hasMeetingWork: meetingSession.hasRuntimeDiagnosticsWork,
-            isSpeakerReviewPending: meetingSession.isSpeakerReviewPending
+            hasMeetingWork: meetingSession.hasRuntimeDiagnosticsWork
         )
     }
 

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -164,8 +164,7 @@ enum SavedMeetingRetranscriptionAvailabilityPolicy {
         isDictationActive: Bool,
         isMeetingRecording: Bool,
         isPreparingModels: Bool,
-        hasMeetingWork: Bool,
-        isSpeakerReviewPending: Bool
+        hasMeetingWork: Bool
     ) -> String? {
         if isDictationActive {
             return "Wait for the current dictation to finish before re-transcribing saved audio."
@@ -178,9 +177,6 @@ enum SavedMeetingRetranscriptionAvailabilityPolicy {
         }
         if hasMeetingWork {
             return "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio."
-        }
-        if isSpeakerReviewPending {
-            return "Finish the speaker review window before re-transcribing saved audio."
         }
         return nil
     }

--- a/Tests/MeetingCaptureVolumeDiagnosticsTests.swift
+++ b/Tests/MeetingCaptureVolumeDiagnosticsTests.swift
@@ -472,6 +472,7 @@ func testMeetingCaptureVolumeDiagnostics() {
         assertEqual(context?["capture_quality"], "degraded", "degraded context should include capture quality")
         assertEqual(context?["gap_count_bucket"], "4_9", "degraded context should include gap bucket")
         assertEqual(context?["mic_file_available"], "false", "degraded context should include mic file availability")
+        assertEqual(context?["system_failed"], "true", "degraded context should distinguish system capture failure")
         assertEqual(context?["system_stream_present"], "false", "degraded context should include system stream presence")
         assertEqual(context?["stop_timed_out"], "true", "degraded context should include timeout")
     }

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -202,8 +202,7 @@ func testRecentCaptureScanners() async {
                 isDictationActive: false,
                 isMeetingRecording: false,
                 isPreparingModels: true,
-                hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                hasMeetingWork: false
             ),
             "Preparing models...",
             "saved-meeting re-transcription should not accept duplicate clicks while model prep is in flight"
@@ -216,8 +215,7 @@ func testRecentCaptureScanners() async {
                 isDictationActive: true,
                 isMeetingRecording: false,
                 isPreparingModels: false,
-                hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                hasMeetingWork: false
             ),
             "Wait for the current dictation to finish before re-transcribing saved audio.",
             "saved-meeting re-transcription should not race an active dictation"
@@ -227,8 +225,7 @@ func testRecentCaptureScanners() async {
                 isDictationActive: false,
                 isMeetingRecording: true,
                 isPreparingModels: false,
-                hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                hasMeetingWork: false
             ),
             "Stop the current recording before re-transcribing saved audio.",
             "saved-meeting re-transcription should not start while a meeting is recording"
@@ -238,22 +235,19 @@ func testRecentCaptureScanners() async {
                 isDictationActive: false,
                 isMeetingRecording: false,
                 isPreparingModels: false,
-                hasMeetingWork: true,
-                isSpeakerReviewPending: false
+                hasMeetingWork: true
             ),
             "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.",
             "saved-meeting re-transcription should stay single-flight with background meeting work"
         )
-        assertEqual(
+        assertNil(
             SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
                 isDictationActive: false,
                 isMeetingRecording: false,
                 isPreparingModels: false,
-                hasMeetingWork: false,
-                isSpeakerReviewPending: true
+                hasMeetingWork: false
             ),
-            "Finish the speaker review window before re-transcribing saved audio.",
-            "saved-meeting re-transcription should wait until speaker review is resolved"
+            "pending speaker review must not strand retained-audio re-transcription recovery"
         )
     }
 
@@ -263,8 +257,7 @@ func testRecentCaptureScanners() async {
                 isDictationActive: false,
                 isMeetingRecording: false,
                 isPreparingModels: false,
-                hasMeetingWork: false,
-                isSpeakerReviewPending: false
+                hasMeetingWork: false
             ),
             "idle saved meetings with retained audio should stay re-transcribable"
         )

--- a/Tests/RetranscribeLocalSpeakerPreferenceContractTests.swift
+++ b/Tests/RetranscribeLocalSpeakerPreferenceContractTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+func testRetranscribeLocalSpeakerPreferenceContract() {
+    runSuite("Meeting transcription entry points resolve splitLocalSpeakers from the preference") {
+        let controller = readSourceFixture("Sources/Meeting/MeetingSessionController.swift")
+        let coordinator = readSourceFixture("Sources/Meeting/TranscriptionQueueCoordinator.swift")
+
+        guard let retranscribeStart = controller.range(of: "func retranscribeSavedMeeting("),
+              let retranscribeEnd = controller.range(
+                  of: "private func handleReplacementTranscriptCommitted(",
+                  range: retranscribeStart.upperBound..<controller.endIndex
+              ) else {
+            assertTrue(false, "test should find retranscribeSavedMeeting")
+            return
+        }
+        let retranscribe = String(controller[retranscribeStart.lowerBound..<retranscribeEnd.lowerBound])
+
+        assertTrue(
+            retranscribe.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
+            "saved-audio retranscription should honour the People-in-the-room preference"
+        )
+        assertTrue(
+            !retranscribe.contains("splitLocalSpeakers: true"),
+            "saved-audio retranscription should not hard-code local speaker splitting"
+        )
+        assertTrue(
+            coordinator.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
+            "live capture transcription should keep reading the preference"
+        )
+    }
+}

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -276,6 +276,7 @@ func testSentryEventPolicy() {
                 "default_output_volume_dropped": "true",
                 "default_system_output_volume_dropped": "true",
                 "default_input_volume_dropped": "false",
+                "buffer_success_bucket": "98_100",
                 "output_ducking_detected": "true",
                 "quiet_mic_recovered": "false",
                 "quiet_mic_unrecovered": "true",
@@ -284,6 +285,7 @@ func testSentryEventPolicy() {
                 "reason": "user_stop",
                 "stop_timed_out": "false",
                 "system_stream_present": "false",
+                "system_failed": "true",
                 "system_status": "failed",
             ]
         )
@@ -291,6 +293,7 @@ func testSentryEventPolicy() {
         assertEqual(tags["default_output_volume_dropped"], "true", "output volume drops should be queryable in APPLE-MACOS-1B")
         assertEqual(tags["default_system_output_volume_dropped"], "true", "system output drops should be queryable in APPLE-MACOS-1B")
         assertEqual(tags["default_input_volume_dropped"], "false", "input volume state should stay available as a control")
+        assertEqual(tags["buffer_success_bucket"], "98_100", "coarse buffer success should distinguish expected silence from write loss")
         assertEqual(tags["output_ducking_detected"], "true", "ducking classification should stay queryable")
         assertEqual(tags["quiet_mic_recovered"], "false", "quiet mic recovery state should stay queryable")
         assertEqual(tags["quiet_mic_unrecovered"], "true", "unrecovered quiet mic state should stay queryable")
@@ -299,6 +302,7 @@ func testSentryEventPolicy() {
         assertEqual(tags["reason"], "user_stop", "stop reason should stay queryable for degraded captures")
         assertEqual(tags["stop_timed_out"], "false", "stop timeout state should stay queryable for degraded captures")
         assertEqual(tags["system_stream_present"], "false", "system file presence should stay queryable for degraded captures")
+        assertEqual(tags["system_failed"], "true", "system capture failure should stay queryable for degraded captures")
         assertEqual(tags["system_status"], "failed", "existing meeting health tags should still survive")
     }
 

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
@@ -409,6 +409,16 @@ extension TranscriptionTaskManagerMetadataTests {
         // Never created: beginReplacingTranscript refuses to reserve a file that is not
         // there, which is the "that meeting moved" case the user-facing copy describes.
         let missingTranscriptURL = transcriptsDirectory.appendingPathComponent("Moved_Meeting.md")
+        let pendingReview = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: missingTranscriptURL,
+            transcriptId: UUID(),
+            systemAudioURL: systemURL,
+            micAudioURL: nil,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        )
+        manager.enqueueSpeakerNamingRequest(pendingReview)
 
         manager.startSavedAudioRetranscription(
             micURL: nil,
@@ -438,6 +448,11 @@ extension TranscriptionTaskManagerMetadataTests {
 
         // Retained user audio is never scratch — it survives the rejection untouched.
         XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertEqual(
+            manager.speakerNamingRequest?.id,
+            pendingReview.id,
+            "failed replacement setup must leave the original review recoverable"
+        )
 
         guard case .failed(let message) = manager.displayStatus else {
             return XCTFail("Expected a missing replacement target to publish a failed status")

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerMetadataTests.swift
@@ -189,23 +189,54 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(manager.lastSavedTranscriptTaskId, taskId)
     }
 
-    func testDeferPendingSpeakerNamingReviewCompletesWithReviewLater() {
+    func testDeferPendingSpeakerNamingReviewCompletesWithReviewLater() throws {
         let manager = makeManager()
+        let transcriptId = UUID()
+        let requestId = UUID()
         var completedUpdates: [SpeakerNameUpdate]?
-        manager.speakerNamingRequest = SpeakerNamingRequest(
-            speakers: [],
+        let clipURL = tempDirectory.appendingPathComponent("speaker_clips/deferred.wav")
+        try Data("clip".utf8).write(to: clipURL)
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            id: requestId,
+            speakers: [
+                SpeakerNamingEntry(
+                    id: UUID(),
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "hello",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false
+                )
+            ],
             transcriptURL: tempDirectory.appendingPathComponent("call.md"),
-            transcriptId: UUID(),
+            transcriptId: transcriptId,
             systemAudioURL: tempDirectory.appendingPathComponent("system.wav"),
             micAudioURL: nil,
             onComplete: { updates in
                 completedUpdates = updates
             }
-        )
+        ))
 
         XCTAssertTrue(manager.deferPendingSpeakerNamingReview(reason: "queued_transcription"))
         XCTAssertEqual(completedUpdates?.count, 0)
         XCTAssertNil(manager.speakerNamingRequest)
+        XCTAssertEqual(
+            manager.speakerNamingRequestIds(transcriptId: transcriptId),
+            Set([requestId]),
+            "deferred ownership must remain discoverable until finalization or replacement"
+        )
+        manager.supersedeSpeakerNamingRequests(
+            transcriptId: transcriptId,
+            requestIds: [requestId]
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path),
+                       "successful replacement must clean deferred review clips")
+        XCTAssertFalse(manager.speakerNamingRequestOwnership.isCurrent(
+            requestId: requestId,
+            transcriptId: transcriptId
+        ))
         XCTAssertFalse(manager.deferPendingSpeakerNamingReview(reason: "queued_transcription"))
     }
 
@@ -275,6 +306,145 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
 
         XCTAssertEqual(manager.speakerNamingRequest?.transcriptId, firstId)
         XCTAssertEqual(manager.pendingSpeakerNamingRequests.map(\.transcriptId), [secondId])
+    }
+
+    func testReplacementSpeakerReviewSupersedesOldGenerationAndPreservesSourceAudio() throws {
+        let manager = makeManager()
+        let transcriptId = UUID()
+        let oldRequestId = UUID()
+        let freshRequestId = UUID()
+        let transcriptURL = tempDirectory.appendingPathComponent("meeting.md")
+        let micURL = tempDirectory.appendingPathComponent("audio/old-mic.wav")
+        let systemURL = tempDirectory.appendingPathComponent("audio/old-system.wav")
+        let clipURL = tempDirectory.appendingPathComponent("speaker_clips/old-clip.wav")
+        try transcriptContent(id: transcriptId, title: "Meeting").write(
+            to: transcriptURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        try Data("mic".utf8).write(to: micURL)
+        try Data("system".utf8).write(to: systemURL)
+        try Data("clip".utf8).write(to: clipURL)
+
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            id: oldRequestId,
+            speakers: [
+                SpeakerNamingEntry(
+                    id: UUID(),
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "hello",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            shouldRemoveTemporaryAudioOnCleanup: true,
+            onComplete: { _ in }
+        ))
+
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: transcriptURL))
+        defer { TranscriptSaver.finishReplacingTranscript(reservation) }
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            id: freshRequestId,
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        ))
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: clipURL.path),
+                      "the old review must survive until replacement commit")
+        XCTAssertFalse(manager.speakerNamingRequestOwnership.isCurrent(
+            requestId: oldRequestId,
+            transcriptId: transcriptId
+        ))
+        XCTAssertEqual(manager.speakerNamingRequest?.id, oldRequestId)
+        XCTAssertEqual(manager.pendingSpeakerNamingRequests.map(\.id), [freshRequestId])
+        XCTAssertTrue(manager.speakerNamingRequestOwnership.isCurrent(
+            requestId: freshRequestId,
+            transcriptId: transcriptId
+        ))
+
+        manager.supersedeSpeakerNamingRequests(
+            transcriptId: transcriptId,
+            requestIds: [oldRequestId]
+        )
+
+        XCTAssertEqual(manager.speakerNamingRequest?.id, freshRequestId,
+                       "commit must retire the old review and promote the replacement")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertTrue(manager.speakerNamingRequestOwnership.isCurrent(
+            requestId: freshRequestId,
+            transcriptId: transcriptId
+        ))
+    }
+
+    func testFailedReplacementRestoresDeferredSpeakerReviewOwnership() throws {
+        let manager = makeManager()
+        let transcriptId = UUID()
+        let oldRequestId = UUID()
+        let freshRequestId = UUID()
+        let transcriptURL = tempDirectory.appendingPathComponent("deferred.md")
+        try transcriptContent(id: transcriptId, title: "Deferred").write(
+            to: transcriptURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            id: oldRequestId,
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: tempDirectory.appendingPathComponent("old-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+        XCTAssertTrue(manager.deferPendingSpeakerNamingReview(reason: "replacement"))
+
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: transcriptURL))
+        defer { TranscriptSaver.finishReplacingTranscript(reservation) }
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            id: freshRequestId,
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: tempDirectory.appendingPathComponent("fresh-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+        XCTAssertTrue(manager.speakerNamingRequestOwnership.isCurrent(
+            requestId: freshRequestId,
+            transcriptId: transcriptId
+        ))
+
+        manager.cancelSpeakerNamingRequest(
+            transcriptId: transcriptId,
+            requestId: freshRequestId
+        )
+
+        XCTAssertNil(manager.speakerNamingRequest)
+        XCTAssertTrue(manager.speakerNamingRequestOwnership.isCurrent(
+            requestId: oldRequestId,
+            transcriptId: transcriptId
+        ))
+        XCTAssertEqual(
+            manager.speakerNamingRequestIds(transcriptId: transcriptId),
+            Set([oldRequestId])
+        )
     }
 
     func testClearCompletedSpeakerNamingRequestClearsActiveReviewAndPromotesNext() {

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerMetadataTests.swift
@@ -308,22 +308,26 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(manager.pendingSpeakerNamingRequests.map(\.transcriptId), [secondId])
     }
 
-    func testReplacementSpeakerReviewSupersedesOldGenerationAndPreservesSourceAudio() throws {
+    func testReplacementSpeakerReviewCleansOldScratchAndPreservesReplacementAudio() throws {
         let manager = makeManager()
         let transcriptId = UUID()
         let oldRequestId = UUID()
         let freshRequestId = UUID()
         let transcriptURL = tempDirectory.appendingPathComponent("meeting.md")
-        let micURL = tempDirectory.appendingPathComponent("audio/old-mic.wav")
-        let systemURL = tempDirectory.appendingPathComponent("audio/old-system.wav")
+        let oldMicURL = tempDirectory.appendingPathComponent("audio/old-mic.wav")
+        let oldSystemURL = tempDirectory.appendingPathComponent("audio/old-system.wav")
+        let freshMicURL = tempDirectory.appendingPathComponent("audio/fresh-mic.wav")
+        let freshSystemURL = tempDirectory.appendingPathComponent("audio/fresh-system.wav")
         let clipURL = tempDirectory.appendingPathComponent("speaker_clips/old-clip.wav")
         try transcriptContent(id: transcriptId, title: "Meeting").write(
             to: transcriptURL,
             atomically: true,
             encoding: .utf8
         )
-        try Data("mic".utf8).write(to: micURL)
-        try Data("system".utf8).write(to: systemURL)
+        try Data("old mic".utf8).write(to: oldMicURL)
+        try Data("old system".utf8).write(to: oldSystemURL)
+        try Data("fresh mic".utf8).write(to: freshMicURL)
+        try Data("fresh system".utf8).write(to: freshSystemURL)
         try Data("clip".utf8).write(to: clipURL)
 
         manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
@@ -342,8 +346,8 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             ],
             transcriptURL: transcriptURL,
             transcriptId: transcriptId,
-            systemAudioURL: systemURL,
-            micAudioURL: micURL,
+            systemAudioURL: oldSystemURL,
+            micAudioURL: oldMicURL,
             shouldRemoveTemporaryAudioOnCleanup: true,
             onComplete: { _ in }
         ))
@@ -355,14 +359,16 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             speakers: [],
             transcriptURL: transcriptURL,
             transcriptId: transcriptId,
-            systemAudioURL: systemURL,
-            micAudioURL: micURL,
+            systemAudioURL: freshSystemURL,
+            micAudioURL: freshMicURL,
             shouldRemoveTemporaryAudioOnCleanup: false,
             onComplete: { _ in }
         ))
 
-        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldMicURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldSystemURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: freshMicURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: freshSystemURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: clipURL.path),
                       "the old review must survive until replacement commit")
         XCTAssertFalse(manager.speakerNamingRequestOwnership.isCurrent(
@@ -384,8 +390,14 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(manager.speakerNamingRequest?.id, freshRequestId,
                        "commit must retire the old review and promote the replacement")
         XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
-        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldMicURL.path),
+                       "successful supersession must clean the old generation's mic scratch")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldSystemURL.path),
+                       "successful supersession must clean the old generation's system scratch")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: freshMicURL.path),
+                      "superseding the old request must not delete replacement mic audio")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: freshSystemURL.path),
+                      "superseding the old request must not delete replacement system audio")
         XCTAssertTrue(manager.speakerNamingRequestOwnership.isCurrent(
             requestId: freshRequestId,
             transcriptId: transcriptId

--- a/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerTests/SpeakerNamingCoordinatorTests.swift
@@ -199,6 +199,129 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testOldNamingCallbackResumesWhenReplacementFails() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let oldRequestId = UUID()
+        let replacementRequestId = UUID()
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.25, count: 256),
+            existingId: nil
+        ).id
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("Replacement_Failure.md")
+        let clipURL = harness.paths.speakerClips.appendingPathComponent("speaker.wav")
+        let micURL = harness.paths.audioCaptures.appendingPathComponent("mic.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("system.wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "System",
+                label: "Speaker 1",
+                text: "Thanks for joining."
+            )
+        ]
+
+        try sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: [
+                BreakdownEntry(name: "Speaker 1", utterances: 1, wordCount: 3, duration: "00:03")
+            ],
+            totalWords: 3
+        ).write(to: transcriptURL, atomically: true, encoding: .utf8)
+        try Data().write(to: clipURL)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+
+        harness.manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            id: oldRequestId,
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        ))
+
+        let reservation = try XCTUnwrap(TranscriptSaver.beginReplacingTranscript(at: transcriptURL))
+        var reservationFinished = false
+        defer {
+            if !reservationFinished {
+                TranscriptSaver.finishReplacingTranscript(reservation)
+            }
+        }
+        harness.manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            id: replacementRequestId,
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            shouldRemoveTemporaryAudioOnCleanup: false,
+            onComplete: { _ in }
+        ))
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Sarah Graham",
+                    previousName: nil,
+                    action: .named
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: sampleTranscriptionResult(speakers: speakers, utterances: utterances),
+            micURL: micURL,
+            systemURL: systemURL,
+            shouldRemoveTemporaryAudio: false,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "Thanks for joining.",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: [Float](repeating: 0.25, count: 256)
+                )
+            ],
+            requestId: oldRequestId
+        )
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertFalse(try String(contentsOf: transcriptURL).contains("Sarah Graham"))
+
+        harness.manager.cancelSpeakerNamingRequest(
+            transcriptId: transcriptId,
+            requestId: replacementRequestId
+        )
+        TranscriptSaver.finishReplacingTranscript(reservation)
+        reservationFinished = true
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+                && harness.manager.displayStatus == .transcriptSaved
+        }
+
+        XCTAssertTrue(try String(contentsOf: transcriptURL).contains("Sarah Graham"))
+    }
+
+    @MainActor
     func testHandleNamingCompleteCoalescesSplitSpeakerRowsWithSameName() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()


### PR DESCRIPTION
## Summary
- make saved-audio retranscription available without globally blocking on speaker review
- add generation ownership and replacement reservations so stale speaker callbacks cannot overwrite a fresh transcript
- preserve and clean deferred review artifacts across failed or successful replacement
- honor the local-speaker preference during retranscription
- report failed system-audio startup and expose bounded capture-health tags

## Verification
- independent full-diff review: PASS, no P1/P2/P3 findings
- swift test: 1037 tests, 13 skipped, 0 failures
- focused recovery suite: 96 tests, 0 failures
- bash build-deps.sh --force: passed
- bash build.sh --no-open: passed; signed app; launch smoke 1303 ms
- bash run-integration-smoke.sh: passed
- mapped telemetry/UI fast-test filters: passed
- full fast-test suite: 12195/12200; 5 unrelated existing failures from /tmp versus /private/tmp URL equality in HomeMeetingRenameTests and MeetingArtifactRecoveryStoreTests

## Proof boundary
This is branch and deterministic build proof. It is not installed-client, Bluetooth/AirPods, real-provider, release, Sparkle, or production proof. Current public 1.1.56 remains red until merge, release, and device dogfood.