### PR TITLE
Add Transcripted Lab experiment workbench and CLI

### DIFF
--- a/.github/workflows/transcripted-lab.yml
+++ b/.github/workflows/transcripted-lab.yml
@@ -1,0 +1,36 @@
+name: Transcripted Lab
+
+on:
+  pull_request:
+    paths:
+      - "Tools/TranscriptedLab/**"
+      - "docs/transcripted-lab.md"
+      - "Tools/README.md"
+      - ".github/workflows/transcripted-lab.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Tools/TranscriptedLab/**"
+      - "docs/transcripted-lab.md"
+      - "Tools/README.md"
+      - ".github/workflows/transcripted-lab.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Swift version
+        run: swift --version
+      - name: Test Lab kit and CLI
+        run: swift test --package-path Tools/TranscriptedLab --jobs 4
+      - name: Build CLI
+        run: swift build --package-path Tools/TranscriptedLab --product transcripted-lab --jobs 4
+      - name: Build SwiftUI app
+        run: swift build --package-path Tools/TranscriptedLab --product TranscriptedLab --jobs 4
+      - name: Verify app bundle
+        run: Tools/TranscriptedLab/script/build_and_run.sh --verify

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -9,6 +9,7 @@
 - `TranscriptedMCP/` — read-only MCP server for saved meetings and dictations
 - `TranscriptedQA/` — artifact validation and QA CLI
 - `SpeakerEvalHarness/` — headless AMI speaker-naming eval harness for diarization, embedding, clustering, and cross-meeting match sweeps
+- `TranscriptedLab/` — native experiment workbench plus `transcripted-lab` CLI; orchestrates the real speaker, transcription, dictation, and QA lanes and writes comparable regression reports
 
 ## Read first
 
@@ -17,6 +18,7 @@ Each package has its own local `CLAUDE.md` and `Package.swift`.
 - `Tools/SpeakerEvalHarness/CLAUDE.md`
 - `Tools/TranscriptedCaptureKit/CLAUDE.md`
 - `Tools/TranscriptedCLI/CLAUDE.md`
+- `Tools/TranscriptedLab/CLAUDE.md`
 - `Tools/TranscriptedMCP/CLAUDE.md`
 - `Tools/TranscriptedQA/CLAUDE.md`
 

--- a/Tools/TranscriptedLab/CLAUDE.md
+++ b/Tools/TranscriptedLab/CLAUDE.md
@@ -1,0 +1,36 @@
+# Transcripted Lab package guidance
+
+Transcripted Lab is an experiment orchestrator, not a second implementation of Transcripted.
+
+## Boundaries
+
+- Reuse repository-owned scripts and production benchmark seams.
+- Do not copy the diarizer, STT engine, dictation session, speaker matcher, or artifact writer into this package.
+- Add a narrow production adapter only when the app has no measurable seam for a required benchmark.
+- Keep `TranscriptedLabKit` Foundation-only. The SwiftUI target consumes it; the CLI consumes the same API.
+- Keep reports versioned, Codable, and backward-readable whenever practical.
+- Do not persist raw audio, embeddings, prompt text, transcript bodies, or speaker clips in Lab JSON reports.
+
+## Hard gates
+
+Never average these away:
+
+- cross-person false merge or false automatic speaker name
+- profile contamination regression
+- lost or duplicated audio/text
+- speech/silence inversion
+- delivery failure
+- process crash, timeout, or blocking QA failure
+
+## Validation
+
+For changes inside this package:
+
+```bash
+swift test --package-path Tools/TranscriptedLab
+swift build --package-path Tools/TranscriptedLab --product transcripted-lab
+swift build --package-path Tools/TranscriptedLab --product TranscriptedLab
+Tools/TranscriptedLab/script/build_and_run.sh --verify
+```
+
+The app target is macOS-only. The package manifest intentionally omits it on non-macOS hosts so the Foundation-only kit and CLI remain testable elsewhere.

--- a/Tools/TranscriptedLab/Package.swift
+++ b/Tools/TranscriptedLab/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+var products: [Product] = [
+    .library(name: "TranscriptedLabKit", targets: ["TranscriptedLabKit"]),
+    .executable(name: "transcripted-lab", targets: ["TranscriptedLabCLI"]),
+]
+
+var targets: [Target] = [
+    .target(
+        name: "TranscriptedLabKit",
+        path: "Sources/TranscriptedLabKit"
+    ),
+    .executableTarget(
+        name: "TranscriptedLabCLI",
+        dependencies: ["TranscriptedLabKit"],
+        path: "Sources/transcripted-lab"
+    ),
+    .testTarget(
+        name: "TranscriptedLabKitTests",
+        dependencies: ["TranscriptedLabKit"],
+        path: "Tests/TranscriptedLabKitTests"
+    ),
+]
+
+#if os(macOS)
+products.append(.executable(name: "TranscriptedLab", targets: ["TranscriptedLab"]))
+targets.append(
+    .executableTarget(
+        name: "TranscriptedLab",
+        dependencies: ["TranscriptedLabKit"],
+        path: "Sources/TranscriptedLab"
+    )
+)
+#endif
+
+let package = Package(
+    name: "TranscriptedLab",
+    platforms: [.macOS(.v14)],
+    products: products,
+    targets: targets
+)

--- a/Tools/TranscriptedLab/README.md
+++ b/Tools/TranscriptedLab/README.md
@@ -1,0 +1,147 @@
+# Transcripted Lab
+
+Transcripted Lab is a local macOS experiment workbench for Transcripted. It does not reimplement the app. It launches the repository's real speaker, transcription, dictation, and QA lanes, then stores one normalized report contract for every run.
+
+The package contains:
+
+- `TranscriptedLab` — native SwiftUI app for configuring experiments and comparing runs.
+- `transcripted-lab` — headless CLI backed by the same runner, analyzers, scorecards, and report store.
+- `TranscriptedLabKit` — reusable experiment configuration, process orchestration, metric parsing, scoring, and report persistence.
+
+## Build and open the app
+
+From the Transcripted repository root:
+
+```bash
+Tools/TranscriptedLab/script/build_and_run.sh
+```
+
+The script builds both products, creates `Tools/TranscriptedLab/dist/Transcripted Lab.app`, ad-hoc signs it, and opens it.
+
+Verify without opening:
+
+```bash
+Tools/TranscriptedLab/script/build_and_run.sh --verify
+```
+
+## CLI
+
+```bash
+swift run --package-path Tools/TranscriptedLab transcripted-lab help
+swift run --package-path Tools/TranscriptedLab transcripted-lab doctor
+```
+
+A few useful runs:
+
+```bash
+# Score the last seven days of production latency events.
+swift run --package-path Tools/TranscriptedLab transcripted-lab snapshot \
+  --window-hours 168 \
+  --minimum-samples 10
+
+# Exercise the real production dictation stop path five times per fixture.
+swift run --package-path Tools/TranscriptedLab transcripted-lab run dictation-stop \
+  --variant production \
+  --repetitions 5 \
+  --include-silence
+
+# Sweep same-voice consolidation and cross-meeting match thresholds.
+swift run --package-path Tools/TranscriptedLab transcripted-lab run speaker-identity \
+  --speaker-mode threshold-sweep \
+  --speaker-corpus ami \
+  --consolidation "none 0.82 0.85 0.88 0.91" \
+  --match "0.50 0.55 0.60 0.65 0.70"
+
+# Run the existing quick QA lane.
+swift run --package-path Tools/TranscriptedLab transcripted-lab run qa \
+  --qa-mode quick
+```
+
+List, inspect, and compare saved runs:
+
+```bash
+swift run --package-path Tools/TranscriptedLab transcripted-lab list
+swift run --package-path Tools/TranscriptedLab transcripted-lab show RUN_ID
+swift run --package-path Tools/TranscriptedLab transcripted-lab compare BASELINE_ID CANDIDATE_ID
+```
+
+Every command also supports `--json` for automation.
+
+## The benches
+
+### Runtime Snapshot
+
+Reads `~/Library/Application Support/Transcripted/logs/events.jsonl` by default and reports:
+
+- transcription elapsed time and real-time factor at p50/p95/p99
+- dictation fast start
+- request-to-recording
+- start-to-first-audio-sample
+- stop-to-paste and stop-to-done
+- fallback, retry, and deferred-start events
+
+The targets mirror Transcripted's existing performance budget instead of creating new definitions of fast.
+
+### Dictation Bench
+
+Wraps `scripts/ops/dictation-stop-autoeval.sh` and the app's `DictationStopBenchmarkRunner`. It exposes:
+
+- production, native, pre-resampled, and chunked paths
+- repetitions
+- encoder compute units
+- finalization order
+- Auto Enter delay
+- chunk size
+- silence guardrail
+
+Hard gates catch missing saved text, speech/silence inversion, and output-hash drift across identical repetitions. This lane measures speed and consistency, not word error rate.
+
+### Transcription Bench
+
+Wraps the repository's `corpus-compare` QA mode. It validates a local truth corpus and compares Transcripted Markdown against the expected transcript using the repository's existing recall gates.
+
+Use Runtime Snapshot beside it for production speed. A future lane can add first-token streaming latency once Transcripted ships a stable event for it.
+
+### Speaker Bench
+
+Two modes:
+
+- **Threshold Sweep** runs `scripts/run_speaker_eval.sh` against AMI, ICSI, VoxConverse, or the bounded VoxCeleb sample. It scores DER, identity fragmentation, false merges, and cross-meeting re-identification.
+- **ASK / SUGGEST / AUTO Research** runs the frozen, resumable speaker auto-research loop with train/dev/locked-holdout promotion gates.
+
+False cross-person merges are hard failures. The threshold-sweep leaderboard is safety-first: zero false merges beats a more aggressive candidate with higher apparent recall.
+
+The auto-research lane keeps its native final report rather than flattening false automatic names, open-set errors, and contamination gates into a fake single number.
+
+### QA Bench
+
+Wraps `scripts/ops/transcripted-qa-bench.sh` and normalizes its PASS/WARN/FAIL/SKIP output. Quick, deep, full, UI, packaged, artifact, synthetic audio, pasteback, and live modes are available.
+
+## Storage and privacy
+
+Lab reports live under:
+
+```text
+~/Library/Application Support/Transcripted Lab/Runs/
+```
+
+Run artifacts live under:
+
+```text
+~/Library/Application Support/Transcripted Lab/Artifacts/
+```
+
+Speaker corpora and their existing reports remain in Transcripted's gitignored `data/` paths. Transcripted Lab stores aggregate metrics, hashes, command output tails, and artifact paths. It does not copy raw audio or transcript bodies into the Lab report.
+
+## Score rules
+
+One average never gets to hide a serious failure. A run is failed before its number matters when it has conditions such as:
+
+- a cross-person speaker merge
+- missing final dictation text
+- silence producing text
+- identical audio producing unstable output hashes
+- a blocking QA failure
+- an experiment timeout or non-zero process exit
+
+That is the whole point of the Lab: make regressions loud, reproducible, and hard to rationalize away.

--- a/Tools/TranscriptedLab/Sources/TranscriptedLab/LabContentView.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLab/LabContentView.swift
@@ -1,0 +1,420 @@
+import AppKit
+import SwiftUI
+import TranscriptedLabKit
+
+struct LabContentView: View {
+    @EnvironmentObject private var workspace: LabWorkspaceStore
+
+    var body: some View {
+        NavigationSplitView {
+            List(selection: $workspace.selection) {
+                Label("New Experiment", systemImage: "flask")
+                    .tag(LabSidebarSelection.newExperiment)
+
+                Section("Runs") {
+                    ForEach(workspace.reports) { report in
+                        RunSidebarRow(report: report)
+                            .tag(LabSidebarSelection.run(report.id))
+                    }
+                }
+            }
+            .navigationSplitViewColumnWidth(min: 240, ideal: 270)
+        } detail: {
+            switch workspace.selection ?? .newExperiment {
+            case .newExperiment:
+                LabExperimentView()
+            case .run(let id):
+                if let report = workspace.report(id: id) {
+                    LabRunDetailView(report: report)
+                } else {
+                    ContentUnavailableView("Run not found", systemImage: "questionmark.folder")
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    workspace.refresh()
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+            }
+        }
+        .alert("Transcripted Lab", isPresented: Binding(
+            get: { workspace.errorMessage != nil },
+            set: { if !$0 { workspace.errorMessage = nil } }
+        )) {
+            Button("OK") { workspace.errorMessage = nil }
+        } message: {
+            Text(workspace.errorMessage ?? "Unknown error")
+        }
+    }
+}
+
+private struct RunSidebarRow: View {
+    let report: LabRunReport
+
+    var body: some View {
+        HStack(spacing: 9) {
+            Circle()
+                .fill(statusColor(report.status))
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(report.configuration.name)
+                    .lineLimit(1)
+                Text("\(report.configuration.bench.title) · \(report.scorecard.overallScore.map(String.init) ?? "—")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct LabExperimentView: View {
+    @EnvironmentObject private var workspace: LabWorkspaceStore
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Transcripted Lab")
+                        .font(.largeTitle.bold())
+                    Text("Change one arm, run the real Transcripted path, and compare it with the last run. Raw audio and transcripts stay in the local corpus or existing Transcripted folders.")
+                        .foregroundStyle(.secondary)
+                }
+
+                GroupBox("Experiment") {
+                    Form {
+                        TextField("Name", text: $workspace.configuration.name)
+                        Picker("Bench", selection: $workspace.configuration.bench) {
+                            ForEach(LabBench.allCases) { bench in
+                                Text(bench.title).tag(bench)
+                            }
+                        }
+                        TextField("Transcripted repository", text: $workspace.configuration.repositoryPath)
+                        LabeledContent("What it runs") {
+                            Text(workspace.configuration.bench.summary)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                    .formStyle(.grouped)
+                }
+
+                benchControls
+
+                GroupBox("Execution") {
+                    Form {
+                        TextField("Timeout (seconds)", value: $workspace.configuration.timeoutSeconds, format: .number)
+                        Toggle("Reuse current app / tool build", isOn: $workspace.configuration.skipBuild)
+                    }
+                    .formStyle(.grouped)
+                }
+
+                HStack {
+                    if workspace.isRunning {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Experiment running…")
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button("Run Experiment") {
+                        workspace.runExperiment()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.return, modifiers: [.command])
+                    .disabled(workspace.isRunning)
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: 920, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var benchControls: some View {
+        switch workspace.configuration.bench {
+        case .runtimeSnapshot:
+            GroupBox("Runtime Snapshot") {
+                Form {
+                    TextField("events.jsonl", text: $workspace.configuration.runtimeEventsPath)
+                    TextField("Window (hours)", value: $workspace.configuration.runtimeWindowHours, format: .number)
+                    Stepper("Minimum samples: \(workspace.configuration.minimumSamples)", value: $workspace.configuration.minimumSamples, in: 1...1_000)
+                    Toggle("Fail on dictation fallback / retry events", isOn: $workspace.configuration.strictGates)
+                }
+                .formStyle(.grouped)
+            }
+
+        case .dictationStop:
+            GroupBox("Dictation Arm") {
+                Form {
+                    Picker("Pipeline variant", selection: $workspace.configuration.dictationVariant) {
+                        ForEach(DictationVariant.allCases) { Text($0.title).tag($0) }
+                    }
+                    Stepper("Repetitions per fixture: \(workspace.configuration.repetitions)", value: $workspace.configuration.repetitions, in: 1...100)
+                    Picker("Encoder compute", selection: $workspace.configuration.encoderComputeMode) {
+                        ForEach(EncoderComputeMode.allCases) { Text($0.title).tag($0) }
+                    }
+                    Picker("Finalization order", selection: $workspace.configuration.dictationFinalizationOrder) {
+                        ForEach(DictationFinalizationOrder.allCases) { Text($0.title).tag($0) }
+                    }
+                    if workspace.configuration.dictationVariant == .chunked {
+                        TextField("Chunk seconds", value: $workspace.configuration.chunkSeconds, format: .number)
+                    }
+                    Toggle("Include silence guardrail", isOn: $workspace.configuration.includeSilence)
+                    Toggle("Simulate Auto Enter delay", isOn: $workspace.configuration.simulateAutoEnter)
+                }
+                .formStyle(.grouped)
+            }
+
+        case .transcriptionCorpus:
+            GroupBox("Transcription Corpus") {
+                Form {
+                    TextField("Corpus root", text: $workspace.configuration.corpusRoot)
+                    TextField("Meeting IDs (optional, comma-separated)", text: $workspace.configuration.corpusIDs)
+                    TextField("Transcripted output directory", text: $workspace.configuration.corpusOutputDirectory)
+                    TextField("Candidate map JSON (optional)", text: $workspace.configuration.corpusCandidateMap)
+                    TextField("Minimum word recall", value: $workspace.configuration.corpusMinimumRecall, format: .number)
+                    TextField("Minimum content-word recall", value: $workspace.configuration.corpusMinimumContentRecall, format: .number)
+                }
+                .formStyle(.grouped)
+            }
+
+        case .speakerIdentity:
+            GroupBox("Speaker Arm") {
+                Form {
+                    Picker("Experiment", selection: $workspace.configuration.speakerMode) {
+                        ForEach(SpeakerExperimentMode.allCases) { Text($0.title).tag($0) }
+                    }
+                    if workspace.configuration.speakerMode == .thresholdSweep {
+                        Picker("Corpus", selection: $workspace.configuration.speakerCorpus) {
+                            ForEach(SpeakerCorpus.allCases) { Text($0.title).tag($0) }
+                        }
+                        TextField("Meeting series (optional)", text: $workspace.configuration.speakerSeries)
+                        TextField("Consolidation grid", text: $workspace.configuration.consolidationThresholds)
+                        TextField("Cross-meeting match grid", text: $workspace.configuration.matchThresholds)
+                        TextField("DER collar", value: $workspace.configuration.speakerCollar, format: .number)
+                        Toggle("Allow partial local corpus", isOn: $workspace.configuration.allowPartialCorpus)
+                    } else {
+                        TextField("Frozen manifest", text: $workspace.configuration.speakerManifestPath)
+                        TextField("Fingerprint cache root", text: $workspace.configuration.speakerInputRoot)
+                        TextField("State directory (optional)", text: $workspace.configuration.speakerStateDirectory)
+                        Picker("Phase", selection: $workspace.configuration.speakerResearchPhase) {
+                            ForEach(SpeakerResearchPhase.allCases) { Text($0.title).tag($0) }
+                        }
+                        Stepper("Finalists: \(workspace.configuration.speakerTopK)", value: $workspace.configuration.speakerTopK, in: 1...32)
+                    }
+                }
+                .formStyle(.grouped)
+            }
+
+        case .qa:
+            GroupBox("QA Arm") {
+                Form {
+                    Picker("Mode", selection: $workspace.configuration.qaMode) {
+                        ForEach(QABenchMode.allCases) { Text($0.title).tag($0) }
+                    }
+                }
+                .formStyle(.grouped)
+            }
+        }
+    }
+}
+
+private struct LabRunDetailView: View {
+    @EnvironmentObject private var workspace: LabWorkspaceStore
+    let report: LabRunReport
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(report.configuration.name)
+                            .font(.largeTitle.bold())
+                        Text("\(report.configuration.bench.title) · \(report.startedAt.formatted(date: .abbreviated, time: .standard))")
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 4) {
+                        Text(report.status.title)
+                            .font(.headline)
+                            .foregroundStyle(statusColor(report.status))
+                        Text(report.scorecard.overallScore.map { "\($0) / 100" } ?? "No flat score")
+                            .font(.title2.monospacedDigit())
+                    }
+                }
+
+                Text(report.summary)
+
+                if let comparison = workspace.comparison(for: report) {
+                    GroupBox("Compared with previous \(report.configuration.bench.title)") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            if let delta = comparison.scoreDelta {
+                                Text("Score \(delta >= 0 ? "+" : "")\(delta)")
+                                    .font(.title3.bold())
+                            }
+                            ForEach(comparison.metricDeltas.prefix(8)) { metric in
+                                HStack {
+                                    Text(metric.label)
+                                    Spacer()
+                                    Text("\(metric.delta >= 0 ? "+" : "")\(metricValue(metric.delta)) \(metric.unit)")
+                                        .monospacedDigit()
+                                }
+                            }
+                        }
+                        .padding(8)
+                    }
+                }
+
+                if !report.scorecard.hardGateFailures.isEmpty {
+                    GroupBox("Hard failures") {
+                        VStack(alignment: .leading, spacing: 7) {
+                            ForEach(report.scorecard.hardGateFailures, id: \.self) {
+                                Label($0, systemImage: "xmark.octagon.fill")
+                                    .foregroundStyle(.red)
+                            }
+                        }
+                        .padding(8)
+                    }
+                }
+
+                if !report.scorecard.warnings.isEmpty {
+                    GroupBox("Read this before choosing a winner") {
+                        VStack(alignment: .leading, spacing: 7) {
+                            ForEach(report.scorecard.warnings, id: \.self) {
+                                Label($0, systemImage: "exclamationmark.triangle")
+                            }
+                        }
+                        .padding(8)
+                    }
+                }
+
+                if !report.scorecard.dimensions.isEmpty {
+                    GroupBox("Scorecard") {
+                        VStack(spacing: 10) {
+                            ForEach(report.scorecard.dimensions) { dimension in
+                                HStack(alignment: .firstTextBaseline) {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(dimension.label).bold()
+                                        Text(dimension.explanation)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    Text("\(dimension.score)")
+                                        .font(.title3.monospacedDigit())
+                                }
+                            }
+                        }
+                        .padding(8)
+                    }
+                }
+
+                if !report.metrics.isEmpty {
+                    GroupBox("Metrics") {
+                        Grid(alignment: .leading, horizontalSpacing: 22, verticalSpacing: 8) {
+                            GridRow {
+                                Text("Metric").bold()
+                                Text("Value").bold()
+                                Text("Target").bold()
+                                Text("Samples").bold()
+                            }
+                            Divider().gridCellColumns(4)
+                            ForEach(report.metrics) { metric in
+                                GridRow {
+                                    Text(metric.label)
+                                    Text("\(metricValue(metric.value)) \(metric.unit)").monospacedDigit()
+                                    Text(metric.target.map { "\(metricValue($0)) \(metric.unit)" } ?? "—")
+                                        .foregroundStyle(.secondary)
+                                    Text(metric.sampleCount.map(String.init) ?? "—")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .padding(8)
+                    }
+                }
+
+                if !report.artifacts.isEmpty {
+                    GroupBox("Artifacts") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(report.artifacts) { artifact in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(artifact.label).bold()
+                                        Text(artifact.path)
+                                            .font(.caption.monospaced())
+                                            .foregroundStyle(.secondary)
+                                            .textSelection(.enabled)
+                                    }
+                                    Spacer()
+                                    Button("Reveal") {
+                                        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: artifact.path)])
+                                    }
+                                }
+                            }
+                        }
+                        .padding(8)
+                    }
+                }
+
+                if let command = report.command {
+                    DisclosureGroup("Command") {
+                        Text(command.displayCommand)
+                            .font(.caption.monospaced())
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.vertical, 8)
+                    }
+                }
+
+                if let process = report.process, !process.stderrTail.isEmpty || !process.stdoutTail.isEmpty {
+                    DisclosureGroup("Process output") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            if !process.stdoutTail.isEmpty {
+                                Text("stdout").bold()
+                                Text(process.stdoutTail).font(.caption.monospaced()).textSelection(.enabled)
+                            }
+                            if !process.stderrTail.isEmpty {
+                                Text("stderr").bold()
+                                Text(process.stderrTail).font(.caption.monospaced()).textSelection(.enabled)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, 8)
+                    }
+                }
+
+                HStack {
+                    Button("Duplicate as Candidate") {
+                        workspace.duplicateConfiguration(from: report)
+                    }
+                    Spacer()
+                    Button("Delete Run", role: .destructive) {
+                        workspace.delete(report)
+                    }
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: 960, alignment: .leading)
+        }
+    }
+}
+
+private func statusColor(_ status: LabRunStatus) -> Color {
+    switch status {
+    case .passed: return .green
+    case .warning, .incomplete: return .orange
+    case .failed: return .red
+    case .cancelled: return .secondary
+    }
+}
+
+private func metricValue(_ value: Double) -> String {
+    if abs(value) >= 100 { return String(format: "%.0f", value) }
+    if abs(value) >= 10 { return String(format: "%.1f", value) }
+    return String(format: "%.3f", value)
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLab/LabWorkspaceStore.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLab/LabWorkspaceStore.swift
@@ -1,0 +1,85 @@
+import Combine
+import Foundation
+import TranscriptedLabKit
+
+enum LabSidebarSelection: Hashable {
+    case newExperiment
+    case run(UUID)
+}
+
+@MainActor
+final class LabWorkspaceStore: ObservableObject {
+    @Published var configuration: LabRunConfiguration
+    @Published var reports: [LabRunReport]
+    @Published var selection: LabSidebarSelection? = .newExperiment
+    @Published var isRunning = false
+    @Published var errorMessage: String?
+
+    private let runner: LabExperimentRunner
+    private let reportStore: LabReportStore
+
+    init() {
+        let repository = LabRepositoryLocator.locate()?.path ?? FileManager.default.currentDirectoryPath
+        self.configuration = LabRunConfiguration.defaults(repositoryPath: repository)
+        self.reportStore = LabReportStore()
+        self.runner = LabExperimentRunner(reportStore: reportStore)
+        self.reports = (try? reportStore.loadAll()) ?? []
+    }
+
+    func runExperiment() {
+        guard !isRunning else { return }
+        isRunning = true
+        errorMessage = nil
+        let snapshot = configuration
+        Task {
+            let report = await runner.run(snapshot)
+            reports = (try? reportStore.loadAll()) ?? [report]
+            selection = .run(report.id)
+            isRunning = false
+        }
+    }
+
+    func refresh() {
+        do {
+            reports = try reportStore.loadAll()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func report(id: UUID) -> LabRunReport? {
+        reports.first { $0.id == id }
+    }
+
+    func previousComparableReport(for report: LabRunReport) -> LabRunReport? {
+        reports
+            .filter {
+                $0.id != report.id
+                    && $0.configuration.bench == report.configuration.bench
+                    && $0.startedAt < report.startedAt
+            }
+            .sorted { $0.startedAt > $1.startedAt }
+            .first
+    }
+
+    func comparison(for report: LabRunReport) -> LabRunComparison? {
+        guard let baseline = previousComparableReport(for: report) else { return nil }
+        return LabReportComparator.compare(baseline: baseline, candidate: report)
+    }
+
+    func duplicateConfiguration(from report: LabRunReport) {
+        configuration = report.configuration
+        configuration.name = report.configuration.name + " candidate"
+        selection = .newExperiment
+    }
+
+    func delete(_ report: LabRunReport) {
+        do {
+            try reportStore.delete(id: report.id)
+            refresh()
+            selection = .newExperiment
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLab/TranscriptedLabApp.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLab/TranscriptedLabApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@main
+struct TranscriptedLabApp: App {
+    @StateObject private var workspace = LabWorkspaceStore()
+
+    var body: some Scene {
+        WindowGroup("Transcripted Lab") {
+            LabContentView()
+                .environmentObject(workspace)
+                .frame(minWidth: 980, minHeight: 680)
+        }
+        .defaultSize(width: 1180, height: 780)
+    }
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabAnalyzers.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabAnalyzers.swift
@@ -325,14 +325,14 @@ public enum SpeakerSweepAnalyzer {
     public static func analyze(configuration: LabRunConfiguration) throws -> LabAnalysisResult {
         let reportDirectory = URL(fileURLWithPath: configuration.repositoryPath, isDirectory: true)
             .appendingPathComponent("data/eval/\(configuration.speakerCorpus.rawValue)/reports", isDirectory: true)
-        let consolidation = Set(configuration.consolidationThresholds.split(whereSeparator: \.isWhitespace).map(String.init))
-        let matches = Set(configuration.matchThresholds.split(whereSeparator: \.isWhitespace).map(String.init))
+        let consolidation = Set(configuration.consolidationThresholds.split(whereSeparator: \.isWhitespace).map { canonicalThreshold(String($0)) })
+        let matches = Set(configuration.matchThresholds.split(whereSeparator: \.isWhitespace).map { canonicalThreshold(String($0)) })
         let files = (try? FileManager.default.contentsOfDirectory(at: reportDirectory, includingPropertiesForKeys: nil)) ?? []
         var candidates: [SpeakerCandidate] = []
         for file in files where file.pathExtension == "json" && file.lastPathComponent.hasPrefix("cons_") {
             guard let candidate = try? decodeCandidate(file) else { continue }
-            if !consolidation.isEmpty && !consolidation.contains(candidate.consolidation) { continue }
-            if !matches.isEmpty && !matches.contains(candidate.match) { continue }
+            if !consolidation.isEmpty && !consolidation.contains(canonicalThreshold(candidate.consolidation)) { continue }
+            if !matches.isEmpty && !matches.contains(canonicalThreshold(candidate.match)) { continue }
             candidates.append(candidate)
         }
         guard !candidates.isEmpty else {
@@ -381,6 +381,11 @@ public enum SpeakerSweepAnalyzer {
         )
     }
 
+    private static func canonicalThreshold(_ value: String) -> String {
+        guard let number = Double(value), number.isFinite else { return value }
+        return String(number)
+    }
+
     private struct SpeakerCandidate {
         let path: String
         let consolidation: String
@@ -419,7 +424,7 @@ public enum SpeakerSweepAnalyzer {
         }
         let match: String
         if let value = config["matchThreshold"] as? NSNumber {
-            match = String(format: "%.2f", value.doubleValue)
+            match = value.stringValue
         } else {
             match = config["matchThreshold"] as? String ?? "0"
         }

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabAnalyzers.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabAnalyzers.swift
@@ -1,0 +1,547 @@
+import Foundation
+
+public enum RuntimeEventAnalyzer {
+    public static func analyze(
+        eventsURL: URL,
+        windowHours: Double,
+        minimumSamples: Int,
+        strictGates: Bool,
+        now: Date = Date()
+    ) throws -> LabAnalysisResult {
+        guard FileManager.default.fileExists(atPath: eventsURL.path) else {
+            throw LabRunnerError.missingInput(eventsURL.path)
+        }
+
+        let text = try readTailText(eventsURL, maximumBytes: 64 * 1024 * 1024)
+        let cutoff = windowHours > 0 ? now.addingTimeInterval(-windowHours * 3_600) : nil
+        var transcriptionElapsed: [Double] = []
+        var transcriptionRTF: [Double] = []
+        var fastStart: [Double] = []
+        var requestToRecording: [Double] = []
+        var startToFirstSample: [Double] = []
+        var stopToPaste: [Double] = []
+        var stopToDone: [Double] = []
+        var fallbackCount = 0
+        var errorCount = 0
+        var parsedCount = 0
+
+        text.enumerateLines { line, _ in
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let event = object["event"] as? String else { return }
+            if let cutoff,
+               let timestampText = object["timestamp"] as? String,
+               let timestamp = parseISO8601(timestampText),
+               timestamp < cutoff {
+                return
+            }
+            parsedCount += 1
+            let context = object["context"] as? [String: Any] ?? [:]
+            switch event {
+            case "transcription_complete":
+                if let value = context.labDouble("elapsed_s") { transcriptionElapsed.append(value) }
+                if let value = context.labDouble("rtf") { transcriptionRTF.append(value) }
+            case "dictation_recording_fast_start":
+                if let value = context.labDouble("start_ms") { fastStart.append(value) }
+                if let value = context.labDouble("request_to_recording_ms") { requestToRecording.append(value) }
+            case "dictation_started_after_wait":
+                if let value = context.labDouble("request_to_recording_ms") { requestToRecording.append(value) }
+            case "audio_samples_detected":
+                if let value = context.labDouble("start_to_first_sample_ms") { startToFirstSample.append(value) }
+            case "dictation_stop_latency_measured":
+                if let value = context.labDouble("stop_to_paste_ms") { stopToPaste.append(value) }
+                if let value = context.labDouble("stop_to_done_ms") { stopToDone.append(value) }
+            case "dictation_fast_start_fell_back_to_wait", "dictation_recording_retry", "audio_start_deferred":
+                fallbackCount += 1
+            default:
+                break
+            }
+            if (object["level"] as? String)?.lowercased() == "error" {
+                errorCount += 1
+            }
+        }
+
+        var metrics: [LabMetric] = [
+            LabMetric(key: "events.parsed", label: "Events parsed", value: Double(parsedCount), unit: "events"),
+            LabMetric(key: "dictation.fallbacks", label: "Start fallbacks / retries", value: Double(fallbackCount), unit: "events", target: 0, direction: .lowerIsBetter),
+            LabMetric(key: "events.errors", label: "Error-level events", value: Double(errorCount), unit: "events", direction: .informational),
+        ]
+        addPercentiles(prefix: "transcription.elapsed", label: "Transcription", values: transcriptionElapsed, unit: "s", targetP95: 0.5, metrics: &metrics)
+        addPercentiles(prefix: "transcription.rtf", label: "Transcription RTF", values: transcriptionRTF, unit: "RTF", targetP95: 0.05, metrics: &metrics)
+        addPercentiles(prefix: "dictation.fast-start", label: "Dictation fast start", values: fastStart, unit: "ms", targetP95: 250, metrics: &metrics)
+        addPercentiles(prefix: "dictation.request-to-recording", label: "Request to recording", values: requestToRecording, unit: "ms", targetP95: 250, metrics: &metrics)
+        addPercentiles(prefix: "dictation.first-sample", label: "Start to first sample", values: startToFirstSample, unit: "ms", targetP95: 350, metrics: &metrics)
+        addPercentiles(prefix: "dictation.stop-to-paste", label: "Stop to paste", values: stopToPaste, unit: "ms", targetP95: 750, metrics: &metrics)
+        addPercentiles(prefix: "dictation.stop-to-done", label: "Stop to done", values: stopToDone, unit: "ms", targetP95: 1_000, metrics: &metrics)
+
+        var dimensions: [LabScoreDimension] = []
+        var warnings: [String] = []
+        var hardFailures: [String] = []
+
+        let transcriptionScores = [
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(transcriptionElapsed, 0.95), target: 0.5),
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(transcriptionRTF, 0.95), target: 0.05),
+        ].compactMap { $0 }
+        if transcriptionElapsed.count >= minimumSamples || transcriptionRTF.count >= minimumSamples,
+           let score = averageScore(transcriptionScores) {
+            dimensions.append(LabScoreDimension(
+                key: "transcription-speed",
+                label: "Transcription speed",
+                score: score,
+                weight: 0.30,
+                explanation: "p95 decode time and real-time factor against Transcripted's existing budgets."
+            ))
+        } else {
+            warnings.append("Not enough transcription samples to score reliably (need \(minimumSamples)).")
+        }
+
+        let startScores = [
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(fastStart, 0.95), target: 250),
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(requestToRecording, 0.95), target: 250),
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(startToFirstSample, 0.95), target: 350),
+        ].compactMap { $0 }
+        if max(fastStart.count, requestToRecording.count, startToFirstSample.count) >= minimumSamples,
+           let score = averageScore(startScores) {
+            dimensions.append(LabScoreDimension(
+                key: "dictation-start",
+                label: "Dictation start",
+                score: score,
+                weight: 0.30,
+                explanation: "ready-engine start, request-to-recording, and first-audio-sample p95."
+            ))
+        } else {
+            warnings.append("Not enough dictation-start samples to score reliably (need \(minimumSamples)).")
+        }
+
+        let stopScores = [
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(stopToPaste, 0.95), target: 750),
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(stopToDone, 0.95), target: 1_000),
+        ].compactMap { $0 }
+        if max(stopToPaste.count, stopToDone.count) >= minimumSamples,
+           let score = averageScore(stopScores) {
+            dimensions.append(LabScoreDimension(
+                key: "dictation-stop",
+                label: "Dictation stop",
+                score: score,
+                weight: 0.25,
+                explanation: "stop-to-paste and full stop-pipeline p95."
+            ))
+        } else {
+            warnings.append("Not enough dictation-stop samples to score reliably (need \(minimumSamples)).")
+        }
+
+        let reliabilityScore = max(0, 100 - fallbackCount * 20)
+        dimensions.append(LabScoreDimension(
+            key: "runtime-reliability",
+            label: "Runtime reliability",
+            score: reliabilityScore,
+            weight: 0.15,
+            explanation: "Fast-start fallback, retry, and deferred-start events."
+        ))
+        if strictGates && fallbackCount > 0 {
+            hardFailures.append("Found \(fallbackCount) dictation fallback/retry event(s) in the selected window.")
+        }
+
+        let scorecard = LabScorecard.weighted(
+            dimensions: dimensions,
+            hardGateFailures: hardFailures,
+            warnings: warnings
+        )
+        let summary = "Scored \(parsedCount) runtime events from the last \(Int(windowHours)) hours. \(fallbackCount) dictation fallback/retry events were observed."
+        return LabAnalysisResult(
+            summary: summary,
+            metrics: metrics,
+            scorecard: scorecard,
+            artifacts: [LabArtifact(label: "Runtime events", path: eventsURL.path)]
+        )
+    }
+
+    private static func readTailText(_ url: URL, maximumBytes: UInt64) throws -> String {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let size = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        if size > maximumBytes {
+            try handle.seek(toOffset: size - maximumBytes)
+        }
+        let data = try handle.readToEnd() ?? Data()
+        var text = String(decoding: data, as: UTF8.self)
+        if size > maximumBytes, let firstNewline = text.firstIndex(of: "\n") {
+            text = String(text[text.index(after: firstNewline)...])
+        }
+        return text
+    }
+
+    private static func parseISO8601(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+
+    private static func addPercentiles(
+        prefix: String,
+        label: String,
+        values: [Double],
+        unit: String,
+        targetP95: Double,
+        metrics: inout [LabMetric]
+    ) {
+        guard !values.isEmpty else { return }
+        if let value = LabStatistics.percentile(values, 0.50) {
+            metrics.append(LabMetric(key: "\(prefix).p50", label: "\(label) p50", value: value, unit: unit, sampleCount: values.count, direction: .lowerIsBetter))
+        }
+        if let value = LabStatistics.percentile(values, 0.95) {
+            metrics.append(LabMetric(key: "\(prefix).p95", label: "\(label) p95", value: value, unit: unit, sampleCount: values.count, target: targetP95, direction: .lowerIsBetter))
+        }
+        if let value = LabStatistics.percentile(values, 0.99) {
+            metrics.append(LabMetric(key: "\(prefix).p99", label: "\(label) p99", value: value, unit: unit, sampleCount: values.count, direction: .lowerIsBetter))
+        }
+    }
+}
+
+public enum DictationBenchmarkAnalyzer {
+    public static func analyze(resultURL: URL, summaryURL: URL?) throws -> LabAnalysisResult {
+        guard FileManager.default.fileExists(atPath: resultURL.path) else {
+            throw LabRunnerError.reportNotFound(resultURL.path)
+        }
+        let text = try String(contentsOf: resultURL, encoding: .utf8)
+        var cases: [[String: Any]] = []
+        var runStart: [String: Any] = [:]
+        text.enumerateLines { line, _ in
+            guard let data = line.data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+            if object["record_type"] as? String == "run_start" {
+                runStart = object
+            } else if object["record_type"] as? String == "case_result" {
+                cases.append(object)
+            }
+        }
+        guard !cases.isEmpty else {
+            throw LabRunnerError.reportNotFound("No case_result rows in \(resultURL.path)")
+        }
+
+        let stopToText = cases.compactMap { $0.labDouble("stop_to_text_s") }
+        let stopToDelivery = cases.compactMap { $0.labDouble("stop_to_delivery_s") }
+        let decode = cases.compactMap { $0.labDouble("decode_s") }
+        let rtfs = cases.compactMap { row -> Double? in
+            guard let decode = row.labDouble("decode_s"), let duration = row.labDouble("audio_duration_s"), duration > 0 else { return nil }
+            return decode / duration
+        }
+
+        var hardFailures: [String] = []
+        var warnings: [String] = ["This lane measures speed, delivery integrity, and output stability. It does not calculate word error rate."]
+        var hashesByCase: [String: Set<String>] = [:]
+        var expectedSpeechFailures = 0
+        var silenceFailures = 0
+        for row in cases {
+            let id = row.labString("case_id") ?? "unknown"
+            let noSpeech = (row["no_speech"] as? Bool) ?? false
+            let saved = (row["saved"] as? Bool) ?? false
+            let isSilence = id.contains("silence")
+            if isSilence {
+                if !noSpeech { silenceFailures += 1 }
+            } else {
+                if noSpeech || !saved { expectedSpeechFailures += 1 }
+                if let hash = row.labString("text_hash"), !hash.isEmpty {
+                    hashesByCase[id, default: []].insert(hash)
+                }
+            }
+        }
+        let unstableCases = hashesByCase.filter { $0.value.count > 1 }.map(\.key).sorted()
+        if expectedSpeechFailures > 0 {
+            hardFailures.append("\(expectedSpeechFailures) speech case(s) produced no final saved text.")
+        }
+        if silenceFailures > 0 {
+            hardFailures.append("\(silenceFailures) silence case(s) produced text.")
+        }
+        if !unstableCases.isEmpty {
+            hardFailures.append("Output changed across identical repetitions for: \(unstableCases.joined(separator: ", ")).")
+        }
+
+        var metrics: [LabMetric] = []
+        if let value = runStart.labDouble("model_init_s") {
+            metrics.append(LabMetric(key: "model.init", label: "Model initialization", value: value, unit: "s", direction: .lowerIsBetter))
+        }
+        addBenchPercentiles(prefix: "stop-to-text", label: "Stop to text", values: stopToText, unit: "s", target: 0.5, metrics: &metrics)
+        addBenchPercentiles(prefix: "stop-to-delivery", label: "Stop to delivery", values: stopToDelivery, unit: "s", target: 0.75, metrics: &metrics)
+        addBenchPercentiles(prefix: "decode", label: "Decode", values: decode, unit: "s", target: 0.5, metrics: &metrics)
+        addBenchPercentiles(prefix: "rtf", label: "Decode RTF", values: rtfs, unit: "RTF", target: 0.05, metrics: &metrics)
+        metrics.append(LabMetric(key: "cases.total", label: "Case evaluations", value: Double(cases.count), unit: "cases"))
+        metrics.append(LabMetric(key: "cases.unstable", label: "Unstable cases", value: Double(unstableCases.count), unit: "cases", target: 0, direction: .lowerIsBetter))
+
+        let speedParts = [
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(stopToText, 0.95), target: 0.5),
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(rtfs, 0.95), target: 0.05),
+        ].compactMap { $0 }
+        let deliveryParts = [
+            LabStatistics.lowerIsBetterScore(value: LabStatistics.percentile(stopToDelivery, 0.95), target: 0.75),
+        ].compactMap { $0 }
+        let integrityScore = hardFailures.isEmpty ? 100 : 0
+        var dimensions: [LabScoreDimension] = []
+        if let score = averageScore(speedParts) {
+            dimensions.append(LabScoreDimension(key: "dictation-speed", label: "Dictation speed", score: score, weight: 0.45, explanation: "p95 stop-to-text and decode real-time factor."))
+        }
+        if let score = averageScore(deliveryParts) {
+            dimensions.append(LabScoreDimension(key: "delivery-speed", label: "Delivery speed", score: score, weight: 0.25, explanation: "p95 stop-to-delivery."))
+        }
+        dimensions.append(LabScoreDimension(key: "text-integrity", label: "Text integrity", score: integrityScore, weight: 0.30, explanation: "Speech produces saved text, silence stays silent, and repeated cases keep stable output hashes."))
+
+        if decode.isEmpty {
+            warnings.append("This variant did not emit a separate decode stage; stop-to-text remains the end-to-end speed measure.")
+        }
+        var artifacts = [LabArtifact(label: "Raw dictation results", path: resultURL.path)]
+        if let summaryURL, FileManager.default.fileExists(atPath: summaryURL.path) {
+            artifacts.append(LabArtifact(label: "Dictation summary", path: summaryURL.path))
+        }
+        return LabAnalysisResult(
+            summary: "Ran \(cases.count) dictation case evaluations. p95 stop-to-text was \(format(LabStatistics.percentile(stopToText, 0.95)))s.",
+            metrics: metrics,
+            scorecard: LabScorecard.weighted(dimensions: dimensions, hardGateFailures: hardFailures, warnings: warnings),
+            artifacts: artifacts
+        )
+    }
+
+    private static func addBenchPercentiles(prefix: String, label: String, values: [Double], unit: String, target: Double, metrics: inout [LabMetric]) {
+        guard !values.isEmpty else { return }
+        for (suffix, quantile) in [("p50", 0.50), ("p95", 0.95), ("p99", 0.99)] {
+            if let value = LabStatistics.percentile(values, quantile) {
+                metrics.append(LabMetric(
+                    key: "dictation.\(prefix).\(suffix)",
+                    label: "\(label) \(suffix)",
+                    value: value,
+                    unit: unit,
+                    sampleCount: values.count,
+                    target: suffix == "p95" ? target : nil,
+                    direction: .lowerIsBetter
+                ))
+            }
+        }
+    }
+}
+
+public enum SpeakerSweepAnalyzer {
+    public static func analyze(configuration: LabRunConfiguration) throws -> LabAnalysisResult {
+        let reportDirectory = URL(fileURLWithPath: configuration.repositoryPath, isDirectory: true)
+            .appendingPathComponent("data/eval/\(configuration.speakerCorpus.rawValue)/reports", isDirectory: true)
+        let consolidation = Set(configuration.consolidationThresholds.split(whereSeparator: \.isWhitespace).map(String.init))
+        let matches = Set(configuration.matchThresholds.split(whereSeparator: \.isWhitespace).map(String.init))
+        let files = (try? FileManager.default.contentsOfDirectory(at: reportDirectory, includingPropertiesForKeys: nil)) ?? []
+        var candidates: [SpeakerCandidate] = []
+        for file in files where file.pathExtension == "json" && file.lastPathComponent.hasPrefix("cons_") {
+            guard let candidate = try? decodeCandidate(file) else { continue }
+            if !consolidation.isEmpty && !consolidation.contains(candidate.consolidation) { continue }
+            if !matches.isEmpty && !matches.contains(candidate.match) { continue }
+            candidates.append(candidate)
+        }
+        guard !candidates.isEmpty else {
+            throw LabRunnerError.reportNotFound("No speaker score JSON files matched the configured sweep in \(reportDirectory.path)")
+        }
+
+        let best = candidates.sorted(by: candidateIsBetter).first!
+        var hardFailures: [String] = []
+        if best.falseMergeCount > 0 {
+            hardFailures.append("Best candidate still made \(best.falseMergeCount) cross-person false merge(s).")
+        }
+        var warnings = ["Threshold Sweep measures diarization, fragmentation, false merges, and cross-meeting re-identification. Run ASK / SUGGEST / AUTO research to measure false automatic names and profile contamination directly."]
+        if best.trueSpeakerCount != best.profilesAtEnd {
+            warnings.append("Best candidate ended with \(best.profilesAtEnd) profiles for \(best.trueSpeakerCount) true speakers.")
+        }
+
+        let safetyScore = best.falseMergeCount == 0 ? 100 : max(0, 100 - best.falseMergeCount * 35)
+        let reIDScore = LabStatistics.higherIsBetterScore(value: best.reID, target: 1) ?? 0
+        let fragmentationScore = max(0, min(100, Int((100 - abs(best.fragmentation - 1) * 50).rounded())))
+        let diarizationScore = max(0, min(100, Int(((1 - best.der) * 100).rounded())))
+        let dimensions = [
+            LabScoreDimension(key: "speaker-safety", label: "Speaker safety", score: safetyScore, weight: 0.40, explanation: "Cross-person false merges. Any false merge is a hard failure."),
+            LabScoreDimension(key: "speaker-reid", label: "Cross-meeting re-ID", score: reIDScore, weight: 0.25, explanation: "How often recurring speakers map back to the correct stored identity after first appearance."),
+            LabScoreDimension(key: "speaker-fragmentation", label: "Identity stability", score: fragmentationScore, weight: 0.20, explanation: "How close the system stays to one profile per real person."),
+            LabScoreDimension(key: "diarization", label: "Diarization", score: diarizationScore, weight: 0.15, explanation: "One minus mean diarization error rate."),
+        ]
+        let metrics = [
+            LabMetric(key: "speaker.false-merges", label: "False merges", value: Double(best.falseMergeCount), unit: "merges", target: 0, direction: .lowerIsBetter),
+            LabMetric(key: "speaker.reid", label: "Re-ID after first appearance", value: best.reID, unit: "rate", target: 1, direction: .higherIsBetter),
+            LabMetric(key: "speaker.fragmentation", label: "Profiles per person", value: best.fragmentation, unit: "profiles/person", target: 1, direction: .target),
+            LabMetric(key: "speaker.der", label: "Mean DER", value: best.der, unit: "rate", target: 0, direction: .lowerIsBetter),
+            LabMetric(key: "speaker.profiles", label: "Profiles at end", value: Double(best.profilesAtEnd), unit: "profiles", target: Double(best.trueSpeakerCount), direction: .target),
+            LabMetric(key: "speaker.true-speakers", label: "True speakers", value: Double(best.trueSpeakerCount), unit: "speakers"),
+            LabMetric(key: "speaker.consolidation", label: "Best consolidation threshold", value: Double(best.consolidation) ?? -1, unit: best.consolidation == "none" ? "none" : "cosine"),
+            LabMetric(key: "speaker.match", label: "Best match threshold", value: Double(best.match) ?? 0, unit: "cosine"),
+        ]
+        let sweep = reportDirectory.appendingPathComponent("SWEEP.md")
+        return LabAnalysisResult(
+            summary: "Best safe-first speaker candidate: consolidation \(best.consolidation), match \(best.match), false merges \(best.falseMergeCount), re-ID \(format(best.reID)).",
+            metrics: metrics,
+            scorecard: LabScorecard.weighted(dimensions: dimensions, hardGateFailures: hardFailures, warnings: warnings),
+            artifacts: [
+                LabArtifact(label: "Best speaker score JSON", path: best.path),
+                LabArtifact(label: "Speaker sweep", path: sweep.path),
+            ]
+        )
+    }
+
+    private struct SpeakerCandidate {
+        let path: String
+        let consolidation: String
+        let match: String
+        let der: Double
+        let fragmentation: Double
+        let falseMergeCount: Int
+        let reID: Double
+        let profilesAtEnd: Int
+        let trueSpeakerCount: Int
+    }
+
+    private static func decodeCandidate(_ url: URL) throws -> SpeakerCandidate {
+        let data = try Data(contentsOf: url)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let config = root["config"] as? [String: Any],
+              let der = root["der"] as? [String: Any],
+              let fragmentation = root["fragmentation"] as? [String: Any],
+              let falseMerge = root["false_merge"] as? [String: Any] else {
+            throw LabRunnerError.reportNotFound(url.path)
+        }
+        let curve = root["reid_curve_by_appearance"] as? [String: Any] ?? [:]
+        let later = curve.compactMap { key, value -> Double? in
+            guard (Int(key) ?? 0) >= 2 else { return nil }
+            if let number = value as? NSNumber { return number.doubleValue }
+            if let string = value as? String { return Double(string) }
+            return nil
+        }
+        let consolidation: String
+        if let value = config["consolidationThreshold"] as? String {
+            consolidation = value
+        } else if let value = config["consolidationThreshold"] as? NSNumber {
+            consolidation = value.stringValue
+        } else {
+            consolidation = "none"
+        }
+        let match: String
+        if let value = config["matchThreshold"] as? NSNumber {
+            match = String(format: "%.2f", value.doubleValue)
+        } else {
+            match = config["matchThreshold"] as? String ?? "0"
+        }
+        return SpeakerCandidate(
+            path: url.path,
+            consolidation: consolidation,
+            match: match,
+            der: der.labDouble("mean_der") ?? 1,
+            fragmentation: fragmentation.labDouble("mean_profiles_per_person") ?? 99,
+            falseMergeCount: Int(falseMerge.labDouble("count") ?? 0),
+            reID: LabStatistics.mean(later) ?? 0,
+            profilesAtEnd: Int(root.labDouble("profiles_at_end") ?? 0),
+            trueSpeakerCount: (root["true_speakers"] as? [Any])?.count ?? 0
+        )
+    }
+
+    private static func candidateIsBetter(_ lhs: SpeakerCandidate, _ rhs: SpeakerCandidate) -> Bool {
+        let left = (
+            lhs.falseMergeCount,
+            abs(lhs.profilesAtEnd - lhs.trueSpeakerCount),
+            -lhs.reID,
+            abs(lhs.fragmentation - 1),
+            lhs.der
+        )
+        let right = (
+            rhs.falseMergeCount,
+            abs(rhs.profilesAtEnd - rhs.trueSpeakerCount),
+            -rhs.reID,
+            abs(rhs.fragmentation - 1),
+            rhs.der
+        )
+        if left.0 != right.0 { return left.0 < right.0 }
+        if left.1 != right.1 { return left.1 < right.1 }
+        if left.2 != right.2 { return left.2 < right.2 }
+        if left.3 != right.3 { return left.3 < right.3 }
+        return left.4 < right.4
+    }
+}
+
+public enum QAResultsAnalyzer {
+    public static func analyze(resultsURL: URL, reportURL: URL, title: String) throws -> LabAnalysisResult {
+        guard FileManager.default.fileExists(atPath: resultsURL.path) else {
+            throw LabRunnerError.reportNotFound(resultsURL.path)
+        }
+        let text = try String(contentsOf: resultsURL, encoding: .utf8)
+        var pass = 0
+        var warn = 0
+        var fail = 0
+        var skip = 0
+        var totalDuration = 0.0
+        text.enumerateLines { line, _ in
+            let columns = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+            guard columns.count >= 5 else { return }
+            switch columns[2] {
+            case "PASS": pass += 1
+            case "WARN": warn += 1
+            case "FAIL": fail += 1
+            case "SKIP": skip += 1
+            default: break
+            }
+            totalDuration += Double(columns[4]) ?? 0
+        }
+        let scored = pass + warn + fail
+        let score = scored > 0 ? Int(((Double(pass) + Double(warn) * 0.5) / Double(scored) * 100).rounded()) : nil
+        var hardFailures: [String] = []
+        if fail > 0 { hardFailures.append("\(fail) blocking QA step(s) failed.") }
+        var warnings: [String] = []
+        if warn > 0 { warnings.append("\(warn) QA step(s) completed with warnings.") }
+        if scored == 0 { warnings.append("No scored QA steps were found.") }
+        let dimensions = score.map { [LabScoreDimension(key: "qa", label: title, score: $0, weight: 1, explanation: "PASS counts fully, WARN counts half, and FAIL counts zero.")] } ?? []
+        return LabAnalysisResult(
+            summary: "\(title): \(pass) passed, \(warn) warned, \(fail) failed, and \(skip) skipped.",
+            metrics: [
+                LabMetric(key: "qa.pass", label: "Passed steps", value: Double(pass), unit: "steps", direction: .higherIsBetter),
+                LabMetric(key: "qa.warn", label: "Warnings", value: Double(warn), unit: "steps", direction: .lowerIsBetter),
+                LabMetric(key: "qa.fail", label: "Failed steps", value: Double(fail), unit: "steps", target: 0, direction: .lowerIsBetter),
+                LabMetric(key: "qa.skip", label: "Skipped steps", value: Double(skip), unit: "steps"),
+                LabMetric(key: "qa.duration", label: "Step duration", value: totalDuration, unit: "s", direction: .informational),
+            ],
+            scorecard: LabScorecard.weighted(dimensions: dimensions, hardGateFailures: hardFailures, warnings: warnings),
+            artifacts: [
+                LabArtifact(label: "QA report", path: reportURL.path),
+                LabArtifact(label: "QA results", path: resultsURL.path),
+            ]
+        )
+    }
+}
+
+public enum SpeakerAutoResearchAnalyzer {
+    public static func analyze(stateDirectory: URL) -> LabAnalysisResult {
+        let report = stateDirectory.appendingPathComponent("final-report.md")
+        let ledger = stateDirectory.appendingPathComponent("results.tsv")
+        var artifacts: [LabArtifact] = []
+        if FileManager.default.fileExists(atPath: report.path) {
+            artifacts.append(LabArtifact(label: "Speaker auto-research report", path: report.path))
+        }
+        if FileManager.default.fileExists(atPath: ledger.path) {
+            artifacts.append(LabArtifact(label: "Speaker experiment ledger", path: ledger.path))
+        }
+        let complete = FileManager.default.fileExists(atPath: report.path)
+        return LabAnalysisResult(
+            summary: complete
+                ? "Speaker auto-research completed. Open the final report for promoted candidates and holdout evidence."
+                : "Speaker auto-research phase completed without a final holdout report.",
+            metrics: [],
+            scorecard: LabScorecard(
+                overallScore: nil,
+                dimensions: [],
+                hardGateFailures: [],
+                warnings: ["The auto-research evaluator owns its promotion gates. Transcripted Lab preserves its report instead of flattening those safety checks into a misleading single score."]
+            ),
+            artifacts: artifacts
+        )
+    }
+}
+
+func averageScore(_ values: [Int]) -> Int? {
+    guard !values.isEmpty else { return nil }
+    return Int((Double(values.reduce(0, +)) / Double(values.count)).rounded())
+}
+
+func format(_ value: Double?) -> String {
+    guard let value else { return "n/a" }
+    return String(format: "%.3f", value)
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabCommandBuilder.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabCommandBuilder.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+public enum LabCommandBuilder {
+    public static func build(
+        configuration: LabRunConfiguration,
+        runID: UUID,
+        artifactDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws -> LabCommand? {
+        let repo = URL(fileURLWithPath: configuration.repositoryPath, isDirectory: true).standardizedFileURL
+        guard LabRepositoryLocator.isTranscriptedRepository(repo, fileManager: fileManager) else {
+            throw LabRunnerError.invalidRepository(configuration.repositoryPath)
+        }
+
+        switch configuration.bench {
+        case .runtimeSnapshot:
+            return nil
+
+        case .dictationStop:
+            let script = repo.appendingPathComponent("scripts/ops/dictation-stop-autoeval.sh")
+            try requireFile(script, fileManager: fileManager)
+            let label = LabShell.safeLabel(configuration.name) + "-" + runID.uuidString.lowercased().prefix(8)
+            var arguments = [
+                script.path,
+                "--label", String(label),
+                "--variant", configuration.dictationVariant.rawValue,
+                "--iterations", String(max(1, configuration.repetitions)),
+                "--chunk-seconds", String(configuration.chunkSeconds),
+                "--finalization-order", configuration.dictationFinalizationOrder.rawValue,
+                "--encoder-compute", configuration.encoderComputeMode.rawValue,
+            ]
+            if configuration.skipBuild { arguments.append("--skip-build") }
+            if configuration.includeSilence { arguments.append("--include-silence") }
+            if !configuration.simulateAutoEnter { arguments.append("--no-auto-enter") }
+            return LabCommand(
+                executable: "/bin/bash",
+                arguments: arguments,
+                environment: [
+                    "TRANSCRIPTED_DICTATION_STOP_BENCH_WORK_DIR": artifactDirectory.appendingPathComponent("dictation", isDirectory: true).path,
+                    "TRANSCRIPTED_DISABLE_FILE_LOGGER": "1",
+                    "TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS": "1",
+                ],
+                workingDirectory: repo.path,
+                summary: "Replay dictation fixtures through Transcripted's production finalization path."
+            )
+
+        case .transcriptionCorpus:
+            let script = repo.appendingPathComponent("scripts/ops/transcripted-qa-bench.sh")
+            try requireFile(script, fileManager: fileManager)
+            guard !configuration.corpusRoot.isEmpty else {
+                throw LabRunnerError.invalidConfiguration("Transcription Bench needs a corpus root.")
+            }
+            let outputRoot = artifactDirectory.appendingPathComponent("transcription", isDirectory: true)
+            var arguments = [
+                script.path,
+                "--mode", "corpus-compare",
+                "--run-id", runID.uuidString.lowercased(),
+                "--out-root", outputRoot.path,
+                "--corpus-root", configuration.corpusRoot,
+                "--corpus-min-recall", String(configuration.corpusMinimumRecall),
+                "--corpus-min-content-recall", String(configuration.corpusMinimumContentRecall),
+            ]
+            if !configuration.corpusIDs.isEmpty {
+                arguments += ["--corpus-ids", configuration.corpusIDs]
+            }
+            if !configuration.corpusOutputDirectory.isEmpty {
+                arguments += ["--corpus-output-dir", configuration.corpusOutputDirectory]
+            }
+            if !configuration.corpusCandidateMap.isEmpty {
+                arguments += ["--corpus-candidate-map", configuration.corpusCandidateMap]
+            }
+            return LabCommand(
+                executable: "/bin/bash",
+                arguments: arguments,
+                environment: ["TRANSCRIPTED_DISABLE_FILE_LOGGER": "1"],
+                workingDirectory: repo.path,
+                summary: "Validate a local meeting corpus and compare Transcripted Markdown against its truth transcript."
+            )
+
+        case .speakerIdentity:
+            switch configuration.speakerMode {
+            case .thresholdSweep:
+                let script = repo.appendingPathComponent("scripts/run_speaker_eval.sh")
+                try requireFile(script, fileManager: fileManager)
+                var environment = [
+                    "CORPUS": configuration.speakerCorpus.rawValue,
+                    "CONSOLIDATION": configuration.consolidationThresholds,
+                    "MATCH": configuration.matchThresholds,
+                    "COLLAR": String(configuration.speakerCollar),
+                    "ALLOW_PARTIAL_CORPUS": configuration.allowPartialCorpus ? "1" : "0",
+                ]
+                if !configuration.speakerSeries.isEmpty {
+                    environment["SERIES"] = configuration.speakerSeries
+                }
+                return LabCommand(
+                    executable: "/bin/bash",
+                    arguments: [script.path],
+                    environment: environment,
+                    workingDirectory: repo.path,
+                    summary: "Run labeled-audio speaker diarization, clustering, and cross-meeting identity threshold sweeps."
+                )
+
+            case .autoResearch:
+                let script = repo.appendingPathComponent("scripts/run_speaker_autoresearch.py")
+                try requireFile(script, fileManager: fileManager)
+                guard !configuration.speakerManifestPath.isEmpty else {
+                    throw LabRunnerError.invalidConfiguration("Speaker auto-research needs a frozen manifest.")
+                }
+                guard !configuration.speakerInputRoot.isEmpty else {
+                    throw LabRunnerError.invalidConfiguration("Speaker auto-research needs an input root.")
+                }
+                let stateDirectory = configuration.speakerStateDirectory.isEmpty
+                    ? artifactDirectory.appendingPathComponent("speaker-autoresearch", isDirectory: true).path
+                    : configuration.speakerStateDirectory
+                var arguments = [
+                    "python3", script.path,
+                    "--manifest", configuration.speakerManifestPath,
+                    "--input-root", configuration.speakerInputRoot,
+                    "--state-dir", stateDirectory,
+                    "--phase", configuration.speakerResearchPhase.rawValue,
+                    "--top-k", String(max(1, configuration.speakerTopK)),
+                ]
+                if configuration.skipBuild { arguments.append("--skip-build") }
+                return LabCommand(
+                    executable: "/usr/bin/env",
+                    arguments: arguments,
+                    environment: [:],
+                    workingDirectory: repo.path,
+                    summary: "Run the frozen ASK / SUGGEST / AUTO speaker-identity research loop with locked holdout validation."
+                )
+            }
+
+        case .qa:
+            let script = repo.appendingPathComponent("scripts/ops/transcripted-qa-bench.sh")
+            try requireFile(script, fileManager: fileManager)
+            let outputRoot = artifactDirectory.appendingPathComponent("qa", isDirectory: true)
+            var arguments = [
+                script.path,
+                "--mode", configuration.qaMode.rawValue,
+                "--run-id", runID.uuidString.lowercased(),
+                "--out-root", outputRoot.path,
+            ]
+            if configuration.skipBuild { arguments.append("--skip-build") }
+            return LabCommand(
+                executable: "/bin/bash",
+                arguments: arguments,
+                environment: ["TRANSCRIPTED_DISABLE_FILE_LOGGER": "1"],
+                workingDirectory: repo.path,
+                summary: "Run Transcripted's existing QA orchestrator in \(configuration.qaMode.rawValue) mode."
+            )
+        }
+    }
+
+    public static func expectedArtifacts(
+        configuration: LabRunConfiguration,
+        runID: UUID,
+        artifactDirectory: URL
+    ) -> [LabArtifact] {
+        switch configuration.bench {
+        case .runtimeSnapshot:
+            return [LabArtifact(label: "Runtime events", path: configuration.runtimeEventsPath)]
+        case .dictationStop:
+            let label = LabShell.safeLabel(configuration.name) + "-" + runID.uuidString.lowercased().prefix(8)
+            let stem = "\(label)-\(configuration.dictationVariant.rawValue)-\(configuration.encoderComputeMode.rawValue)"
+            let resultRoot = artifactDirectory.appendingPathComponent("dictation/results", isDirectory: true)
+            return [
+                LabArtifact(label: "Raw dictation results", path: resultRoot.appendingPathComponent("\(stem).jsonl").path),
+                LabArtifact(label: "Dictation summary", path: resultRoot.appendingPathComponent("\(stem).summary.md").path),
+            ]
+        case .transcriptionCorpus:
+            let root = artifactDirectory
+                .appendingPathComponent("transcription", isDirectory: true)
+                .appendingPathComponent(runID.uuidString.lowercased(), isDirectory: true)
+            return [
+                LabArtifact(label: "Transcription QA report", path: root.appendingPathComponent("qa-report.md").path),
+                LabArtifact(label: "Transcription QA results", path: root.appendingPathComponent("results.tsv").path),
+            ]
+        case .speakerIdentity:
+            if configuration.speakerMode == .thresholdSweep {
+                let root = URL(fileURLWithPath: configuration.repositoryPath, isDirectory: true)
+                    .appendingPathComponent("data/eval/\(configuration.speakerCorpus.rawValue)/reports", isDirectory: true)
+                return [LabArtifact(label: "Speaker sweep", path: root.appendingPathComponent("SWEEP.md").path)]
+            }
+            let root = configuration.speakerStateDirectory.isEmpty
+                ? artifactDirectory.appendingPathComponent("speaker-autoresearch", isDirectory: true)
+                : URL(fileURLWithPath: configuration.speakerStateDirectory, isDirectory: true)
+            return [
+                LabArtifact(label: "Speaker auto-research report", path: root.appendingPathComponent("final-report.md").path),
+                LabArtifact(label: "Speaker experiment ledger", path: root.appendingPathComponent("results.tsv").path),
+            ]
+        case .qa:
+            let root = artifactDirectory
+                .appendingPathComponent("qa", isDirectory: true)
+                .appendingPathComponent(runID.uuidString.lowercased(), isDirectory: true)
+            return [
+                LabArtifact(label: "QA report", path: root.appendingPathComponent("qa-report.md").path),
+                LabArtifact(label: "QA results", path: root.appendingPathComponent("results.tsv").path),
+            ]
+        }
+    }
+
+    private static func requireFile(_ url: URL, fileManager: FileManager) throws {
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw LabRunnerError.missingInput(url.path)
+        }
+    }
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabExperimentRunner.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabExperimentRunner.swift
@@ -87,12 +87,13 @@ public actor LabExperimentRunner {
             try reportStore.save(report, fileManager: fileManager)
             return report
         } catch {
-            let message = error.localizedDescription
+            let wasCancelled = error is CancellationError
+            let message = wasCancelled ? "Experiment cancelled." : error.localizedDescription
             let report = LabRunReport(
                 id: id,
                 startedAt: startedAt,
                 finishedAt: Date(),
-                status: .failed,
+                status: wasCancelled ? .cancelled : .failed,
                 configuration: configuration,
                 summary: message,
                 scorecard: LabScorecard(overallScore: 0, hardGateFailures: [message]),

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabExperimentRunner.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabExperimentRunner.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+public actor LabExperimentRunner {
+    private let processRunner: LabProcessRunner
+    private let reportStore: LabReportStore
+    private let artifactRoot: URL
+    private let fileManager: FileManager
+
+    public init(
+        processRunner: LabProcessRunner = LabProcessRunner(),
+        reportStore: LabReportStore = LabReportStore(),
+        artifactRoot: URL = LabPaths.artifactsRoot(),
+        fileManager: FileManager = .default
+    ) {
+        self.processRunner = processRunner
+        self.reportStore = reportStore
+        self.artifactRoot = artifactRoot
+        self.fileManager = fileManager
+    }
+
+    public func run(_ configuration: LabRunConfiguration) async -> LabRunReport {
+        let id = UUID()
+        let startedAt = Date()
+        let runArtifacts = artifactRoot.appendingPathComponent(id.uuidString.lowercased(), isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: runArtifacts, withIntermediateDirectories: true)
+            let command = try LabCommandBuilder.build(
+                configuration: configuration,
+                runID: id,
+                artifactDirectory: runArtifacts,
+                fileManager: fileManager
+            )
+            let expected = LabCommandBuilder.expectedArtifacts(
+                configuration: configuration,
+                runID: id,
+                artifactDirectory: runArtifacts
+            )
+            let processResult: LabProcessResult?
+            if let command {
+                processResult = try await processRunner.run(command, timeoutSeconds: configuration.timeoutSeconds)
+            } else {
+                processResult = nil
+            }
+
+            if let processResult, processResult.timedOut || processResult.exitCode != 0 {
+                let failure = processResult.timedOut
+                    ? "Experiment timed out after \(Int(configuration.timeoutSeconds)) seconds."
+                    : "Experiment process exited with code \(processResult.exitCode)."
+                let report = LabRunReport(
+                    id: id,
+                    startedAt: startedAt,
+                    finishedAt: Date(),
+                    status: .failed,
+                    configuration: configuration,
+                    summary: failure,
+                    scorecard: LabScorecard(overallScore: 0, hardGateFailures: [failure]),
+                    metrics: [],
+                    command: command,
+                    process: processResult,
+                    artifacts: existingArtifacts(expected),
+                    sourceRevision: gitRevision(repositoryPath: configuration.repositoryPath)
+                )
+                _ = try? reportStore.save(report, fileManager: fileManager)
+                return report
+            }
+
+            let analysis = try analyze(
+                configuration: configuration,
+                runID: id,
+                artifactDirectory: runArtifacts,
+                expectedArtifacts: expected
+            )
+            let report = LabRunReport(
+                id: id,
+                startedAt: startedAt,
+                finishedAt: Date(),
+                status: status(for: analysis.scorecard),
+                configuration: configuration,
+                summary: analysis.summary,
+                scorecard: analysis.scorecard,
+                metrics: analysis.metrics,
+                command: command,
+                process: processResult,
+                artifacts: uniqueArtifacts(analysis.artifacts + existingArtifacts(expected)),
+                sourceRevision: gitRevision(repositoryPath: configuration.repositoryPath)
+            )
+            try reportStore.save(report, fileManager: fileManager)
+            return report
+        } catch {
+            let message = error.localizedDescription
+            let report = LabRunReport(
+                id: id,
+                startedAt: startedAt,
+                finishedAt: Date(),
+                status: .failed,
+                configuration: configuration,
+                summary: message,
+                scorecard: LabScorecard(overallScore: 0, hardGateFailures: [message]),
+                metrics: [],
+                command: nil,
+                process: nil,
+                artifacts: [],
+                sourceRevision: gitRevision(repositoryPath: configuration.repositoryPath)
+            )
+            _ = try? reportStore.save(report, fileManager: fileManager)
+            return report
+        }
+    }
+
+    private func analyze(
+        configuration: LabRunConfiguration,
+        runID: UUID,
+        artifactDirectory: URL,
+        expectedArtifacts: [LabArtifact]
+    ) throws -> LabAnalysisResult {
+        switch configuration.bench {
+        case .runtimeSnapshot:
+            return try RuntimeEventAnalyzer.analyze(
+                eventsURL: URL(fileURLWithPath: configuration.runtimeEventsPath),
+                windowHours: configuration.runtimeWindowHours,
+                minimumSamples: max(1, configuration.minimumSamples),
+                strictGates: configuration.strictGates
+            )
+
+        case .dictationStop:
+            guard let raw = expectedArtifacts.first(where: { $0.label == "Raw dictation results" }) else {
+                throw LabRunnerError.reportNotFound("dictation JSONL")
+            }
+            let summary = expectedArtifacts.first(where: { $0.label == "Dictation summary" })
+            return try DictationBenchmarkAnalyzer.analyze(
+                resultURL: URL(fileURLWithPath: raw.path),
+                summaryURL: summary.map { URL(fileURLWithPath: $0.path) }
+            )
+
+        case .transcriptionCorpus:
+            guard let report = expectedArtifacts.first(where: { $0.label == "Transcription QA report" }),
+                  let results = expectedArtifacts.first(where: { $0.label == "Transcription QA results" }) else {
+                throw LabRunnerError.reportNotFound("transcription corpus report")
+            }
+            return try QAResultsAnalyzer.analyze(
+                resultsURL: URL(fileURLWithPath: results.path),
+                reportURL: URL(fileURLWithPath: report.path),
+                title: "Transcription corpus"
+            )
+
+        case .speakerIdentity:
+            if configuration.speakerMode == .thresholdSweep {
+                return try SpeakerSweepAnalyzer.analyze(configuration: configuration)
+            }
+            let stateDirectory = configuration.speakerStateDirectory.isEmpty
+                ? artifactDirectory.appendingPathComponent("speaker-autoresearch", isDirectory: true)
+                : URL(fileURLWithPath: configuration.speakerStateDirectory, isDirectory: true)
+            return SpeakerAutoResearchAnalyzer.analyze(stateDirectory: stateDirectory)
+
+        case .qa:
+            guard let report = expectedArtifacts.first(where: { $0.label == "QA report" }),
+                  let results = expectedArtifacts.first(where: { $0.label == "QA results" }) else {
+                throw LabRunnerError.reportNotFound("QA report")
+            }
+            return try QAResultsAnalyzer.analyze(
+                resultsURL: URL(fileURLWithPath: results.path),
+                reportURL: URL(fileURLWithPath: report.path),
+                title: "Transcripted QA"
+            )
+        }
+    }
+
+    private func status(for scorecard: LabScorecard) -> LabRunStatus {
+        if !scorecard.hardGateFailures.isEmpty { return .failed }
+        if !scorecard.warnings.isEmpty { return .warning }
+        if scorecard.overallScore == nil { return .incomplete }
+        return .passed
+    }
+
+    private func existingArtifacts(_ artifacts: [LabArtifact]) -> [LabArtifact] {
+        artifacts.filter { fileManager.fileExists(atPath: $0.path) }
+    }
+
+    private func uniqueArtifacts(_ artifacts: [LabArtifact]) -> [LabArtifact] {
+        var seen = Set<String>()
+        return artifacts.filter { seen.insert($0.path).inserted }
+    }
+
+    private func gitRevision(repositoryPath: String) -> String? {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = ["-C", repositoryPath, "rev-parse", "HEAD"]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+    }
+}
+
+public struct LabDoctorCheck: Codable, Equatable, Identifiable, Sendable {
+    public var id: String { name }
+    public let name: String
+    public let passed: Bool
+    public let detail: String
+}
+
+public enum LabDoctor {
+    public static func inspect(repositoryPath: String, fileManager: FileManager = .default) -> [LabDoctorCheck] {
+        let root = URL(fileURLWithPath: repositoryPath, isDirectory: true)
+        let checks: [(String, String)] = [
+            ("Transcripted repository", "AGENTS.md"),
+            ("QA bench", "scripts/ops/transcripted-qa-bench.sh"),
+            ("Dictation benchmark", "scripts/ops/dictation-stop-autoeval.sh"),
+            ("Speaker eval", "scripts/run_speaker_eval.sh"),
+            ("Speaker auto-research", "scripts/run_speaker_autoresearch.py"),
+            ("Speaker harness", "Tools/SpeakerEvalHarness/Package.swift"),
+        ]
+        var results = checks.map { name, relative in
+            let url = root.appendingPathComponent(relative)
+            return LabDoctorCheck(name: name, passed: fileManager.fileExists(atPath: url.path), detail: url.path)
+        }
+        for executable in ["/usr/bin/git", "/bin/bash", "/usr/bin/env"] {
+            results.append(LabDoctorCheck(
+                name: URL(fileURLWithPath: executable).lastPathComponent,
+                passed: fileManager.isExecutableFile(atPath: executable),
+                detail: executable
+            ))
+        }
+        return results
+    }
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabModels.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabModels.swift
@@ -1,0 +1,518 @@
+import Foundation
+
+public enum LabBench: String, Codable, CaseIterable, Identifiable, Sendable {
+    case runtimeSnapshot = "runtime-snapshot"
+    case dictationStop = "dictation-stop"
+    case transcriptionCorpus = "transcription-corpus"
+    case speakerIdentity = "speaker-identity"
+    case qa = "qa"
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .runtimeSnapshot: return "Runtime Snapshot"
+        case .dictationStop: return "Dictation Bench"
+        case .transcriptionCorpus: return "Transcription Bench"
+        case .speakerIdentity: return "Speaker Bench"
+        case .qa: return "QA Bench"
+        }
+    }
+
+    public var summary: String {
+        switch self {
+        case .runtimeSnapshot:
+            return "Score recent production telemetry for transcription, dictation start, dictation stop, and fallback behavior."
+        case .dictationStop:
+            return "Replay synthetic WAV fixtures through Transcripted's production dictation finalization path and measure decode, text-ready, save, and delivery latency."
+        case .transcriptionCorpus:
+            return "Compare Transcripted meeting output against a local truth corpus. Accuracy and artifact integrity are scored; runtime speed comes from the Runtime Snapshot."
+        case .speakerIdentity:
+            return "Run the app's real diarizer, voice embeddings, clustering, and cross-meeting identity matcher against labeled audio."
+        case .qa:
+            return "Run the existing Transcripted QA orchestrator and normalize its pass, warn, fail, and skip results into a Lab report."
+        }
+    }
+}
+
+public enum DictationVariant: String, Codable, CaseIterable, Identifiable, Sendable {
+    case production
+    case native
+    case preResampled = "pre_resampled"
+    case chunked
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .production: return "Production path"
+        case .native: return "Native model input"
+        case .preResampled: return "Pre-resampled"
+        case .chunked: return "Chunked"
+        }
+    }
+}
+
+public enum DictationFinalizationOrder: String, Codable, CaseIterable, Identifiable, Sendable {
+    case saveBeforeAutoEnter
+    case saveAfterAutoEnter
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .saveBeforeAutoEnter: return "Save before Auto Enter"
+        case .saveAfterAutoEnter: return "Save after Auto Enter"
+        }
+    }
+}
+
+public enum EncoderComputeMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case `default`
+    case cpuAndGPU = "cpu-and-gpu"
+    case all
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .default: return "Default"
+        case .cpuAndGPU: return "CPU + GPU"
+        case .all: return "All compute units"
+        }
+    }
+}
+
+public enum SpeakerExperimentMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case thresholdSweep = "threshold-sweep"
+    case autoResearch = "auto-research"
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .thresholdSweep: return "Threshold sweep"
+        case .autoResearch: return "ASK / SUGGEST / AUTO research"
+        }
+    }
+}
+
+public enum SpeakerCorpus: String, Codable, CaseIterable, Identifiable, Sendable {
+    case ami
+    case icsi
+    case voxconverse
+    case voxceleb
+
+    public var id: String { rawValue }
+    public var title: String { rawValue.uppercased() }
+}
+
+public enum SpeakerResearchPhase: String, Codable, CaseIterable, Identifiable, Sendable {
+    case prepare
+    case discover
+    case validate
+    case all
+
+    public var id: String { rawValue }
+    public var title: String { rawValue.capitalized }
+}
+
+public enum QABenchMode: String, Codable, CaseIterable, Identifiable, Sendable {
+    case quick
+    case deep
+    case full
+    case ui
+    case importedAudioNative = "imported-audio-native"
+    case packaged
+    case artifact
+    case audioSynthetic = "audio-synthetic"
+    case pastebackSynthetic = "pasteback-synthetic"
+    case live
+
+    public var id: String { rawValue }
+    public var title: String { rawValue.replacingOccurrences(of: "-", with: " ").capitalized }
+}
+
+public struct LabRunConfiguration: Codable, Equatable, Sendable {
+    public var name: String
+    public var bench: LabBench
+    public var repositoryPath: String
+    public var repetitions: Int
+    public var timeoutSeconds: Double
+    public var skipBuild: Bool
+
+    public var runtimeEventsPath: String
+    public var runtimeWindowHours: Double
+    public var minimumSamples: Int
+    public var strictGates: Bool
+
+    public var dictationVariant: DictationVariant
+    public var dictationFinalizationOrder: DictationFinalizationOrder
+    public var encoderComputeMode: EncoderComputeMode
+    public var chunkSeconds: Double
+    public var includeSilence: Bool
+    public var simulateAutoEnter: Bool
+
+    public var corpusRoot: String
+    public var corpusIDs: String
+    public var corpusOutputDirectory: String
+    public var corpusCandidateMap: String
+    public var corpusMinimumRecall: Double
+    public var corpusMinimumContentRecall: Double
+
+    public var speakerMode: SpeakerExperimentMode
+    public var speakerCorpus: SpeakerCorpus
+    public var speakerSeries: String
+    public var consolidationThresholds: String
+    public var matchThresholds: String
+    public var speakerCollar: Double
+    public var allowPartialCorpus: Bool
+    public var speakerManifestPath: String
+    public var speakerInputRoot: String
+    public var speakerStateDirectory: String
+    public var speakerResearchPhase: SpeakerResearchPhase
+    public var speakerTopK: Int
+
+    public var qaMode: QABenchMode
+
+    public init(
+        name: String = "Transcripted experiment",
+        bench: LabBench = .runtimeSnapshot,
+        repositoryPath: String,
+        repetitions: Int = 3,
+        timeoutSeconds: Double = 3_600,
+        skipBuild: Bool = false,
+        runtimeEventsPath: String = "",
+        runtimeWindowHours: Double = 168,
+        minimumSamples: Int = 10,
+        strictGates: Bool = true,
+        dictationVariant: DictationVariant = .production,
+        dictationFinalizationOrder: DictationFinalizationOrder = .saveBeforeAutoEnter,
+        encoderComputeMode: EncoderComputeMode = .default,
+        chunkSeconds: Double = 30,
+        includeSilence: Bool = true,
+        simulateAutoEnter: Bool = true,
+        corpusRoot: String = "",
+        corpusIDs: String = "",
+        corpusOutputDirectory: String = "",
+        corpusCandidateMap: String = "",
+        corpusMinimumRecall: Double = 0.45,
+        corpusMinimumContentRecall: Double = 0.35,
+        speakerMode: SpeakerExperimentMode = .thresholdSweep,
+        speakerCorpus: SpeakerCorpus = .ami,
+        speakerSeries: String = "",
+        consolidationThresholds: String = "none 0.82 0.85 0.88 0.91",
+        matchThresholds: String = "0.50 0.55 0.60 0.65 0.70",
+        speakerCollar: Double = 0.25,
+        allowPartialCorpus: Bool = false,
+        speakerManifestPath: String = "",
+        speakerInputRoot: String = "",
+        speakerStateDirectory: String = "",
+        speakerResearchPhase: SpeakerResearchPhase = .all,
+        speakerTopK: Int = 8,
+        qaMode: QABenchMode = .quick
+    ) {
+        self.name = name
+        self.bench = bench
+        self.repositoryPath = repositoryPath
+        self.repetitions = repetitions
+        self.timeoutSeconds = timeoutSeconds
+        self.skipBuild = skipBuild
+        self.runtimeEventsPath = runtimeEventsPath
+        self.runtimeWindowHours = runtimeWindowHours
+        self.minimumSamples = minimumSamples
+        self.strictGates = strictGates
+        self.dictationVariant = dictationVariant
+        self.dictationFinalizationOrder = dictationFinalizationOrder
+        self.encoderComputeMode = encoderComputeMode
+        self.chunkSeconds = chunkSeconds
+        self.includeSilence = includeSilence
+        self.simulateAutoEnter = simulateAutoEnter
+        self.corpusRoot = corpusRoot
+        self.corpusIDs = corpusIDs
+        self.corpusOutputDirectory = corpusOutputDirectory
+        self.corpusCandidateMap = corpusCandidateMap
+        self.corpusMinimumRecall = corpusMinimumRecall
+        self.corpusMinimumContentRecall = corpusMinimumContentRecall
+        self.speakerMode = speakerMode
+        self.speakerCorpus = speakerCorpus
+        self.speakerSeries = speakerSeries
+        self.consolidationThresholds = consolidationThresholds
+        self.matchThresholds = matchThresholds
+        self.speakerCollar = speakerCollar
+        self.allowPartialCorpus = allowPartialCorpus
+        self.speakerManifestPath = speakerManifestPath
+        self.speakerInputRoot = speakerInputRoot
+        self.speakerStateDirectory = speakerStateDirectory
+        self.speakerResearchPhase = speakerResearchPhase
+        self.speakerTopK = speakerTopK
+        self.qaMode = qaMode
+    }
+
+    public static func defaults(repositoryPath: String, homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> LabRunConfiguration {
+        let appSupport = homeDirectory
+            .appendingPathComponent("Library/Application Support/Transcripted", isDirectory: true)
+        let corpusRoot = homeDirectory.appendingPathComponent("Downloads/meeting-corpus", isDirectory: true)
+        return LabRunConfiguration(
+            repositoryPath: repositoryPath,
+            runtimeEventsPath: appSupport.appendingPathComponent("logs/events.jsonl").path,
+            corpusRoot: corpusRoot.path,
+            corpusOutputDirectory: corpusRoot.appendingPathComponent("transcripted-output", isDirectory: true).path
+        )
+    }
+}
+
+public enum LabRunStatus: String, Codable, Sendable {
+    case passed
+    case warning
+    case failed
+    case incomplete
+    case cancelled
+
+    public var title: String { rawValue.capitalized }
+}
+
+public enum LabMetricDirection: String, Codable, Sendable {
+    case lowerIsBetter
+    case higherIsBetter
+    case target
+    case informational
+}
+
+public struct LabMetric: Codable, Equatable, Identifiable, Sendable {
+    public var id: String { key }
+    public let key: String
+    public let label: String
+    public let value: Double
+    public let unit: String
+    public let sampleCount: Int?
+    public let target: Double?
+    public let direction: LabMetricDirection
+
+    public init(
+        key: String,
+        label: String,
+        value: Double,
+        unit: String,
+        sampleCount: Int? = nil,
+        target: Double? = nil,
+        direction: LabMetricDirection = .informational
+    ) {
+        self.key = key
+        self.label = label
+        self.value = value
+        self.unit = unit
+        self.sampleCount = sampleCount
+        self.target = target
+        self.direction = direction
+    }
+}
+
+public struct LabScoreDimension: Codable, Equatable, Identifiable, Sendable {
+    public var id: String { key }
+    public let key: String
+    public let label: String
+    public let score: Int
+    public let weight: Double
+    public let explanation: String
+
+    public init(key: String, label: String, score: Int, weight: Double, explanation: String) {
+        self.key = key
+        self.label = label
+        self.score = max(0, min(100, score))
+        self.weight = weight
+        self.explanation = explanation
+    }
+}
+
+public struct LabScorecard: Codable, Equatable, Sendable {
+    public let overallScore: Int?
+    public let dimensions: [LabScoreDimension]
+    public let hardGateFailures: [String]
+    public let warnings: [String]
+
+    public init(
+        overallScore: Int?,
+        dimensions: [LabScoreDimension] = [],
+        hardGateFailures: [String] = [],
+        warnings: [String] = []
+    ) {
+        self.overallScore = overallScore.map { max(0, min(100, $0)) }
+        self.dimensions = dimensions
+        self.hardGateFailures = hardGateFailures
+        self.warnings = warnings
+    }
+
+    public static func weighted(
+        dimensions: [LabScoreDimension],
+        hardGateFailures: [String] = [],
+        warnings: [String] = []
+    ) -> LabScorecard {
+        let usable = dimensions.filter { $0.weight > 0 }
+        guard !usable.isEmpty else {
+            return LabScorecard(overallScore: nil, dimensions: dimensions, hardGateFailures: hardGateFailures, warnings: warnings)
+        }
+        let totalWeight = usable.reduce(0) { $0 + $1.weight }
+        let weighted = usable.reduce(0.0) { $0 + Double($1.score) * $1.weight }
+        return LabScorecard(
+            overallScore: Int((weighted / totalWeight).rounded()),
+            dimensions: dimensions,
+            hardGateFailures: hardGateFailures,
+            warnings: warnings
+        )
+    }
+}
+
+public struct LabArtifact: Codable, Equatable, Identifiable, Sendable {
+    public var id: String { path }
+    public let label: String
+    public let path: String
+
+    public init(label: String, path: String) {
+        self.label = label
+        self.path = path
+    }
+}
+
+public struct LabCommand: Codable, Equatable, Sendable {
+    public let executable: String
+    public let arguments: [String]
+    public let environment: [String: String]
+    public let workingDirectory: String
+    public let summary: String
+
+    public init(
+        executable: String,
+        arguments: [String],
+        environment: [String: String] = [:],
+        workingDirectory: String,
+        summary: String
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.environment = environment
+        self.workingDirectory = workingDirectory
+        self.summary = summary
+    }
+
+    public var displayCommand: String {
+        ([executable] + arguments).map(LabShell.quote).joined(separator: " ")
+    }
+}
+
+public struct LabProcessResult: Codable, Equatable, Sendable {
+    public let exitCode: Int32
+    public let timedOut: Bool
+    public let durationSeconds: Double
+    public let stdoutTail: String
+    public let stderrTail: String
+
+    public init(exitCode: Int32, timedOut: Bool, durationSeconds: Double, stdoutTail: String, stderrTail: String) {
+        self.exitCode = exitCode
+        self.timedOut = timedOut
+        self.durationSeconds = durationSeconds
+        self.stdoutTail = stdoutTail
+        self.stderrTail = stderrTail
+    }
+}
+
+public struct LabAnalysisResult: Sendable {
+    public let summary: String
+    public let metrics: [LabMetric]
+    public let scorecard: LabScorecard
+    public let artifacts: [LabArtifact]
+
+    public init(summary: String, metrics: [LabMetric], scorecard: LabScorecard, artifacts: [LabArtifact] = []) {
+        self.summary = summary
+        self.metrics = metrics
+        self.scorecard = scorecard
+        self.artifacts = artifacts
+    }
+}
+
+public struct LabRunReport: Codable, Equatable, Identifiable, Sendable {
+    public static let schemaVersion = 1
+
+    public let schema: Int
+    public let id: UUID
+    public let startedAt: Date
+    public let finishedAt: Date
+    public let status: LabRunStatus
+    public let configuration: LabRunConfiguration
+    public let summary: String
+    public let scorecard: LabScorecard
+    public let metrics: [LabMetric]
+    public let command: LabCommand?
+    public let process: LabProcessResult?
+    public let artifacts: [LabArtifact]
+    public let sourceRevision: String?
+
+    public init(
+        id: UUID,
+        startedAt: Date,
+        finishedAt: Date,
+        status: LabRunStatus,
+        configuration: LabRunConfiguration,
+        summary: String,
+        scorecard: LabScorecard,
+        metrics: [LabMetric],
+        command: LabCommand?,
+        process: LabProcessResult?,
+        artifacts: [LabArtifact],
+        sourceRevision: String?
+    ) {
+        self.schema = Self.schemaVersion
+        self.id = id
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.status = status
+        self.configuration = configuration
+        self.summary = summary
+        self.scorecard = scorecard
+        self.metrics = metrics
+        self.command = command
+        self.process = process
+        self.artifacts = artifacts
+        self.sourceRevision = sourceRevision
+    }
+
+    public var durationSeconds: Double { finishedAt.timeIntervalSince(startedAt) }
+}
+
+public struct LabMetricDelta: Codable, Equatable, Identifiable, Sendable {
+    public var id: String { key }
+    public let key: String
+    public let label: String
+    public let baseline: Double
+    public let candidate: Double
+    public let delta: Double
+    public let percentChange: Double?
+    public let unit: String
+}
+
+public struct LabRunComparison: Codable, Equatable, Sendable {
+    public let baselineID: UUID
+    public let candidateID: UUID
+    public let scoreDelta: Int?
+    public let metricDeltas: [LabMetricDelta]
+    public let newHardGateFailures: [String]
+    public let resolvedHardGateFailures: [String]
+}
+
+public enum LabRunnerError: LocalizedError, Equatable {
+    case invalidRepository(String)
+    case missingInput(String)
+    case invalidConfiguration(String)
+    case processLaunch(String)
+    case reportNotFound(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRepository(let path): return "Not a Transcripted repository: \(path)"
+        case .missingInput(let detail): return "Missing input: \(detail)"
+        case .invalidConfiguration(let detail): return "Invalid configuration: \(detail)"
+        case .processLaunch(let detail): return "Could not launch experiment: \(detail)"
+        case .reportNotFound(let detail): return "Lab report not found: \(detail)"
+        }
+    }
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabProcessRunner.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabProcessRunner.swift
@@ -9,6 +9,10 @@ public final class LabProcessRunner: @unchecked Sendable {
     public init() {}
 
     public func run(_ command: LabCommand, timeoutSeconds: Double) async throws -> LabProcessResult {
+        try Task.checkCancellation()
+        guard timeoutSeconds.isFinite, timeoutSeconds > 0 else {
+            throw LabRunnerError.invalidConfiguration("Timeout must be a finite positive number.")
+        }
         let fileManager = FileManager.default
         let tempRoot = fileManager.temporaryDirectory
             .appendingPathComponent("transcripted-lab-process-\(UUID().uuidString)", isDirectory: true)
@@ -44,24 +48,33 @@ public final class LabProcessRunner: @unchecked Sendable {
             throw LabRunnerError.processLaunch(error.localizedDescription)
         }
 
-        let timeout = max(1, timeoutSeconds)
+        // Foundation launches Process in a separate process group on supported
+        // hosts. Verify that ownership before ever signaling a negative PID.
+        // The leader may already have exited by the time run() returns.
+        let groupID = process.processIdentifier
+        let observedGroup = getpgid(groupID)
+        guard groupID > 0, groupID != getpgrp(),
+              observedGroup == groupID || (observedGroup == -1 && errno == ESRCH) else {
+            // Ownership failed: signal only our direct child, never its group.
+            await stopOwnedProcesses(signalTarget: process.processIdentifier)
+            process.waitUntilExit()
+            throw LabRunnerError.processLaunch("Experiment did not receive an isolated process group.")
+        }
+
+        let deadline = ProcessInfo.processInfo.systemUptime + max(1, timeoutSeconds)
         var timedOut = false
-        while process.isRunning {
-            if Date().timeIntervalSince(startedAt) >= timeout {
+        while process.isRunning && !Task.isCancelled {
+            if ProcessInfo.processInfo.systemUptime >= deadline {
                 timedOut = true
-                process.terminate()
-                let graceDeadline = Date().addingTimeInterval(2)
-                while process.isRunning && Date() < graceDeadline {
-                    try? await Task.sleep(nanoseconds: 100_000_000)
-                }
-                if process.isRunning {
-                    _ = kill(process.processIdentifier, SIGKILL)
-                }
                 break
             }
-            try? await Task.sleep(nanoseconds: 100_000_000)
+            await pause()
+        }
+        if timedOut || Task.isCancelled || kill(-groupID, 0) == 0 {
+            await stopOwnedProcesses(signalTarget: -groupID)
         }
         process.waitUntilExit()
+        try Task.checkCancellation()
 
         try? stdoutHandle.synchronize()
         try? stderrHandle.synchronize()
@@ -76,5 +89,26 @@ public final class LabProcessRunner: @unchecked Sendable {
             stdoutTail: LabText.tail(LabText.sanitized(stdout)),
             stderrTail: LabText.tail(LabText.sanitized(stderr))
         )
+    }
+
+    private func stopOwnedProcesses(signalTarget: pid_t) async {
+        _ = kill(signalTarget, SIGTERM)
+        let deadline = ProcessInfo.processInfo.systemUptime + 2
+        while kill(signalTarget, 0) == 0 && ProcessInfo.processInfo.systemUptime < deadline {
+            await pause()
+        }
+        // The shell can exit before a child that ignores TERM. Escalate against
+        // the same owned group even after the Process leader has exited.
+        if kill(signalTarget, 0) == 0 { _ = kill(signalTarget, SIGKILL) }
+    }
+
+    private func pause() async {
+        // Cleanup must still yield after cancellation; try? Task.sleep would
+        // return immediately and spin while waiting for children to exit.
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                continuation.resume()
+            }
+        }
     }
 }

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabProcessRunner.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabProcessRunner.swift
@@ -1,0 +1,80 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+public final class LabProcessRunner: @unchecked Sendable {
+    public init() {}
+
+    public func run(_ command: LabCommand, timeoutSeconds: Double) async throws -> LabProcessResult {
+        let fileManager = FileManager.default
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("transcripted-lab-process-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let stdoutURL = tempRoot.appendingPathComponent("stdout.log")
+        let stderrURL = tempRoot.appendingPathComponent("stderr.log")
+        _ = fileManager.createFile(atPath: stdoutURL.path, contents: nil)
+        _ = fileManager.createFile(atPath: stderrURL.path, contents: nil)
+
+        let stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+        let stderrHandle = try FileHandle(forWritingTo: stderrURL)
+        defer {
+            try? stdoutHandle.close()
+            try? stderrHandle.close()
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: command.executable)
+        process.arguments = command.arguments
+        process.currentDirectoryURL = URL(fileURLWithPath: command.workingDirectory, isDirectory: true)
+        process.standardOutput = stdoutHandle
+        process.standardError = stderrHandle
+        var environment = ProcessInfo.processInfo.environment
+        command.environment.forEach { environment[$0.key] = $0.value }
+        process.environment = environment
+
+        let startedAt = Date()
+        do {
+            try process.run()
+        } catch {
+            throw LabRunnerError.processLaunch(error.localizedDescription)
+        }
+
+        let timeout = max(1, timeoutSeconds)
+        var timedOut = false
+        while process.isRunning {
+            if Date().timeIntervalSince(startedAt) >= timeout {
+                timedOut = true
+                process.terminate()
+                let graceDeadline = Date().addingTimeInterval(2)
+                while process.isRunning && Date() < graceDeadline {
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
+                if process.isRunning {
+                    _ = kill(process.processIdentifier, SIGKILL)
+                }
+                break
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        process.waitUntilExit()
+
+        try? stdoutHandle.synchronize()
+        try? stderrHandle.synchronize()
+        let stdout = (try? String(contentsOf: stdoutURL, encoding: .utf8)) ?? ""
+        let stderr = (try? String(contentsOf: stderrURL, encoding: .utf8)) ?? ""
+        let duration = Date().timeIntervalSince(startedAt)
+
+        return LabProcessResult(
+            exitCode: process.terminationStatus,
+            timedOut: timedOut,
+            durationSeconds: duration,
+            stdoutTail: LabText.tail(LabText.sanitized(stdout)),
+            stderrTail: LabText.tail(LabText.sanitized(stderr))
+        )
+    }
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabReportStore.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabReportStore.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+public struct LabReportStore: Sendable {
+    public let rootDirectory: URL
+
+    public init(rootDirectory: URL = LabPaths.reportsRoot()) {
+        self.rootDirectory = rootDirectory
+    }
+
+    @discardableResult
+    public func save(_ report: LabRunReport, fileManager: FileManager = .default) throws -> URL {
+        try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let filename = "\(formatter.string(from: report.startedAt))-\(report.id.uuidString.lowercased()).json"
+        let url = rootDirectory.appendingPathComponent(filename)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(report).write(to: url, options: .atomic)
+        return url
+    }
+
+    public func loadAll(fileManager: FileManager = .default) throws -> [LabRunReport] {
+        guard fileManager.fileExists(atPath: rootDirectory.path) else { return [] }
+        let urls = try fileManager.contentsOfDirectory(
+            at: rootDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension == "json" }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return urls.compactMap { url in
+            guard let data = try? Data(contentsOf: url) else { return nil }
+            return try? decoder.decode(LabRunReport.self, from: data)
+        }.sorted { $0.startedAt > $1.startedAt }
+    }
+
+    public func load(id: UUID, fileManager: FileManager = .default) throws -> LabRunReport {
+        if let report = try loadAll(fileManager: fileManager).first(where: { $0.id == id }) {
+            return report
+        }
+        throw LabRunnerError.reportNotFound(id.uuidString)
+    }
+
+    public func delete(id: UUID, fileManager: FileManager = .default) throws {
+        guard fileManager.fileExists(atPath: rootDirectory.path) else { return }
+        for url in try fileManager.contentsOfDirectory(at: rootDirectory, includingPropertiesForKeys: nil) {
+            guard url.pathExtension == "json",
+                  url.lastPathComponent.contains(id.uuidString.lowercased()) else { continue }
+            try fileManager.removeItem(at: url)
+        }
+    }
+}
+
+public enum LabReportComparator {
+    public static func compare(baseline: LabRunReport, candidate: LabRunReport) -> LabRunComparison {
+        let baselineMetrics = Dictionary(uniqueKeysWithValues: baseline.metrics.map { ($0.key, $0) })
+        let deltas = candidate.metrics.compactMap { metric -> LabMetricDelta? in
+            guard let prior = baselineMetrics[metric.key], prior.unit == metric.unit else { return nil }
+            let delta = metric.value - prior.value
+            let percent = prior.value == 0 ? nil : delta / abs(prior.value) * 100
+            return LabMetricDelta(
+                key: metric.key,
+                label: metric.label,
+                baseline: prior.value,
+                candidate: metric.value,
+                delta: delta,
+                percentChange: percent,
+                unit: metric.unit
+            )
+        }.sorted { $0.label < $1.label }
+        let baselineFailures = Set(baseline.scorecard.hardGateFailures)
+        let candidateFailures = Set(candidate.scorecard.hardGateFailures)
+        return LabRunComparison(
+            baselineID: baseline.id,
+            candidateID: candidate.id,
+            scoreDelta: scoreDelta(baseline.scorecard.overallScore, candidate.scorecard.overallScore),
+            metricDeltas: deltas,
+            newHardGateFailures: Array(candidateFailures.subtracting(baselineFailures)).sorted(),
+            resolvedHardGateFailures: Array(baselineFailures.subtracting(candidateFailures)).sorted()
+        )
+    }
+
+    private static func scoreDelta(_ baseline: Int?, _ candidate: Int?) -> Int? {
+        guard let baseline, let candidate else { return nil }
+        return candidate - baseline
+    }
+}

--- a/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabUtilities.swift
+++ b/Tools/TranscriptedLab/Sources/TranscriptedLabKit/LabUtilities.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+public enum LabShell {
+    public static func quote(_ value: String) -> String {
+        guard !value.isEmpty else { return "''" }
+        let safe = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_./:-"))
+        if value.unicodeScalars.allSatisfy({ safe.contains($0) }) {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
+    public static func safeLabel(_ value: String) -> String {
+        let lowered = value.lowercased()
+        let mapped = lowered.map { character -> Character in
+            if character.isLetter || character.isNumber || character == "-" || character == "_" {
+                return character
+            }
+            return "-"
+        }
+        let collapsed = String(mapped)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+        return collapsed.isEmpty ? "run" : String(collapsed.prefix(64))
+    }
+}
+
+public enum LabRepositoryLocator {
+    public static func locate(
+        startingAt start: URL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath),
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        if let explicit = environment["TRANSCRIPTED_REPO"], !explicit.isEmpty {
+            let candidate = URL(fileURLWithPath: explicit).standardizedFileURL
+            if isTranscriptedRepository(candidate, fileManager: fileManager) {
+                return candidate
+            }
+        }
+
+        var candidate = start.standardizedFileURL
+        while true {
+            if isTranscriptedRepository(candidate, fileManager: fileManager) {
+                return candidate
+            }
+            let parent = candidate.deletingLastPathComponent()
+            if parent.path == candidate.path { break }
+            candidate = parent
+        }
+        return nil
+    }
+
+    public static func isTranscriptedRepository(_ url: URL, fileManager: FileManager = .default) -> Bool {
+        let guide = url.appendingPathComponent("AGENTS.md").path
+        let qaBench = url.appendingPathComponent("scripts/ops/transcripted-qa-bench.sh").path
+        let speakerHarness = url.appendingPathComponent("Tools/SpeakerEvalHarness/Package.swift").path
+        return fileManager.fileExists(atPath: guide)
+            && fileManager.fileExists(atPath: qaBench)
+            && fileManager.fileExists(atPath: speakerHarness)
+    }
+}
+
+public enum LabPaths {
+    public static func applicationSupportRoot(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> URL {
+        homeDirectory
+            .appendingPathComponent("Library/Application Support/Transcripted Lab", isDirectory: true)
+    }
+
+    public static func reportsRoot(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        applicationSupportRoot(homeDirectory: homeDirectory).appendingPathComponent("Runs", isDirectory: true)
+    }
+
+    public static func artifactsRoot(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        applicationSupportRoot(homeDirectory: homeDirectory).appendingPathComponent("Artifacts", isDirectory: true)
+    }
+}
+
+public enum LabText {
+    public static func tail(_ text: String, limit: Int = 40_000) -> String {
+        guard text.count > limit else { return text }
+        return "…\n" + String(text.suffix(limit))
+    }
+
+    public static func sanitized(
+        _ text: String,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+    ) -> String {
+        text.replacingOccurrences(of: homeDirectory.path, with: "~")
+    }
+}
+
+public enum LabStatistics {
+    public static func percentile(_ values: [Double], _ quantile: Double) -> Double? {
+        guard !values.isEmpty else { return nil }
+        let sorted = values.sorted()
+        let clamped = min(1, max(0, quantile))
+        let index = Int((Double(sorted.count - 1) * clamped).rounded())
+        return sorted[index]
+    }
+
+    public static func mean(_ values: [Double]) -> Double? {
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    public static func lowerIsBetterScore(value: Double?, target: Double) -> Int? {
+        guard let value, value.isFinite, value >= 0, target > 0 else { return nil }
+        if value <= target { return 100 }
+        return max(0, min(100, Int((target / value * 100).rounded())))
+    }
+
+    public static func higherIsBetterScore(value: Double?, target: Double = 1) -> Int? {
+        guard let value, value.isFinite, target > 0 else { return nil }
+        return max(0, min(100, Int((value / target * 100).rounded())))
+    }
+}
+
+extension Dictionary where Key == String, Value == Any {
+    func labDouble(_ key: String) -> Double? {
+        guard let value = self[key] else { return nil }
+        if let number = value as? NSNumber { return number.doubleValue }
+        if let string = value as? String { return Double(string) }
+        return nil
+    }
+
+    func labString(_ key: String) -> String? {
+        if let value = self[key] as? String { return value }
+        if let value = self[key] as? NSNumber { return value.stringValue }
+        return nil
+    }
+}

--- a/Tools/TranscriptedLab/Sources/transcripted-lab/TranscriptedLabCLI.swift
+++ b/Tools/TranscriptedLab/Sources/transcripted-lab/TranscriptedLabCLI.swift
@@ -1,0 +1,320 @@
+import Foundation
+import TranscriptedLabKit
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+@main
+struct TranscriptedLabCLI {
+    static func main() async {
+        do {
+            let code = try await run(arguments: Array(CommandLine.arguments.dropFirst()))
+            exit(code)
+        } catch {
+            fputs("transcripted-lab: \(error.localizedDescription)\n", stderr)
+            exit(2)
+        }
+    }
+
+    private static func run(arguments: [String]) async throws -> Int32 {
+        guard let command = arguments.first else {
+            printHelp()
+            return 0
+        }
+        switch command {
+        case "help", "-h", "--help":
+            printHelp()
+            return 0
+        case "run":
+            return try await runExperiment(Array(arguments.dropFirst()))
+        case "snapshot":
+            return try await runExperiment([LabBench.runtimeSnapshot.rawValue] + Array(arguments.dropFirst()))
+        case "doctor":
+            return try doctor(Array(arguments.dropFirst()))
+        case "list":
+            return try listReports(Array(arguments.dropFirst()))
+        case "show":
+            return try showReport(Array(arguments.dropFirst()))
+        case "compare":
+            return try compareReports(Array(arguments.dropFirst()))
+        default:
+            throw LabRunnerError.invalidConfiguration("Unknown command '\(command)'. Run transcripted-lab help.")
+        }
+    }
+
+    private static func runExperiment(_ arguments: [String]) async throws -> Int32 {
+        guard let benchValue = arguments.first, let bench = LabBench(rawValue: benchValue) else {
+            throw LabRunnerError.invalidConfiguration("Run needs a bench: \(LabBench.allCases.map(\.rawValue).joined(separator: ", ")).")
+        }
+        let locatedRepo = LabRepositoryLocator.locate()?.path ?? FileManager.default.currentDirectoryPath
+        var configuration = LabRunConfiguration.defaults(repositoryPath: locatedRepo)
+        configuration.bench = bench
+        configuration.name = bench.title
+        var outputJSON = false
+        var index = 1
+        while index < arguments.count {
+            let option = arguments[index]
+            switch option {
+            case "--repo": configuration.repositoryPath = try value(after: option, in: arguments, index: &index)
+            case "--name": configuration.name = try value(after: option, in: arguments, index: &index)
+            case "--repetitions": configuration.repetitions = try integer(after: option, in: arguments, index: &index)
+            case "--timeout": configuration.timeoutSeconds = try number(after: option, in: arguments, index: &index)
+            case "--skip-build": configuration.skipBuild = true
+            case "--events": configuration.runtimeEventsPath = try value(after: option, in: arguments, index: &index)
+            case "--window-hours": configuration.runtimeWindowHours = try number(after: option, in: arguments, index: &index)
+            case "--minimum-samples": configuration.minimumSamples = try integer(after: option, in: arguments, index: &index)
+            case "--no-strict-gates": configuration.strictGates = false
+            case "--variant": configuration.dictationVariant = try enumValue(after: option, in: arguments, index: &index)
+            case "--finalization-order": configuration.dictationFinalizationOrder = try enumValue(after: option, in: arguments, index: &index)
+            case "--encoder-compute": configuration.encoderComputeMode = try enumValue(after: option, in: arguments, index: &index)
+            case "--chunk-seconds": configuration.chunkSeconds = try number(after: option, in: arguments, index: &index)
+            case "--include-silence": configuration.includeSilence = true
+            case "--exclude-silence": configuration.includeSilence = false
+            case "--no-auto-enter": configuration.simulateAutoEnter = false
+            case "--corpus-root": configuration.corpusRoot = try value(after: option, in: arguments, index: &index)
+            case "--corpus-ids": configuration.corpusIDs = try value(after: option, in: arguments, index: &index)
+            case "--corpus-output-dir": configuration.corpusOutputDirectory = try value(after: option, in: arguments, index: &index)
+            case "--corpus-candidate-map": configuration.corpusCandidateMap = try value(after: option, in: arguments, index: &index)
+            case "--minimum-recall": configuration.corpusMinimumRecall = try number(after: option, in: arguments, index: &index)
+            case "--minimum-content-recall": configuration.corpusMinimumContentRecall = try number(after: option, in: arguments, index: &index)
+            case "--speaker-mode": configuration.speakerMode = try enumValue(after: option, in: arguments, index: &index)
+            case "--speaker-corpus": configuration.speakerCorpus = try enumValue(after: option, in: arguments, index: &index)
+            case "--series": configuration.speakerSeries = try value(after: option, in: arguments, index: &index)
+            case "--consolidation": configuration.consolidationThresholds = try value(after: option, in: arguments, index: &index)
+            case "--match": configuration.matchThresholds = try value(after: option, in: arguments, index: &index)
+            case "--collar": configuration.speakerCollar = try number(after: option, in: arguments, index: &index)
+            case "--allow-partial-corpus": configuration.allowPartialCorpus = true
+            case "--manifest": configuration.speakerManifestPath = try value(after: option, in: arguments, index: &index)
+            case "--input-root": configuration.speakerInputRoot = try value(after: option, in: arguments, index: &index)
+            case "--state-dir": configuration.speakerStateDirectory = try value(after: option, in: arguments, index: &index)
+            case "--phase": configuration.speakerResearchPhase = try enumValue(after: option, in: arguments, index: &index)
+            case "--top-k": configuration.speakerTopK = try integer(after: option, in: arguments, index: &index)
+            case "--qa-mode": configuration.qaMode = try enumValue(after: option, in: arguments, index: &index)
+            case "--json": outputJSON = true
+            case "-h", "--help":
+                printRunHelp()
+                return 0
+            default:
+                throw LabRunnerError.invalidConfiguration("Unknown run option '\(option)'.")
+            }
+            index += 1
+        }
+
+        let runner = LabExperimentRunner()
+        let report = await runner.run(configuration)
+        if outputJSON {
+            try printJSON(report)
+        } else {
+            printReport(report)
+        }
+        return report.status == .failed ? 1 : 0
+    }
+
+    private static func doctor(_ arguments: [String]) throws -> Int32 {
+        var repositoryPath = LabRepositoryLocator.locate()?.path ?? FileManager.default.currentDirectoryPath
+        var outputJSON = false
+        var index = 0
+        while index < arguments.count {
+            switch arguments[index] {
+            case "--repo": repositoryPath = try value(after: "--repo", in: arguments, index: &index)
+            case "--json": outputJSON = true
+            default: throw LabRunnerError.invalidConfiguration("Unknown doctor option '\(arguments[index])'.")
+            }
+            index += 1
+        }
+        let checks = LabDoctor.inspect(repositoryPath: repositoryPath)
+        if outputJSON {
+            try printJSON(checks)
+        } else {
+            print("Transcripted Lab doctor — \(repositoryPath)")
+            checks.forEach { print("\($0.passed ? "PASS" : "FAIL")  \($0.name): \($0.detail)") }
+        }
+        return checks.allSatisfy(\.passed) ? 0 : 1
+    }
+
+    private static func listReports(_ arguments: [String]) throws -> Int32 {
+        let outputJSON = arguments.contains("--json")
+        let reports = try LabReportStore().loadAll()
+        if outputJSON {
+            try printJSON(reports)
+        } else if reports.isEmpty {
+            print("No Transcripted Lab runs yet.")
+        } else {
+            for report in reports {
+                let score = report.scorecard.overallScore.map(String.init) ?? "—"
+                print("\(report.id.uuidString.lowercased())  \(report.status.rawValue.uppercased())  \(score)  \(report.configuration.bench.title)  \(report.configuration.name)")
+            }
+        }
+        return 0
+    }
+
+    private static func showReport(_ arguments: [String]) throws -> Int32 {
+        guard let token = arguments.first else {
+            throw LabRunnerError.invalidConfiguration("show needs a report UUID or prefix.")
+        }
+        let report = try findReport(token)
+        if arguments.contains("--json") {
+            try printJSON(report)
+        } else {
+            printReport(report)
+        }
+        return report.status == .failed ? 1 : 0
+    }
+
+    private static func compareReports(_ arguments: [String]) throws -> Int32 {
+        guard arguments.count >= 2 else {
+            throw LabRunnerError.invalidConfiguration("compare needs BASELINE_ID CANDIDATE_ID.")
+        }
+        let baseline = try findReport(arguments[0])
+        let candidate = try findReport(arguments[1])
+        let comparison = LabReportComparator.compare(baseline: baseline, candidate: candidate)
+        if arguments.contains("--json") {
+            try printJSON(comparison)
+        } else {
+            print("Baseline:  \(baseline.id.uuidString.lowercased())")
+            print("Candidate: \(candidate.id.uuidString.lowercased())")
+            print("Score delta: \(comparison.scoreDelta.map { $0 >= 0 ? "+\($0)" : "\($0)" } ?? "n/a")")
+            for metric in comparison.metricDeltas {
+                let sign = metric.delta >= 0 ? "+" : ""
+                print("\(metric.label): \(numberString(metric.baseline)) → \(numberString(metric.candidate)) \(metric.unit) (\(sign)\(numberString(metric.delta)))")
+            }
+            if !comparison.newHardGateFailures.isEmpty {
+                print("New hard failures:")
+                comparison.newHardGateFailures.forEach { print("- \($0)") }
+            }
+            if !comparison.resolvedHardGateFailures.isEmpty {
+                print("Resolved hard failures:")
+                comparison.resolvedHardGateFailures.forEach { print("- \($0)") }
+            }
+        }
+        return comparison.newHardGateFailures.isEmpty ? 0 : 1
+    }
+
+    private static func findReport(_ token: String) throws -> LabRunReport {
+        let normalized = token.lowercased()
+        let matches = try LabReportStore().loadAll().filter {
+            $0.id.uuidString.lowercased().hasPrefix(normalized)
+        }
+        guard matches.count == 1, let report = matches.first else {
+            throw LabRunnerError.reportNotFound(matches.isEmpty ? token : "Ambiguous prefix \(token)")
+        }
+        return report
+    }
+
+    private static func value(after option: String, in arguments: [String], index: inout Int) throws -> String {
+        let next = index + 1
+        guard next < arguments.count else {
+            throw LabRunnerError.invalidConfiguration("\(option) needs a value.")
+        }
+        index = next
+        return arguments[next]
+    }
+
+    private static func integer(after option: String, in arguments: [String], index: inout Int) throws -> Int {
+        let raw = try value(after: option, in: arguments, index: &index)
+        guard let value = Int(raw) else { throw LabRunnerError.invalidConfiguration("\(option) needs an integer.") }
+        return value
+    }
+
+    private static func number(after option: String, in arguments: [String], index: inout Int) throws -> Double {
+        let raw = try value(after: option, in: arguments, index: &index)
+        guard let value = Double(raw) else { throw LabRunnerError.invalidConfiguration("\(option) needs a number.") }
+        return value
+    }
+
+    private static func enumValue<T: RawRepresentable>(after option: String, in arguments: [String], index: inout Int) throws -> T where T.RawValue == String {
+        let raw = try value(after: option, in: arguments, index: &index)
+        guard let value = T(rawValue: raw) else { throw LabRunnerError.invalidConfiguration("Unknown value '\(raw)' for \(option).") }
+        return value
+    }
+
+    private static func printJSON<T: Encodable>(_ value: T) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        print(String(decoding: try encoder.encode(value), as: UTF8.self))
+    }
+
+    private static func printReport(_ report: LabRunReport) {
+        print("\(report.configuration.name)")
+        print("Bench: \(report.configuration.bench.title)")
+        print("Status: \(report.status.rawValue.uppercased())")
+        print("Score: \(report.scorecard.overallScore.map(String.init) ?? "n/a")")
+        print(report.summary)
+        if !report.scorecard.hardGateFailures.isEmpty {
+            print("Hard failures:")
+            report.scorecard.hardGateFailures.forEach { print("- \($0)") }
+        }
+        if !report.scorecard.warnings.isEmpty {
+            print("Warnings:")
+            report.scorecard.warnings.forEach { print("- \($0)") }
+        }
+        if !report.metrics.isEmpty {
+            print("Metrics:")
+            report.metrics.forEach { print("- \($0.label): \(numberString($0.value)) \($0.unit)") }
+        }
+        print("Run ID: \(report.id.uuidString.lowercased())")
+    }
+
+    private static func numberString(_ value: Double) -> String {
+        if abs(value) >= 100 { return String(format: "%.0f", value) }
+        if abs(value) >= 10 { return String(format: "%.1f", value) }
+        return String(format: "%.3f", value)
+    }
+
+    private static func printHelp() {
+        print("""
+        Transcripted Lab — experiment workbench for Transcripted
+
+        Usage:
+          transcripted-lab run BENCH [options]
+          transcripted-lab snapshot [options]
+          transcripted-lab doctor [--repo PATH] [--json]
+          transcripted-lab list [--json]
+          transcripted-lab show RUN_ID [--json]
+          transcripted-lab compare BASELINE_ID CANDIDATE_ID [--json]
+
+        Benches:
+          runtime-snapshot       Score recent events.jsonl latency and reliability
+          dictation-stop         Run the production dictation stop benchmark
+          transcription-corpus   Compare Transcripted output with a local truth corpus
+          speaker-identity       Sweep speaker thresholds or run speaker auto-research
+          qa                     Run the existing QA bench
+
+        Run `transcripted-lab run runtime-snapshot --help` for the main knob list.
+        """)
+    }
+
+    private static func printRunHelp() {
+        print("""
+        Common:
+          --repo PATH --name NAME --timeout SECONDS --skip-build --json
+
+        Runtime Snapshot:
+          --events PATH --window-hours N --minimum-samples N --no-strict-gates
+
+        Dictation Bench:
+          --variant production|native|pre_resampled|chunked
+          --repetitions N --finalization-order saveBeforeAutoEnter|saveAfterAutoEnter
+          --encoder-compute default|cpu-and-gpu|all --chunk-seconds N
+          --include-silence|--exclude-silence --no-auto-enter
+
+        Transcription Bench:
+          --corpus-root PATH --corpus-ids IDS --corpus-output-dir PATH
+          --corpus-candidate-map PATH --minimum-recall N --minimum-content-recall N
+
+        Speaker Bench:
+          --speaker-mode threshold-sweep|auto-research
+          --speaker-corpus ami|icsi|voxconverse|voxceleb
+          --series "IDS" --consolidation "GRID" --match "GRID" --collar N
+          --allow-partial-corpus
+          Auto-research: --manifest PATH --input-root PATH --state-dir PATH
+                         --phase prepare|discover|validate|all --top-k N
+
+        QA Bench:
+          --qa-mode quick|deep|full|ui|imported-audio-native|packaged|artifact|audio-synthetic|pasteback-synthetic|live
+        """)
+    }
+}

--- a/Tools/TranscriptedLab/Tests/TranscriptedLabKitTests/TranscriptedLabKitTests.swift
+++ b/Tools/TranscriptedLab/Tests/TranscriptedLabKitTests/TranscriptedLabKitTests.swift
@@ -1,4 +1,9 @@
 import XCTest
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 @testable import TranscriptedLabKit
 
 final class TranscriptedLabKitTests: XCTestCase {
@@ -80,6 +85,67 @@ final class TranscriptedLabKitTests: XCTestCase {
         XCTAssertTrue(analysis.scorecard.hardGateFailures.isEmpty)
         XCTAssertEqual(analysis.metrics.first(where: { $0.key == "speaker.false-merges" })?.value, 0)
         XCTAssertEqual(analysis.metrics.first(where: { $0.key == "speaker.match" })?.value, 0.65)
+        config.consolidationThresholds = "0.880 0.850"
+        config.matchThresholds = "0.6 0.650"
+        let equivalent = try SpeakerSweepAnalyzer.analyze(configuration: config)
+        XCTAssertEqual(equivalent.metrics, analysis.metrics, "Numerically identical thresholds must select the same candidates")
+    }
+
+    func testProcessTimeoutStopsChildrenThatIgnoreTermination() async throws {
+        let root = try temporaryDirectory()
+        let childPID = root.appendingPathComponent("child.pid")
+        let result = try await LabProcessRunner().run(childCommand(root: root, pidFile: childPID), timeoutSeconds: 1)
+        XCTAssertTrue(result.timedOut)
+        try await assertChildExited(pidFile: childPID)
+    }
+
+    func testProcessCancellationStopsChildrenThatIgnoreTermination() async throws {
+        let root = try temporaryDirectory()
+        let childPID = root.appendingPathComponent("child.pid")
+        let command = childCommand(root: root, pidFile: childPID)
+        let task = Task { try await LabProcessRunner().run(command, timeoutSeconds: 30) }
+        for _ in 0..<100 where !FileManager.default.fileExists(atPath: childPID.path) {
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Cancellation must not return a successful process result")
+        } catch is CancellationError {
+            // Expected only after the owned process group has been stopped.
+        }
+        try await assertChildExited(pidFile: childPID)
+    }
+
+    func testProcessSuccessKeepsOutputAndExitCode() async throws {
+        let result = try await LabProcessRunner().run(
+            LabCommand(executable: "/bin/echo", arguments: ["synthetic output"], workingDirectory: "/tmp", summary: "fixture"),
+            timeoutSeconds: 5
+        )
+        XCTAssertEqual(result.exitCode, 0)
+        XCTAssertFalse(result.timedOut)
+        XCTAssertEqual(result.stdoutTail, "synthetic output\n")
+    }
+
+    private func childCommand(root: URL, pidFile: URL) -> LabCommand {
+        LabCommand(
+            executable: "/bin/bash",
+            arguments: ["-c", "(trap '' TERM; exec /bin/sleep 30) & echo $! > \"$1\"; wait", "lab-test", pidFile.path],
+            workingDirectory: root.path,
+            summary: "Synthetic child that ignores TERM"
+        )
+    }
+
+    private func assertChildExited(pidFile: URL) async throws {
+        let pidText = try String(contentsOf: pidFile, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        let pid = try XCTUnwrap(Int32(pidText))
+        // Give the OS time to reap an orphaned child after group SIGKILL.
+        for _ in 0..<100 {
+            if kill(pid, 0) == -1 && errno == ESRCH { return }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        _ = kill(pid, SIGKILL) // A failed regression must not leak its fixture.
+        XCTFail("Experiment child survived timeout/cancellation")
     }
 
     func testCommandBuilderExposesDictationKnobs() throws {

--- a/Tools/TranscriptedLab/Tests/TranscriptedLabKitTests/TranscriptedLabKitTests.swift
+++ b/Tools/TranscriptedLab/Tests/TranscriptedLabKitTests/TranscriptedLabKitTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import TranscriptedLabKit
+
+final class TranscriptedLabKitTests: XCTestCase {
+    func testRuntimeAnalyzerScoresLatencyAndFallbackGate() throws {
+        let root = try temporaryDirectory()
+        let events = root.appendingPathComponent("events.jsonl")
+        let now = Date()
+        let timestamp = ISO8601DateFormatter().string(from: now)
+        var lines: [String] = []
+        for _ in 0..<10 {
+            lines.append(jsonLine(event: "transcription_complete", timestamp: timestamp, context: ["elapsed_s": 0.25, "rtf": 0.02]))
+            lines.append(jsonLine(event: "dictation_recording_fast_start", timestamp: timestamp, context: ["start_ms": 100, "request_to_recording_ms": 120]))
+            lines.append(jsonLine(event: "audio_samples_detected", timestamp: timestamp, context: ["start_to_first_sample_ms": 180]))
+            lines.append(jsonLine(event: "dictation_stop_latency_measured", timestamp: timestamp, context: ["stop_to_paste_ms": 400, "stop_to_done_ms": 600]))
+        }
+        lines.append(jsonLine(event: "dictation_recording_retry", timestamp: timestamp, context: [:]))
+        try (lines.joined(separator: "\n") + "\n").write(to: events, atomically: true, encoding: .utf8)
+
+        let analysis = try RuntimeEventAnalyzer.analyze(
+            eventsURL: events,
+            windowHours: 24,
+            minimumSamples: 10,
+            strictGates: true,
+            now: now
+        )
+
+        XCTAssertEqual(analysis.scorecard.overallScore, 97)
+        XCTAssertEqual(analysis.scorecard.hardGateFailures.count, 1)
+        XCTAssertEqual(analysis.metrics.first(where: { $0.key == "transcription.rtf.p95" })?.value, 0.02)
+    }
+
+    func testDictationAnalyzerRejectsUnstableOutput() throws {
+        let root = try temporaryDirectory()
+        let result = root.appendingPathComponent("run.jsonl")
+        let rows = [
+            #"{"record_type":"run_start","model_init_s":1.2}"#,
+            #"{"record_type":"case_result","case_id":"short","audio_duration_s":10,"decode_s":0.2,"stop_to_text_s":0.3,"stop_to_delivery_s":0.5,"no_speech":false,"saved":true,"text_hash":"aaa"}"#,
+            #"{"record_type":"case_result","case_id":"short","audio_duration_s":10,"decode_s":0.2,"stop_to_text_s":0.3,"stop_to_delivery_s":0.5,"no_speech":false,"saved":true,"text_hash":"bbb"}"#,
+            #"{"record_type":"case_result","case_id":"silence_guardrail","audio_duration_s":5,"stop_to_text_s":0.1,"stop_to_delivery_s":0.1,"no_speech":true,"saved":false,"text_hash":""}"#,
+        ]
+        try (rows.joined(separator: "\n") + "\n").write(to: result, atomically: true, encoding: .utf8)
+
+        let analysis = try DictationBenchmarkAnalyzer.analyze(resultURL: result, summaryURL: nil)
+        XCTAssertFalse(analysis.scorecard.hardGateFailures.isEmpty)
+        XCTAssertEqual(analysis.metrics.first(where: { $0.key == "cases.unstable" })?.value, 1)
+    }
+
+    func testSpeakerSweepUsesSafetyFirstOrdering() throws {
+        let root = try temporaryDirectory()
+        let reports = root.appendingPathComponent("data/eval/ami/reports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reports, withIntermediateDirectories: true)
+        try speakerScore(
+            consolidation: "0.88",
+            match: 0.60,
+            der: 0.2,
+            fragmentation: 1.0,
+            falseMerges: 1,
+            reID: 1.0,
+            profiles: 2,
+            trueSpeakers: ["a", "b"]
+        ).write(to: reports.appendingPathComponent("cons_0.88_match_0.60.json"), atomically: true, encoding: .utf8)
+        try speakerScore(
+            consolidation: "0.85",
+            match: 0.65,
+            der: 0.25,
+            fragmentation: 1.2,
+            falseMerges: 0,
+            reID: 0.8,
+            profiles: 2,
+            trueSpeakers: ["a", "b"]
+        ).write(to: reports.appendingPathComponent("cons_0.85_match_0.65.json"), atomically: true, encoding: .utf8)
+
+        var config = LabRunConfiguration.defaults(repositoryPath: root.path, homeDirectory: root)
+        config.speakerCorpus = .ami
+        config.consolidationThresholds = "0.88 0.85"
+        config.matchThresholds = "0.60 0.65"
+        let analysis = try SpeakerSweepAnalyzer.analyze(configuration: config)
+
+        XCTAssertTrue(analysis.scorecard.hardGateFailures.isEmpty)
+        XCTAssertEqual(analysis.metrics.first(where: { $0.key == "speaker.false-merges" })?.value, 0)
+        XCTAssertEqual(analysis.metrics.first(where: { $0.key == "speaker.match" })?.value, 0.65)
+    }
+
+    func testCommandBuilderExposesDictationKnobs() throws {
+        let root = try fakeRepository()
+        var config = LabRunConfiguration.defaults(repositoryPath: root.path, homeDirectory: root)
+        config.bench = .dictationStop
+        config.name = "Fast Stop"
+        config.repetitions = 7
+        config.dictationVariant = .chunked
+        config.encoderComputeMode = .cpuAndGPU
+        config.skipBuild = true
+        config.includeSilence = true
+        config.simulateAutoEnter = false
+
+        let command = try XCTUnwrap(LabCommandBuilder.build(
+            configuration: config,
+            runID: UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!,
+            artifactDirectory: root.appendingPathComponent("artifacts")
+        ))
+
+        XCTAssertEqual(command.executable, "/bin/bash")
+        XCTAssertTrue(command.arguments.contains("chunked"))
+        XCTAssertTrue(command.arguments.contains("7"))
+        XCTAssertTrue(command.arguments.contains("cpu-and-gpu"))
+        XCTAssertTrue(command.arguments.contains("--skip-build"))
+        XCTAssertTrue(command.arguments.contains("--include-silence"))
+        XCTAssertTrue(command.arguments.contains("--no-auto-enter"))
+    }
+
+    func testReportStoreRoundTripAndComparison() throws {
+        let root = try temporaryDirectory()
+        let store = LabReportStore(rootDirectory: root)
+        let config = LabRunConfiguration.defaults(repositoryPath: "/tmp")
+        let baseline = makeReport(id: UUID(), score: 80, metric: 500, config: config)
+        let candidate = makeReport(id: UUID(), score: 90, metric: 400, config: config)
+        try store.save(baseline)
+        try store.save(candidate)
+
+        XCTAssertEqual(try store.loadAll().count, 2)
+        let comparison = LabReportComparator.compare(baseline: baseline, candidate: candidate)
+        XCTAssertEqual(comparison.scoreDelta, 10)
+        XCTAssertEqual(comparison.metricDeltas.first?.delta, -100)
+    }
+
+    private func makeReport(id: UUID, score: Int, metric: Double, config: LabRunConfiguration) -> LabRunReport {
+        LabRunReport(
+            id: id,
+            startedAt: Date(),
+            finishedAt: Date(),
+            status: .passed,
+            configuration: config,
+            summary: "test",
+            scorecard: LabScorecard(overallScore: score),
+            metrics: [LabMetric(key: "latency", label: "Latency", value: metric, unit: "ms")],
+            command: nil,
+            process: nil,
+            artifacts: [],
+            sourceRevision: nil
+        )
+    }
+
+    private func fakeRepository() throws -> URL {
+        let root = try temporaryDirectory()
+        for relative in [
+            "AGENTS.md",
+            "scripts/ops/transcripted-qa-bench.sh",
+            "scripts/ops/dictation-stop-autoeval.sh",
+            "scripts/run_speaker_eval.sh",
+            "scripts/run_speaker_autoresearch.py",
+            "Tools/SpeakerEvalHarness/Package.swift",
+        ] {
+            let url = root.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try "fixture".write(to: url, atomically: true, encoding: .utf8)
+        }
+        return root
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func jsonLine(event: String, timestamp: String, context: [String: Any]) -> String {
+        let object: [String: Any] = ["event": event, "timestamp": timestamp, "context": context]
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func speakerScore(
+        consolidation: String,
+        match: Double,
+        der: Double,
+        fragmentation: Double,
+        falseMerges: Int,
+        reID: Double,
+        profiles: Int,
+        trueSpeakers: [String]
+    ) -> String {
+        let object: [String: Any] = [
+            "config": ["consolidationThreshold": consolidation, "matchThreshold": match],
+            "der": ["mean_der": der],
+            "fragmentation": ["mean_profiles_per_person": fragmentation, "max_profiles_per_person": fragmentation],
+            "false_merge": ["count": falseMerges],
+            "reid_curve_by_appearance": ["1": 0.0, "2": reID, "3": reID],
+            "profiles_at_end": profiles,
+            "true_speakers": trueSpeakers,
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Tools/TranscriptedLab/script/build_and_run.sh
+++ b/Tools/TranscriptedLab/script/build_and_run.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TOOL_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIGURATION="debug"
+VERIFY_ONLY=0
+
+usage() {
+  cat <<'USAGE'
+Usage: Tools/TranscriptedLab/script/build_and_run.sh [--release] [--verify]
+
+Builds TranscriptedLab + transcripted-lab, creates a local app bundle, ad-hoc
+signs it, and opens it unless --verify is supplied.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --release) CONFIGURATION="release"; shift ;;
+    --verify) VERIFY_ONLY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+
+swift build --package-path "$TOOL_ROOT" -c "$CONFIGURATION" --product TranscriptedLab
+swift build --package-path "$TOOL_ROOT" -c "$CONFIGURATION" --product transcripted-lab
+BIN_DIR="$(swift build --package-path "$TOOL_ROOT" -c "$CONFIGURATION" --show-bin-path)"
+
+DIST="$TOOL_ROOT/dist"
+APP="$DIST/Transcripted Lab.app"
+CONTENTS="$APP/Contents"
+rm -rf "$APP"
+mkdir -p "$CONTENTS/MacOS" "$CONTENTS/Helpers" "$CONTENTS/Resources"
+cp "$BIN_DIR/TranscriptedLab" "$CONTENTS/MacOS/TranscriptedLab"
+cp "$BIN_DIR/transcripted-lab" "$CONTENTS/Helpers/transcripted-lab"
+chmod +x "$CONTENTS/MacOS/TranscriptedLab" "$CONTENTS/Helpers/transcripted-lab"
+
+cat > "$CONTENTS/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Transcripted Lab</string>
+  <key>CFBundleExecutable</key>
+  <string>TranscriptedLab</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.r3dbars.transcripted-lab</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>Transcripted Lab</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
+if command -v codesign >/dev/null 2>&1; then
+  codesign --force --deep --sign - "$APP"
+  codesign --verify --deep --strict --verbose=2 "$APP"
+fi
+
+printf 'Built %s\n' "$APP"
+if [[ "$VERIFY_ONLY" -eq 0 ]]; then
+  open "$APP"
+fi

--- a/docs/transcripted-lab.md
+++ b/docs/transcripted-lab.md
@@ -1,0 +1,49 @@
+# Transcripted Lab architecture
+
+Transcripted Lab is the regression and experiment surface for Transcripted. It lives as a standalone package under `Tools/TranscriptedLab` and does not ship inside the customer app.
+
+## Contract
+
+```text
+Experiment configuration
+        │
+        ▼
+TranscriptedLabKit command adapter
+        │
+        ├── runtime events analyzer
+        ├── production dictation benchmark
+        ├── corpus compare QA lane
+        ├── speaker eval / auto-research
+        └── repository QA bench
+        │
+        ▼
+Versioned aggregate report
+        │
+        ├── hard gates
+        ├── dimension scores
+        ├── p50 / p95 / p99 metrics
+        ├── local artifact pointers
+        └── baseline → candidate deltas
+```
+
+The SwiftUI app and `transcripted-lab` CLI both call this contract. A result from the GUI and the equivalent CLI command must mean the same thing.
+
+## Current score dimensions
+
+- Runtime Snapshot: transcription speed, dictation start, dictation stop, reliability.
+- Dictation Bench: stop/decode speed, delivery speed, text integrity.
+- Speaker Threshold Sweep: false-merge safety, cross-meeting re-ID, fragmentation, DER.
+- Transcription Corpus and QA: repository PASS/WARN/FAIL evidence.
+- Speaker Auto-Research: keeps its native multi-gate holdout report; no flattened score yet.
+
+## Isolation
+
+Each Lab run gets its own artifact directory under Transcripted Lab Application Support. Existing benchmark scripts already isolate app homes and capture libraries where required. Corpus assets remain in their current gitignored locations so the Lab does not duplicate large audio collections.
+
+## Next build slices
+
+1. Add a first-token streaming event and a live partial-transcript latency lane when the production STT path has a stable event contract.
+2. Add a dedicated labeled dictation corpus with WER/CER, names/numbers/punctuation buckets, and noise/device-route slices.
+3. Normalize speaker auto-research holdout JSON into the app while preserving every safety gate and condition bucket.
+4. Add campaign recipes so one click can sweep a bounded matrix and promote only candidates that beat the frozen baseline without a hard-gate regression.
+5. Add a real-hardware lane for built-in mic, AirPods/HFP, USB microphones, sleep/wake, and route changes. CI remains correctness proof, not hardware latency proof.


### PR DESCRIPTION
## What this adds

A separate local **Transcripted Lab** product for running repeatable experiments against Transcripted's real production and repository-owned test paths.

- Native SwiftUI `Transcripted Lab.app`
- Shared `TranscriptedLabKit` experiment/report engine
- Headless `transcripted-lab` CLI backed by the same contract
- Versioned JSON reports, run history, and baseline/candidate comparisons
- Hard gates that fail before the numeric score can hide a serious regression

## Benches

- **Runtime Snapshot** — transcription elapsed/RTF, dictation start, first sample, stop-to-paste/done, fallback/retry events
- **Dictation Bench** — production/native/pre-resampled/chunked variants, compute units, finalization order, repetitions, Auto Enter, silence guardrail, stable output hashes
- **Transcription Bench** — existing local corpus validation and Transcripted-vs-truth comparison
- **Speaker Bench** — labeled-audio threshold sweeps plus the existing frozen ASK/SUGGEST/AUTO auto-research path
- **QA Bench** — quick/deep/full/UI/packaged/artifact/synthetic/live repository lanes

## Safety rules

The score cannot average away:

- cross-person speaker false merges
- missing final dictation text
- silence producing text
- identical input producing unstable output hashes
- blocking QA failures
- timeouts or non-zero experiment exits

## Local verification completed

- `swift test --package-path Tools/TranscriptedLab --jobs 4` — 5/5 focused tests passed
- `swift build --package-path Tools/TranscriptedLab --product transcripted-lab`
- CLI help and command parsing exercised
- app-bundle script syntax validated

The new macOS workflow builds and tests the Foundation kit/CLI, compiles the SwiftUI app, and verifies the ad-hoc-signed app bundle.

## Current intentional limits

- Dictation Bench currently measures speed, delivery integrity, silence behavior, and repeatability. A dedicated labeled dictation WER/CER corpus is the next accuracy lane.
- Transcription corpus accuracy and production runtime speed are separate lanes today.
- Speaker auto-research keeps its native multi-gate holdout report rather than flattening false automatic names and contamination checks into a misleading single score.

## Review hardening

Independent review identified and fixed child processes surviving experiment timeouts, cancellation cleanup, and equivalent numeric speaker thresholds failing comparison. Synthetic timeout/cancellation regressions and the full Lab suite pass (8 tests); CLI/app builds and signed bundle verification passed. Reviewed fixes are at 69c92446.
