### PR TITLE
Rename paste diagnostics key so the local sanitizer stops blanking it

### DIFF
--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -534,6 +534,10 @@ private struct FocusedTextPasteConfirmation {
         return nil
     }
 
+    // Key names here must not contain any sensitive-key fragment from
+    // PayloadSanitizationCore (e.g. "text", "name") or the local sanitizer
+    // blanks the boolean to "[redacted-sensitive-value]" in events.jsonl.
+    // "target_value_observable" reports whether kAXValueAttribute was readable.
     func diagnosticsContext(
         clipboardReadAt: CFAbsoluteTime?,
         pasteDispatchedAt: CFAbsoluteTime
@@ -543,7 +547,7 @@ private struct FocusedTextPasteConfirmation {
             "target_change_after_dispatch": "\((changeObserver?.changedAt ?? 0) >= pasteDispatchedAt)",
             "target_change_observer_available": "\(changeObserver != nil)",
             "target_selection_observable": "\(initialSelectionRange != nil)",
-            "target_text_observable": "\(initialValue != nil)",
+            "target_value_observable": "\(initialValue != nil)",
         ]
     }
 
@@ -814,7 +818,7 @@ final class ClipboardRestoringTextPaster {
                 "target_change_after_dispatch": "false",
                 "target_change_observer_available": "false",
                 "target_selection_observable": "false",
-                "target_text_observable": "false",
+                "target_value_observable": "false",
             ]
             let targetStillFrontmost = pasteConfirmationResult == .unconfirmed
             diagnostics["target_still_frontmost"] = "\(targetStillFrontmost)"

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -373,6 +373,75 @@ func testClipboardRestoringTextPaster() async {
             }
         }
 
+        runSuite("ClipboardRestoringTextPaster confirmation diagnostics survive the local event sanitizer") {
+            // Regression: "target_text_observable" contained the sensitive fragment
+            // "text", so LocalObservabilityPayloadSanitizer blanked the boolean to
+            // "[redacted-sensitive-value]" in events.jsonl and blinded a paste
+            // investigation. Pin that every emitted diagnostics key stays readable.
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedDiagnosticsSanitizer-\(UUID().uuidString)"))
+            let paster = ClipboardRestoringTextPaster()
+            let adapter = SyntheticPasteTargetAdapter(kind: .codex, appliesPaste: false)
+
+            pasteboard.clearContents()
+            pasteboard.setString("synthetic original clipboard", forType: .string)
+            let outcome = paster.paste(
+                "synthetic unconfirmed dictation",
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: { true },
+                confirmationSource: { adapter },
+                targetIsFrontmost: { true },
+                pasteConfirmationWait: 0
+            )
+
+            assertEqual(
+                outcome.copyReason,
+                .pasteConfirmationUnavailable,
+                "an unconfirmed paste with a live confirmation source should report confirmation-unavailable"
+            )
+            let diagnostic = paster.lastConfirmationDiagnostic
+            assertEqual(
+                diagnostic?.event,
+                "dictation_paste_confirmation_diagnostics",
+                "the unconfirmed path should emit the confirmation diagnostics event"
+            )
+            let context = diagnostic?.context ?? [:]
+            assertTrue(
+                context.keys.contains("target_value_observable"),
+                "the AX-value observability flag should be present under its sanitizer-safe name"
+            )
+            for key in context.keys {
+                assertFalse(
+                    PayloadSanitizationCore.shouldDrop(
+                        key: key,
+                        sensitiveFragments: LocalObservabilityPayloadSanitizer.sensitiveKeyFragments
+                    ),
+                    "diagnostics key \(key) must not match a sensitive fragment or events.jsonl loses the value"
+                )
+            }
+
+            let sanitized = LocalObservabilityPayloadSanitizer.sanitize(
+                ObservabilityEvent(
+                    timestamp: "2026-08-24T00:00:00Z",
+                    level: "warning",
+                    engine: "overlay",
+                    event: diagnostic?.event ?? "dictation_paste_confirmation_diagnostics",
+                    message: "Paste delivery could not be confirmed from privacy-safe target signals",
+                    context: context,
+                    appVersion: "1.0.0",
+                    osVersion: "26.0"
+                )
+            )
+            for (key, value) in context {
+                assertEqual(
+                    sanitized.context?[key],
+                    value,
+                    "diagnostics value for \(key) should reach events.jsonl unredacted"
+                )
+            }
+        }
+
         runSuite("ClipboardRestoringTextPaster.restorePasteboardItems — preserves user clipboard changes") {
             let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedClipboardTest-\(UUID().uuidString)"))
             let paster = ClipboardRestoringTextPaster()
@@ -1762,7 +1831,7 @@ private final class SyntheticPasteTargetAdapter: ClipboardPasteConfirmationSourc
             "target_change_after_dispatch": "\((targetChangedAt ?? 0) >= pasteDispatchedAt)",
             "target_change_observer_available": kind == .browser ? "true" : "false",
             "target_selection_observable": kind == .notes ? "true" : "false",
-            "target_text_observable": kind == .codex ? "true" : "false",
+            "target_value_observable": kind == .codex ? "true" : "false",
         ]
     }
 }


### PR DESCRIPTION
## Why

The dictation paste-confirmation diagnostics key `target_text_observable` is a pure boolean, but it showed up as `[redacted-sensitive-value]` in local `events.jsonl`: `LocalObservabilityPayloadSanitizer` drops any context key matching `PayloadSanitizationCore.baseSensitiveKeyFragments`, and the key name contains the fragment `text`. That blinded a real investigation into `dictation_paste_confirmation_diagnostics` events.

## Product Impact

- Affects: `dictation`
- Lane: `dictation reliability`
- Why this matters: paste-confirmation failures can only be debugged from the local event log; a redacted boolean removes the one signal that says whether the target's AX value was even observable.

## What changed

- Renamed the key to `target_value_observable` (it reports whether `kAXValueAttribute` was readable, so the new name is also more accurate) in both emit sites in `Sources/Support/ClipboardRestoringTextPaster.swift`: the real `FocusedTextPasteConfirmation.diagnosticsContext(...)` and the fallback literal dict on the unconfirmed-paste path.
- Added a short comment stating the constraint: diagnostics keys must avoid `PayloadSanitizationCore` sensitive fragments or the local sanitizer blanks their values.
- Updated the `SyntheticPasteTargetAdapter` test fake to match, and added a regression suite that drives a real unconfirmed paste, then asserts every emitted diagnostics key passes the local sanitizer's `shouldDrop` predicate and survives an end-to-end `LocalObservabilityPayloadSanitizer.sanitize` unredacted.

Rename over a safe-key exemption: the local sanitizer has no exemption mechanism today, and adding one for a single boolean is more machinery than the rename.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed (`python3 scripts/dev/check-build-source-lists.py`, `bash run-slow-pasteback-smoke.sh` — both pass)
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` (12215 tests, all pass, new regression suite confirmed running)
- [x] Performance budget passed (`bash build.sh --no-open` bundle gate)
- [ ] `bash run-integration-smoke.sh` if I touched `Sources/Meeting/` or `Sources/TranscriptedCore/` — not touched
- [ ] `swift test` if I touched `Package.swift`, `Sources/TranscriptedCore/`, or the public core seam — not touched
- [x] Manual check: repo-wide grep confirms no remaining reference to the old key outside the regression comment

## Risk Review

- [x] Privacy / local-first behavior reviewed — the event is local-only (`dictation_paste_confirmation_diagnostics` appears in no Sentry allowlist and no analytics PSV); the new key clears all three sanitizers' fragment lists, including Sentry's extra `context`/`identifier` fragments
- [x] Storage path or migration impact reviewed — none
- [x] Public-facing copy stays concrete and matches current product scope — no copy changes
- [x] Release/update impact reviewed — none
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — no UI changes
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Only pastes logged after a restart on the new build carry the renamed key; historical `events.jsonl` lines keep the redacted marker, so split any log analysis at the deploy date.

## Agent handoff

`COORD_DONE: GREEN | PR URL below | renamed target_text_observable → target_value_observable + regression suite | none | none | build.sh, run-tests.sh, check-build-source-lists.py, run-slow-pasteback-smoke.sh | human review + merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)