### PR TITLE
Fix unconfirmed paste clipboard outcome

### DIFF
--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -620,6 +620,20 @@ final class ClipboardRestoringTextPaster {
         let pasteboard: any ClipboardPasteboard
     }
 
+    private enum ClipboardFallbackState: String {
+        case dictationPresent = "dictation_present"
+        case clipboardChanged = "clipboard_changed"
+        case clipboardEmpty = "clipboard_empty"
+        case unavailable
+
+        var hasVerifiedDictation: Bool {
+            self == .dictationPresent
+        }
+    }
+
+    private static let unverifiedClipboardRecoveryFailure =
+        "Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."
+
     private var clipboardRestoreTask: Task<Void, Never>?
     private var clipboardAutoEnterReadinessTask: Task<Void, Never>?
     private var clipboardAutoEnterReadyToken: SupersessionEpoch.Token?
@@ -834,8 +848,14 @@ final class ClipboardRestoringTextPaster {
             )
             let clipboardReadAfterDispatch = (temporaryProvider?.firstReadAt ?? 0) >= pasteDispatchedAt
             if !targetStillFrontmost {
-                guard leaveTemporaryClipboardAvailable() else {
-                    return .failed("Couldn't keep the dictation copied after focus moved. The dictation was saved, but paste-back did not run.")
+                let clipboardFallbackState = leaveTemporaryClipboardAvailable()
+                diagnostics["clipboard_fallback_state"] = clipboardFallbackState.rawValue
+                lastConfirmationDiagnostic = ClipboardPasteConfirmationDiagnostic(
+                    event: "dictation_paste_confirmation_diagnostics",
+                    context: diagnostics
+                )
+                guard clipboardFallbackState.hasVerifiedDictation else {
+                    return .failed(Self.unverifiedClipboardRecoveryFailure)
                 }
                 return .copied(
                     "Focus moved before Transcripted could confirm paste. The text is on your clipboard — press ⌘V.",
@@ -859,8 +879,14 @@ final class ClipboardRestoringTextPaster {
                     reason: .pasteConfirmationUnavailableAutoSendEligible
                 )
             }
-            guard leaveTemporaryClipboardAvailable() else {
-                return .failed("Couldn't keep the dictation copied after paste-back was unconfirmed. The dictation was saved, but paste-back did not run.")
+            let clipboardFallbackState = leaveTemporaryClipboardAvailable()
+            diagnostics["clipboard_fallback_state"] = clipboardFallbackState.rawValue
+            lastConfirmationDiagnostic = ClipboardPasteConfirmationDiagnostic(
+                event: "dictation_paste_confirmation_diagnostics",
+                context: diagnostics
+            )
+            guard clipboardFallbackState.hasVerifiedDictation else {
+                return .failed(Self.unverifiedClipboardRecoveryFailure)
             }
 
             // AX confirmation is positive-only. Some editors apply Cmd+V but do not
@@ -918,18 +944,26 @@ final class ClipboardRestoringTextPaster {
 
     private func leaveTemporaryClipboardAvailable(
         retainingRestoreForPasteRetry: Bool = false
-    ) -> Bool {
-        guard let pending = clearPendingClipboardRestore() else { return true }
+    ) -> ClipboardFallbackState {
+        guard let pending = clearPendingClipboardRestore() else { return .unavailable }
 
         // A user copy with the same plain text can still carry rich data. Keep it
-        // intact when the pasteboard changed after paste started. An unchanged
-        // pasteboard may still hold our lazy provider, so materialize it before
-        // returning the text for manual recovery.
+        // intact when the pasteboard changed after paste started, but only count
+        // that as recovery when the dictation text is actually still present.
+        // An unchanged pasteboard may still hold our lazy provider, so materialize
+        // it before returning the text for manual recovery.
         if pending.pasteboard.changeCount != pending.temporaryChangeCount {
-            return true
+            guard let currentString = pending.pasteboard.string(forType: .string) else {
+                return pending.pasteboard.pasteboardItems?.isEmpty == false
+                    ? .clipboardChanged
+                    : .clipboardEmpty
+            }
+            return currentString == pending.temporaryString
+                ? .dictationPresent
+                : .clipboardChanged
         }
         guard copyTextToClipboard(pending.temporaryString, to: pending.pasteboard) else {
-            return false
+            return .unavailable
         }
         if retainingRestoreForPasteRetry {
             retainedClipboardRestoreForPasteRetry = PendingClipboardRestore(
@@ -939,7 +973,7 @@ final class ClipboardRestoringTextPaster {
                 pasteboard: pending.pasteboard
             )
         }
-        return true
+        return .dictationPresent
     }
 
     private func restoreRetainedClipboardNow() {

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -632,7 +632,7 @@ final class ClipboardRestoringTextPaster {
     }
 
     private static let unverifiedClipboardRecoveryFailure =
-        "Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."
+        "Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard. Check your dictation history."
 
     private var clipboardRestoreTask: Task<Void, Never>?
     private var clipboardAutoEnterReadinessTask: Task<Void, Never>?

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -632,7 +632,7 @@ final class ClipboardRestoringTextPaster {
     }
 
     private static let unverifiedClipboardRecoveryFailure =
-        "Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."
+        "Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."
 
     private var clipboardRestoreTask: Task<Void, Never>?
     private var clipboardAutoEnterReadinessTask: Task<Void, Never>?
@@ -953,14 +953,33 @@ final class ClipboardRestoringTextPaster {
         // An unchanged pasteboard may still hold our lazy provider, so materialize
         // it before returning the text for manual recovery.
         if pending.pasteboard.changeCount != pending.temporaryChangeCount {
-            guard let currentString = pending.pasteboard.string(forType: .string) else {
-                return pending.pasteboard.pasteboardItems?.isEmpty == false
-                    ? .clipboardChanged
-                    : .clipboardEmpty
+            let observedChangeCount = pending.pasteboard.changeCount
+            let currentString = pending.pasteboard.string(forType: .string)
+            // Clipboard managers may rewrite a lazy pasteboard while it is read.
+            // Never classify text from one generation as belonging to another.
+            guard pending.pasteboard.changeCount == observedChangeCount else {
+                return .clipboardChanged
             }
-            return currentString == pending.temporaryString
-                ? .dictationPresent
-                : .clipboardChanged
+            if let currentString {
+                return currentString == pending.temporaryString
+                    ? .dictationPresent
+                    : .clipboardChanged
+            }
+            let currentItems = pending.pasteboard.pasteboardItems
+            guard pending.pasteboard.changeCount == observedChangeCount else {
+                return .clipboardChanged
+            }
+            guard currentItems?.isEmpty != false else {
+                return .clipboardChanged
+            }
+
+            // A failed paste consumer can clear the temporary pasteboard without
+            // replacing it. Recover only from that truly-empty state; never
+            // overwrite a non-empty user or clipboard-manager change.
+            guard copyTextToClipboard(pending.temporaryString, to: pending.pasteboard) else {
+                return .clipboardEmpty
+            }
+            return .dictationPresent
         }
         guard copyTextToClipboard(pending.temporaryString, to: pending.pasteboard) else {
             return .unavailable

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -717,7 +717,7 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard. Check your dictation history."),
                 "an unconfirmed paste must not claim copied delivery after a different user copy"
             )
             assertEqual(
@@ -755,7 +755,7 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard. Check your dictation history."),
                 "an unconfirmed paste must not claim copied delivery after a rich user copy"
             )
             assertEqual(
@@ -794,7 +794,7 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard. Check your dictation history."),
                 "text read from a superseded clipboard generation must not count as verified recovery"
             )
             assertEqual(
@@ -831,7 +831,7 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard. Check your dictation history."),
                 "an item-query generation change must not be overwritten by recovery"
             )
             assertEqual(

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -662,6 +662,110 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster.paste — empty clipboard is not reported as copied") {
+            let pasteboard = FakeClipboardPasteboard(initialString: "synthetic original clipboard")
+            let paster = ClipboardRestoringTextPaster()
+
+            let outcome = paster.paste(
+                "synthetic unconfirmed dictation",
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    pasteboard.clearContents()
+                    return true
+                },
+                pasteConfirmationWait: 0
+            )
+
+            assertEqual(
+                outcome,
+                .failed("Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."),
+                "an unconfirmed paste must not claim copied delivery when the clipboard is empty"
+            )
+            assertNil(
+                pasteboard.string(forType: .string),
+                "an external clipboard clear should not be overwritten"
+            )
+            assertEqual(
+                paster.lastConfirmationDiagnostic?.context["clipboard_fallback_state"],
+                "clipboard_empty",
+                "the diagnostic should distinguish an empty clipboard from a verified recovery copy"
+            )
+        }
+
+        runSuite("ClipboardRestoringTextPaster.paste — user clipboard change is not reported as copied") {
+            let pasteboard = FakeClipboardPasteboard(initialString: "synthetic original clipboard")
+            let paster = ClipboardRestoringTextPaster()
+
+            let outcome = paster.paste(
+                "synthetic unconfirmed dictation",
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    pasteboard.clearContents()
+                    pasteboard.setString("synthetic user copy", forType: .string)
+                    return true
+                },
+                pasteConfirmationWait: 0
+            )
+
+            assertEqual(
+                outcome,
+                .failed("Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."),
+                "an unconfirmed paste must not claim copied delivery after a different user copy"
+            )
+            assertEqual(
+                pasteboard.string(forType: .string),
+                "synthetic user copy",
+                "a user clipboard change should remain untouched"
+            )
+            assertEqual(
+                paster.lastConfirmationDiagnostic?.context["clipboard_fallback_state"],
+                "clipboard_changed",
+                "the diagnostic should distinguish a user clipboard change from a verified recovery copy"
+            )
+        }
+
+        runSuite("ClipboardRestoringTextPaster.paste — rich clipboard change is preserved and diagnosed") {
+            let pasteboard = FakeClipboardPasteboard(initialString: "synthetic original clipboard")
+            let paster = ClipboardRestoringTextPaster()
+            let richType = NSPasteboard.PasteboardType("com.transcripted.synthetic-rich-copy")
+            let richData = Data([0xca, 0xfe])
+
+            let outcome = paster.paste(
+                "synthetic unconfirmed dictation",
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    let richItem = NSPasteboardItem()
+                    richItem.setData(richData, forType: richType)
+                    pasteboard.clearContents()
+                    pasteboard.writePasteboardItems([richItem])
+                    return true
+                },
+                pasteConfirmationWait: 0
+            )
+
+            assertEqual(
+                outcome,
+                .failed("Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."),
+                "an unconfirmed paste must not claim copied delivery after a rich user copy"
+            )
+            assertEqual(
+                pasteboard.pasteboardItems?.first?.data(forType: richType),
+                richData,
+                "a rich user clipboard change should remain untouched"
+            )
+            assertEqual(
+                paster.lastConfirmationDiagnostic?.context["clipboard_fallback_state"],
+                "clipboard_changed",
+                "a non-text clipboard item is changed, not empty"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.paste — same-text user rich clipboard survives unconfirmed paste") {
             let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedSameTextRichClipboardTest-\(UUID().uuidString)"))
             let paster = ClipboardRestoringTextPaster()

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -662,7 +662,7 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
-        runSuite("ClipboardRestoringTextPaster.paste — empty clipboard is not reported as copied") {
+        runSuite("ClipboardRestoringTextPaster.paste — empty clipboard is recovered with verified dictation") {
             let pasteboard = FakeClipboardPasteboard(initialString: "synthetic original clipboard")
             let paster = ClipboardRestoringTextPaster()
 
@@ -680,17 +680,21 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."),
-                "an unconfirmed paste must not claim copied delivery when the clipboard is empty"
+                .copied(
+                    "Transcripted sent paste, but this target did not expose paste confirmation. The text stays copied.",
+                    reason: .pasteConfirmationUnavailable
+                ),
+                "an unconfirmed paste should recover a truly empty clipboard with a verified copy"
             )
-            assertNil(
+            assertEqual(
                 pasteboard.string(forType: .string),
-                "an external clipboard clear should not be overwritten"
+                "synthetic unconfirmed dictation",
+                "the dictation should be recopied after the paste path clears the clipboard"
             )
             assertEqual(
                 paster.lastConfirmationDiagnostic?.context["clipboard_fallback_state"],
-                "clipboard_empty",
-                "the diagnostic should distinguish an empty clipboard from a verified recovery copy"
+                "dictation_present",
+                "the diagnostic should report the verified recovery copy"
             )
         }
 
@@ -713,7 +717,7 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."),
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
                 "an unconfirmed paste must not claim copied delivery after a different user copy"
             )
             assertEqual(
@@ -751,7 +755,7 @@ func testClipboardRestoringTextPaster() async {
 
             assertEqual(
                 outcome,
-                .failed("Transcripted sent paste, but could not confirm it, and could not verify a recovery copy on the clipboard. The dictation is saved in your history."),
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
                 "an unconfirmed paste must not claim copied delivery after a rich user copy"
             )
             assertEqual(
@@ -763,6 +767,82 @@ func testClipboardRestoringTextPaster() async {
                 paster.lastConfirmationDiagnostic?.context["clipboard_fallback_state"],
                 "clipboard_changed",
                 "a non-text clipboard item is changed, not empty"
+            )
+        }
+
+        runSuite("ClipboardRestoringTextPaster.paste — clipboard generation change during read is preserved") {
+            let dictationText = "synthetic unconfirmed dictation"
+            let pasteboard = FakeClipboardPasteboard(initialString: "synthetic original clipboard")
+            let paster = ClipboardRestoringTextPaster()
+
+            let outcome = paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    pasteboard.clearContents()
+                    pasteboard.setString(dictationText, forType: .string)
+                    pasteboard.onStringRead = {
+                        pasteboard.onStringRead = nil
+                        pasteboard.setString("synthetic clipboard-manager rewrite", forType: .string)
+                    }
+                    return true
+                },
+                pasteConfirmationWait: 0
+            )
+
+            assertEqual(
+                outcome,
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
+                "text read from a superseded clipboard generation must not count as verified recovery"
+            )
+            assertEqual(
+                pasteboard.string(forType: .string),
+                "synthetic clipboard-manager rewrite",
+                "a clipboard-manager rewrite during a lazy read should remain untouched"
+            )
+            assertEqual(
+                paster.lastConfirmationDiagnostic?.context["clipboard_fallback_state"],
+                "clipboard_changed",
+                "the diagnostic should classify a generation race as a clipboard change"
+            )
+        }
+
+        runSuite("ClipboardRestoringTextPaster.paste — clipboard generation change during item query is preserved") {
+            let pasteboard = FakeClipboardPasteboard(initialString: "synthetic original clipboard")
+            let paster = ClipboardRestoringTextPaster()
+
+            let outcome = paster.paste(
+                "synthetic unconfirmed dictation",
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    pasteboard.clearContents()
+                    pasteboard.onPasteboardItemsRead = {
+                        pasteboard.onPasteboardItemsRead = nil
+                        pasteboard.setString("synthetic user copy during item query", forType: .string)
+                    }
+                    return true
+                },
+                pasteConfirmationWait: 0
+            )
+
+            assertEqual(
+                outcome,
+                .failed("Transcripted sent paste, but could not confirm it or place a recovery copy on the clipboard."),
+                "an item-query generation change must not be overwritten by recovery"
+            )
+            assertEqual(
+                pasteboard.string(forType: .string),
+                "synthetic user copy during item query",
+                "a user copy arriving during item inspection should remain untouched"
+            )
+            assertEqual(
+                paster.lastConfirmationDiagnostic?.context["clipboard_fallback_state"],
+                "clipboard_changed",
+                "the diagnostic should classify an item-query race as a clipboard change"
             )
         }
 
@@ -2022,6 +2102,8 @@ private final class FakeClipboardPasteboard: ClipboardPasteboard {
     private var setStringResults: [Bool]?
     private var storedString: String?
     private var storedItems: [NSPasteboardItem]?
+    var onStringRead: (() -> Void)?
+    var onPasteboardItemsRead: (() -> Void)?
 
     init(
         initialString: String?,
@@ -2038,13 +2120,17 @@ private final class FakeClipboardPasteboard: ClipboardPasteboard {
     }
 
     var pasteboardItems: [NSPasteboardItem]? {
+        let result: [NSPasteboardItem]?
         if let storedString,
            let data = storedString.data(using: .utf8) {
             let item = NSPasteboardItem()
             item.setData(data, forType: .string)
-            return [item]
+            result = [item]
+        } else {
+            result = storedItems
         }
-        return storedItems
+        onPasteboardItemsRead?()
+        return result
     }
 
     @discardableResult
@@ -2076,13 +2162,17 @@ private final class FakeClipboardPasteboard: ClipboardPasteboard {
 
     func string(forType dataType: NSPasteboard.PasteboardType) -> String? {
         guard dataType == .string else { return nil }
+        let result: String?
         if let storedString {
-            return storedString
+            result = storedString
+        } else {
+            result = storedItems?.compactMap { item in
+                item.data(forType: .string)
+                    .flatMap { String(data: $0, encoding: .utf8) }
+            }.first
         }
-        return storedItems?.compactMap { item in
-            item.data(forType: .string)
-                .flatMap { String(data: $0, encoding: .utf8) }
-        }.first
+        onStringRead?()
+        return result
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
- verify the dictation is actually present before reporting an unconfirmed paste as copied
- recover Andrey's reported empty-clipboard failure by re-copying and verifying the dictation
- preserve non-empty text, rich clipboard content, and clipboard-manager rewrites without overwriting them
- fence clipboard generation changes during lazy text and item reads
- avoid claiming the dictation is saved before persistence completes
- record coarse fallback state for local diagnostics

## Verification
- `bash build.sh --no-open`
- `bash run-tests.sh` (12,233 passed)
- `bash run-tests.sh --filter ClipboardRestoringTextPasterTests` (175 passed)
- `bash run-slow-pasteback-smoke.sh` (9/9)
- `bash run-e2e-smoke.sh`
- `python3 scripts/dev/check-build-source-lists.py`
- `git diff --check`

## Review
Two independent Codex reviews challenged the outcome boundary, rich clipboard classification, persistence wording, and clipboard-generation races. The empty-clipboard recovery, text-read race, and item-query race now have deterministic regression coverage. Non-empty user clipboard changes remain untouched.

## Scope boundary
This fixes the observed empty-clipboard recovery failure and false copied-success reporting. It does not yet prove why the original target rejected Cmd+V or that automatic paste succeeds in Andrey's environment.

## Manual proof
Before release-level closure, run the physical trigger in a real target app with macOS Accessibility enabled and verify target insertion or explicit failure, clipboard fallback, saved history, and the new diagnostic state.
