### PR TITLE
Fix meeting capture sleep/wake, stop-state, and failed-meeting recovery

### DIFF
--- a/Sources/Meeting/FailedMeetingStore.swift
+++ b/Sources/Meeting/FailedMeetingStore.swift
@@ -175,7 +175,8 @@ final class FailedMeetingStore {
         systemAudioURL: URL?,
         errorMessage: String,
         meetingTitle: String?,
-        recordingDate: Date? = nil
+        recordingDate: Date? = nil,
+        splitLocalSpeakers: Bool = false
     ) -> Bool {
         // A completion can win the main-actor race and be buffered before the
         // timeout continuation resumes. Use those finalized URLs as fallbacks
@@ -193,7 +194,8 @@ final class FailedMeetingStore {
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
             archiveAudio: false,
-            clearRecordingJournalAfterPersistence: false
+            clearRecordingJournalAfterPersistence: false,
+            splitLocalSpeakers: splitLocalSpeakers
         )
         guard preserved else {
             timedOutFinalizationHandoff.markPersistenceFailed(id: taskId)
@@ -222,7 +224,8 @@ final class FailedMeetingStore {
         errorMessage: String,
         meetingTitle: String?,
         recordingDate: Date? = nil,
-        archiveAudio: Bool = true
+        archiveAudio: Bool = true,
+        splitLocalSpeakers: Bool = false
     ) -> Bool {
         let preserved = persistFailedMeetingForRetry(
             taskId: taskId,
@@ -231,7 +234,8 @@ final class FailedMeetingStore {
             errorMessage: errorMessage,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
-            archiveAudio: archiveAudio
+            archiveAudio: archiveAudio,
+            splitLocalSpeakers: splitLocalSpeakers
         )
         if preserved {
             publishRefresh()
@@ -363,7 +367,8 @@ final class FailedMeetingStore {
         meetingTitle: String?,
         recordingDate: Date?,
         archiveAudio: Bool,
-        clearRecordingJournalAfterPersistence: Bool = true
+        clearRecordingJournalAfterPersistence: Bool = true,
+        splitLocalSpeakers: Bool = false
     ) -> Bool {
         taskManager.addFailedTranscriptionRetainingAvailableAudio(
             micAudioURL: micAudioURL,
@@ -373,7 +378,8 @@ final class FailedMeetingStore {
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
             archiveAudio: archiveAudio,
-            clearRecordingJournalAfterPersistence: clearRecordingJournalAfterPersistence
+            clearRecordingJournalAfterPersistence: clearRecordingJournalAfterPersistence,
+            splitLocalSpeakers: splitLocalSpeakers
         )
     }
 

--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -110,7 +110,9 @@ final class MeetingCaptureBridge: ObservableObject {
 
     /// Start a new recording session. Returns immediately; the session remains
     /// active until `stopAndAwaitFiles()` is called.
-    func startRecording() async -> Bool {
+    func startRecording(
+        timeout: UInt64 = TranscriptedConstants.meetingStartTimeout
+    ) async -> Bool {
         expectedStopGeneration = nil
         let staleStopResult = currentStopResult()
         for continuation in completionAttempt.reset() {
@@ -157,7 +159,7 @@ final class MeetingCaptureBridge: ObservableObject {
             audio.start()
 
             startAttempt.setTimeoutTask(Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: TranscriptedConstants.meetingStartTimeout)
+                try? await Task.sleep(nanoseconds: timeout)
                 guard let self else { return }
                 let waiters = self.startAttempt.resetIfCurrent(attemptID)
                 guard !waiters.isEmpty else { return }
@@ -176,11 +178,11 @@ final class MeetingCaptureBridge: ObservableObject {
                     // the timeout stage before resuming the caller below.
                     self.startFailureStage = resolvedTimeoutStage
                 }
-                self.errorMessage = AudioCaptureStartState.timeoutFailureMessage(
-                    existingErrorMessage: self.errorMessage,
-                    micAudioStreaming: self.audio.micAudioStreaming,
-                    systemAudioStreaming: self.audio.systemAudioStreaming
-                )
+                // Prefer an already-observed permission denial over the generic
+                // timeout copy; the helper falls back to
+                // `AudioCaptureStartState.timeoutFailureMessage` otherwise, so
+                // the typed stage above and this message stay consistent.
+                self.errorMessage = self.startTimeoutFailureMessage()
                 self.audio.stop()
                 for continuation in waiters {
                     continuation.resume(returning: false)
@@ -326,6 +328,38 @@ final class MeetingCaptureBridge: ObservableObject {
     }
 
     // MARK: - Private
+
+    /// Prefer an already-observed permission denial over a generic start-timeout
+    /// message. An inconclusive first-run check uses the 120s permission
+    /// budget; a known-grant start still uses 12s. If a denial already landed
+    /// before that deadline, keep it.
+    private func startTimeoutFailureMessage() -> String {
+        let existing = [errorMessage, audio.error]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
+
+        if let existing, Self.namesPermissionDenial(existing) {
+            return existing
+        }
+        if audio.systemAudioStartPermissionExplicitlyDenied {
+            return existing ?? "Turn on System Audio Recording before recording a meeting."
+        }
+        return AudioCaptureStartState.timeoutFailureMessage(
+            existingErrorMessage: existing,
+            micAudioStreaming: audio.micAudioStreaming,
+            systemAudioStreaming: audio.systemAudioStreaming
+        )
+    }
+
+    private static func namesPermissionDenial(_ message: String) -> Bool {
+        let normalized = message.lowercased()
+        if MeetingStartFailureClassifier.kind(from: normalized) == "permission_missing" {
+            return true
+        }
+        return normalized.contains("denied")
+            || normalized.contains("turn on microphone")
+            || normalized.contains("turn on system audio")
+    }
 
     private func finishPendingStartAttemptIfPossible() {
         if startFailureStage == .unknown, audio.startFailureStage != .unknown {

--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -60,7 +60,7 @@ struct MeetingFailureCopy: Equatable {
         case .noSpeechDetected:
             return MeetingFailureCopy(
                 title: "No speech found",
-                detail: "Transcripted found audio, but not enough spoken words to write a transcript. Open Home to retry, or record again with clearer voices."
+                detail: "Transcripted found audio, but not enough spoken words to write a transcript. The audio was kept. Try recording again with clearer voices."
             )
         case .saveFailed:
             return MeetingFailureCopy(

--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -182,6 +182,16 @@ final class MeetingPromptDetector {
         }
     }
 
+    /// Re-run prompt evaluation after a gate that was blocking prompts
+    /// clears (own-capture ending). Workspace / sensor observers already
+    /// re-evaluate on their own edges; this covers the case where a call
+    /// started during dictation and would otherwise wait for the poll.
+    func requestEvaluation() {
+        Task { @MainActor [weak self] in
+            await self?.evaluate()
+        }
+    }
+
     @discardableResult
     func dismiss(candidate: Candidate) -> MeetingPromptBackoffDecision {
         // An explicit dismissal during a live call means the user chose not to
@@ -233,8 +243,10 @@ final class MeetingPromptDetector {
     /// in the call or on another Space — so schedule a short candidate-level
     /// re-offer instead of the provider-wide dismissal backoff. Capped at
     /// `MeetingPromptHeuristics.maxPromptExpiryReoffers` consecutive expiries;
-    /// past the cap the candidate inherits the normal dismissal so an ignored
-    /// call eventually goes quiet.
+    /// past the cap the candidate gets the same quiet backoff as `dismiss`,
+    /// but is not marked `userDeclined` and does not increment the dismiss
+    /// streak. An ignored call goes quiet without being recorded as an
+    /// explicit no, so a missed-call nudge can still fire.
     @discardableResult
     func expire(candidate: Candidate) -> MeetingPromptBackoffDecision {
         let now = Date()
@@ -246,7 +258,10 @@ final class MeetingPromptDetector {
         promptExpiryHistory[candidate.id] = (expiryCount, now)
 
         guard MeetingPromptHeuristics.shouldReofferAfterExpiry(expiryCount: expiryCount) else {
-            return dismiss(candidate: candidate)
+            // Quiet suppress only. The public `dismiss(candidate:)` path is
+            // the user's Not now tap — it sets userDeclined and grows the
+            // streak. An unattended countdown past the cap must not.
+            return dismiss(candidate: candidate, interval: nil)
         }
 
         // Candidate-level cooldown only — no `suppressRuntimePrompts` — so the

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -21,6 +21,7 @@
 // The session controller does NOT own a hotkey or UI — Lane C (meeting-ui)
 // wires those up.
 
+import AppKit
 import Combine
 import Foundation
 import TranscriptedCore
@@ -472,7 +473,19 @@ final class MeetingSessionController: ObservableObject {
 
         // Capture bridge owns an `Audio` instance with our storage paths so
         // raw mic/system WAV captures land in the app scratch folder.
-        self.capture = MeetingCaptureBridge(audio: Audio(paths: storagePaths))
+        // Core's `.macOSWorkspace` default listens on `NotificationCenter.default`,
+        // which never receives NSWorkspace sleep/wake. Pass the workspace center
+        // explicitly — same wiring MeetingCaptureBridge uses when it builds Audio.
+        self.capture = MeetingCaptureBridge(
+            audio: Audio(
+                paths: storagePaths,
+                sleepWakeNotifications: AudioSleepWakeNotifications(
+                    center: NSWorkspace.shared.notificationCenter,
+                    willSleepName: Notification.Name("NSWorkspaceWillSleepNotification"),
+                    didWakeName: Notification.Name("NSWorkspaceDidWakeNotification")
+                )
+            )
+        )
 
         // STT: wrap the app's selected speech router in the Core-facing adapter.
         self.sttAdapter = MeetingSTTAdapter(router: sttRouter)
@@ -697,7 +710,10 @@ final class MeetingSessionController: ObservableObject {
                 message: "Meeting start ignored because another meeting flow is active",
                 context: baseDiagnosticsContext(extra: ["trigger": trigger.rawValue])
             )
-            return true
+            // The caller did not start a recording. Returning false keeps a
+            // prompt or menu action from treating an already-active capture
+            // as an accepted Record.
+            return false
         case .idle, .loadingModels, .ready, .transcribing, .error:
             break
         }
@@ -749,13 +765,19 @@ final class MeetingSessionController: ObservableObject {
                     ]
                 )
             )
-            transition(
-                to: .error(
+            // A permission miss on a new start must not hide a live queued or
+            // active transcription. `reportUnrelatedFailure` already refuses
+            // to stomp capture; skip `.transcribing` here as well.
+            switch state {
+            case .transcribing:
+                break
+            default:
+                reportUnrelatedFailure(
                     startDecision.errorMessage
-                        ?? "Turn on the required permissions in System Settings before recording a meeting."
-                ),
-                reason: "start_blocked_permission"
-            )
+                        ?? "Turn on the required permissions in System Settings before recording a meeting.",
+                    reason: "start_blocked_permission"
+                )
+            }
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "start_blocked_permission")
             trackDetectedPromptOutcome(
                 .recordingStartFailed,
@@ -790,7 +812,13 @@ final class MeetingSessionController: ObservableObject {
         installSharedDictationMicRelay()
 
         transition(to: .startingRecording, reason: "capture_start_requested")
-        let started = await capture.startRecording()
+        // A first-run or inconclusive System Audio check can still be sitting
+        // on the macOS dialog. Use the permission-prompt budget then; keep
+        // the 12s streaming deadline once access is already known.
+        let startTimeout = startDecision.systemAudioPermissionCheckWasInconclusive
+            ? TranscriptedConstants.systemAudioPermissionRequestTimeout
+            : TranscriptedConstants.meetingStartTimeout
+        let started = await capture.startRecording(timeout: startTimeout)
         guard started else {
             await capture.flushSharedDictationMicHandler()
             clearSharedDictationMicRelay()
@@ -1115,8 +1143,9 @@ final class MeetingSessionController: ObservableObject {
         activeRecordingTrigger = .unknown
         activeRecordingSuggestedTitle = nil
         activeRecordingStartedAt = nil
-        transition(to: .transcribing, reason: "stop_completed")
-        Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
+        // Stay in `.stoppingRecording` until timeout / missing-files / enqueue
+        // decides the outcome. Moving to `.transcribing` here used to hide a
+        // failed stop behind a saving state the user could not recover from.
         let stopDiagnosticsContext = stopCaptureDiagnostics.merging(
             [
                 "trigger": recordingSnapshot.trigger.rawValue,
@@ -1199,7 +1228,8 @@ final class MeetingSessionController: ObservableObject {
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stop timed out before audio files were finalized.",
                 meetingTitle: recordingSnapshot.suggestedTitle,
-                recordingDate: recordingSnapshot.recordingStartedAt
+                recordingDate: recordingSnapshot.recordingStartedAt,
+                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
             )
             DiagnosticsTrail.record(
                 level: .warning,
@@ -1225,6 +1255,14 @@ final class MeetingSessionController: ObservableObject {
         }
 
         guard files.micURL != nil || files.systemURL != nil else {
+            let preserved = failedMeetingStore.preserveFailedMeetingForRetry(
+                micAudioURL: files.micURL,
+                systemAudioURL: files.systemURL,
+                errorMessage: "No meeting audio was captured.",
+                meetingTitle: recordingSnapshot.suggestedTitle,
+                recordingDate: recordingSnapshot.recordingStartedAt,
+                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
+            )
             DiagnosticsTrail.record(
                 level: .error,
                 engine: "meeting",
@@ -1234,7 +1272,7 @@ final class MeetingSessionController: ObservableObject {
                     extra: [
                         "reason": reason.rawValue,
                         "system_file_present": boolString(false),
-                        "preserved_for_retry": boolString(false)
+                        "preserved_for_retry": boolString(preserved)
                     ]
                 )
             )
@@ -1294,6 +1332,8 @@ final class MeetingSessionController: ObservableObject {
                 : nil
         )
         clearDetectedPromptRecordingTelemetry()
+        transition(to: .transcribing, reason: "stop_completed")
+        Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
 
         let queueDepth = transcriptionQueue.queuedTranscriptionJobs.count
         DiagnosticsTrail.record(
@@ -1880,13 +1920,14 @@ final class MeetingSessionController: ObservableObject {
 
         for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
-            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
+            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate, let splitLocalSpeakers):
                 failedMeetingStore.preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: "Transcription cancelled",
                     meetingTitle: meetingTitle,
-                    recordingDate: recordingDate
+                    recordingDate: recordingDate,
+                    splitLocalSpeakers: splitLocalSpeakers
                 )
             case .imported(let audioURL, let suggestedTitle, let recordingDate):
                 if reason == .userRequested {
@@ -2002,7 +2043,8 @@ final class MeetingSessionController: ObservableObject {
                     systemAudioURL: files.systemURL,
                     errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening.",
                     meetingTitle: meetingTitle,
-                    recordingDate: recordingDate
+                    recordingDate: recordingDate,
+                    splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
                 )
             } else if files.micURL != nil || files.systemURL != nil {
                 didPreserveRecording = failedMeetingStore.preserveFailedMeetingForRetry(
@@ -2011,7 +2053,8 @@ final class MeetingSessionController: ObservableObject {
                     systemAudioURL: files.systemURL,
                     errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening.",
                     meetingTitle: meetingTitle,
-                    recordingDate: recordingDate
+                    recordingDate: recordingDate,
+                    splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
                 )
             }
         } else {
@@ -2058,21 +2101,13 @@ final class MeetingSessionController: ObservableObject {
         }
     }
 
-    /// Bounded wait for an in-flight `startRecording()` call to resolve
-    /// before termination decides what to preserve. `capture.startRecording()`
-    /// has its own internal timeout (`TranscriptedConstants.meetingStartTimeout`,
-    /// 12s) that guarantees `state` leaves `.startingRecording` well before
-    /// this generous outer deadline; the outer bound only guards against an
-    /// unexpected hang so quit is never blocked forever.
     /// Bounded wait for an in-flight `startRecording()` call to resolve —
     /// used both by `prepareForTermination()` (join before deciding what to
     /// save) and `stopRecordingJoiningPendingStart(reason:)` (join before
     /// stopping, so an explicit "Stop and Transcribe" during the mic-engage
-    /// window can't be silently dropped). `capture.startRecording()` has its
-    /// own internal timeout (`TranscriptedConstants.meetingStartTimeout`,
-    /// 12s) that guarantees `state` leaves `.startingRecording` well before
-    /// this generous outer deadline; the outer bound only guards against an
-    /// unexpected hang so neither caller blocks forever.
+    /// window can't be silently dropped). The bridge start deadline is 12s
+    /// after a known grant, or 120s while a first-run permission prompt may
+    /// still be up. Either way it is shorter than this outer bound.
     private func waitForPendingRecordingStartToResolve() async {
         let deadline = Date().addingTimeInterval(TranscriptedConstants.meetingTerminationFinishWaitTimeout)
         while isStartingRecording && Date() < deadline {
@@ -2087,6 +2122,9 @@ final class MeetingSessionController: ObservableObject {
         // the time capture reports an unexpected completion, state is only
         // ever still .recording when nothing else asked for the stop.
         guard case .recording = state else { return }
+        // Leave `.recording` before any suspension so stop/cancel (which still
+        // require `.recording`) cannot interleave with this flush/preserve work.
+        transition(to: .stoppingRecording, reason: "unexpected_capture_stop")
 
         _ = audioInactivityDetector.stopRecording()
         audioInactivityWarning = nil
@@ -2110,7 +2148,8 @@ final class MeetingSessionController: ObservableObject {
             systemAudioURL: files.systemURL,
             errorMessage: failureMessage,
             meetingTitle: recordingSnapshot.suggestedTitle,
-            recordingDate: recordingSnapshot.recordingStartedAt
+            recordingDate: recordingSnapshot.recordingStartedAt,
+            splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
         )
 
         DiagnosticsTrail.record(

--- a/Sources/Meeting/TranscriptionQueueCoordinator.swift
+++ b/Sources/Meeting/TranscriptionQueueCoordinator.swift
@@ -32,7 +32,8 @@ final class TranscriptionQueueCoordinator {
                 healthInfo: RecordingHealthInfo,
                 captureDiagnostics: [String: String],
                 meetingTitle: String?,
-                recordingDate: Date
+                recordingDate: Date,
+                splitLocalSpeakers: Bool
             )
             case imported(
                 audioURL: URL,
@@ -50,9 +51,20 @@ final class TranscriptionQueueCoordinator {
         let promptRecordingStartedAt: Date?
         var importedRecoverySession: ImportedTranscriptionQueueJournalSession?
 
+        /// Snapshot of People-in-the-room at enqueue for recorded jobs.
+        /// Imports stay `false` (system-channel).
+        var splitLocalSpeakers: Bool {
+            switch kind {
+            case .recorded(_, _, _, _, _, _, let splitLocalSpeakers):
+                return splitLocalSpeakers
+            case .imported:
+                return false
+            }
+        }
+
         var captureDiagnostics: [String: String]? {
             switch kind {
-            case .recorded(_, _, _, let captureDiagnostics, _, _):
+            case .recorded(_, _, _, let captureDiagnostics, _, _, _):
                 return captureDiagnostics
             case .imported:
                 return nil
@@ -65,7 +77,7 @@ final class TranscriptionQueueCoordinator {
         /// under it.
         var reservedAudioURLs: [URL] {
             switch kind {
-            case .recorded(let micURL, let systemURL, _, _, _, _):
+            case .recorded(let micURL, let systemURL, _, _, _, _, _):
                 return [micURL, systemURL].compactMap { $0 }
             case .imported(let audioURL, _, _):
                 return [audioURL]
@@ -152,7 +164,8 @@ final class TranscriptionQueueCoordinator {
                 healthInfo: healthInfo,
                 captureDiagnostics: captureDiagnostics,
                 meetingTitle: meetingTitle,
-                recordingDate: recordingDate
+                recordingDate: recordingDate,
+                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
             ),
             startTrigger: startTrigger,
             sttModel: controller.sttRouter.selectedModel,
@@ -372,7 +385,7 @@ final class TranscriptionQueueCoordinator {
         controller.activeStoppedAudioRecovery = job.stoppedAudioRecovery
 
         switch job.kind {
-        case .recorded(let micURL, let systemURL, let healthInfo, _, let meetingTitle, let recordingDate):
+        case .recorded(let micURL, let systemURL, let healthInfo, _, let meetingTitle, let recordingDate, let splitLocalSpeakers):
             controller.taskManager.startTranscription(
                 taskId: job.id,
                 micURL: micURL,
@@ -380,7 +393,7 @@ final class TranscriptionQueueCoordinator {
                 outputFolder: MeetingStoragePaths.transcriptsFolder,
                 healthInfo: healthInfo,
                 meetingTitle: meetingTitle,
-                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled(),
+                splitLocalSpeakers: splitLocalSpeakers,
                 recordingDate: recordingDate
             )
         case .imported(let audioURL, let suggestedTitle, let recordingDate):
@@ -412,13 +425,14 @@ final class TranscriptionQueueCoordinator {
 
         var preserved = false
         switch job.kind {
-        case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
+        case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate, let splitLocalSpeakers):
             preserved = controller.failedMeetingStore.preserveFailedMeetingForRetry(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
                 errorMessage: message,
                 meetingTitle: meetingTitle,
-                recordingDate: recordingDate
+                recordingDate: recordingDate,
+                splitLocalSpeakers: splitLocalSpeakers
             )
         case .imported(let audioURL, let suggestedTitle, let recordingDate):
             preserved = controller.failedMeetingStore.preserveFailedMeetingForRetry(
@@ -715,13 +729,14 @@ final class TranscriptionQueueCoordinator {
         var preservedCount = 0
         for job in jobs {
             switch job.kind {
-            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
+            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate, let splitLocalSpeakers):
                 if controller.failedMeetingStore.preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: errorMessage,
                     meetingTitle: meetingTitle,
-                    recordingDate: recordingDate
+                    recordingDate: recordingDate,
+                    splitLocalSpeakers: splitLocalSpeakers
                 ) {
                     preservedCount += 1
                 }

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -174,9 +174,22 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         let version = updateStatus.availableUpdateVersion
         trackUpdateActionClicked(surface: surface, state: state, version: version)
 
-        if case .readyToInstall(let version) = state, let pendingImmediateInstallHandler {
-            pendingImmediateInstallVersion = version
-            pendingImmediateInstallHandler()
+        if case .readyToInstall(let version) = state {
+            switch ReadyUpdateActionRoutingPolicy.route(
+                hasImmediateInstallHandler: pendingImmediateInstallHandler != nil
+            ) {
+            case .installImmediately:
+                pendingImmediateInstallVersion = version
+                pendingImmediateInstallHandler?()
+            case .presentStandardUpdateUI:
+                // A downloaded update can require authorization or be resumed in
+                // Sparkle's standard user driver without producing the automatic
+                // install-on-quit callback. In that state Sparkle intentionally
+                // keeps a session in progress, so the normal guarded check path
+                // would no-op. Calling the standard controller directly brings
+                // the existing update UI forward and lets Sparkle finish it.
+                updaterController.checkForUpdates(nil)
+            }
             return
         }
 

--- a/Sources/Observability/UpdateActionSafetyPolicy.swift
+++ b/Sources/Observability/UpdateActionSafetyPolicy.swift
@@ -10,6 +10,17 @@ enum UpdateActionSafetyState: Equatable {
     case readyToInstall
 }
 
+enum ReadyUpdateActionRoute: Equatable {
+    case installImmediately
+    case presentStandardUpdateUI
+}
+
+enum ReadyUpdateActionRoutingPolicy {
+    static func route(hasImmediateInstallHandler: Bool) -> ReadyUpdateActionRoute {
+        hasImmediateInstallHandler ? .installImmediately : .presentStandardUpdateUI
+    }
+}
+
 enum UpdateActionSafetyPolicy {
     static let activeCaptureHelp = "Finish the current recording or processing work before checking for updates."
 

--- a/Sources/Speech/PersistentDictationInputController.swift
+++ b/Sources/Speech/PersistentDictationInputController.swift
@@ -22,9 +22,14 @@ final class PersistentDictationInputController {
     private var runtimeOwnershipRelinquished = false
     private var lastMaintainedInput: AudioDeviceID?
     private let isDictationActive: () -> Bool
+    private let isMeetingCaptureActive: () -> Bool
 
-    init(isDictationActive: @escaping () -> Bool = { false }) {
+    init(
+        isDictationActive: @escaping () -> Bool = { false },
+        isMeetingCaptureActive: @escaping () -> Bool = { false }
+    ) {
         self.isDictationActive = isDictationActive
+        self.isMeetingCaptureActive = isMeetingCaptureActive
     }
 
     func start() {
@@ -162,7 +167,8 @@ final class PersistentDictationInputController {
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
             guard !Task.isCancelled, let self else { return }
             while DictationPersistentInputRefreshPolicy.shouldDefer(
-                isDictationActive: self.isDictationActive()
+                isDictationActive: self.isDictationActive(),
+                isMeetingCaptureActive: self.isMeetingCaptureActive()
             ) {
                 try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
                 guard !Task.isCancelled else { return }

--- a/Sources/Support/DictationPersistentInputPreferences.swift
+++ b/Sources/Support/DictationPersistentInputPreferences.swift
@@ -149,8 +149,14 @@ enum DictationPersistentInputRefreshPolicy {
     /// The live speech engine already owns its selected input while dictation
     /// is active. Changing the system-wide default at that point can stop an
     /// otherwise healthy graph, so persistent preference maintenance waits
-    /// until the recording has finished.
-    static func shouldDefer(isDictationActive: Bool) -> Bool {
-        isDictationActive
+    /// until the recording has finished. Meeting capture has the same
+    /// constraint: a Mac-wide default-input write mid-meeting can disrupt
+    /// the capture graph. `isMeetingCaptureActive` is the full capture
+    /// session (starting / recording / stopping), not steady-state only.
+    static func shouldDefer(
+        isDictationActive: Bool,
+        isMeetingCaptureActive: Bool
+    ) -> Bool {
+        isDictationActive || isMeetingCaptureActive
     }
 }

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -93,10 +93,10 @@ enum TranscriptedConstants {
     static let meetingStartTimeout: UInt64 = 12_000_000_000  // 12 seconds
 
     /// Bounds the ScreenCaptureKit probe used to verify System Audio Recording
-    /// access before meeting capture. A stalled TCC/ScreenCaptureKit callback
-    /// must return an honest denied result instead of leaving the meeting UI
-    /// in its starting state forever.
-    static let systemAudioPermissionRequestTimeout: UInt64 = 12_000_000_000  // 12 seconds
+    /// access before meeting capture. Must outlast the first-run macOS
+    /// permission prompt (`SCKAudioCapture`'s 120s shareable-content wait).
+    /// A shorter budget killed the probe while the dialog was still up.
+    static let systemAudioPermissionRequestTimeout: UInt64 = 120_000_000_000  // 120 seconds
 
     /// Base timeout for waiting on meeting capture file-close callbacks after
     /// stop. Long recordings can need more time to flush and merge audio, so
@@ -122,11 +122,11 @@ enum TranscriptedConstants {
         return min(scaledTimeout, meetingMaximumStopTimeout)
     }
 
-    /// Max time app termination waits for an in-flight meeting stop to finish.
-    /// This must stay above the maximum scaled stop timeout so quit
-    /// preservation does not give up before the bridge returns retained audio
-    /// URLs.
-    static let meetingTerminationFinishWaitTimeout: TimeInterval = 125.0
+    /// Max time app termination waits for an in-flight meeting stop or start
+    /// to finish. Must stay above the longest scaled stop timeout and the
+    /// first-run System Audio permission budget so quit preservation does
+    /// not give up while the macOS dialog is still up.
+    static let meetingTerminationFinishWaitTimeout: TimeInterval = 145.0
 
     /// Failed meeting audio is recoverable, but old unretried files should not grow forever.
     /// This is the floor: a shorter user retention window never prunes failed audio sooner.

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -209,6 +209,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     lazy var cameraActivityMonitor = CameraActivityMonitor()
     @available(macOS 14.0, *)
     private var meetingPromptRecordAction: MeetingPromptRecordAction?
+    private var meetingPromptRecordInFlight = false
+    private var meetingPromptSubscriptions: Set<AnyCancellable> = []
     private var meetingPromptShownAtByCandidateID: [String: Date] = [:]
     private var workspaceObservers: [NSObjectProtocol] = []
     private var micPreferenceObserver: NSObjectProtocol?
@@ -225,6 +227,10 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     private lazy var persistentDictationInputController = PersistentDictationInputController(
         isDictationActive: { [weak self] in
             self?.sessionController.isDictating == true
+        },
+        isMeetingCaptureActive: { [weak self] in
+            guard #available(macOS 14.0, *), let self else { return false }
+            return self.appState.meetingSession.isCaptureSessionActive
         }
     )
 
@@ -275,6 +281,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingOverlayController.setup(meetingSession: meetingSession)
             let promptRecordAction = MeetingPromptRecordAction(
                 onStartRequested: { [weak self] in
+                    self?.meetingPromptRecordInFlight = true
                     self?.meetingOverlayController.showDetectedMeetingStartInProgress()
                 },
                 startRecording: { [weak self] candidate, promptTelemetryProperties in
@@ -286,6 +293,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                     )
                 },
                 onCompleted: { [weak self] candidate, started in
+                    self?.meetingPromptRecordInFlight = false
                     guard started else { return }
                     self?.meetingPromptDetector.markAccepted(candidate: candidate)
                 }
@@ -313,6 +321,11 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                     candidate: candidate,
                     promptTelemetryProperties: promptFunnelProperties
                 ) else { return }
+                // Mark accepted when start begins, not only after
+                // startRecording returns. evaluate() can run while models
+                // load / .startingRecording, and would otherwise close the
+                // detected-call session as unrecorded.
+                self.meetingPromptDetector.markAccepted(candidate: candidate)
                 AnalyticsReporter.track(
                     "meeting_prompt_choice_made",
                     properties: MeetingPromptTelemetry.choiceProperties(
@@ -503,11 +516,14 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             // same prompt pipeline. See docs/auto-call-detection-spec.md.
             meetingPromptDetector.isOwnCaptureActive = { [weak self] in
                 guard let self else { return false }
-                return self.appState.meetingSession.isRecording || self.appState.sttRouter.isRecording
+                return self.appState.meetingSession.isCaptureSessionActive
+                    || self.meetingPromptRecordInFlight
+                    || self.appState.sttRouter.isRecording
             }
             meetingPromptDetector.ownCaptureActivity = { [weak self] in
                 guard let self else { return .none }
-                if self.appState.meetingSession.isRecording {
+                if self.appState.meetingSession.isCaptureSessionActive
+                    || self.meetingPromptRecordInFlight {
                     return .meetingRecording
                 }
                 if self.appState.sttRouter.isRecording {
@@ -543,6 +559,18 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingPromptDetector.start()
             applyAutoCallDetectionPreference()
             observeAutoCallDetectionPreference()
+            // A call that starts during dictation is gated by own-capture.
+            // When dictation ends, re-evaluate immediately so the prompt
+            // is not stuck waiting for the 120s poll.
+            appState.sttRouter.$isRecording
+                .removeDuplicates()
+                .dropFirst()
+                .filter { !$0 }
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    self?.meetingPromptDetector.requestEvaluation()
+                }
+                .store(in: &meetingPromptSubscriptions)
             appState.contextCapture.onMeetingToggle = { [weak self] in
                 self?.meetingOverlayController.toggleFromHotkey()
             }

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -181,7 +181,6 @@ public struct AudioSleepWakeNotifications: Sendable {
 /// hold weak references to this object.
 public class Audio: ObservableObject, @unchecked Sendable {
     @Published public var isRecording: Bool = false
-    @Published public private(set) var isMonitoring: Bool = false  // Lightweight level metering without file recording
     private var isStarting: Bool = false  // Prevents double-start during async setup
     private var pendingStartIntentId: UUID?
     @Published public var audioLevel: Float = 0.0
@@ -245,6 +244,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
     // segments, this remains the anchor used to name any merged output passed to
     // the pipeline on stop.
     var originalMicAudioFileURL: URL?
+    /// System-audio URL set when the WAV is created, not after I/O start
+    /// returns. Stop reads this (and ownership / journal) instead of relying
+    /// only on the @Published `systemAudioFileURL`, which can still be nil.
+    var originalSystemAudioFileURL: URL?
     private var _micSegments: [MicRecordingSegment] = []
     private let micSegmentsLock = NSLock()
     var micSegments: [MicRecordingSegment] {
@@ -402,6 +405,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
             duration: duration,
             reason: "System audio reconnect"
         ))
+        writeSystemRecoverySilencePad(
+            duration: duration,
+            generation: recordingSessionGeneration
+        )
+        setSystemRecoveryWriteHold(false)
     }
 
     /// Commit recovery artifacts only while the recovery still owns the
@@ -552,6 +560,38 @@ public class Audio: ObservableObject, @unchecked Sendable {
             defer { lastBufferTimeLock.unlock() }
             _lastBufferTime = newValue
         }
+    }
+
+    /// Last system-audio buffer arrival (monotonic). Used by the post-wake
+    /// handler so a healthy stream is not restarted just because the Mac woke.
+    private var _lastSystemBufferTime: CFTimeInterval = CACurrentMediaTime()
+    private let lastSystemBufferTimeLock = NSLock()
+    var lastSystemBufferTime: CFTimeInterval {
+        get {
+            lastSystemBufferTimeLock.lock()
+            defer { lastSystemBufferTimeLock.unlock() }
+            return _lastSystemBufferTime
+        }
+        set {
+            lastSystemBufferTimeLock.lock()
+            defer { lastSystemBufferTimeLock.unlock() }
+            _lastSystemBufferTime = newValue
+        }
+    }
+
+    /// When set, system-file writes are dropped so a recovery silence pad
+    /// can be written first. Not a second PCM queue — writes are discarded.
+    private let systemRecoveryWriteHoldLock = NSLock()
+    private var _holdSystemWritesForRecoveryPad = false
+    func setSystemRecoveryWriteHold(_ hold: Bool) {
+        systemRecoveryWriteHoldLock.lock()
+        _holdSystemWritesForRecoveryPad = hold
+        systemRecoveryWriteHoldLock.unlock()
+    }
+    func isHoldingSystemWritesForRecoveryPad() -> Bool {
+        systemRecoveryWriteHoldLock.lock()
+        defer { systemRecoveryWriteHoldLock.unlock() }
+        return _holdSystemWritesForRecoveryPad
     }
     var watchdogTimer: Timer?
 
@@ -914,9 +954,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
     }
     private let systemAudioCaptureFactory:
         () -> (any SystemAudioCaptureEngine & Sendable)?
-    private let systemAudioMonitoringAttemptLock = NSLock()
-    private var systemAudioMonitoringAttempt: SystemAudioCaptureStartAttempt?
-
     // Audio file recording
     var systemAudioCaptureAttemptOwnership =
         SystemAudioCaptureAttemptOwnership<SystemAudioCaptureStartAttempt, AVAudioFile>()
@@ -1155,6 +1192,9 @@ public class Audio: ObservableObject, @unchecked Sendable {
     // mic path). Separate from `systemAudioCancellable` so re-wiring one
     // subscription on a new capture attempt doesn't need to touch the other.
     private var systemAudioRecoveryEventCancellable: AnyCancellable?
+    /// Synchronous subscriber so recovery write-hold is armed on the sending
+    /// thread before SCK's async restart can deliver buffers.
+    private var systemAudioRecoveryPadCancellable: AnyCancellable?
     // Protected by systemSilenceLock — written from callback thread, reset on main thread
     private var _systemAudioSilenceStart: Date?
     private let systemSilenceLock = NSLock()
@@ -1309,24 +1349,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
         return capture
     }
 
-    func replaceSystemAudioMonitoringAttempt(
-        with attempt: SystemAudioCaptureStartAttempt?
-    ) -> SystemAudioCaptureStartAttempt? {
-        systemAudioMonitoringAttemptLock.lock()
-        let previous = systemAudioMonitoringAttempt
-        systemAudioMonitoringAttempt = attempt
-        systemAudioMonitoringAttemptLock.unlock()
-        return previous
-    }
-
-    private func currentSystemAudioMonitoringAttemptIs(
-        _ attempt: SystemAudioCaptureStartAttempt
-    ) -> Bool {
-        systemAudioMonitoringAttemptLock.lock()
-        defer { systemAudioMonitoringAttemptLock.unlock() }
-        return systemAudioMonitoringAttempt === attempt
-    }
-
     private func wireSystemAudioStatusPublisher(from capture: any SystemAudioCaptureEngine) {
         systemAudioCancellable = capture.errorMessagePublisher
             .receive(on: DispatchQueue.main)
@@ -1343,6 +1365,13 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 case .gap(let duration):
                     self.recordSystemAudioGap(duration: duration)
                 }
+            }
+        // Arm the write-hold on the sending thread so it is visible before
+        // SCK start() can deliver the first post-restart buffer.
+        systemAudioRecoveryPadCancellable = capture.recoveryEventPublisher
+            .sink { [weak self] event in
+                guard case .deviceSwitch = event else { return }
+                self?.setSystemRecoveryWriteHold(true)
             }
     }
 
@@ -1384,18 +1413,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 }
                 self.sleepTimestamp = nil
 
-                // Proactively trigger mic recovery instead of waiting for the 3-5s watchdog delay
+                // Always kick both recoveries. CACurrentMediaTime pauses
+                // during sleep, so last-buffer timestamps look fresh after
+                // lid-open even when SCK is silently stuck. That is why
+                // recoverAfterSystemWake exists — do not gate it on stall.
                 let sessionGeneration = self.recordingSessionGeneration
                 DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1.0) { [weak self] in
                     guard let self = self, self.isRecording else { return }
                     self.recoverFromDeviceChange(sessionGeneration: sessionGeneration)
-
-                    // Give system audio the same proactive post-wake recovery
-                    // opportunity as the mic path, instead of only relying on
-                    // SCK's own buffer-stall watchdog (which can take up to
-                    // `AudioRecoveryTuning.SystemAudio.stallTimeoutSeconds`
-                    // to notice). No-ops for backends without bounded
-                    // recovery (see `SystemAudioCaptureEngine`'s default).
                     self.systemAudioCapture?.recoverAfterSystemWake()
                 }
             }
@@ -1404,9 +1429,9 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     @discardableResult
     func ensureEngineInitialized() throws -> (AVAudioEngine, AVAudioInputNode) {
-        // Delay AVAudioEngine/input-node access until monitoring or recording
-        // actually begins. Launch-time warmup can construct Audio long before
-        // the user has explicitly asked to record anything.
+        // Delay AVAudioEngine/input-node access until recording actually
+        // begins. Launch-time warmup can construct Audio long before the
+        // user has explicitly asked to record anything.
         if engine == nil {
             engine = AVAudioEngine()
         }
@@ -1960,8 +1985,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // Reset capture artifacts so a previous session cannot make a new start
         // look ready before the fresh mic/system files exist.
         originalMicAudioFileURL = nil
+        originalSystemAudioFileURL = nil
         micAudioFileURL = nil
         systemAudioFileURL = nil
+        lastSystemBufferTime = CACurrentMediaTime()
+        setSystemRecoveryWriteHold(false)
 
         // Reset health tracking for new recording session
         recordingGaps = []
@@ -2015,11 +2043,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // reaches prepareForNewRecordingStart(). Clear the previous attempt's
         // typed stage before any validation can return.
         startFailureStage = .unknown
-
-        // Stop monitoring if active — full recording takes over the engine and taps
-        if isMonitoring {
-            stopMonitoring()
-        }
 
         // Pre-flight validation checks
         let validationResult = RecordingValidator.validateRecordingConditions(paths: paths)
@@ -2154,9 +2177,40 @@ public class Audio: ObservableObject, @unchecked Sendable {
     func assignSystemAudioFileURLIfCurrent(_ fileURL: URL, sessionGeneration: UInt64) {
         guard recordingSessionGeneration == sessionGeneration else { return }
 
+        originalSystemAudioFileURL = fileURL
         systemAudioFileURL = fileURL
         recordingJournal.recordSystemAudio(fileURL, session: journalSession)
         restoreSystemAudioHealthyStatusAfterSuccessfulStart()
+    }
+
+    /// Journal + publish the system URL as soon as the WAV exists. Generation
+    /// guarded like `assignSystemAudioFileURLIfCurrent`. The published
+    /// assignment hops to main; the original/journal write happens now.
+    func publishSystemAudioFileURLAtCreation(_ fileURL: URL, sessionGeneration: UInt64) {
+        guard recordingSessionGeneration == sessionGeneration else { return }
+        originalSystemAudioFileURL = fileURL
+        recordingJournal.recordSystemAudio(fileURL, session: journalSession)
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.recordingSessionGeneration == sessionGeneration else { return }
+            self.systemAudioFileURL = fileURL
+            self.restoreSystemAudioHealthyStatusAfterSuccessfulStart()
+        }
+    }
+
+    /// Stop-path system URL: ownership / journal / writer, not only the
+    /// published property that can still be nil if main hasn't assigned it.
+    func resolvedSystemAudioFileURL(generation: UInt64) -> URL? {
+        if let url = originalSystemAudioFileURL { return url }
+        if let url = systemAudioCaptureAttemptOwnership.fileURLOwned(by: generation) {
+            return url
+        }
+        if let attempt = systemAudioCaptureAttemptOwnership.current,
+           attempt.generation == generation,
+           let writer = attempt.writer {
+            return writer.url
+        }
+        if let url = recordingJournal.currentSystemAudioURL() { return url }
+        return systemAudioFileURL
     }
 
     /// Records that the system-audio tap has started streaming for this
@@ -2215,7 +2269,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // contains the bulk of the recording.
         let primaryMicURL = originalMicAudioFileURL ?? micAudioFileURL
         let micSegmentsSnapshot = self.micSegments
-        let finalSystemURL = systemAudioFileURL
+        let finalSystemURL = resolvedSystemAudioFileURL(generation: captureGeneration)
         let cueHandler = self.onCaptureLifecycleCue
 
         // Take (read-and-clear) journal ownership: only the stop that ends an
@@ -2376,127 +2430,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
         }
     }
 
-    // MARK: - Audio Level Monitoring (no file recording)
-
-    /// Start lightweight level metering for mic + system audio without recording to files.
-    /// Used by MeetingDetector to detect bidirectional speech before full recording starts.
-    /// Automatically stops when `start()` is called for full recording.
-    public func startMonitoring() {
-        guard !isMonitoring, !isRecording, !isStarting else { return }
-        ensureCaptureInfrastructureConfigured()
-
-        let engine: AVAudioEngine
-        let inputNode: AVAudioInputNode
-        do {
-            (engine, inputNode) = try ensureEngineInitialized()
-        } catch {
-            AppLogger.audio.warning("Failed to initialize monitoring engine", ["error": error.localizedDescription])
-            return
-        }
-
-        AppLogger.audio.info("Starting audio level monitoring")
-
-        let monitorFormat = withAudioGraphLock {
-            recordingFormat(for: inputNode)
-        }
-        guard AudioRecordingFormatPolicy.snapshot(monitorFormat) != nil else {
-            AppLogger.audio.warning("Cannot start monitoring — invalid input format")
-            return
-        }
-
-        do {
-            try withAudioGraphLock {
-                // Install mic tap for level metering only (no file writing)
-                tearDownInputTapSafely(
-                    engine: engine,
-                    inputNode: inputNode,
-                    operation: "monitoring_start"
-                )
-                inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
-                    self?.calculateLevel(buffer: buffer)
-                }
-                try engine.start()
-            }
-        } catch {
-            AppLogger.audio.warning("Failed to start monitoring engine", ["error": error.localizedDescription])
-            withAudioGraphLock {
-                tearDownInputTapSafely(
-                    engine: engine,
-                    inputNode: inputNode,
-                    operation: "monitoring_start_failed"
-                )
-            }
-            return
-        }
-
-        // Start system audio capture for level metering only (no file writing)
-        if let capture = systemAudioCapture {
-            let monitoringAttempt = SystemAudioCaptureStartAttempt(capture: capture)
-            if let displacedAttempt = replaceSystemAudioMonitoringAttempt(with: monitoringAttempt) {
-                systemAudioSetupQueue.async {
-                    displacedAttempt.cancel()
-                }
-            }
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                do {
-                    try monitoringAttempt.prepare()
-                    let started = try monitoringAttempt.startIfNotCancelled { [weak self] systemBuffer in
-                        self?.calculateSystemLevel(buffer: systemBuffer)
-                    }
-                    if started,
-                       self?.currentSystemAudioMonitoringAttemptIs(monitoringAttempt) == true {
-                        AppLogger.audioSystem.info("System audio monitoring started")
-                    }
-                } catch {
-                    AppLogger.audioSystem.warning("System audio monitoring unavailable", ["error": error.localizedDescription])
-                    // Mic monitoring still works — system audio is optional
-                }
-            }
-        }
-
-        isMonitoring = true
-    }
-
-    /// Stop level metering. Called automatically before `start()` begins full recording.
-    public func stopMonitoring() {
-        let monitoringAttempt = replaceSystemAudioMonitoringAttempt(with: nil)
-        guard isMonitoring || monitoringAttempt != nil else { return }
-
-        AppLogger.audio.info("Stopping audio level monitoring")
-
-        withAudioGraphLock {
-            if let engine = engine, let inputNode = inputNode {
-                tearDownInputTapSafely(
-                    engine: engine,
-                    inputNode: inputNode,
-                    operation: "monitoring_stop"
-                )
-                disarmVoiceProcessing(on: inputNode)
-            }
-
-            // Monitoring shares the engine but not the AGC; drop it here so a
-            // monitoring session followed by a recording session both start
-            // with a fresh gain history.
-            realtimeAGC = nil
-        }
-
-        if let monitoringAttempt {
-            // ScreenCaptureKit start/stop can each wait for a bounded callback.
-            // Keep that serialization on the attempt, but never make the UI
-            // thread wait while monitoring hands off to full recording.
-            systemAudioSetupQueue.async {
-                monitoringAttempt.cancel()
-            }
-        }
-
-        DispatchQueue.main.async {
-            self.isMonitoring = false
-            self.audioLevel = 0.0
-            self.audioLevelHistory = Array(repeating: 0.0, count: 15)
-            self.systemAudioLevelHistory = Array(repeating: 0.0, count: 15)
-        }
-    }
-
     deinit {
         // Remove sleep/wake observers to prevent leaks
         if let observer = sleepObserver {
@@ -2509,7 +2442,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         watchdogTimer?.invalidate()
         systemAudioCancellable?.cancel()
         systemAudioRecoveryEventCancellable?.cancel()
-        replaceSystemAudioMonitoringAttempt(with: nil)?.cancel()
+        systemAudioRecoveryPadCancellable?.cancel()
         systemAudioCapture?.stopSync()
 
         withAudioGraphLock {

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 @preconcurrency import AVFoundation
 import QuartzCore
 import ScreenCaptureKit
@@ -26,6 +27,7 @@ final class SystemAudioCaptureStartAttempt: @unchecked Sendable {
     let capture: any SystemAudioCaptureEngine & Sendable
     private let lifecycleLock = NSLock()
     private var cancelled = false
+    private var startRequested = false
 
     init(capture: any SystemAudioCaptureEngine & Sendable) {
         self.capture = capture
@@ -33,6 +35,14 @@ final class SystemAudioCaptureStartAttempt: @unchecked Sendable {
 
     func prepare() throws {
         try capture.prepare()
+        // prepare() can block on ScreenCaptureKit. Honor a cancel that
+        // arrived while it ran so start() never begins a doomed stream.
+        lifecycleLock.lock()
+        let wasCancelled = cancelled
+        lifecycleLock.unlock()
+        if wasCancelled {
+            capture.stopSync()
+        }
     }
 
     @discardableResult
@@ -40,17 +50,32 @@ final class SystemAudioCaptureStartAttempt: @unchecked Sendable {
         bufferCallback: @escaping (AVAudioPCMBuffer) -> Void
     ) throws -> Bool {
         lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-        guard !cancelled else { return false }
+        guard !cancelled else {
+            lifecycleLock.unlock()
+            return false
+        }
+        startRequested = true
+        lifecycleLock.unlock()
+
+        // Do not hold lifecycleLock across start() — cancel() shares that
+        // lock and must not block behind a ScreenCaptureKit start callback.
         try capture.start(bufferCallback: bufferCallback)
+
+        lifecycleLock.lock()
+        let wasCancelled = cancelled
+        lifecycleLock.unlock()
+        if wasCancelled {
+            capture.stopSync()
+            return false
+        }
         return true
     }
 
     func cancel() {
         lifecycleLock.lock()
         cancelled = true
-        capture.stopSync()
         lifecycleLock.unlock()
+        capture.stopSync()
     }
 }
 
@@ -63,6 +88,7 @@ final class SystemAudioCaptureAttemptOwnership<Capture, Writer: AnyObject>: @unc
         let capture: Capture
         let captureID: ObjectIdentifier
         var writer: Writer?
+        var fileURL: URL?
     }
 
     private let lock = NSLock()
@@ -91,7 +117,8 @@ final class SystemAudioCaptureAttemptOwnership<Capture, Writer: AnyObject>: @unc
             generation: generation,
             capture: capture,
             captureID: ObjectIdentifier(capture as AnyObject),
-            writer: nil
+            writer: nil,
+            fileURL: nil
         )
         return displacedAttempt
     }
@@ -99,7 +126,8 @@ final class SystemAudioCaptureAttemptOwnership<Capture, Writer: AnyObject>: @unc
     func install(
         _ writer: Writer,
         generation: UInt64,
-        capture: Capture
+        capture: Capture,
+        fileURL: URL? = nil
     ) -> Bool {
         lock.lock()
         defer { lock.unlock() }
@@ -110,8 +138,16 @@ final class SystemAudioCaptureAttemptOwnership<Capture, Writer: AnyObject>: @unc
             return false
         }
         current.writer = writer
+        current.fileURL = fileURL
         storedCurrent = current
         return true
+    }
+
+    func fileURLOwned(by generation: UInt64) -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard storedCurrent?.generation == generation else { return nil }
+        return storedCurrent?.fileURL
     }
 
     func owns(generation: UInt64, capture: Capture) -> Bool {
@@ -353,7 +389,8 @@ extension Audio {
                         strongSelf.systemAudioCaptureAttemptOwnership.install(
                             file,
                             generation: sessionGeneration,
-                            capture: captureAttempt
+                            capture: captureAttempt,
+                            fileURL: fileURL
                         )
                     }
                     guard installed else {
@@ -361,6 +398,12 @@ extension Audio {
                         cleanupAbandonedSetup()
                         return
                     }
+                    // Publish + journal at create so stop can resolve the URL
+                    // even if I/O start is still in flight.
+                    strongSelf.publishSystemAudioFileURLAtCreation(
+                        fileURL,
+                        sessionGeneration: sessionGeneration
+                    )
                     AppLogger.audioSystem.info("System audio file created before I/O proc", ["sampleRate": AudioRecordingFormatPolicy.displaySampleRate(sampleRate), "channels": "\(tapFormat.channelCount)"])
 
                     guard sessionIsCurrent() else {
@@ -375,6 +418,7 @@ extension Audio {
                         guard sessionGeneration == self.recordingSessionGeneration else { return }
 
                         self.systemBufferCount += 1
+                        self.lastSystemBufferTime = CACurrentMediaTime()
                         let currentBufferCount = self.systemBufferCount
                         if currentBufferCount == 1 {
                             // First real buffer: the tap is actually streaming
@@ -406,6 +450,10 @@ extension Audio {
                             let fmt = bufferForAsyncUse.format
                             let bufferSampleRate = AudioRecordingFormatPolicy.displaySampleRate(fmt.sampleRate)
                             AppLogger.audioSystem.debug("System buffer", ["number": "\(currentBufferCount)", "sampleRate": bufferSampleRate, "channels": "\(fmt.channelCount)", "frames": "\(bufferForAsyncUse.frameLength)"])
+                        }
+
+                        if self.isHoldingSystemWritesForRecoveryPad() {
+                            return
                         }
 
                         let retainedBytes = PCMBufferBackpressureGate.retainedByteCount(
@@ -466,10 +514,6 @@ extension Audio {
                         return
                     }
 
-                    DispatchQueue.main.async {
-                        guard sessionGeneration == strongSelf.recordingSessionGeneration else { return }
-                        strongSelf.assignSystemAudioFileURLIfCurrent(fileURL, sessionGeneration: sessionGeneration)
-                    }
                     AppLogger.audioSystem.info("System audio capture started")
 
                 } catch {
@@ -558,6 +602,9 @@ extension Audio {
             writerInstall.displacedWriter?.close()
             FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
             journalSession = recordingJournal.begin(primaryMicURL: fileURL)
+            if let systemURL = originalSystemAudioFileURL {
+                recordingJournal.recordSystemAudio(systemURL, session: journalSession)
+            }
             AppLogger.audioMic.info("Saving as mono", ["sampleRate": "\(recordingSnapshot.sampleRate)"])
         } catch {
             await MainActor.run {
@@ -786,7 +833,7 @@ extension Audio {
             AppLogger.audioSystem.error("System audio write failed", context)
         }
         guard count >= maxConsecutiveWriteErrors else { return false }
-        AppLogger.audioSystem.error("Too many consecutive system write errors, stopping recording")
+        AppLogger.audioSystem.error("Too many consecutive system write errors, keeping microphone recording")
         surfaceSystemWriteFailureAndStop(generation: generation)
         return true
     }
@@ -812,10 +859,81 @@ extension Audio {
             guard let self,
                   self.recordingSessionGeneration == generation,
                   self.isRecording else { return }
-            self.systemAudioFailed = true
-            self.systemAudioStatus = .failed
-            self.error = "Recording stopped \u{2014} Transcripted couldn't save system audio to disk. Check that there's free space and the save location is still available, then start a new recording."
-            self.stop()
+            self.failSystemAudioKeepMic(generation: generation)
+            self.error = "System audio couldn't be saved to disk. Microphone recording continues. Check that there's free space and the save location is still available."
+        }
+    }
+
+    /// Marks system audio failed and tears down SCK + the system writer
+    /// without stopping the microphone — the same mic-only policy as a
+    /// system-audio start failure.
+    static let maxSystemRecoverySilencePadSeconds: TimeInterval = 180
+    static let systemRecoverySilencePadChunkSeconds: TimeInterval = 1
+
+    /// Writes a bounded silence pad into the current system writer on the
+    /// file queue. Called after confirmed SCK recovery, before new buffers
+    /// are accepted (writes are held until this returns).
+    func writeSystemRecoverySilencePad(duration: TimeInterval, generation: UInt64) {
+        let capped = min(max(0, duration), Self.maxSystemRecoverySilencePadSeconds)
+        guard capped > 0 else { return }
+        systemAudioFileQueue.sync {
+            guard let attempt = self.systemAudioCaptureAttemptOwnership.current,
+                  attempt.generation == generation,
+                  let writer = attempt.writer else { return }
+            let format = writer.processingFormat
+            let sampleRate = format.sampleRate
+            guard sampleRate > 0, format.channelCount > 0 else { return }
+            var remaining = AVAudioFrameCount((capped * sampleRate).rounded())
+            let chunkFrames = AVAudioFrameCount(
+                max(1, (Self.systemRecoverySilencePadChunkSeconds * sampleRate).rounded())
+            )
+            while remaining > 0 {
+                let frames = min(remaining, chunkFrames)
+                guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else {
+                    break
+                }
+                buffer.frameLength = frames
+                if let channels = buffer.floatChannelData {
+                    let channelCount = format.isInterleaved ? 1 : Int(format.channelCount)
+                    let samplesPerChannel = format.isInterleaved
+                        ? Int(frames) * Int(format.channelCount)
+                        : Int(frames)
+                    for channel in 0..<channelCount {
+                        memset(channels[channel], 0, samplesPerChannel * MemoryLayout<Float>.size)
+                    }
+                }
+                do {
+                    try writer.write(from: buffer)
+                    self.recordSystemWriteSuccess(generation: generation)
+                } catch {
+                    AppLogger.audioSystem.warning("Failed to write system recovery silence pad", [
+                        "error": error.localizedDescription
+                    ])
+                    break
+                }
+                remaining -= frames
+            }
+        }
+    }
+
+    func failSystemAudioKeepMic(generation: UInt64) {
+        systemAudioFailed = true
+        systemAudioStatus = .failed
+        let captureAttempt = systemAudioCaptureAttemptOwnership.captureOwned(
+            by: generation
+        )
+        systemAudioSetupQueue.async {
+            captureAttempt?.cancel()
+        }
+        systemAudioFileQueue.async { [weak self] in
+            guard let self else { return }
+            guard let captureAttempt else { return }
+            let writer = self.systemAudioCaptureAttemptOwnership.takeWriterOwned(
+                by: generation,
+                capture: captureAttempt
+            )
+            writer?.close()
+            self.endSystemWriteErrorTracking(generation: generation)
         }
     }
 
@@ -917,7 +1035,7 @@ extension Audio {
             self.diskCheckCounter += 1
             if self.diskCheckCounter >= 150 {
                 self.diskCheckCounter = 0
-                if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory()),
+                if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: self.paths.audioCaptures.path),
                    let freeSpace = attrs[FileAttributeKey.systemFreeSize] as? Int64 {
                     if freeSpace < 50_000_000 { // 50MB
                         AppLogger.audio.error("Disk space critically low during recording, stopping", ["freeSpace": "\(freeSpace / 1_000_000)MB"])

--- a/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
+++ b/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
@@ -114,7 +114,10 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
             primaryMicURL.deletingPathExtension().lastPathComponent + Self.filenameSuffix
         )
         let session = MeetingRecordingJournalSession(journalURL: journalURL)
-        queue.async {
+        // First persist is synchronous so a crash between begin() and the
+        // utility-queue write cannot leave a live recording with no journal.
+        // Later mutations stay async.
+        queue.sync {
             self.activeSession = session
             self.journalURL = journalURL
             self.journal = MeetingRecordingJournal(
@@ -133,6 +136,18 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
             self.persistLocked()
         }
         return session
+    }
+
+    /// Snapshot of the in-memory journal's system-audio filename, resolved
+    /// against this store's directory. Used by stop when the published URL
+    /// has not been assigned yet.
+    func currentSystemAudioURL() -> URL? {
+        queue.sync {
+            guard let filename = journal?.systemAudioFilename, !filename.isEmpty else {
+                return nil
+            }
+            return directory.appendingPathComponent(filename)
+        }
     }
 
     func recordSystemAudio(_ url: URL, session: MeetingRecordingJournalSession?) {
@@ -262,6 +277,17 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
             let data = try encoder.encode(journal)
             try data.write(to: journalURL, options: .atomic)
             FileManager.default.restrictToOwnerOnly(atPath: journalURL.path)
+            // Atomic replacement prevents torn JSON; synchronize establishes
+            // the write for process and machine failures, matching
+            // MeetingArtifactRecoveryStore.
+            let handle = try FileHandle(forWritingTo: journalURL)
+            do {
+                try handle.synchronize()
+                try handle.close()
+            } catch {
+                try? handle.close()
+                throw error
+            }
         } catch {
             AppLogger.audio.warning("Failed to persist recording journal", [
                 "file": journalURL.lastPathComponent,

--- a/Sources/TranscriptedCore/Audio/QuietMicAttenuationDetector.swift
+++ b/Sources/TranscriptedCore/Audio/QuietMicAttenuationDetector.swift
@@ -49,9 +49,10 @@ public struct QuietMicAttenuationDetector {
     /// real input activity — then always `false` until a fresh instance
     /// replaces this one.
     ///
-    /// Any non-qualifying tick (no buffers during engine restarts, nil gain
-    /// when VPIO is on / AGC absent, zero raw peak when muted, loud raw,
-    /// usable processed, unpinned gain) resets the streak. A qualifying
+    /// Any non-qualifying tick (no buffers during engine restarts, zero raw
+    /// peak when muted, loud raw, usable processed, unpinned gain when AGC
+    /// is present) resets the streak. When gain is absent, a conservative
+    /// raw-level cue still qualifies if activity is present. A qualifying
     /// streak may extend past the detection window while waiting for enough
     /// activity ticks; it never resets while ticks keep qualifying.
     public mutating func consume(
@@ -63,18 +64,25 @@ public struct QuietMicAttenuationDetector {
     ) -> Bool {
         guard !hasFired else { return false }
 
-        let gainPinnedAtMax: Bool
+        let qualifies: Bool
         if let appliedGain, let agcMaxGain {
-            gainPinnedAtMax = appliedGain >= Self.gainPinnedFraction * agcMaxGain
+            // Existing AGC-pinned path: Boost only when software gain is
+            // already maxed out and the raw mic is still quiet.
+            let gainPinnedAtMax = appliedGain >= Self.gainPinnedFraction * agcMaxGain
+            qualifies = sawBuffer
+                && gainPinnedAtMax
+                && rawPeak > 0
+                && rawPeak < Self.quietMicRawPeakThreshold
+                && processedPeak < Self.usableMicProcessedPeakThreshold
         } else {
-            gainPinnedAtMax = false
+            // Raw/off: no AGC gain to pin. Use a conservative raw-level cue —
+            // sustained very-low peak while activity is present. Total silence
+            // is inactivity, not a quiet mic, so it must not qualify.
+            qualifies = sawBuffer
+                && rawPeak >= Self.activityRawPeakFloor
+                && rawPeak < Self.quietMicRawPeakThreshold
+                && processedPeak < Self.usableMicProcessedPeakThreshold
         }
-
-        let qualifies = sawBuffer
-            && gainPinnedAtMax
-            && rawPeak > 0
-            && rawPeak < Self.quietMicRawPeakThreshold
-            && processedPeak < Self.usableMicProcessedPeakThreshold
 
         guard qualifies else {
             consecutiveAttenuatedTicks = 0

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -133,6 +133,27 @@ private final class SCKStopCallbackState {
 }
 
 @available(macOS 26.0, *)
+private final class SCKShareableContentFetchState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var content: SCShareableContent?
+    private var fetchError: Error?
+    let semaphore = DispatchSemaphore(value: 0)
+
+    func complete(content: SCShareableContent?, error: Error?) {
+        lock.lock()
+        self.content = content
+        self.fetchError = error
+        lock.unlock()
+        semaphore.signal()
+    }
+
+    func result() -> (content: SCShareableContent?, error: Error?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (content, fetchError)
+    }
+}
+
 private final class SCKStartCallbackState: @unchecked Sendable {
     private let lock = NSLock()
     private var error: Error?
@@ -282,29 +303,34 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
 
         // Fetch shareable content. On first use this can be held by the macOS
         // permission prompt, so it gets a longer timeout than normal callbacks.
-        let semaphore = DispatchSemaphore(value: 0)
-        var content: SCShareableContent?
-        var fetchError: Error?
+        // Heap-box the result so a late callback after cancel/timeout cannot
+        // write into prepare()'s stack frame.
+        let fetchState = SCKShareableContentFetchState()
 
         SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) { result, error in
-            content = result
-            fetchError = error
-            semaphore.signal()
+            fetchState.complete(content: result, error: error)
         }
         try Self.waitForCallback(
-            semaphore,
+            fetchState.semaphore,
             operation: "shareable content fetch",
             timeout: Self.permissionPromptCallbackTimeout,
-            timeoutSeconds: Self.permissionPromptCallbackTimeoutSeconds
+            timeoutSeconds: Self.permissionPromptCallbackTimeoutSeconds,
+            shouldAbort: { [self] in
+                self.currentGeneration() != prepareGeneration
+            }
         )
         try validateRecoveryToken(recoveryToken)
+        guard currentGeneration() == prepareGeneration else {
+            throw SCKRecoveryCancelledError()
+        }
 
-        if let error = fetchError {
+        let fetch = fetchState.result()
+        if let error = fetch.error {
             AppLogger.audioSystem.error("SCKAudioCapture: failed to get shareable content", ["error": error.localizedDescription])
             throw error
         }
 
-        guard let display = content?.displays.first else {
+        guard let display = fetch.content?.displays.first else {
             throw "SCKAudioCapture: no display found"
         }
 
@@ -441,7 +467,11 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
             ) else {
                 throw SCKRecoveryCancelledError()
             }
-            publishHealthyIfCurrent(identity: streamIdentity, generation: startGeneration)
+            // Recovery success must wait for a real buffer before publishing
+            // healthy. A non-recovery start can clear the error immediately.
+            if recoveryToken == nil {
+                publishHealthyIfCurrent(identity: streamIdentity, generation: startGeneration)
+            }
             AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
         } catch {
             let recoveryWasCancelled = error is SCKRecoveryCancelledError
@@ -936,15 +966,28 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         _ semaphore: DispatchSemaphore,
         operation: String,
         timeout: DispatchTimeInterval,
-        timeoutSeconds: Int
+        timeoutSeconds: Int,
+        shouldAbort: (() -> Bool)? = nil
     ) throws {
-        guard semaphore.wait(timeout: .now() + timeout) == .success else {
-            let error = SCKCaptureTimeoutError(operation: operation)
-            AppLogger.audioSystem.error("SCKAudioCapture: callback timed out", [
-                "operation": operation,
-                "timeoutSeconds": "\(timeoutSeconds)"
-            ])
-            throw error
+        let deadline = DispatchTime.now() + timeout
+        while true {
+            if shouldAbort?() == true {
+                throw SCKRecoveryCancelledError()
+            }
+            let slice: DispatchTime = shouldAbort == nil
+                ? deadline
+                : .now() + .milliseconds(250)
+            if semaphore.wait(timeout: slice) == .success {
+                return
+            }
+            if DispatchTime.now() >= deadline {
+                let error = SCKCaptureTimeoutError(operation: operation)
+                AppLogger.audioSystem.error("SCKAudioCapture: callback timed out", [
+                    "operation": operation,
+                    "timeoutSeconds": "\(timeoutSeconds)"
+                ])
+                throw error
+            }
         }
     }
 
@@ -965,6 +1008,8 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     func recoverAfterSystemWake() {
         let state = currentStreamState()
         guard state.isCapturing, let generation = state.generation else { return }
+        // Do not gate on last-buffer age. CACurrentMediaTime pauses during
+        // sleep, so a stuck stream looks freshly healthy after lid-open.
         AppLogger.audioSystem.info("SCKAudioCapture: proactive recovery after system wake")
         handleMidRecordingFailure(
             "System audio reconnecting after system wake.",
@@ -1071,6 +1116,25 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
         return _lastBufferTime
     }
 
+    /// Mirrors `Audio.waitForMicBuffer`: poll until a real buffer arrives or
+    /// the timeout expires. Used after a recovery `start()` so a silent
+    /// restart does not refund the attempt budget.
+    private func waitForRestartedBuffer(timeout: TimeInterval) -> Bool {
+        let deadline = CACurrentMediaTime() + timeout
+        while CACurrentMediaTime() < deadline {
+            if !currentStreamState().isCapturing { return false }
+            watchdogLock.lock()
+            let got = _hasReceivedFirstBuffer
+            watchdogLock.unlock()
+            if got { return true }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        if !currentStreamState().isCapturing { return false }
+        watchdogLock.lock()
+        defer { watchdogLock.unlock() }
+        return _hasReceivedFirstBuffer
+    }
+
     private func startWatchdog(generation: UInt64) {
         stopWatchdog()
         let timer = DispatchSource.makeTimerSource(queue: watchdogQueue)
@@ -1096,11 +1160,14 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
     private func checkWatchdog(generation: UInt64) {
         guard isActiveCaptureGeneration(generation) else { return }
         watchdogLock.lock()
-        let hasReceivedFirstBuffer = _hasReceivedFirstBuffer
         let elapsed = CACurrentMediaTime() - _lastBufferTime
         watchdogLock.unlock()
 
-        guard hasReceivedFirstBuffer, elapsed >= Self.bufferStallTimeoutSeconds else { return }
+        // Missing-buffer stall, including the silent-after-restart case
+        // where start() reset lastBufferTime to now and first-buffer is
+        // still false. Do not require a prior buffer. Amplitude silence
+        // alone never reaches this path.
+        guard elapsed >= Self.bufferStallTimeoutSeconds else { return }
         AppLogger.audioSystem.error("SCKAudioCapture: buffer watchdog timed out", [
             "elapsedSeconds": String(format: "%.1f", elapsed)
         ])
@@ -1186,32 +1253,21 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
                 guard self.shouldContinueRecovery(recoveryToken, at: "before start") else { return }
                 try self.start(bufferCallback: callback, recoveryToken: recoveryToken)
                 guard self.shouldContinueRecovery(recoveryToken, at: "after start") else { return }
+                // start() only proves ScreenCaptureKit accepted the restart.
+                // Wait for a real buffer before refunding the attempt budget
+                // or publishing healthy — same 2s gate as waitForMicBuffer.
+                guard self.waitForRestartedBuffer(timeout: 2.0) else {
+                    AppLogger.audioSystem.error("SCKAudioCapture: stream recovery start succeeded but no audio buffer arrived")
+                    self.publishErrorMessage("System audio failed - ScreenCaptureKit could not restart audio capture.")
+                    return
+                }
+                guard self.shouldContinueRecovery(recoveryToken, at: "after first buffer") else { return }
                 AppLogger.audioSystem.info("SCKAudioCapture: stream recovery succeeded")
-                // Reset the attempt budget on success, mirroring the mic
-                // path's `finalizeMicRecoveryArtifacts` resetting
-                // `recoveryAttemptCount = 0` once a recovery is confirmed.
-                // Without this, a successful proactive post-wake kick
-                // (`recoverAfterSystemWake`) would permanently spend this
-                // capture's one-attempt budget even though nothing was
-                // actually broken, leaving a LATER genuine failure in the
-                // same recording with zero attempts left — a regression
-                // from pre-wake-hook behavior. Resetting on every success
-                // (reactive or proactive) guarantees a wake kick can never
-                // reduce the recovery capacity available to a subsequent
-                // real failure.
                 self.resetRecoveryAttemptsAfterSuccess()
-                // Report the gap the same way the mic path appends an
-                // `AudioGap` once recovery is confirmed, so the interruption
-                // shows up in saved transcript health metadata. NOTE: unlike
-                // the mic path's `waitForMicBuffer`, `start()` succeeding
-                // here only proves ScreenCaptureKit accepted the restart
-                // request, not that a real audio frame has flowed yet — SCK
-                // has no equivalent post-start buffer-wait. A stream that
-                // silently never resumes after a "successful" restart would
-                // still publish a short gap here and only be caught by the
-                // buffer-stall watchdog on its next stall detection. This is
-                // a known, intentionally-undocumented-elsewhere divergence
-                // from mic semantics, not a fixed parity.
+                if let identity = self.currentStreamState().stream?.captureIdentity,
+                   let generation = self.currentStreamState().generation {
+                    self.publishHealthyIfCurrent(identity: identity, generation: generation)
+                }
                 let gapDuration = max(0, CACurrentMediaTime() - lastKnownBufferTimeAtFailure)
                 self.recoveryEventSubject.send(.gap(duration: gapDuration))
             } catch is SCKRecoveryCancelledError {
@@ -1296,6 +1352,26 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
 
     func lastKnownBufferTimeForTesting() -> CFTimeInterval {
         lastKnownBufferTime()
+    }
+
+    func setLastBufferTimeForTesting(_ time: CFTimeInterval) {
+        watchdogLock.lock()
+        _lastBufferTime = time
+        watchdogLock.unlock()
+    }
+
+    func checkWatchdogForTesting(generation: UInt64) {
+        checkWatchdog(generation: generation)
+    }
+
+    func waitForRestartedBufferForTesting(timeout: TimeInterval) -> Bool {
+        waitForRestartedBuffer(timeout: timeout)
+    }
+
+    func hasReceivedFirstBufferForTesting() -> Bool {
+        watchdogLock.lock()
+        defer { watchdogLock.unlock() }
+        return _hasReceivedFirstBuffer
     }
 }
 

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -88,6 +88,10 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     /// that never carried a typed `PipelineError` (e.g. permission/import
     /// failures) — those keep classifying through the legacy string fallback.
     public var errorKind: PipelineErrorKind?
+    /// Whether the original live recorded job asked the mic channel to be
+    /// diarized into multiple local speakers. Imports stay `false` (they are
+    /// system-channel). Missing on pre-field rows and decoded as `false`.
+    public let splitLocalSpeakers: Bool
 
     public init(
         id: UUID = UUID(),
@@ -99,7 +103,8 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         meetingTitle: String? = nil,
         retryCount: Int = 0,
         lastRetryDate: Date? = nil,
-        errorKind: PipelineErrorKind? = nil
+        errorKind: PipelineErrorKind? = nil,
+        splitLocalSpeakers: Bool = false
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -111,6 +116,51 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         self.retryCount = retryCount
         self.lastRetryDate = lastRetryDate
         self.errorKind = errorKind
+        self.splitLocalSpeakers = splitLocalSpeakers
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case timestamp
+        case recordingDate
+        case micAudioURL
+        case systemAudioURL
+        case errorMessage
+        case meetingTitle
+        case retryCount
+        case lastRetryDate
+        case errorKind
+        case splitLocalSpeakers
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        recordingDate = try container.decodeIfPresent(Date.self, forKey: .recordingDate)
+        micAudioURL = try container.decode(URL.self, forKey: .micAudioURL)
+        systemAudioURL = try container.decodeIfPresent(URL.self, forKey: .systemAudioURL)
+        errorMessage = try container.decode(String.self, forKey: .errorMessage)
+        meetingTitle = try container.decodeIfPresent(String.self, forKey: .meetingTitle)
+        retryCount = try container.decodeIfPresent(Int.self, forKey: .retryCount) ?? 0
+        lastRetryDate = try container.decodeIfPresent(Date.self, forKey: .lastRetryDate)
+        errorKind = try container.decodeIfPresent(PipelineErrorKind.self, forKey: .errorKind)
+        splitLocalSpeakers = try container.decodeIfPresent(Bool.self, forKey: .splitLocalSpeakers) ?? false
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(timestamp, forKey: .timestamp)
+        try container.encodeIfPresent(recordingDate, forKey: .recordingDate)
+        try container.encode(micAudioURL, forKey: .micAudioURL)
+        try container.encodeIfPresent(systemAudioURL, forKey: .systemAudioURL)
+        try container.encode(errorMessage, forKey: .errorMessage)
+        try container.encodeIfPresent(meetingTitle, forKey: .meetingTitle)
+        try container.encode(retryCount, forKey: .retryCount)
+        try container.encodeIfPresent(lastRetryDate, forKey: .lastRetryDate)
+        try container.encodeIfPresent(errorKind, forKey: .errorKind)
+        try container.encode(splitLocalSpeakers, forKey: .splitLocalSpeakers)
     }
 
     /// Returns a user-friendly formatted timestamp
@@ -225,14 +275,20 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         return message.contains("recording too short") || mentionsTooShortAudio || mentionsAudioMinimum
     }
 
-    /// Checks if the audio files still exist on disk
+    /// Checks if any surviving regular audio file still exists on disk.
+    /// A missing counterpart (placeholder mic, dropped system track) must not
+    /// hide retry when the other file is still there.
     public func audioFilesExist() -> Bool {
-        let micExists = FileManager.default.fileExists(atPath: micAudioURL.path)
-        if let systemURL = systemAudioURL {
-            let systemExists = FileManager.default.fileExists(atPath: systemURL.path)
-            return micExists && systemExists
+        isSurvivingRegularFile(micAudioURL)
+            || (systemAudioURL.map(isSurvivingRegularFile) ?? false)
+    }
+
+    private func isSurvivingRegularFile(_ url: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            return false
         }
-        return micExists
+        return !isDirectory.boolValue
     }
 
     /// Returns the total size of audio files in bytes

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -773,11 +773,11 @@ extension Transcription {
     }
 
     /// Recover/transcribe a live meeting when only the microphone WAV survived.
-    /// This intentionally uses the single-"You" mic path: the speaker-review flow
-    /// currently owns system-audio cleanup, so mic-only recovery should save a
-    /// trustworthy transcript instead of opening a review sheet it cannot clean up.
+    /// Honors `splitLocalSpeakers` when the mic file is actually on disk; if
+    /// that file is gone, stay on the single-"You" path.
     nonisolated func transcribeMicrophoneOnly(
         micURL: URL,
+        splitLocalSpeakers: Bool = false,
         onProgress: ((Double) -> Void)? = nil
     ) async throws -> TranscriptionResult {
         let parakeet = await MainActor.run { self.parakeet }
@@ -804,6 +804,61 @@ extension Transcription {
 
             await MainActor.run {
                 self.processingStatus = "Transcribing microphone audio..."
+            }
+
+            let shouldSplitLocalSpeakers = splitLocalSpeakers
+                && FileManager.default.fileExists(atPath: micURL.path)
+            if shouldSplitLocalSpeakers {
+                let diarization = await MainActor.run { self.diarization }
+                let speakerDB = await MainActor.run { self.speakerDB }
+                let micSignalAnalysis = AudioSignalRecovery.analyze(samples: micSamples, sampleRate: 16000)
+                let diarizationMicSamples = AudioSignalRecovery.normalizeForSpeech(
+                    samples: micSamples,
+                    sampleRate: 16000,
+                    analysis: micSignalAnalysis
+                ).samples
+                micSamples = []
+                var droppedSegments = 0
+                let existingProfiles = speakerDB.allSpeakers()
+                let micResult = try await Self.processMicChannelWithDiarization(
+                    samples: diarizationMicSamples,
+                    diarization: diarization,
+                    parakeet: parakeet,
+                    speakerDB: speakerDB,
+                    existingProfiles: existingProfiles,
+                    droppedSegments: &droppedSegments,
+                    onProgress: onProgress
+                )
+                let mergedMicUtterances = Self.mergeConsecutiveUtterances(micResult.utterances, maxGap: 1.5)
+                guard !mergedMicUtterances.isEmpty else {
+                    throw PipelineError.noSpeechDetected
+                }
+
+                let processingTime = Date().timeIntervalSince(processingStartTime)
+                await MainActor.run {
+                    self.processingStatus = "Transcription complete!"
+                    self.isProcessing = false
+                }
+                onProgress?(1.0)
+
+                AppLogger.transcription.info("Mic-only split transcription complete", [
+                    "micUtterances": "\(mergedMicUtterances.count)",
+                    "speakers": "\(Set(mergedMicUtterances.map { $0.speakerId }).count)",
+                    "processingTime": "\(String(format: "%.1f", processingTime))s",
+                    "droppedSegments": "\(droppedSegments)"
+                ])
+
+                return TranscriptionResult(
+                    micUtterances: mergedMicUtterances,
+                    systemUtterances: [],
+                    micSpeakerContexts: micResult.speakerContexts,
+                    newlyCreatedMicProfileIds: micResult.newlyCreatedProfileIds,
+                    duration: duration,
+                    processingTime: processingTime,
+                    droppedSegments: droppedSegments,
+                    microphoneAudioOutcome: .usable,
+                    systemAudioOutcome: .notProvided
+                )
             }
 
             let micSegments = Self.detectSpeechSegments(samples: micSamples, sampleRate: 16000)

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -137,6 +137,7 @@ extension TranscriptionTaskManager {
             guard let micURL else {
                 throw PipelineError.invalidAudioFormat(detail: "No meeting audio files were available")
             }
+            let micExists = FileManager.default.fileExists(atPath: micURL.path)
             return try await transcribeMicrophoneOnlyPipeline(
                 micURL: micURL,
                 outputFolder: outputFolder,
@@ -145,7 +146,8 @@ extension TranscriptionTaskManager {
                 meetingTitle: meetingTitle,
                 recordingDate: recordingDate,
                 sourceFailedTranscriptionId: sourceFailedTranscriptionId,
-                removeSourceAudioAfterArchive: removeSourceAudioAfterArchive
+                removeSourceAudioAfterArchive: removeSourceAudioAfterArchive,
+                splitLocalSpeakers: splitLocalSpeakers && micExists
             )
         }
 
@@ -171,7 +173,8 @@ extension TranscriptionTaskManager {
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
-        removeSourceAudioAfterArchive: Bool = true
+        removeSourceAudioAfterArchive: Bool = true,
+        splitLocalSpeakers: Bool = false
     ) async throws -> URL {
         let transcription = await MainActor.run { self.transcription }
         try await transcription.ensureModelsReadyForPipeline()
@@ -186,6 +189,7 @@ extension TranscriptionTaskManager {
 
         let result = try await transcription.transcribeMicrophoneOnly(
             micURL: micURL,
+            splitLocalSpeakers: splitLocalSpeakers,
             onProgress: { [weak self] progress in
                 Task { @MainActor in
                     self?.displayStatus = .transcribing(progress: progress)

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -14,6 +14,7 @@ public class TranscriptionTaskManager: ObservableObject {
         let meetingTitle: String?
         let recordingDate: Date?
         let importedRecoverySession: (any ImportedTranscriptionRecoverySession)?
+        let splitLocalSpeakers: Bool
     }
 
     /// Every task tracked by this manager is in exactly one of these states by
@@ -344,7 +345,8 @@ public class TranscriptionTaskManager: ObservableObject {
             systemURL: systemURL,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
-            importedRecoverySession: nil
+            importedRecoverySession: nil,
+            splitLocalSpeakers: splitLocalSpeakers
         ))
         publishNonFailureStatus(.gettingReady)
 
@@ -409,7 +411,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     taskId: task.id,
                     meetingTitle: task.meetingTitle,
                     recordingDate: task.recordingDate,
-                    errorKind: errorKind
+                    errorKind: errorKind,
+                    splitLocalSpeakers: task.splitLocalSpeakers
                 )
 
                 await MainActor.run {
@@ -435,7 +438,8 @@ public class TranscriptionTaskManager: ObservableObject {
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
         archiveAudio: Bool = true,
-        errorKind: PipelineErrorKind? = nil
+        errorKind: PipelineErrorKind? = nil,
+        splitLocalSpeakers: Bool = false
     ) async -> Bool {
         guard micAudioURL != nil || systemAudioURL != nil else {
             AppLogger.pipeline.error("No audio files available to retain for failed transcription", [
@@ -468,7 +472,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     meetingTitle: meetingTitle,
                     recordingDate: recordingDate,
                     removeOriginalsAfterArchive: true,
-                    errorKind: errorKind
+                    errorKind: errorKind,
+                    splitLocalSpeakers: splitLocalSpeakers
                 )
             }
         }
@@ -481,13 +486,15 @@ public class TranscriptionTaskManager: ObservableObject {
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
             archiveAudio: archiveAudio,
-            errorKind: errorKind
+            errorKind: errorKind,
+            splitLocalSpeakers: splitLocalSpeakers
         )
     }
 
     /// Start a new transcription task for an imported audio file.
-    /// Imported files reuse the system-audio speaker path and are not added to the
-    /// failed-transcription queue because the user can simply re-import the source file.
+    /// Imported files reuse the system-audio speaker path. Early reject gates
+    /// (busy / too-short) delete the scratch copy without queueing. Mid-pipeline
+    /// failures archive that copy into the failed queue first, then delete scratch.
     public func startImportedTranscription(
         taskId: UUID = UUID(),
         audioURL: URL,
@@ -538,11 +545,12 @@ public class TranscriptionTaskManager: ObservableObject {
         activeCount += 1
         backgroundTaskCount += 1
         tasks[taskId] = .active(audio: ActiveTaskAudio(
-            micURL: audioURL,
-            systemURL: nil,
+            micURL: nil,
+            systemURL: audioURL,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
-            importedRecoverySession: recoverySession
+            importedRecoverySession: recoverySession,
+            splitLocalSpeakers: false
         ))
         publishNonFailureStatus(.gettingReady)
 
@@ -576,10 +584,12 @@ public class TranscriptionTaskManager: ObservableObject {
                     "error": error.localizedDescription
                 ])
 
-                await MainActor.run {
+                let errorKind = Self.failureKind(for: error)
+
+                let shouldPreserveFailedAudio = await MainActor.run { () -> Bool in
                     if self.consumePreservedForShutdownMarker(taskId: taskId) {
                         self.handleTaskCompletion(taskId: taskId)
-                        return
+                        return false
                     }
                     if self.finishCancelledTaskIfNeeded(taskId: taskId, error: error) {
                         if self.removeImportedRecordingFile(
@@ -589,16 +599,35 @@ public class TranscriptionTaskManager: ObservableObject {
                         ) {
                             recoverySession?.scratchCleanupConfirmed()
                         }
-                        return
+                        return false
                     }
-                    if self.removeImportedRecordingFile(
-                        audioURL,
-                        recoverySession: recoverySession,
-                        label: "failed imported recording"
-                    ) {
-                        recoverySession?.scratchCleanupConfirmed()
-                    }
+
                     self.publishFailure(Self.failurePresentation(for: error, flow: .importedAudio))
+                    return true
+                }
+
+                guard shouldPreserveFailedAudio else { return }
+
+                // Archive the imported scratch copy into the failed queue first
+                // (system slot + placeholder mic), matching coordinator-preserved
+                // imports. AfterArchive deletes the scratch original only after
+                // the row is durable. Early-reject gates above still delete
+                // without queueing.
+                let didPersist = await self.addFailedTranscriptionRetainingAvailableAudioAfterArchive(
+                    micAudioURL: nil,
+                    systemAudioURL: audioURL,
+                    errorMessage: error.localizedDescription,
+                    taskId: taskId,
+                    meetingTitle: meetingTitle,
+                    recordingDate: recordingDate,
+                    errorKind: errorKind,
+                    splitLocalSpeakers: false
+                )
+
+                await MainActor.run {
+                    if didPersist {
+                        recoverySession?.failedQueueHandoffConfirmed()
+                    }
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: taskId)
                     self.scheduleStatusReset(delay: 4)
@@ -1154,7 +1183,8 @@ public class TranscriptionTaskManager: ObservableObject {
         recordingDate: Date? = nil,
         archiveAudio: Bool = true,
         clearRecordingJournalAfterPersistence: Bool = true,
-        errorKind: PipelineErrorKind? = nil
+        errorKind: PipelineErrorKind? = nil,
+        splitLocalSpeakers: Bool = false
     ) -> Bool {
         guard micAudioURL != nil || systemAudioURL != nil else {
             AppLogger.pipeline.error("No audio files available to retain for failed transcription", [
@@ -1173,7 +1203,8 @@ public class TranscriptionTaskManager: ObservableObject {
             recordingDate: recordingDate,
             removeOriginalsAfterArchive: false,
             clearRecordingJournalAfterPersistence: clearRecordingJournalAfterPersistence,
-            errorKind: errorKind
+            errorKind: errorKind,
+            splitLocalSpeakers: splitLocalSpeakers
         )
         if didPersist, archiveAudio {
             scheduleFailedRecordingAudioArchive(
@@ -1199,7 +1230,8 @@ public class TranscriptionTaskManager: ObservableObject {
         recordingDate: Date?,
         removeOriginalsAfterArchive: Bool,
         clearRecordingJournalAfterPersistence: Bool = true,
-        errorKind: PipelineErrorKind? = nil
+        errorKind: PipelineErrorKind? = nil,
+        splitLocalSpeakers: Bool = false
     ) -> Bool {
         let retainedMicURL = existingAudioURL(retainedAudio?.micURL)
         let retainedSystemURL = existingAudioURL(retainedAudio?.systemURL)
@@ -1232,7 +1264,8 @@ public class TranscriptionTaskManager: ObservableObject {
             errorMessage: errorMessage,
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
-            errorKind: errorKind
+            errorKind: errorKind,
+            splitLocalSpeakers: splitLocalSpeakers
         )
         guard didPersist else {
             if let retainedAudio {
@@ -1861,16 +1894,13 @@ public class TranscriptionTaskManager: ObservableObject {
         }
 
         do {
-            // Retries don't carry the original task's splitLocalSpeakers flag — retries are
-            // rare and the feature default is off, so we use the default. If users retry
-            // after enabling local split, they can restart the meeting capture instead.
             let transcriptURL = try await transcribeWithSpeakerIdentification(
                 micURL: failed.micAudioURL,
                 systemURL: failed.systemAudioURL,
                 outputFolder: outputFolder,
                 taskId: failedId,
                 healthInfo: nil,
-                splitLocalSpeakers: false,
+                splitLocalSpeakers: failed.splitLocalSpeakers,
                 meetingTitle: failed.meetingTitle,
                 recordingDate: failed.recordingDate ?? failed.timestamp,
                 sourceFailedTranscriptionId: failedId
@@ -2156,7 +2186,8 @@ public class TranscriptionTaskManager: ObservableObject {
                 errorMessage: errorMessage,
                 taskId: taskId,
                 meetingTitle: audio.meetingTitle,
-                recordingDate: audio.recordingDate
+                recordingDate: audio.recordingDate,
+                splitLocalSpeakers: audio.splitLocalSpeakers
             )
             if didPersist {
                 preservedCount += 1

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -247,12 +247,18 @@ public class FailedTranscriptionManager: ObservableObject {
         // Audio preserved during a quit that interrupted finalization can have
         // an unpatched WAV header, which reads back as zero-length and makes
         // every retry fail. Nothing else re-runs finalization after relaunch.
-        repairWAVHeaderIfNeeded(at: micURL, entryId: entry.id)
-        if let systemURL {
+        if fileManager.fileExists(atPath: micURL.path) {
+            repairWAVHeaderIfNeeded(at: micURL, entryId: entry.id)
+        }
+        if let systemURL, fileManager.fileExists(atPath: systemURL.path) {
             repairWAVHeaderIfNeeded(at: systemURL, entryId: entry.id)
         }
 
-        if !fileManager.fileExists(atPath: micURL.path) {
+        let micExists = fileManager.fileExists(atPath: micURL.path)
+        let systemExists = systemURL.map { fileManager.fileExists(atPath: $0.path) } ?? false
+        // Coordinator-preserved imports are placeholder mic + real system.
+        // A missing counterpart must not hide the surviving file.
+        if !micExists && !systemExists {
             AppLogger.pipeline.error("Dropping failed transcription entry with missing audio", [
                 "id": entry.id.uuidString,
                 "micFile": micURL.lastPathComponent,
@@ -260,13 +266,12 @@ public class FailedTranscriptionManager: ObservableObject {
             ])
             return (nil, didHeal, false)
         }
-        if let systemURL, !fileManager.fileExists(atPath: systemURL.path) {
-            AppLogger.pipeline.error("Dropping failed transcription entry with missing audio", [
+        if !micExists, systemExists {
+            AppLogger.pipeline.warning("Kept failed transcription with missing microphone audio because system audio survived", [
                 "id": entry.id.uuidString,
                 "micFile": micURL.lastPathComponent,
-                "systemFile": systemURL.lastPathComponent
+                "systemFile": systemURL?.lastPathComponent ?? "none"
             ])
-            return (nil, didHeal, false)
         }
 
         guard didHeal else { return (entry, false, false) }
@@ -518,7 +523,8 @@ public class FailedTranscriptionManager: ObservableObject {
         errorMessage: String,
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
-        errorKind: PipelineErrorKind? = nil
+        errorKind: PipelineErrorKind? = nil,
+        splitLocalSpeakers: Bool = false
     ) -> Bool {
         // Security: validate incoming audio URLs before they ever reach the queue.
         // The on-disk load path already re-checks sandboxing, but without this guard an
@@ -539,7 +545,8 @@ public class FailedTranscriptionManager: ObservableObject {
             systemAudioURL: systemAudioURL,
             errorMessage: errorMessage,
             meetingTitle: meetingTitle,
-            errorKind: errorKind
+            errorKind: errorKind,
+            splitLocalSpeakers: splitLocalSpeakers
         )
 
         failedTranscriptions.append(failed)

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -82,7 +82,7 @@ final class MenuBarPanelController: NSViewController {
         appState.contextCapture.refreshShortcutStatus()
 
         let warmupStatus = appState.meetingSession.warmupStatus
-        let isMeetingRecording = appState.meetingSession.isRecording
+        let isMeetingRecording = appState.meetingSession.isCaptureSessionActive
         let modelState = appState.sttRouter.modelDownloadState
         let dictationState = FirstRunExperience.dictationAction(for: modelState)
         let meetingState = FirstRunExperience.meetingAction(
@@ -281,14 +281,19 @@ final class MenuBarPanelController: NSViewController {
     }
 
     private func startMeetingFromMenu() {
-        let isRecording = appState.meetingSession.isRecording
-        trackMenuAction(isRecording ? "stop_meeting" : "start_meeting")
+        let meetingSession = appState.meetingSession
+        let captureActive = meetingSession.isCaptureSessionActive
+        trackMenuAction(captureActive ? "stop_meeting" : "start_meeting")
         let sourceApp = resolvedSourceApp()
         dismissPopover()
         sourceApp?.activate(options: [])
-        Task { [meetingSession = appState.meetingSession] in
-            if isRecording {
-                await meetingSession.stopRecording(reason: .menuBarStopButton)
+        Task { [meetingSession] in
+            if meetingSession.isCaptureSessionActive {
+                if case .startingRecording = meetingSession.state {
+                    await meetingSession.stopRecordingJoiningPendingStart(reason: .menuBarStopButton)
+                } else {
+                    await meetingSession.stopRecording(reason: .menuBarStopButton)
+                }
             } else {
                 await meetingSession.startRecording(trigger: .menu)
             }

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -627,6 +627,9 @@ final class MeetingOverlayController: NSObject {
 
         let response = alert.runModal()
         guard response == .alertSecondButtonReturn else { return }
+        // The confirm sheet can outlive the recording. Stop or an unexpected
+        // capture end may already be preserving audio — do not cancel then.
+        guard case .recording = session.state else { return }
 
         Task { [weak session] in
             await session?.cancelRecording(reason: .discardButton)
@@ -821,15 +824,20 @@ final class MeetingOverlayController: NSObject {
         pinItem.state = MeetingOverlayPillPreferences.keepControlsVisible() ? .on : .off
         menu.addItem(pinItem)
 
-        menu.addItem(.separator())
+        // Overlay `.recording` also covers `.stoppingRecording` (keep the pill
+        // up through teardown). Discard must require the session itself to
+        // still be `.recording`, or the item no-ops after a stop starts.
+        if case .recording = meetingSession?.state {
+            menu.addItem(.separator())
 
-        let discardItem = NSMenuItem(
-            title: "Discard Recording…",
-            action: #selector(handleMenuDiscard),
-            keyEquivalent: ""
-        )
-        discardItem.target = self
-        menu.addItem(discardItem)
+            let discardItem = NSMenuItem(
+                title: "Discard Recording…",
+                action: #selector(handleMenuDiscard),
+                keyEquivalent: ""
+            )
+            discardItem.target = self
+            menu.addItem(discardItem)
+        }
 
         return menu
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -2018,7 +2018,7 @@ struct TranscriptedSettingsView: View {
                 help: splitLocalSpeakersEnabled ? "Name voices sharing this Mac's mic." : "Your mic stays labeled You.",
                 info: GeneralInfo(
                     title: "People in the room",
-                    message: "After shared-room meetings, asks you to name the voices your mic captured. Off keeps your mic labeled \"You\" — simpler when it's just you. Applies from the next recording."
+                    message: "After shared-room meetings, asks you to name the voices your mic captured. Off keeps your mic labeled \"You\" — simpler when it's just you. Applies when the meeting is transcribed."
                 ),
                 automationIdentifier: "transcripted.settings.general.people-in-room"
             )
@@ -2257,7 +2257,7 @@ struct TranscriptedSettingsView: View {
             title: "Mic processing",
             info: GeneralInfo(
                 title: "Mic processing",
-                message: "Auto-level (default) evens out quiet mics. Raw records unprocessed. Apple voice processing can rescue quiet WebRTC calls but may duck other audio. Applies from the next recording."
+                message: "Auto-level (default) evens out quiet meeting mics. Raw records unprocessed meeting input. Apple voice processing applies to meetings and dictation (dictation skips it on split Bluetooth playback). Applies from the next recording."
             ),
             showsDivider: false
         ) {

--- a/Tests/BluetoothRouteContractTests.swift
+++ b/Tests/BluetoothRouteContractTests.swift
@@ -672,6 +672,10 @@ func testBluetoothRouteContract() {
             "system input reconciliation must happen only after the active-dictation wait"
         )
         assertTrue(
+            schedulerBody.contains("isMeetingCaptureActive:"),
+            "persistent input maintenance must also wait out an active meeting capture"
+        )
+        assertTrue(
             schedulerBody.contains("topologyRefreshTask?.cancel()"),
             "repeated preference notifications should coalesce into one post-dictation refresh"
         )

--- a/Tests/DictationInputDeviceSelectionPolicyTests.swift
+++ b/Tests/DictationInputDeviceSelectionPolicyTests.swift
@@ -172,12 +172,32 @@ func testDictationInputDeviceSelectionPolicy() {
             "unrelated topology noise should remain idle when there is no preference or recovery work"
         )
         assertTrue(
-            DictationPersistentInputRefreshPolicy.shouldDefer(isDictationActive: true),
+            DictationPersistentInputRefreshPolicy.shouldDefer(
+                isDictationActive: true,
+                isMeetingCaptureActive: false
+            ),
             "persistent input maintenance must not interrupt a live dictation graph"
         )
+        assertTrue(
+            DictationPersistentInputRefreshPolicy.shouldDefer(
+                isDictationActive: false,
+                isMeetingCaptureActive: true
+            ),
+            "persistent input maintenance must not write the Mac-wide default mid-meeting"
+        )
+        assertTrue(
+            DictationPersistentInputRefreshPolicy.shouldDefer(
+                isDictationActive: true,
+                isMeetingCaptureActive: true
+            ),
+            "either live capture path is enough to defer the system-default write"
+        )
         assertFalse(
-            DictationPersistentInputRefreshPolicy.shouldDefer(isDictationActive: false),
-            "persistent input maintenance should resume after dictation stops"
+            DictationPersistentInputRefreshPolicy.shouldDefer(
+                isDictationActive: false,
+                isMeetingCaptureActive: false
+            ),
+            "persistent input maintenance should resume after dictation and meeting capture stop"
         )
     }
 

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -326,6 +326,17 @@ func testDictationRecordingStartOverlayPolicy() {
             body.contains("resumeRegularRecordingAfterSharedMeetingMicEndedIfNeeded"),
             "unexpected stop should resume any in-flight dictation on the regular mic"
         )
+        guard let recordingGuard = body.range(of: "guard case .recording = state"),
+              let leaveRecording = body.range(of: "transition(to: .stoppingRecording, reason: \"unexpected_capture_stop\")"),
+              let firstAwait = body.range(of: "await capture.flushSharedDictationMicHandler()") else {
+            assertTrue(false, "unexpected stop must leave .recording before any await")
+            return
+        }
+        assertTrue(
+            recordingGuard.lowerBound < leaveRecording.lowerBound
+                && leaveRecording.lowerBound < firstAwait.lowerBound,
+            "unexpected stop must enter .stoppingRecording before flush/preserve awaits"
+        )
     }
 
     runSuite("DictationSessionController clears the start-task handle on the recovery-path start too") {

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -105,19 +105,20 @@ func testFailedMeetingPresentation() {
         assertEqual(copy.detail, "Could not write transcript to meetings", "save failures should preserve the short write error")
     }
 
-    runSuite("FailedMeetingPresentation no-speech failures point to Home recovery") {
+    runSuite("FailedMeetingPresentation no-speech failures do not promise a retry") {
         let copy = MeetingFailureCopy.make(
             forMessage: "No speech detected",
             shortErrorMessage: "No speech detected",
-            isRetryable: true
+            isRetryable: false
         )
 
         assertEqual(copy.title, "No speech found", "no-speech outcomes should be named plainly")
         assertEqual(
             copy.detail,
-            "Transcripted found audio, but not enough spoken words to write a transcript. Open Home to retry, or record again with clearer voices.",
-            "no-speech outcomes should point to a visible recovery path"
+            "Transcripted found audio, but not enough spoken words to write a transcript. The audio was kept. Try recording again with clearer voices.",
+            "no-speech outcomes should keep the audio and ask for a clearer recording, not a Home retry"
         )
+        assertFalse(copy.detail.lowercased().contains("retry"), "no-speech copy must not promise a retry")
     }
 
     runSuite("FailedMeetingPresentation mid-meeting device loss gets device-loss copy, not start-failure copy") {

--- a/Tests/MeetingFailureCopyTests.swift
+++ b/Tests/MeetingFailureCopyTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+func testMeetingFailureCopy() {
+    runSuite("MeetingFailureCopy noSpeechDetected does not promise a retry") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "No speech detected",
+            shortErrorMessage: "No speech detected",
+            isRetryable: false
+        )
+
+        assertEqual(copy.title, "No speech found", "no-speech outcomes should be named plainly")
+        assertFalse(
+            copy.detail.lowercased().contains("retry"),
+            "no-speech copy must not promise a retry Home cannot offer"
+        )
+        assertTrue(
+            copy.detail.contains("audio was kept"),
+            "no-speech copy should say the audio was kept"
+        )
+        assertTrue(
+            copy.detail.contains("clearer voices"),
+            "no-speech copy should tell the user to record again with clearer voices"
+        )
+    }
+}

--- a/Tests/MeetingPromptDetectorTests.swift
+++ b/Tests/MeetingPromptDetectorTests.swift
@@ -695,6 +695,29 @@ func testMeetingPromptDetector() async {
         )
     }
 
+    runSuite("MeetingPromptDetector.expire — past the re-offer cap does not mark the call declined") {
+        let detector = MeetingPromptDetector()
+        detector.frontmostBundleIDProvider = { nil }
+        let candidate = makeMeetingPromptCandidate(id: "mic:zoom", source: .runtimeApp, reason: .micInput)
+
+        for _ in 0..<(MeetingPromptHeuristics.maxPromptExpiryReoffers + 1) {
+            _ = detector.expire(candidate: candidate)
+        }
+
+        assertEqual(
+            detector.dismissStreak(for: .zoom),
+            0,
+            "an unattended expiry cap must not count as the user tapping Not now"
+        )
+
+        _ = detector.dismiss(candidate: candidate)
+        assertEqual(
+            detector.dismissStreak(for: .zoom),
+            1,
+            "an explicit Not now after the expiry cap should start the dismiss streak at 1"
+        )
+    }
+
     await runSuite("MeetingPromptDetector.expire — a re-offered candidate can prompt again after the interval") {
         let detector = MeetingPromptDetector()
         detector.frontmostBundleIDProvider = { nil }
@@ -722,6 +745,28 @@ func testMeetingPromptDetector() async {
         await waitForPromptEvaluation()
 
         assertEqual(box.promptCount, 1, "during the re-offer cooldown the same call must stay quiet, not re-prompt instantly")
+    }
+
+    await runSuite("MeetingPromptDetector.requestEvaluation — own-capture clear can prompt a live call") {
+        let detector = MeetingPromptDetector()
+        detector.frontmostBundleIDProvider = { nil }
+        var ownCapture = true
+        detector.isOwnCaptureActive = { ownCapture }
+        let box = CandidateBox()
+        detector.onPromptRequest = { candidate in
+            box.candidate = candidate
+            box.promptCount += 1
+            return true
+        }
+
+        detector.updateMicInputUsers(["us.zoom.xos"])
+        await waitForPromptEvaluation()
+        assertEqual(box.promptCount, 0, "a live call must stay quiet while own-capture is active")
+
+        ownCapture = false
+        detector.requestEvaluation()
+        await waitForPromptEvaluation()
+        assertEqual(box.promptCount, 1, "clearing own-capture should re-evaluate immediately instead of waiting for the poll")
     }
 
     await runSuite("MeetingPromptDetector.onUnrecordedCallEnded — a short call ending never nudges") {

--- a/Tests/MeetingSessionUIPolicyTests.swift
+++ b/Tests/MeetingSessionUIPolicyTests.swift
@@ -176,4 +176,167 @@ func testMeetingSessionUIPolicy() {
             "transcript titles should be single-line and trimmed before persistence"
         )
     }
+
+    runSuite("MeetingSessionController wires Audio sleep/wake to the workspace center") {
+        let source = readSourceFixture(
+            "Sources/Meeting/MeetingSessionController.swift",
+            description: "MeetingSessionController.swift"
+        )
+        guard let audioInit = source.range(of: "MeetingCaptureBridge("),
+              let audioInitEnd = source.range(
+                of: "self.sttAdapter = MeetingSTTAdapter",
+                range: audioInit.upperBound..<source.endIndex
+              ) else {
+            assertTrue(false, "production Audio construction should stay next to STT adapter setup")
+            return
+        }
+        let body = String(source[audioInit.lowerBound..<audioInitEnd.lowerBound])
+        assertTrue(
+            body.contains("sleepWakeNotifications: AudioSleepWakeNotifications("),
+            "production must inject sleep/wake notifications instead of Audio(paths:) defaults"
+        )
+        assertTrue(
+            body.contains("center: NSWorkspace.shared.notificationCenter"),
+            "sleep/wake must listen on the workspace center, not NotificationCenter.default"
+        )
+        assertTrue(
+            body.contains("NSWorkspaceWillSleepNotification") && body.contains("NSWorkspaceDidWakeNotification"),
+            "workspace sleep/wake notification names must stay wired"
+        )
+    }
+
+    runSuite("MeetingSessionController unexpected stop leaves recording before any await") {
+        let source = readSourceFixture(
+            "Sources/Meeting/MeetingSessionController.swift",
+            description: "MeetingSessionController.swift"
+        )
+        guard let start = source.range(of: "private func handleUnexpectedCaptureStop"),
+              let end = source.range(
+                of: "// preserveQueuedTranscriptionJobsForShutdown",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            assertTrue(false, "unexpected capture-stop handler should remain present")
+            return
+        }
+        let body = String(source[start.lowerBound..<end.lowerBound])
+        guard let recordingGuard = body.range(of: "guard case .recording = state"),
+              let leaveRecording = body.range(of: "transition(to: .stoppingRecording, reason: \"unexpected_capture_stop\")"),
+              let firstAwait = body.range(of: "await capture.flushSharedDictationMicHandler()") else {
+            assertTrue(false, "unexpected stop must guard .recording, leave it, then await flush work")
+            return
+        }
+        assertTrue(
+            recordingGuard.lowerBound < leaveRecording.lowerBound,
+            "unexpected stop must confirm .recording before leaving it"
+        )
+        assertTrue(
+            leaveRecording.lowerBound < firstAwait.lowerBound,
+            "unexpected stop must enter .stoppingRecording before any await so stop/cancel cannot interleave"
+        )
+    }
+
+    runSuite("MeetingSessionController startRecording returns false for active capture") {
+        let source = readSourceFixture(
+            "Sources/Meeting/MeetingSessionController.swift",
+            description: "MeetingSessionController.swift"
+        )
+        guard let ignored = source.range(of: "Meeting start ignored because another meeting flow is active"),
+              let nextCase = source.range(
+                of: "case .idle, .loadingModels, .ready, .transcribing, .error:",
+                range: ignored.upperBound..<source.endIndex
+              ),
+              let ignoredReturn = source.range(
+                of: "return false",
+                range: ignored.upperBound..<nextCase.lowerBound
+              ) else {
+            assertTrue(false, "active-capture start ignore must return false before the free-state cases")
+            return
+        }
+        assertTrue(
+            ignoredReturn.lowerBound < nextCase.lowerBound,
+            "startRecording must not treat an already-active capture as an accepted Record"
+        )
+        assertFalse(
+            String(source[ignored.upperBound..<nextCase.lowerBound]).contains("return true"),
+            "active-capture start ignore must not return true"
+        )
+    }
+
+    runSuite("MeetingOverlayController Discard menu requires session.recording") {
+        let source = readSourceFixture(
+            "Sources/UI/Overlay/MeetingOverlayController.swift",
+            description: "MeetingOverlayController.swift"
+        )
+        guard let start = source.range(of: "private func makeStripMenu()"),
+              let end = source.range(
+                of: "@objc private func handleMenuTogglePin()",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            assertTrue(false, "pill strip menu should remain present")
+            return
+        }
+        let body = String(source[start.lowerBound..<end.lowerBound])
+        guard let sessionRecording = body.range(of: "if case .recording = meetingSession?.state"),
+              let discard = body.range(of: "Discard Recording…") else {
+            assertTrue(false, "Discard must be gated on the session being .recording, not overlay state")
+            return
+        }
+        assertTrue(
+            sessionRecording.lowerBound < discard.lowerBound,
+            "Discard must sit inside the session.recording check so it hides while stopping"
+        )
+    }
+
+    runSuite("MeetingOverlayController Discard confirm re-checks session.recording") {
+        let source = readSourceFixture(
+            "Sources/UI/Overlay/MeetingOverlayController.swift",
+            description: "MeetingOverlayController.swift"
+        )
+        guard let start = source.range(of: "private func handleDiscardRequested()"),
+              let end = source.range(
+                of: "private func scheduleAutoHide(",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            assertTrue(false, "discard confirm handler should remain present")
+            return
+        }
+        let body = String(source[start.lowerBound..<end.lowerBound])
+        guard let confirm = body.range(of: "alert.runModal()") else {
+            assertTrue(false, "discard confirm must present a modal alert")
+            return
+        }
+        let afterConfirm = body[confirm.upperBound...]
+        assertTrue(
+            afterConfirm.contains("guard case .recording = session.state else { return }"),
+            "a Discard confirm that outlived Stop must not cancel a preserve already in flight"
+        )
+    }
+
+    runSuite("MenuBar start/stop uses capture-active instead of steady-state isRecording") {
+        let source = readSourceFixture(
+            "Sources/UI/MenuBar/MenuBarPanelController.swift",
+            description: "MenuBarPanelController.swift"
+        )
+        guard let start = source.range(of: "private func startMeetingFromMenu()"),
+              let end = source.range(
+                of: "private func pasteLastDictationFromMenu()",
+                range: start.upperBound..<source.endIndex
+              ) else {
+            assertTrue(false, "menu meeting action should remain present")
+            return
+        }
+        let body = String(source[start.lowerBound..<end.lowerBound])
+        assertTrue(
+            body.contains("isCaptureSessionActive"),
+            "menu must treat starting/recording/stopping as Stop, not Start"
+        )
+        assertTrue(
+            body.contains("stopRecordingJoiningPendingStart"),
+            "a Stop during .startingRecording must join the pending start"
+        )
+        assertFalse(
+            body.contains("meetingSession.isRecording"),
+            "steady-state isRecording would double-start during starting/stopping"
+        )
+    }
 }

--- a/Tests/RetranscribeLocalSpeakerPreferenceContractTests.swift
+++ b/Tests/RetranscribeLocalSpeakerPreferenceContractTests.swift
@@ -27,5 +27,19 @@ func testRetranscribeLocalSpeakerPreferenceContract() {
             coordinator.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
             "live capture transcription should keep reading the preference"
         )
+        assertTrue(
+            coordinator.contains("splitLocalSpeakers: splitLocalSpeakers"),
+            "queued recorded jobs must persist the snapshot onto the failed-queue row"
+        )
+        assertTrue(
+            controller.contains("preserveFailedMeetingForRetry(")
+                && controller.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
+            "live unexpected/no-file preserves must snapshot People-in-the-room"
+        )
+        assertTrue(
+            controller.contains("preserveTimedOutFailedMeetingForRetry(")
+                && controller.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
+            "stop-timeout preserves must snapshot People-in-the-room"
+        )
     }
 }

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -53,6 +53,12 @@ func testTranscriptedConstants() async {
             TranscriptedConstants.meetingTerminationFinishWaitTimeout > maximumStopTimeoutSeconds,
             "termination wait should outlast the longest scaled stop timeout"
         )
+        let permissionRequestTimeoutSeconds =
+            TimeInterval(TranscriptedConstants.systemAudioPermissionRequestTimeout) / 1_000_000_000
+        assertTrue(
+            TranscriptedConstants.meetingTerminationFinishWaitTimeout > permissionRequestTimeoutSeconds,
+            "termination wait should outlast a first-run System Audio permission prompt"
+        )
     }
 
     runSuite("TranscriptedConstants lets ScreenCaptureKit finish before the meeting start deadline") {
@@ -65,6 +71,16 @@ func testTranscriptedConstants() async {
         assertTrue(
             TranscriptedConstants.meetingStartTimeout > screenCaptureKitStartTimeout,
             "the outer meeting deadline must outlast ScreenCaptureKit's 8-second callback timeout"
+        )
+        assertEqual(
+            TranscriptedConstants.systemAudioPermissionRequestTimeout,
+            120_000_000_000,
+            "the System Audio permission probe must outlast the first-run macOS dialog"
+        )
+        assertTrue(
+            TranscriptedConstants.systemAudioPermissionRequestTimeout
+                > TranscriptedConstants.meetingStartTimeout,
+            "first-run permission wait must be longer than the post-grant streaming deadline"
         )
     }
 

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
@@ -1,7 +1,21 @@
 import XCTest
+import Combine
 @preconcurrency import AVFoundation
 import ScreenCaptureKit
 @testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+private final class URLResolutionStubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked Sendable {
+    var diagnosticBackendName: String { "url_resolution_stub" }
+    var audioFormat: AVAudioFormat?
+    var bufferSuccessRate: Double { 1 }
+    var deliversOwnedAudioBuffers: Bool { true }
+    var errorMessagePublisher: AnyPublisher<String?, Never> { Empty().eraseToAnyPublisher() }
+    func prepare() throws {}
+    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {}
+    func stop() {}
+    func stopSync() {}
+}
 
 @available(macOS 14.0, *)
 final class AudioFileManagerTests: XCTestCase {
@@ -73,7 +87,16 @@ final class AudioFileManagerTests: XCTestCase {
 
         XCTAssertNil(ownership.begin(generation: 1, capture: oldCapture))
         XCTAssertTrue(
-            ownership.install(oldWriter, generation: 1, capture: oldCapture)
+            ownership.install(
+                oldWriter,
+                generation: 1,
+                capture: oldCapture,
+                fileURL: URL(fileURLWithPath: "/tmp/old-system.wav")
+            )
+        )
+        XCTAssertEqual(
+            ownership.fileURLOwned(by: 1)?.lastPathComponent,
+            "old-system.wav"
         )
 
         let displaced = ownership.begin(generation: 2, capture: newCapture)
@@ -138,6 +161,127 @@ final class AudioFileManagerTests: XCTestCase {
         )
         XCTAssertTrue(
             ownership.writerOwned(by: 11, capture: currentCapture) === currentWriter
+        )
+    }
+
+    func testResolvedSystemAudioURLUsesOwnershipWhenPublishedURLIsNil() throws {
+        let root = makeRoot(name: "ResolvedSystemURL")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let audio = makeAudio(root: root)
+        audio.prepareForNewRecordingStart()
+        let generation = audio.recordingSessionGeneration
+        let fileURL = root.appendingPathComponent("owned-system.wav")
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let writer = try AVAudioFile(
+            forWriting: fileURL,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        let attempt = SystemAudioCaptureStartAttempt(
+            capture: URLResolutionStubSystemAudioCapture()
+        )
+        audio.systemAudioFileQueue.sync {
+            _ = audio.systemAudioCaptureAttemptOwnership.begin(
+                generation: generation,
+                capture: attempt
+            )
+            XCTAssertTrue(
+                audio.systemAudioCaptureAttemptOwnership.install(
+                    writer,
+                    generation: generation,
+                    capture: attempt,
+                    fileURL: fileURL
+                )
+            )
+        }
+        audio.systemAudioFileURL = nil
+        audio.originalSystemAudioFileURL = nil
+
+        XCTAssertEqual(
+            audio.resolvedSystemAudioFileURL(generation: generation),
+            fileURL,
+            "stop must read the system URL from ownership when the published URL is still nil"
+        )
+        writer.close()
+    }
+
+    func testSystemRecoverySilencePadWritesBoundedZeroFrames() throws {
+        let root = makeRoot(name: "SilencePad")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let audio = makeAudio(root: root)
+        audio.prepareForNewRecordingStart()
+        let generation = audio.recordingSessionGeneration
+        let fileURL = root.appendingPathComponent("pad-system.wav")
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let writer = try AVAudioFile(
+            forWriting: fileURL,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        let attempt = SystemAudioCaptureStartAttempt(
+            capture: URLResolutionStubSystemAudioCapture()
+        )
+        audio.systemAudioFileQueue.sync {
+            _ = audio.systemAudioCaptureAttemptOwnership.begin(
+                generation: generation,
+                capture: attempt
+            )
+            XCTAssertTrue(
+                audio.systemAudioCaptureAttemptOwnership.install(
+                    writer,
+                    generation: generation,
+                    capture: attempt,
+                    fileURL: fileURL
+                )
+            )
+        }
+
+        audio.writeSystemRecoverySilencePad(duration: 0.25, generation: generation)
+        writer.close()
+
+        let saved = try AVAudioFile(forReading: fileURL)
+        XCTAssertEqual(saved.fileFormat.sampleRate, 16_000, accuracy: 0.1)
+        XCTAssertEqual(saved.length, 4_000, "0.25s at 16kHz is 4000 frames")
+    }
+
+    func testSystemWriteFailureCapKeepsMicRecording() {
+        let root = makeRoot(name: "SystemWriteKeepsMic")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let audio = makeAudio(root: root)
+        audio.prepareForNewRecordingStart()
+        audio.isRecording = true
+
+        struct WriteFailure: Error {}
+        for _ in 1..<audio.maxConsecutiveWriteErrors {
+            XCTAssertFalse(audio.recordSystemWriteFailure(WriteFailure()))
+        }
+        XCTAssertTrue(audio.recordSystemWriteFailure(WriteFailure()))
+
+        let settled = expectation(description: "system write failure settled")
+        DispatchQueue.main.async { settled.fulfill() }
+        wait(for: [settled], timeout: 1.0)
+
+        XCTAssertTrue(audio.isRecording, "system write failure must keep the mic recording")
+        XCTAssertTrue(audio.systemAudioFailed)
+        XCTAssertEqual(audio.systemAudioStatus, .failed)
+        XCTAssertNotNil(audio.error)
+        XCTAssertFalse(
+            (audio.error ?? "").localizedCaseInsensitiveContains("recording stopped"),
+            "copy must not claim the whole meeting stopped"
         )
     }
 

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioInitializationTests.swift
@@ -363,21 +363,21 @@ final class AudioInitializationTests: XCTestCase {
         wait(for: [attemptFinished], timeout: 1)
 
         XCTAssertEqual(capture.startCallCount, 0)
-        XCTAssertEqual(capture.stopSyncCallCount, 1)
+        XCTAssertGreaterThanOrEqual(
+            capture.stopSyncCallCount, 1,
+            "cancel during prepare must tear down, including a post-prepare stop if the stream appeared after cancel()"
+        )
     }
 
-    func testStoppingMonitoringDoesNotWaitForBlockedSystemAudioStart() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("MonitoringHandoffTests-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-
+    func testStartIfNotCancelledCancelDuringStartDoesNotBlock() throws {
         let oldCapture = StubSystemAudioCapture()
         let newCapture = StubSystemAudioCapture()
         let oldAttempt = SystemAudioCaptureStartAttempt(capture: oldCapture)
         let newAttempt = SystemAudioCaptureStartAttempt(capture: newCapture)
-        let oldStartEntered = expectation(description: "old monitoring start entered")
-        let oldAttemptFinished = expectation(description: "old monitoring attempt stopped")
-        let oldStopFinished = expectation(description: "old monitoring backend stopped")
+        let oldStartEntered = expectation(description: "blocked start entered")
+        let oldAttemptFinished = expectation(description: "blocked start finished")
+        let oldStopFinished = expectation(description: "blocked start cancelled")
+        oldStopFinished.assertForOverFulfill = false
         let releaseOldStart = DispatchSemaphore(value: 0)
         oldCapture.onStart = {
             oldStartEntered.fulfill()
@@ -387,34 +387,29 @@ final class AudioInitializationTests: XCTestCase {
             oldStopFinished.fulfill()
         }
 
-        let audio = Audio(
-            paths: makeCoreStoragePaths(root: root),
-            systemAudioCaptureForTesting: oldCapture
-        )
-        XCTAssertNil(audio.replaceSystemAudioMonitoringAttempt(with: oldAttempt))
-
         DispatchQueue.global(qos: .userInitiated).async {
-            _ = try? oldAttempt.startIfNotCancelled { _ in }
+            let didStart = (try? oldAttempt.startIfNotCancelled { _ in }) ?? true
+            XCTAssertFalse(didStart, "cancel during start must not report success")
             oldAttemptFinished.fulfill()
         }
         wait(for: [oldStartEntered], timeout: 1)
 
-        let stopStartedAt = Date()
-        audio.stopMonitoring()
+        let cancelStartedAt = Date()
+        oldAttempt.cancel()
         XCTAssertLessThan(
-            Date().timeIntervalSince(stopStartedAt),
+            Date().timeIntervalSince(cancelStartedAt),
             0.25,
-            "clicking Record must not wait for a blocked monitoring start/stop"
+            "cancel() must not wait behind capture.start()"
         )
         XCTAssertTrue(
             try newAttempt.startIfNotCancelled { _ in },
-            "a fresh recording attempt must be able to start while old monitoring tears down"
+            "a fresh attempt must start while the cancelled start is still inside start()"
         )
 
         releaseOldStart.signal()
         wait(for: [oldAttemptFinished, oldStopFinished], timeout: 1)
         oldCapture.onStopSync = nil
-        XCTAssertEqual(oldCapture.stopSyncCallCount, 1)
+        XCTAssertGreaterThanOrEqual(oldCapture.stopSyncCallCount, 1)
         XCTAssertEqual(newCapture.startCallCount, 1)
         XCTAssertEqual(newCapture.stopSyncCallCount, 0)
     }
@@ -453,7 +448,10 @@ final class AudioInitializationTests: XCTestCase {
         wait(for: [oldAttemptFinished], timeout: 1)
 
         XCTAssertEqual(oldCapture.startCallCount, 0)
-        XCTAssertEqual(oldCapture.stopSyncCallCount, 1)
+        XCTAssertGreaterThanOrEqual(
+            oldCapture.stopSyncCallCount, 1,
+            "the displaced attempt must stop, including after a prepare that finished under cancel"
+        )
         XCTAssertEqual(newCapture.startCallCount, 1)
         XCTAssertEqual(newCapture.stopSyncCallCount, 0)
         XCTAssertTrue(ownership.owns(generation: 2, capture: newAttempt))

--- a/Tests/TranscriptedCoreTests/AudioTests/MeetingRecordingJournalTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/MeetingRecordingJournalTests.swift
@@ -23,7 +23,10 @@ final class MeetingRecordingJournalTests: XCTestCase {
         let journalURL = temporaryDirectory.appendingPathComponent("meeting_2026_mic.recording.json")
 
         let session = store.begin(primaryMicURL: micURL, startedAt: Date(timeIntervalSince1970: 1_000))
-        store.flush()
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: journalURL.path),
+            "begin() must persist the journal before returning"
+        )
         var journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
         XCTAssertEqual(journal.state, .recording)
         XCTAssertEqual(journal.primaryMicFilename, "meeting_2026_mic.wav")
@@ -51,6 +54,18 @@ final class MeetingRecordingJournalTests: XCTestCase {
         store.clear()
         store.flush()
         XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+    }
+
+    func testBeginLeavesJournalFileOnDiskBeforeReturn() throws {
+        let store = MeetingRecordingJournalStore(directory: temporaryDirectory)
+        let micURL = temporaryDirectory.appendingPathComponent("meeting_sync_begin_mic.wav")
+        let journalURL = temporaryDirectory.appendingPathComponent("meeting_sync_begin_mic.recording.json")
+
+        _ = store.begin(primaryMicURL: micURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journalURL.path))
+        let journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
+        XCTAssertEqual(journal.state, .recording)
+        XCTAssertEqual(journal.primaryMicFilename, "meeting_sync_begin_mic.wav")
     }
 
     func testAbandonedFinalizerTransfersJournalToRecoveryAndDropsLateWrite() throws {

--- a/Tests/TranscriptedCoreTests/AudioTests/QuietMicAttenuationDetectorTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/QuietMicAttenuationDetectorTests.swift
@@ -73,12 +73,26 @@ final class QuietMicAttenuationDetectorTests: XCTestCase {
         }
     }
 
-    func testAGCInactiveNeverFires() {
+    func testRawOffQuietActivityFiresBoostCue() {
+        var detector = QuietMicAttenuationDetector()
+        for tick in 1..<150 {
+            XCTAssertFalse(
+                qualifyingTick(&detector, appliedGain: nil, agcMaxGain: nil),
+                "raw/off quiet activity must wait for the 30s window (tick \(tick))"
+            )
+        }
+        XCTAssertTrue(
+            qualifyingTick(&detector, appliedGain: nil, agcMaxGain: nil),
+            "sustained very-low raw activity without AGC gain should still offer Boost"
+        )
+    }
+
+    func testRawOffTotalSilenceNeverFires() {
         var detector = QuietMicAttenuationDetector()
         for tick in 1...300 {
             XCTAssertFalse(
-                qualifyingTick(&detector, appliedGain: nil, agcMaxGain: nil),
-                "VPIO on / AGC absent must keep the detector dormant (tick \(tick))"
+                qualifyingTick(&detector, rawPeak: 0, appliedGain: nil, agcMaxGain: nil),
+                "raw/off total silence is inactivity, not a quiet mic (tick \(tick))"
             )
         }
     }

--- a/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
@@ -491,6 +491,61 @@ final class SCKAudioCaptureInterleavingTests: XCTestCase {
         XCTAssertEqual(capture.lastKnownBufferTimeForTesting(), lastBufferTime, accuracy: 0.001)
     }
 
+    func testWatchdogFiresWhenFirstBufferNeverArrived() {
+        let stream = ControlledSCKStream()
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.installPreparedStreamForTesting(stream)
+        try? capture.start(bufferCallback: { _ in })
+
+        let snapshot = capture.stateSnapshotForTesting()
+        guard let generation = snapshot.generation else {
+            XCTFail("started capture must have a generation")
+            return
+        }
+        XCTAssertFalse(
+            capture.hasReceivedFirstBufferForTesting(),
+            "start() must reset first-buffer so a silent restart can still stall"
+        )
+
+        let deviceSwitchSeen = expectation(description: "missing-buffer watchdog fires without a first buffer")
+        let cancellable = capture.recoveryEventPublisher.sink { event in
+            if event == .deviceSwitch {
+                capture.stopSync()
+                deviceSwitchSeen.fulfill()
+            }
+        }
+
+        capture.setLastBufferTimeForTesting(CACurrentMediaTime() - 6)
+        capture.checkWatchdogForTesting(generation: generation)
+        wait(for: [deviceSwitchSeen], timeout: 1)
+        cancellable.cancel()
+    }
+
+    func testRecoverySuccessWaitsForABufferBeforeResettingAttempts() {
+        let stream = ControlledSCKStream()
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.installPreparedStreamForTesting(stream)
+        try? capture.start(bufferCallback: { _ in })
+        capture.resetBufferWatchdogStateForTesting()
+        XCTAssertFalse(
+            capture.waitForRestartedBufferForTesting(timeout: 0.12),
+            "a silent restart must not confirm recovery"
+        )
+
+        capture.markBufferReceivedForTesting()
+        XCTAssertTrue(
+            capture.waitForRestartedBufferForTesting(timeout: 0.12),
+            "the first post-restart frame confirms recovery"
+        )
+        capture.stopSync()
+    }
+
     func testLastKnownBufferTimeAdvancesOnlyWhenARealBufferArrives() {
         let capture = SCKAudioCapture(
             callbackTimeout: .milliseconds(250),

--- a/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @preconcurrency import AVFoundation
 import Combine
+import QuartzCore
 @testable import TranscriptedCore
 
 /// Covers the mic/system-audio recovery parity work: system-audio recovery

--- a/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
@@ -575,6 +575,77 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertTrue(manager.failedTranscriptions.first?.isRetryable ?? false)
     }
 
+    func testFailedTranscriptionDecodesLegacyJSONMissingSplitLocalSpeakersAsFalse() throws {
+        let modern = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: testRoot.appendingPathComponent("mic.wav"),
+            systemAudioURL: testRoot.appendingPathComponent("system.wav"),
+            errorMessage: "Temporary transcription failure",
+            splitLocalSpeakers: true
+        )
+        let encoded = try JSONEncoder.iso8601.encode(modern)
+        guard var object = try JSONSerialization.jsonObject(with: encoded) as? [String: Any] else {
+            XCTFail("expected a JSON object")
+            return
+        }
+        XCTAssertEqual(object["splitLocalSpeakers"] as? Bool, true)
+        object.removeValue(forKey: "splitLocalSpeakers")
+
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+        let decoded = try JSONDecoder.iso8601.decode(FailedTranscription.self, from: legacyData)
+
+        XCTAssertFalse(decoded.splitLocalSpeakers, "pre-field rows must default to false")
+    }
+
+    func testAudioFilesExistIsTrueWhenOnlySystemFileSurvives() throws {
+        let paths = makePaths(root: testRoot)
+        let archiveDirectory = paths.transcripts
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Imported_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+        let missingPlaceholder = archiveDirectory.appendingPathComponent("microphone_placeholder.wav")
+        let systemURL = archiveDirectory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8))
+
+        let entry = FailedTranscription(
+            micAudioURL: missingPlaceholder,
+            systemAudioURL: systemURL,
+            errorMessage: "Imported transcription failed"
+        )
+
+        XCTAssertTrue(entry.audioFilesExist(), "a surviving system file must keep the row retryable")
+    }
+
+    func testLoadKeepsRowWhenPlaceholderMicIsMissingButSystemAudioExists() throws {
+        let paths = makePaths(root: testRoot)
+        let archiveDirectory = paths.transcripts
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Imported_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+        let placeholderMicURL = archiveDirectory.appendingPathComponent("microphone_placeholder.wav")
+        let systemURL = archiveDirectory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8))
+
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: placeholderMicURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Imported transcription failed",
+            splitLocalSpeakers: false
+        )
+        try writeQueue([entry], to: paths)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        let kept = try XCTUnwrap(manager.failedTranscriptions.first)
+        XCTAssertEqual(kept.id, entry.id)
+        XCTAssertEqual(kept.systemAudioURL, systemURL)
+        XCTAssertTrue(kept.audioFilesExist(), "reload must keep a system-only surviving row retryable")
+        XCTAssertFalse(kept.splitLocalSpeakers)
+    }
+
     func testLoadHealsMissingMicAudioToMergedSibling() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerFailedQueueTests.swift
@@ -438,6 +438,35 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
     }
 
+    func testLiveMidPipelineFailurePersistsSplitLocalSpeakers() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "ignored"),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("split-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("split-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.startTranscription(
+            micURL: micURL,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            splitLocalSpeakers: true
+        )
+
+        try await waitUntil {
+            manager.activeCount == 0 && manager.failedTranscriptionManager.failedTranscriptions.count == 1
+        }
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(failed.splitLocalSpeakers, "live recorded jobs must persist the task's split flag")
+        XCTAssertTrue(failed.audioFilesExist())
+    }
+
     func testLiveMeetingDurationUsesLongestReadableTrack() async throws {
         let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
         let diarization = MetadataStubDiarizationEngine(segments: [

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerImportedAudioTests.swift
@@ -105,9 +105,12 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertEqual(manager.activeCount, 0)
         let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
         XCTAssertEqual(failed.meetingTitle, "Imported customer call")
-        XCTAssertNil(failed.systemAudioURL)
+        XCTAssertFalse(failed.splitLocalSpeakers)
+        XCTAssertTrue(failed.micAudioURL.lastPathComponent.hasPrefix("microphone_placeholder"))
         XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
         XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.systemAudioURL?.path ?? ""))
         XCTAssertFalse(FileManager.default.fileExists(atPath: copiedImportURL.path))
         XCTAssertEqual(recoverySession.failedQueueHandoffCount, 1)
         XCTAssertEqual(recoverySession.scratchCleanupCount, 0)
@@ -162,6 +165,8 @@ extension TranscriptionTaskManagerMetadataTests {
 
         let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
         XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertNotNil(failed.systemAudioURL)
+        XCTAssertFalse(failed.splitLocalSpeakers)
         XCTAssertEqual(recoverySession.failedQueueHandoffCount, 1)
         XCTAssertEqual(recoverySession.scratchCleanupPreparationCount, 0)
         XCTAssertEqual(recoverySession.scratchCleanupCount, 0)
@@ -639,6 +644,53 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertNil(manager.lastSavedTranscriptURL)
     }
 
+    func testImportedMidPipelineFailureArchivesToFailedQueueBeforeDeletingScratch() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "ignored"),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        let scratchURL = scratchDirectory.appendingPathComponent("imported-mid-pipeline.wav")
+        try writeMonoWAV(to: scratchURL, duration: 2.5)
+        let taskId = UUID()
+        let recoverySession = ImportedRecoverySessionSpy(jobID: taskId)
+
+        manager.startImportedTranscription(
+            taskId: taskId,
+            audioURL: scratchURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Imported mid-pipeline failure",
+            recoverySession: recoverySession
+        )
+
+        try await waitUntil {
+            manager.activeTasks.isEmpty
+                && manager.failedTranscriptionManager.failedTranscriptions.count == 1
+        }
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(failed.id, taskId)
+        XCTAssertEqual(failed.meetingTitle, "Imported mid-pipeline failure")
+        XCTAssertFalse(failed.splitLocalSpeakers, "imports are system-channel and must not persist local-mic split")
+        XCTAssertTrue(failed.micAudioURL.lastPathComponent.hasPrefix("microphone_placeholder"))
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
+        XCTAssertTrue(failed.audioFilesExist())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.systemAudioURL?.path ?? ""))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: scratchURL.path),
+            "imported scratch must be deleted only after the failed-queue archive is durable"
+        )
+        XCTAssertEqual(recoverySession.failedQueueHandoffCount, 1)
+        XCTAssertEqual(recoverySession.scratchCleanupCount, 0, "failed-queue handoff owns the journal, not scratch cleanup")
+        XCTAssertNil(manager.lastSavedTranscriptURL)
+    }
+
     func testStartImportedTranscriptionRejectsTooShortAudioWithClearCopy() throws {
         let manager = makeManager()
         let scratchDirectory = tempDirectory.appendingPathComponent("audio")
@@ -656,7 +708,10 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertEqual(manager.activeCount, 0)
         XCTAssertEqual(manager.backgroundTaskCount, 0)
         XCTAssertTrue(manager.activeTasks.isEmpty)
-        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        XCTAssertTrue(
+            manager.failedTranscriptionManager.failedTranscriptions.isEmpty,
+            "too-short imported audio is an early reject and must not enter the failed queue"
+        )
         XCTAssertEqual(manager.lastFailureDiagnosticMessage, "Recording too short")
         guard case .failed(let message) = manager.displayStatus else {
             return XCTFail("Expected too-short imported audio to publish a failed status")

--- a/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRetryTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/TranscriptionTaskManagerRetryTests.swift
@@ -551,4 +551,56 @@ extension TranscriptionTaskManagerMetadataTests {
         XCTAssertEqual(failed.errorMessage, "Retry failed: Parakeet inference failed")
     }
 
+    func testRetryFailedTranscriptionHonorsPersistedSplitLocalSpeakers() async throws {
+        let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
+        let diarization = MetadataStubDiarizationEngine(segments: [
+            SpeakerSegment(
+                speakerId: 1,
+                startTime: 0,
+                endTime: 2,
+                embedding: [Float](repeating: 0.42, count: 256),
+                qualityScore: 0.95
+            )
+        ])
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: diarization,
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let audioDirectory = tempDirectory.appendingPathComponent("audio", isDirectory: true)
+        let micURL = audioDirectory.appendingPathComponent("retry-split-mic.wav")
+        let systemURL = audioDirectory.appendingPathComponent("retry-split-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: PipelineError.modelInferenceFailed(model: "Parakeet", underlying: "temporary").localizedDescription,
+            meetingTitle: "Split customer call",
+            errorKind: .transcriptionInferenceFailed,
+            splitLocalSpeakers: true
+        ))
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(failed.splitLocalSpeakers)
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failed.id,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts", isDirectory: true)
+        )
+
+        XCTAssertTrue(didRetry)
+        try await waitUntil {
+            manager.speakerNamingRequest != nil || manager.lastSavedTranscriptURL != nil
+        }
+        let request = try XCTUnwrap(manager.speakerNamingRequest)
+        XCTAssertTrue(
+            request.speakers.contains { $0.channel == .mic },
+            "retry must honor the persisted splitLocalSpeakers flag"
+        )
+    }
+
 }

--- a/Tests/UpdateActionSafetyPolicyTests.swift
+++ b/Tests/UpdateActionSafetyPolicyTests.swift
@@ -89,4 +89,17 @@ func testUpdateActionSafetyPolicy() {
             "automatic downloads should keep the install button passive while Sparkle prepares the update"
         )
     }
+
+    runSuite("ReadyUpdateActionRoutingPolicy preserves a usable downloaded-update action") {
+        assertEqual(
+            ReadyUpdateActionRoutingPolicy.route(hasImmediateInstallHandler: true),
+            .installImmediately,
+            "a staged automatic update should use Sparkle's immediate install callback"
+        )
+        assertEqual(
+            ReadyUpdateActionRoutingPolicy.route(hasImmediateInstallHandler: false),
+            .presentStandardUpdateUI,
+            "a resumed or authorization-required update should open Sparkle's standard UI"
+        )
+    }
 }

--- a/docs/MEETING_CAPTURE_PROMPTING.md
+++ b/docs/MEETING_CAPTURE_PROMPTING.md
@@ -1,5 +1,10 @@
 # Meeting-Capture Prompting Overhaul
 
+> **Historical — not current runtime.** This document describes a deleted
+> `MeetingDetector` world. Current detection is `MeetingPromptDetector` plus
+> [auto-call-detection-spec.md](auto-call-detection-spec.md). Keep this file
+> as background; do not treat paths or product claims here as live.
+
 **Status:** Draft spec for review
 **Owner:** Design lead (synthesis)
 **Audience:** Justin + eng

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -41,6 +41,11 @@ Future agents should treat this as a release requirement:
   disables Sparkle's scheduled checks but preserves the app's launch-time
   availability refresh and the manual button. If Sparkle has already downloaded
   an update, the primary action becomes `Restart to Update`
+- when a downloaded update has Sparkle's immediate install callback, the restart
+  action invokes it directly; if the callback is unavailable (for example, a
+  resumed update or one requiring authorization), the action calls Sparkle's
+  standard update controller directly so its install UI can resume even while
+  Sparkle reports an update session in progress
 
 ## In-app update prompt surfaces (inventory)
 


### PR DESCRIPTION
## Why

Codex's meeting-reliability pass, rebased onto `main` after today's four reliability merges (#1710, #1708, #1698, #1704) and verified end to end.

The headline fix: Core's `Audio` listened for sleep/wake on `NotificationCenter.default`, which never receives NSWorkspace sleep/wake notifications, so a live meeting capture never reacted to the lid closing. It now takes the workspace notification center explicitly, the same wiring `MeetingCaptureBridge` already used for its own `Audio` instance.

## What changed

**Meeting state machine**
- Stay in `.stoppingRecording` until timeout / missing-files / enqueue decides the outcome, instead of moving to `.transcribing` and hiding a failed stop behind a saving state the user could not recover from.
- `startRecording` returns `false` when another meeting flow is already active, so a detected-meeting prompt or menu action cannot treat an in-flight capture as an accepted Record.
- Leave `.recording` before any suspension in `handleUnexpectedCaptureStop`, so stop/cancel cannot interleave with its flush/preserve work.
- Discard is hidden from the pill menu once the session leaves `.recording`, where it would have no-opped.

**Failed-meeting recovery**
- Preserve a failed meeting for retry when a stop produces no audio files at all.
- Persist `splitLocalSpeakers` on failed rows and honour it on retry, so a retried meeting keeps the People-in-the-room setting it was recorded with.
- Archive an imported mid-pipeline failure into the failed queue *before* the scratch copy is deleted; early-reject gates still delete without queueing.
- Keep a failed row whose counterpart file is missing but whose surviving track is still on disk (placeholder mic + real system audio).

**Start failures and updates**
- Prefer an already-observed permission denial over the generic 12-second start-timeout copy.
- Route a ready-to-install update through Sparkle's standard UI when the immediate-install callback is unavailable, so a resumed or authorization-required update is not a dead button.

**Other**
- Defer Mac-wide default-input maintenance during meeting capture, not just during dictation.
- Remove the dead `startMonitoring` / `stopMonitoring` level-metering path from Core `Audio` — it had no callers outside its own test, and no UI surface.

## Conflict resolution against today's merges

Two files conflicted, both resolved by keeping both sides:

- `MeetingCaptureBridge.swift` (start-timeout path): #1698's typed `AudioCaptureStartFailureStage` publication is kept, and now uses this branch's permission-aware message helper. That helper falls back to `AudioCaptureStartState.timeoutFailureMessage`, so the typed stage and the user-facing message cannot disagree.
- `Audio.swift` (`start()`): #1698's `startFailureStage = .unknown` preflight clear is kept; the monitoring block it sat next to was dropped along with the rest of the removed monitoring path.

## Verification

Run against this branch, rebased on `main` at 9e089f41:

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 12,424 tests, 12,419 passed
- `swift test` — 1,059 tests, 0 failures, 13 skipped
- `bash run-integration-smoke.sh`
- `python3 scripts/dev/check-build-source-lists.py`

The 5 fast-test failures are the known scratch-worktree path artifact (`file:///tmp/…` vs `file:///private/tmp/…` in `HomeMeetingRenameTests` and `MeetingArtifactRecoveryStoreTests`). Neither suite nor its source is touched by this branch, and both pass in CI, which runs from a normal checkout.

## Review

`codex-review` skipped by owner decision (2026-09-03), consistent with today's batch. This branch is Codex's own work; the rebase, conflict resolution, and verification were done by Claude.

## Manual proof still owed

Sleep/wake during a live meeting is the one path no CI job exercises. Before the 1.1.57 cut: start a meeting, close the lid, reopen, and confirm capture recovers and the saved transcript is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
