### PR TITLE
Release the system-audio write hold when a recovery is abandoned; drop deleted system URLs at stop

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -402,7 +402,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         guard isRecording else {
             // No pad to write, but the hold `.deviceSwitch` armed must not
             // outlive the recovery that armed it.
-            setSystemRecoveryWriteHold(false)
+            releaseSystemRecoveryWriteHold()
             return
         }
         appendRecordingGap(AudioGap(
@@ -414,7 +414,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             duration: duration,
             generation: recordingSessionGeneration
         )
-        setSystemRecoveryWriteHold(false)
+        releaseSystemRecoveryWriteHold()
     }
 
     /// Commit recovery artifacts only while the recovery still owns the
@@ -584,19 +584,36 @@ public class Audio: ObservableObject, @unchecked Sendable {
         }
     }
 
-    /// When set, system-file writes are dropped so a recovery silence pad
+    /// While held, system-file writes are dropped so a recovery silence pad
     /// can be written first. Not a second PCM queue — writes are discarded.
+    ///
+    /// A count, not a flag: a recovery's `.gap` is handled on main, so a
+    /// successor recovery can arm (on the sending thread) before the
+    /// predecessor's release runs. With a flag that release would drop the
+    /// successor's hold and its post-restart buffers would land ahead of
+    /// its pad. Each arm is balanced by exactly one release (`.gap` or
+    /// `.recoveryAbandoned`), and a new recording resets the count.
     private let systemRecoveryWriteHoldLock = NSLock()
-    private var _holdSystemWritesForRecoveryPad = false
-    func setSystemRecoveryWriteHold(_ hold: Bool) {
+    private var _systemRecoveryWriteHoldCount = 0
+    func armSystemRecoveryWriteHold() {
         systemRecoveryWriteHoldLock.lock()
-        _holdSystemWritesForRecoveryPad = hold
+        _systemRecoveryWriteHoldCount += 1
+        systemRecoveryWriteHoldLock.unlock()
+    }
+    func releaseSystemRecoveryWriteHold() {
+        systemRecoveryWriteHoldLock.lock()
+        _systemRecoveryWriteHoldCount = max(0, _systemRecoveryWriteHoldCount - 1)
+        systemRecoveryWriteHoldLock.unlock()
+    }
+    func resetSystemRecoveryWriteHold() {
+        systemRecoveryWriteHoldLock.lock()
+        _systemRecoveryWriteHoldCount = 0
         systemRecoveryWriteHoldLock.unlock()
     }
     func isHoldingSystemWritesForRecoveryPad() -> Bool {
         systemRecoveryWriteHoldLock.lock()
         defer { systemRecoveryWriteHoldLock.unlock() }
-        return _holdSystemWritesForRecoveryPad
+        return _systemRecoveryWriteHoldCount > 0
     }
     var watchdogTimer: Timer?
 
@@ -1380,9 +1397,9 @@ public class Audio: ObservableObject, @unchecked Sendable {
             .sink { [weak self] event in
                 switch event {
                 case .deviceSwitch:
-                    self?.setSystemRecoveryWriteHold(true)
+                    self?.armSystemRecoveryWriteHold()
                 case .recoveryAbandoned:
-                    self?.setSystemRecoveryWriteHold(false)
+                    self?.releaseSystemRecoveryWriteHold()
                 case .gap:
                     break
                 }
@@ -2003,7 +2020,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         micAudioFileURL = nil
         systemAudioFileURL = nil
         lastSystemBufferTime = CACurrentMediaTime()
-        setSystemRecoveryWriteHold(false)
+        resetSystemRecoveryWriteHold()
 
         // Reset health tracking for new recording session
         recordingGaps = []

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -399,7 +399,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// system-audio interruptions show up in saved transcript health
     /// metadata the same way mic-side gaps already do.
     func recordSystemAudioGap(duration: TimeInterval) {
-        guard isRecording else { return }
+        guard isRecording else {
+            // No pad to write, but the hold `.deviceSwitch` armed must not
+            // outlive the recovery that armed it.
+            setSystemRecoveryWriteHold(false)
+            return
+        }
         appendRecordingGap(AudioGap(
             start: Date(timeIntervalSinceNow: -duration),
             duration: duration,
@@ -1364,14 +1369,23 @@ public class Audio: ObservableObject, @unchecked Sendable {
                     self.recordSystemAudioDeviceSwitch()
                 case .gap(let duration):
                     self.recordSystemAudioGap(duration: duration)
+                case .recoveryAbandoned:
+                    break
                 }
             }
         // Arm the write-hold on the sending thread so it is visible before
-        // SCK start() can deliver the first post-restart buffer.
+        // SCK start() can deliver the first post-restart buffer, and release
+        // it on the same thread when a recovery ends without a `.gap`.
         systemAudioRecoveryPadCancellable = capture.recoveryEventPublisher
             .sink { [weak self] event in
-                guard case .deviceSwitch = event else { return }
-                self?.setSystemRecoveryWriteHold(true)
+                switch event {
+                case .deviceSwitch:
+                    self?.setSystemRecoveryWriteHold(true)
+                case .recoveryAbandoned:
+                    self?.setSystemRecoveryWriteHold(false)
+                case .gap:
+                    break
+                }
             }
     }
 
@@ -2199,7 +2213,17 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     /// Stop-path system URL: ownership / journal / writer, not only the
     /// published property that can still be nil if main hasn't assigned it.
+    /// A candidate whose file is already gone (a failed system start removes
+    /// its WAV) resolves to nil so the meeting is not stamped as having a
+    /// system track it never had.
     func resolvedSystemAudioFileURL(generation: UInt64) -> URL? {
+        guard let url = resolvedSystemAudioFileURLCandidate(generation: generation) else {
+            return nil
+        }
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    private func resolvedSystemAudioFileURLCandidate(generation: UInt64) -> URL? {
         if let url = originalSystemAudioFileURL { return url }
         if let url = systemAudioCaptureAttemptOwnership.fileURLOwned(by: generation) {
             return url

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -538,6 +538,11 @@ extension Audio {
                             SystemAudioCaptureFailureCopy.isExplicitPermissionDenial(error)
                         )
                         strongSelf.systemAudioFileURL = nil
+                        // The WAV was just removed; the stop path must not
+                        // hand the pipeline a URL for a file that no longer
+                        // exists, or the meeting is stamped as having a
+                        // system track it never had.
+                        strongSelf.originalSystemAudioFileURL = nil
                         strongSelf.recordSystemAudioStartFailure()
                         strongSelf.error = SystemAudioCaptureFailureCopy.message(for: error)
                     }

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -1266,10 +1266,19 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
                 guard self.shouldContinueRecovery(recoveryToken, at: "after start") else { return }
                 // start() only proves ScreenCaptureKit accepted the restart.
                 // Wait for a real buffer before refunding the attempt budget
-                // or publishing healthy — same 2s gate as waitForMicBuffer.
-                guard self.waitForRestartedBuffer(timeout: 2.0) else {
+                // or publishing healthy. Longer than the mic path's 2 s gate:
+                // a post-wake SCK restart can take several seconds to deliver
+                // its first frame, and giving up early costs the rest of the
+                // meeting's system audio.
+                guard self.waitForRestartedBuffer(timeout: 5.0) else {
                     AppLogger.audioSystem.error("SCKAudioCapture: stream recovery start succeeded but no audio buffer arrived")
                     self.publishErrorMessage("System audio failed - ScreenCaptureKit could not restart audio capture.")
+                    // The restarted stream is still running. Once this
+                    // attempt is abandoned the write hold comes down, so a
+                    // buffer that arrives late would be written with no pad
+                    // for the outage and shift the rest of the system track
+                    // against the microphone. Stop it before giving up.
+                    self.stopSync(preservingRecoveryToken: recoveryToken)
                     return
                 }
                 guard self.shouldContinueRecovery(recoveryToken, at: "after first buffer") else { return }

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -1236,7 +1236,18 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
-            defer { self.finishRecovery(recoveryToken) }
+            var recoverySucceeded = false
+            defer {
+                // Every exit that never reached `.gap` must still release
+                // the write hold `.deviceSwitch` armed, or the rest of the
+                // recording's system buffers are dropped. Sent before
+                // finishRecovery so a successor attempt cannot arm its own
+                // hold ahead of this release.
+                if !recoverySucceeded {
+                    self.recoveryEventSubject.send(.recoveryAbandoned)
+                }
+                self.finishRecovery(recoveryToken)
+            }
             do {
                 AppLogger.audioSystem.info("SCKAudioCapture: attempting stream recovery", [
                     "attempt": "\(recoveryAttempt)"
@@ -1269,6 +1280,7 @@ final class SCKAudioCapture: NSObject, ObservableObject, SystemAudioCaptureEngin
                     self.publishHealthyIfCurrent(identity: identity, generation: generation)
                 }
                 let gapDuration = max(0, CACurrentMediaTime() - lastKnownBufferTimeAtFailure)
+                recoverySucceeded = true
                 self.recoveryEventSubject.send(.gap(duration: gapDuration))
             } catch is SCKRecoveryCancelledError {
                 AppLogger.audioSystem.info("SCKAudioCapture: recovery stopped after cancellation")

--- a/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
@@ -16,6 +16,12 @@ public enum SystemAudioRecoveryEvent: Sendable, Equatable {
     /// time (mirrors the mic path appending an `Audio.AudioGap` once
     /// recovery is confirmed by a real audio frame).
     case gap(duration: TimeInterval)
+    /// A bounded recovery attempt ended without a confirmed buffer: it was
+    /// cancelled, superseded, its restart threw, or no buffer arrived within
+    /// the restart timeout. `Audio` releases the system-audio write hold on
+    /// this event; without it every later system buffer would be dropped
+    /// for the rest of the recording.
+    case recoveryAbandoned
 }
 
 /// Common interface for system audio capture backends.

--- a/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/AudioFileManagerTests.swift
@@ -212,6 +212,29 @@ final class AudioFileManagerTests: XCTestCase {
         writer.close()
     }
 
+    func testResolvedSystemAudioURLIgnoresOriginalThatNoLongerExists() throws {
+        // A failed system start removes its WAV. The stop path used to hand
+        // that URL to the pipeline anyway, so the meeting skipped the
+        // missing-system-audio warning and reported a system track it never had.
+        let root = makeRoot(name: "ResolvedSystemURLDeleted")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let audio = makeAudio(root: root)
+        audio.prepareForNewRecordingStart()
+        let generation = audio.recordingSessionGeneration
+
+        audio.originalSystemAudioFileURL = root.appendingPathComponent("system-removed.wav")
+        XCTAssertNil(
+            audio.resolvedSystemAudioFileURL(generation: generation),
+            "a system WAV that no longer exists must not reach the pipeline as a real track"
+        )
+
+        let present = root.appendingPathComponent("system-present.wav")
+        XCTAssertTrue(FileManager.default.createFile(atPath: present.path, contents: Data([0])))
+        audio.originalSystemAudioFileURL = present
+        XCTAssertEqual(audio.resolvedSystemAudioFileURL(generation: generation), present)
+    }
+
     func testSystemRecoverySilencePadWritesBoundedZeroFrames() throws {
         let root = makeRoot(name: "SilencePad")
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SCKAudioCaptureInterleavingTests.swift
@@ -410,6 +410,42 @@ final class SCKAudioCaptureInterleavingTests: XCTestCase {
         cancellable.cancel()
     }
 
+    // MARK: - A recovery that never confirms a buffer must say so
+    //
+    // `Audio` arms its system write hold on `.deviceSwitch` and, before this
+    // event existed, released it only on `.gap`. A cancelled, superseded, or
+    // failed restart therefore left the hold armed and every later system
+    // buffer was dropped for the rest of the meeting.
+
+    func testCancelledRecoveryReportsAbandonmentInsteadOfAGap() {
+        let stream = ControlledSCKStream()
+        let capture = SCKAudioCapture(
+            callbackTimeout: .milliseconds(250),
+            callbackTimeoutSeconds: 1
+        )
+        capture.installPreparedStreamForTesting(stream)
+        try? capture.start(bufferCallback: { _ in })
+
+        let abandoned = expectation(description: "cancelled recovery reports abandonment")
+        let cancellable = capture.recoveryEventPublisher.sink { event in
+            switch event {
+            case .deviceSwitch:
+                capture.stopSync()
+            case .recoveryAbandoned:
+                abandoned.fulfill()
+            case .gap:
+                XCTFail("a cancelled recovery must not report a gap")
+            }
+        }
+        capture.handleStoppedStream(
+            identity: stream.captureIdentity,
+            error: ControlledSCKTestError(message: "stream stopped")
+        )
+
+        wait(for: [abandoned], timeout: 3)
+        cancellable.cancel()
+    }
+
     // MARK: - Recovery-attempt budget must reset on success (review fix)
     //
     // `recoverAfterSystemWake()` reuses the same one-attempt-capped

--- a/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
@@ -158,6 +158,33 @@ final class SystemAudioRecoveryParityTests: XCTestCase {
         XCTAssertTrue(audio.recordingGaps.isEmpty, "an abandoned recovery is not a gap")
     }
 
+    func testOverlappingRecoveriesKeepTheHoldUntilTheLastOneEnds() {
+        // `.gap` is handled on main, so a successor recovery can arm before
+        // the predecessor's release runs. Each arm must be balanced by its
+        // own release; the first release must not drop the second hold.
+        let capture = RecoveryEventStubSystemAudioCapture()
+        let audio = Audio(paths: makePaths(), systemAudioCaptureForTesting: capture)
+        audio.isRecording = true
+
+        capture.emit(recoveryEvent: .deviceSwitch)
+        capture.emit(recoveryEvent: .deviceSwitch)
+        capture.emit(recoveryEvent: .gap(duration: 0.5))
+        waitForMainQueueToSettle()
+        XCTAssertTrue(
+            audio.isHoldingSystemWritesForRecoveryPad(),
+            "the predecessor's gap must not release the successor's hold"
+        )
+
+        capture.emit(recoveryEvent: .recoveryAbandoned)
+        waitForMainQueueToSettle()
+        XCTAssertFalse(audio.isHoldingSystemWritesForRecoveryPad())
+
+        // An unbalanced release cannot go negative and wedge the next arm.
+        capture.emit(recoveryEvent: .recoveryAbandoned)
+        capture.emit(recoveryEvent: .deviceSwitch)
+        XCTAssertTrue(audio.isHoldingSystemWritesForRecoveryPad())
+    }
+
     func testGapWhileNotRecordingStillReleasesSystemWriteHold() {
         let capture = RecoveryEventStubSystemAudioCapture()
         let audio = Audio(paths: makePaths(), systemAudioCaptureForTesting: capture)

--- a/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioTests/SystemAudioRecoveryParityTests.swift
@@ -134,6 +134,43 @@ final class SystemAudioRecoveryParityTests: XCTestCase {
         XCTAssertTrue(audio.recordingGaps.isEmpty)
     }
 
+    // MARK: - Write hold must not outlive the recovery that armed it
+
+    func testAbandonedRecoveryReleasesSystemWriteHold() {
+        let capture = RecoveryEventStubSystemAudioCapture()
+        let audio = Audio(paths: makePaths(), systemAudioCaptureForTesting: capture)
+        audio.isRecording = true
+
+        capture.emit(recoveryEvent: .deviceSwitch)
+        XCTAssertTrue(
+            audio.isHoldingSystemWritesForRecoveryPad(),
+            "a recovery attempt arms the hold before the restarted stream can deliver"
+        )
+
+        capture.emit(recoveryEvent: .recoveryAbandoned)
+        waitForMainQueueToSettle()
+
+        XCTAssertFalse(
+            audio.isHoldingSystemWritesForRecoveryPad(),
+            "a recovery that never confirmed a buffer must release the hold, or every later system buffer is dropped for the rest of the meeting"
+        )
+        XCTAssertEqual(audio.deviceSwitchCount, 1)
+        XCTAssertTrue(audio.recordingGaps.isEmpty, "an abandoned recovery is not a gap")
+    }
+
+    func testGapWhileNotRecordingStillReleasesSystemWriteHold() {
+        let capture = RecoveryEventStubSystemAudioCapture()
+        let audio = Audio(paths: makePaths(), systemAudioCaptureForTesting: capture)
+        // isRecording defaults to false: no pad is written, but the hold
+        // still has to come down.
+
+        capture.emit(recoveryEvent: .deviceSwitch)
+        capture.emit(recoveryEvent: .gap(duration: 1.0))
+        waitForMainQueueToSettle()
+
+        XCTAssertFalse(audio.isHoldingSystemWritesForRecoveryPad())
+    }
+
     // MARK: - Post-wake proactive recovery hook
 
     func testPostWakeProactiveRecoveryReachesInjectedSystemAudioBackend() {


### PR DESCRIPTION
## Summary

Two confirmed defects from the adversarial post-merge review of #1711 (verdict: ship with fix).

**1. System-audio write hold leaked on every non-successful recovery (silent data loss).** The hold was armed on `.deviceSwitch` and released only in `recordSystemAudioGap`, which runs on `.gap`, and `.gap` is sent only after a restarted stream delivers a buffer within 2 s. A recovery that was cancelled, superseded, threw, or got no buffer in time left the hold armed, and `AudioFileManager` then dropped every system buffer for the rest of the meeting. The new wake wiring kicks `recoverAfterSystemWake()` unconditionally, so a slow post-wake restart was exactly the case that lost all remaining system audio.

- New `SystemAudioRecoveryEvent.recoveryAbandoned`, sent from a `defer` in the SCK recovery block on every exit that never reached `.gap`, before `finishRecovery` so a successor attempt cannot arm ahead of the release.
- `Audio` releases the hold on `.recoveryAbandoned` on the sending thread (the same thread that armed it), and `recordSystemAudioGap` releases it even when it bails on `isRecording`.

**2. A failed system-audio start left a phantom system URL.** The WAV was removed but `originalSystemAudioFileURL` stayed set, so `stop()` handed the pipeline a URL for a deleted file: the meeting skipped the missing-system-audio warning and reported `system_stream_present: true`. `resolvedSystemAudioFileURL` now returns nil for a candidate that is not on disk, and the start-failure path clears the original URL.

## Tests

- `testAbandonedRecoveryReleasesSystemWriteHold`, `testGapWhileNotRecordingStillReleasesSystemWriteHold` (SystemAudioRecoveryParityTests)
- `testCancelledRecoveryReportsAbandonmentInsteadOfAGap` (SCKAudioCaptureInterleavingTests)
- `testResolvedSystemAudioURLIgnoresOriginalThatNoLongerExists` (AudioFileManagerTests)

## Verification

`bash build-deps.sh --force` → `bash build.sh --no-open` → `bash run-tests.sh` → `bash run-integration-smoke.sh` → `swift test`, all green locally on this branch.

Still owed on real hardware before the 1.1.57 cut: sleep/wake during a live meeting with audio playing, confirming the saved system WAV contains audio after the wake.

## Not in this PR (review follow-ups)

- Raw-mode quiet-mic detector can prompt for mic boost when the user only listens for 30 s (product call).
- A placeholder-only failed row passes `audioFilesExist()` and can be retried forever (several tests pin placeholder rows as retryable when a system track survives; needs a narrower fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
