### PR TITLE
Stop the Sentry SDK from filing failed HTTP requests as errors

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -38,6 +38,11 @@ final class CrashReporter {
         // choice and later opt-outs aligned with Release Health envelopes.
         options.enableAutoSessionTracking = false
         options.enableNetworkBreadcrumbs = false
+        // The SDK otherwise files every URLSession 5xx as its own error issue
+        // (`HTTPClientError: HTTP Client Error with status code: 503`) with no
+        // URL attached. Those are the appcast or analytics endpoints having a
+        // bad hour, not app failures, and they bury the real issues.
+        options.enableCaptureFailedRequests = false
         options.maxBreadcrumbs = 0
         options.attachStacktrace = false
         options.beforeBreadcrumb = { _ in nil }

--- a/Tests/CrashReporterOptionsTests.swift
+++ b/Tests/CrashReporterOptionsTests.swift
@@ -5,11 +5,17 @@ import Foundation
 /// widens what the SDK reports on its own.
 func testCrashReporterOptions() {
     runSuite("CrashReporter keeps the SDK's automatic reporting switched off") {
-        let source = (try? String(
+        let raw = (try? String(
             contentsOf: repoRoot().appendingPathComponent("Sources/Observability/CrashReporter.swift"),
             encoding: .utf8
         )) ?? ""
-        assertFalse(source.isEmpty, "CrashReporter.swift should be readable from the repo root")
+        assertFalse(raw.isEmpty, "CrashReporter.swift should be readable from the repo root")
+
+        // Only code that actually runs counts: block comments and
+        // `#if false` regions are stripped, line comments are skipped.
+        let liveLines = liveSourceLines(raw)
+        let startIndex = liveLines.firstIndex { $0.hasPrefix("SentrySDK.start(") }
+        assertTrue(startIndex != nil, "CrashReporter should start the SDK exactly where the options are applied")
 
         let pinnedOptions = [
             "options.sendDefaultPii = false",
@@ -22,21 +28,48 @@ func testCrashReporterOptions() {
             // analytics endpoints having a bad hour, filed as app errors.
             "options.enableCaptureFailedRequests = false",
         ]
-        // Each option must be a live statement: exactly one occurrence, on a
-        // line that is not commented out. A commented-out or duplicated
-        // assignment (for example a later `= true`) fails here.
-        let liveLines = source
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .map { $0.trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.hasPrefix("//") }
         for option in pinnedOptions {
-            let matches = liveLines.filter { $0 == option }.count
-            assertEqual(matches, 1, "CrashReporter should set `\(option)` exactly once as live code")
-            let prefix = option.components(separatedBy: " = ")[0] + " = "
-            let assignments = liveLines.filter { $0.hasPrefix(prefix) }.count
-            assertEqual(assignments, 1, "`\(prefix)` must not be assigned again elsewhere in CrashReporter")
+            let occurrences = liveLines.indices.filter { liveLines[$0] == option }
+            assertEqual(occurrences.count, 1, "CrashReporter should set `\(option)` exactly once as live code")
+
+            let property = option.components(separatedBy: " = ")[0] + " = "
+            let assignments = liveLines.filter { $0.hasPrefix(property) }.count
+            assertEqual(assignments, 1, "`\(property)` must not be assigned again elsewhere in CrashReporter")
+
+            if let optionIndex = occurrences.first, let startIndex {
+                assertTrue(
+                    optionIndex < startIndex,
+                    "`\(option)` must be applied before SentrySDK.start or the SDK never sees it"
+                )
+            }
         }
     }
+}
+
+/// Source lines that can execute: `/* ... */` blocks and `#if false ... #endif`
+/// regions removed, then trimmed, with `//` line comments dropped.
+private func liveSourceLines(_ text: String) -> [String] {
+    var stripped = text
+    while let open = stripped.range(of: "/*"),
+          let close = stripped.range(of: "*/", range: open.upperBound..<stripped.endIndex) {
+        stripped.removeSubrange(open.lowerBound..<close.upperBound)
+    }
+    var lines: [String] = []
+    var insideDisabledBlock = false
+    for line in stripped.split(separator: "\n", omittingEmptySubsequences: false) {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix("#if false") {
+            insideDisabledBlock = true
+            continue
+        }
+        if insideDisabledBlock {
+            if trimmed.hasPrefix("#endif") { insideDisabledBlock = false }
+            continue
+        }
+        if trimmed.hasPrefix("//") { continue }
+        lines.append(trimmed)
+    }
+    return lines
 }
 
 private func repoRoot() -> URL {

--- a/Tests/CrashReporterOptionsTests.swift
+++ b/Tests/CrashReporterOptionsTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Pins the Sentry SDK options that decide what leaves the device. Each line
+/// here is a privacy or noise boundary; a refactor that drops one silently
+/// widens what the SDK reports on its own.
+func testCrashReporterOptions() {
+    runSuite("CrashReporter keeps the SDK's automatic reporting switched off") {
+        let source = (try? String(
+            contentsOf: repoRoot().appendingPathComponent("Sources/Observability/CrashReporter.swift"),
+            encoding: .utf8
+        )) ?? ""
+        assertFalse(source.isEmpty, "CrashReporter.swift should be readable from the repo root")
+
+        let pinnedOptions = [
+            "options.sendDefaultPii = false",
+            "options.enableAutoSessionTracking = false",
+            "options.enableNetworkBreadcrumbs = false",
+            "options.maxBreadcrumbs = 0",
+            "options.attachStacktrace = false",
+            // Every URLSession 5xx used to become its own Sentry issue
+            // (`HTTPClientError ... 503`) with no URL attached: appcast or
+            // analytics endpoints having a bad hour, filed as app errors.
+            "options.enableCaptureFailedRequests = false",
+        ]
+        for option in pinnedOptions {
+            assertTrue(source.contains(option), "CrashReporter should keep `\(option)`")
+        }
+    }
+}
+
+private func repoRoot() -> URL {
+    URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}

--- a/Tests/CrashReporterOptionsTests.swift
+++ b/Tests/CrashReporterOptionsTests.swift
@@ -22,8 +22,19 @@ func testCrashReporterOptions() {
             // analytics endpoints having a bad hour, filed as app errors.
             "options.enableCaptureFailedRequests = false",
         ]
+        // Each option must be a live statement: exactly one occurrence, on a
+        // line that is not commented out. A commented-out or duplicated
+        // assignment (for example a later `= true`) fails here.
+        let liveLines = source
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.hasPrefix("//") }
         for option in pinnedOptions {
-            assertTrue(source.contains(option), "CrashReporter should keep `\(option)`")
+            let matches = liveLines.filter { $0 == option }.count
+            assertEqual(matches, 1, "CrashReporter should set `\(option)` exactly once as live code")
+            let prefix = option.components(separatedBy: " = ")[0] + " = "
+            let assignments = liveLines.filter { $0.hasPrefix(prefix) }.count
+            assertEqual(assignments, 1, "`\(prefix)` must not be assigned again elsewhere in CrashReporter")
         }
     }
 }


### PR DESCRIPTION
## Summary

Sentry Cocoa captures every URLSession response with a 5xx status as its own error event by default. On 1.1.56 that produced two `HTTPClientError: HTTP Client Error with status code: 503` issues (APPLE-MACOS-28 and 29) from one machine, with no URL attached: the appcast or analytics endpoint having a bad hour, filed next to real capture failures. The app never acts on those responses, so the events carry nothing actionable and only bury the issues that are.

- `options.enableCaptureFailedRequests = false` in the Sentry bootstrap, next to the other automatic reporting it already keeps off. The bundled Sentry 9.10.0 framework exposes the option.
- New fast test `testCrashReporterOptions` pins the option set (PII, session tracking, breadcrumbs, stack attachment, failed requests) so a refactor cannot quietly widen what the SDK reports on its own.

No app behavior changes. Only what the SDK reports changes.

## Verification

`bash build-deps.sh --force` → `bash build.sh --no-open` → `bash run-tests.sh`, green locally. Codex review (built-in and adversarial pass) attached in the comments.

## After merge

Archive APPLE-MACOS-28 and 29 in Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
