### PR TITLE
Treat a placeholder-only failed row as unretryable

### DIFF
--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -1220,7 +1220,10 @@ enum MeetingAudioStorageManager {
         guard !isSymbolicLink(url, fileManager: fileManager) else { return false }
         let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
         guard values?.isRegularFile == true else { return false }
-        return url.deletingPathExtension().lastPathComponent == "microphone_placeholder"
+        // Prefix match, shared with the pipeline: the archiver can suffix a
+        // colliding placeholder (`microphone_placeholder-2.wav`), and an exact
+        // stem would then treat the whole directory as not-ours.
+        return FailedTranscription.isMicrophonePlaceholder(url)
     }
 
     private static func isStaleTemporaryAudioFile(

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -278,9 +278,22 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     /// Checks if any surviving regular audio file still exists on disk.
     /// A missing counterpart (placeholder mic, dropped system track) must not
     /// hide retry when the other file is still there.
+    ///
+    /// The silent microphone placeholder is a real file, but on its own it
+    /// can only ever transcribe to "no speech detected", so a row whose
+    /// system track is gone would otherwise return to the queue after every
+    /// retry, forever. The placeholder keeps a row retryable only alongside
+    /// a surviving system track.
     public func audioFilesExist() -> Bool {
-        isSurvivingRegularFile(micAudioURL)
+        (!Self.isMicrophonePlaceholder(micAudioURL) && isSurvivingRegularFile(micAudioURL))
             || (systemAudioURL.map(isSurvivingRegularFile) ?? false)
+    }
+
+    /// Matches the `microphone_placeholder[_<id>].<ext>` files the pipeline
+    /// writes for imported and mic-less recordings, in any extension the
+    /// failed-audio compressor may later give them.
+    public static func isMicrophonePlaceholder(_ url: URL) -> Bool {
+        url.lastPathComponent.hasPrefix("microphone_placeholder")
     }
 
     private func isSurvivingRegularFile(_ url: URL) -> Bool {

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -289,12 +289,19 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
             || (systemAudioURL.map(isSurvivingRegularFile) ?? false)
     }
 
-    /// Matches the `microphone_placeholder[_<id>].<ext>` files the pipeline
-    /// writes for imported and mic-less recordings, in any extension the
-    /// failed-audio compressor may later give them.
+    /// Matches only the placeholder names the pipeline generates:
+    /// `microphone_placeholder`, `microphone_placeholder_<UUID>`, and either
+    /// with the archiver's numeric `-N` collision suffix, in any extension the
+    /// failed-audio compressor may later give them. A genuine recording that
+    /// merely starts with the same words (`microphone_placeholder_interview`)
+    /// is not a placeholder.
     public static func isMicrophonePlaceholder(_ url: URL) -> Bool {
-        url.lastPathComponent.hasPrefix("microphone_placeholder")
+        let stem = url.deletingPathExtension().lastPathComponent
+        return stem.range(of: placeholderStemPattern, options: .regularExpression) != nil
     }
+
+    private static let placeholderStemPattern =
+        "^microphone_placeholder(_[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12})?(-[0-9]+)?$"
 
     private func isSurvivingRegularFile(_ url: URL) -> Bool {
         var isDirectory: ObjCBool = false

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -334,6 +334,17 @@ public class FailedTranscriptionManager: ObservableObject {
             ])
         }
 
+        // A placeholder is not audio. If the real system track did not make
+        // it into the active library, healing the placeholder alone would
+        // split the row across two libraries: hidden here (system outside
+        // the roots) and hidden again once the old library is active
+        // (placeholder now outside). Keep both references together in the
+        // old library, where the row is whole and retryable.
+        if FailedTranscription.isMicrophonePlaceholder(entry.micAudioURL),
+           let systemURL, !isSafeAudioURL(systemURL) {
+            micURL = entry.micAudioURL
+            didHeal = false
+        }
         guard didHeal else { return (entry, false) }
         AppLogger.pipeline.info("Healed failed transcription audio paths after capture library relocation", [
             "id": entry.id.uuidString

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -266,6 +266,18 @@ public class FailedTranscriptionManager: ObservableObject {
             ])
             return (nil, didHeal, false)
         }
+        // A surviving placeholder with no system track is not audio: it can
+        // only ever transcribe to silence, and `audioFilesExist()` already
+        // hides Retry for it. Drop the row here so it does not sit in the
+        // list as "audio missing" until the user clears it by hand.
+        if !systemExists, FailedTranscription.isMicrophonePlaceholder(micURL) {
+            AppLogger.pipeline.warning("Dropping failed transcription entry whose only audio is the mic placeholder", [
+                "id": entry.id.uuidString,
+                "micFile": micURL.lastPathComponent,
+                "systemFile": systemURL?.lastPathComponent ?? "none"
+            ])
+            return (nil, didHeal, false)
+        }
         if !micExists, systemExists {
             AppLogger.pipeline.warning("Kept failed transcription with missing microphone audio because system audio survived", [
                 "id": entry.id.uuidString,
@@ -306,10 +318,14 @@ public class FailedTranscriptionManager: ObservableObject {
                   let relocatedSystemURL = relocatedAudioURL(for: existingSystemURL),
                   isSafeAudioURL(relocatedSystemURL),
                   isSafeAudioURL(micURL),
-                  FileManager.default.fileExists(atPath: micURL.path) {
+                  FileManager.default.fileExists(atPath: micURL.path),
+                  !FailedTranscription.isMicrophonePlaceholder(micURL) {
             // The mic was copied into the active library but the optional
             // system track was not. Keep the retryable mic row active instead
             // of hiding it indefinitely behind an inaccessible old reference.
+            // Not when the copied "mic" is the silent placeholder: then the
+            // uncopied system track is the only real audio, and dropping its
+            // reference would strand it for good.
             systemURL = nil
             didHeal = true
             AppLogger.pipeline.warning("Dropped uncopied system audio reference after partial library relocation", [

--- a/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
+++ b/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
@@ -28,10 +28,14 @@ enum RecordingAudioArchiver {
         var firstCopyError: Error?
         let archivedMicURL: URL?
         if let micURL {
+            // The silent placeholder keeps its identity through the archive:
+            // renamed to `microphone.*` it would read as a real recording and
+            // keep a system-less row retryable forever.
+            let micStem = FailedTranscription.isMicrophonePlaceholder(micURL) ? "microphone_placeholder" : "microphone"
             do {
                 archivedMicURL = try copyAudioFile(
                     from: micURL,
-                    to: directory.appendingPathComponent("microphone").appendingPathExtension(fileExtension(for: micURL)),
+                    to: directory.appendingPathComponent(micStem).appendingPathExtension(fileExtension(for: micURL)),
                     fileManager: fileManager
                 )
             } catch {

--- a/Tests/MeetingAudioStorageManagerTests.swift
+++ b/Tests/MeetingAudioStorageManagerTests.swift
@@ -799,6 +799,48 @@ func testMeetingAudioStorageManager() async {
         assertEqual(updates.first?.systemAudioURL?.lastPathComponent, "system_audio.m4a", "system audio should be compressed")
     }
 
+    await runSuite("MeetingAudioStorageManager compresses system-only failed audio with a collision-suffixed placeholder mic") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioRoot = directory.appendingPathComponent("audio", isDirectory: true)
+        let failedAudioDirectory = audioRoot
+            .appendingPathComponent("Failed_2026-05-08_15-29-13_83A63B2D_audio", isDirectory: true)
+        try? FileManager.default.createDirectory(at: failedAudioDirectory, withIntermediateDirectories: true)
+        let placeholderWAV = failedAudioDirectory.appendingPathComponent("microphone_placeholder-2.wav")
+        let systemWAV = failedAudioDirectory.appendingPathComponent("system_audio.wav")
+        try! Data("wav".utf8).write(to: placeholderWAV)
+        try! Data("wav".utf8).write(to: systemWAV)
+
+        var updates = [FailedMeetingAudioCompressionUpdate]()
+        let id = UUID()
+        let result = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
+            candidates: [
+                FailedMeetingAudioCompressionCandidate(
+                    id: id,
+                    micAudioURL: placeholderWAV,
+                    systemAudioURL: systemWAV
+                )
+            ],
+            audioArchiveRoot: audioRoot,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator()
+        ) { update in
+            updates.append(update)
+            return true
+        }
+
+        assertEqual(
+            result,
+            FailedMeetingAudioCompressionResult(scannedEntries: 1, convertedFiles: 2, updatedEntries: 1),
+            "an archiver collision suffix must not make the gate treat the directory as not ours"
+        )
+        assertFalse(FileManager.default.fileExists(atPath: placeholderWAV.path), "placeholder WAV should be removed after persistence")
+        assertFalse(FileManager.default.fileExists(atPath: systemWAV.path), "system WAV should be removed after persistence")
+        assertEqual(updates.first?.micAudioURL.lastPathComponent, "microphone_placeholder-2.m4a", "placeholder mic should stay retryable after compression")
+        assertEqual(updates.first?.systemAudioURL?.lastPathComponent, "system_audio.m4a", "system audio should be compressed")
+    }
+
     await runSuite("MeetingAudioStorageManager keeps failed WAVs if queue update fails") {
         let directory = makeMeetingAudioStorageTestDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
@@ -723,8 +723,15 @@ final class FailedTranscriptionManagerTests: XCTestCase {
 
         let manager = FailedTranscriptionManager(paths: paths)
 
-        let kept = try XCTUnwrap(manager.failedTranscriptions.first)
-        XCTAssertEqual(kept.id, entry.id)
+        // The row's only real audio lives outside the active library, so it
+        // is hidden from the active list rather than shown as a dead row,
+        // but the persisted queue keeps the system reference intact.
+        XCTAssertTrue(manager.failedTranscriptions.isEmpty, "a row whose real audio is outside the active library is hidden, not shown")
+        let persisted = try JSONDecoder.iso8601.decode(
+            [FailedTranscription].self,
+            from: Data(contentsOf: paths.failedQueue)
+        )
+        let kept = try XCTUnwrap(persisted.first { $0.id == entry.id })
         XCTAssertEqual(kept.micAudioURL, currentPlaceholderURL)
         XCTAssertEqual(kept.systemAudioURL, oldSystemURL, "the uncopied system track must keep its reference")
     }

--- a/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
@@ -669,6 +669,66 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertTrue(entry.audioFilesExist(), "a real mic recording is retryable on its own")
     }
 
+    func testLoadDropsRowWhoseOnlyAudioIsThePlaceholderMic() throws {
+        let paths = makePaths(root: testRoot)
+        let archiveDirectory = paths.transcripts
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Imported_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+        let placeholderURL = archiveDirectory.appendingPathComponent("microphone_placeholder.wav")
+        FileManager.default.createFile(atPath: placeholderURL.path, contents: Data("silence".utf8))
+
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: placeholderURL,
+            systemAudioURL: archiveDirectory.appendingPathComponent("system_audio.wav"),
+            errorMessage: "Imported transcription failed",
+            splitLocalSpeakers: false
+        )
+        try writeQueue([entry], to: paths)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertTrue(
+            manager.failedTranscriptions.isEmpty,
+            "a placeholder with no system track cannot be retried and must not linger as an audio-missing row"
+        )
+    }
+
+    func testLoadKeepsUncopiedSystemAudioReferenceWhenOnlyThePlaceholderWasRelocated() throws {
+        // Partial library relocation: the placeholder reached the new library
+        // but the real system track did not. Dropping the old system reference
+        // because "the mic exists" would strand the only real audio for good.
+        let paths = makePaths(root: testRoot)
+        let currentArchiveDirectory = paths.transcripts
+            .appendingPathComponent("audio/Failed_Customer_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentArchiveDirectory, withIntermediateDirectories: true)
+        let currentPlaceholderURL = currentArchiveDirectory.appendingPathComponent("microphone_placeholder.wav")
+        FileManager.default.createFile(atPath: currentPlaceholderURL.path, contents: Data("silence".utf8))
+
+        let oldArchiveDirectory = testRoot
+            .appendingPathComponent("old-library/meetings/audio/Failed_Customer_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: oldArchiveDirectory, withIntermediateDirectories: true)
+        let oldSystemURL = oldArchiveDirectory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: oldSystemURL.path, contents: Data("system".utf8))
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: oldArchiveDirectory.appendingPathComponent("microphone_placeholder.wav"),
+            systemAudioURL: oldSystemURL,
+            errorMessage: "Temporary transcription failure"
+        )
+        try writeQueue([entry], to: paths)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        let kept = try XCTUnwrap(manager.failedTranscriptions.first)
+        XCTAssertEqual(kept.id, entry.id)
+        XCTAssertEqual(kept.micAudioURL, currentPlaceholderURL)
+        XCTAssertEqual(kept.systemAudioURL, oldSystemURL, "the uncopied system track must keep its reference")
+    }
+
     func testLoadKeepsRowWhenPlaceholderMicIsMissingButSystemAudioExists() throws {
         let paths = makePaths(root: testRoot)
         let archiveDirectory = paths.transcripts

--- a/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
@@ -617,6 +617,58 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertTrue(entry.audioFilesExist(), "a surviving system file must keep the row retryable")
     }
 
+    func testAudioFilesExistIsFalseWhenOnlyThePlaceholderMicSurvives() throws {
+        // The placeholder is a real 2.5 s silent WAV. Alone it transcribes to
+        // "no speech detected" every time, so a row with no system track
+        // left must read as unretryable instead of cycling through the queue.
+        let paths = makePaths(root: testRoot)
+        let archiveDirectory = paths.transcripts
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Imported_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+        let placeholderURL = archiveDirectory.appendingPathComponent("microphone_placeholder.wav")
+        FileManager.default.createFile(atPath: placeholderURL.path, contents: Data("silence".utf8))
+        let missingSystemURL = archiveDirectory.appendingPathComponent("system_audio.wav")
+
+        let entry = FailedTranscription(
+            micAudioURL: placeholderURL,
+            systemAudioURL: missingSystemURL,
+            errorMessage: "Imported transcription failed"
+        )
+
+        XCTAssertFalse(entry.audioFilesExist(), "a placeholder with no system track cannot produce a transcript")
+
+        let compressedPlaceholder = archiveDirectory.appendingPathComponent("microphone_placeholder_\(UUID().uuidString).m4a")
+        FileManager.default.createFile(atPath: compressedPlaceholder.path, contents: Data("silence".utf8))
+        let compressedEntry = FailedTranscription(
+            micAudioURL: compressedPlaceholder,
+            systemAudioURL: missingSystemURL,
+            errorMessage: "Imported transcription failed"
+        )
+        XCTAssertFalse(compressedEntry.audioFilesExist(), "task-suffixed and compressed placeholders are still placeholders")
+
+        FileManager.default.createFile(atPath: missingSystemURL.path, contents: Data("system".utf8))
+        XCTAssertTrue(entry.audioFilesExist(), "the placeholder stays retryable alongside a surviving system track")
+    }
+
+    func testAudioFilesExistIsTrueWhenOnlyARealMicFileSurvives() throws {
+        let paths = makePaths(root: testRoot)
+        let archiveDirectory = paths.transcripts
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("Standup_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: archiveDirectory, withIntermediateDirectories: true)
+        let micURL = archiveDirectory.appendingPathComponent("microphone.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+
+        let entry = FailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: archiveDirectory.appendingPathComponent("system_audio.wav"),
+            errorMessage: "Transcription failed"
+        )
+
+        XCTAssertTrue(entry.audioFilesExist(), "a real mic recording is retryable on its own")
+    }
+
     func testLoadKeepsRowWhenPlaceholderMicIsMissingButSystemAudioExists() throws {
         let paths = makePaths(root: testRoot)
         let archiveDirectory = paths.transcripts

--- a/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/PipelineTests/FailedTranscriptionManagerTests.swift
@@ -696,26 +696,36 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         )
     }
 
-    func testLoadKeepsUncopiedSystemAudioReferenceWhenOnlyThePlaceholderWasRelocated() throws {
+    func testPlaceholderRowStaysWholeInTheOldLibraryWhenOnlyThePlaceholderWasCopied() throws {
         // Partial library relocation: the placeholder reached the new library
-        // but the real system track did not. Dropping the old system reference
-        // because "the mic exists" would strand the only real audio for good.
+        // but the real system track did not. Healing the placeholder alone
+        // used to drop the system reference (stranding the only real audio);
+        // healing it while keeping the old system reference would split the
+        // row across two libraries and hide it in both. The row must stay
+        // whole in the old library: hidden while the new one is active,
+        // retryable as soon as the old one is active again.
         let paths = makePaths(root: testRoot)
         let currentArchiveDirectory = paths.transcripts
             .appendingPathComponent("audio/Failed_Customer_Call_audio", isDirectory: true)
         try FileManager.default.createDirectory(at: currentArchiveDirectory, withIntermediateDirectories: true)
-        let currentPlaceholderURL = currentArchiveDirectory.appendingPathComponent("microphone_placeholder.wav")
-        FileManager.default.createFile(atPath: currentPlaceholderURL.path, contents: Data("silence".utf8))
+        FileManager.default.createFile(
+            atPath: currentArchiveDirectory.appendingPathComponent("microphone_placeholder.wav").path,
+            contents: Data("silence".utf8)
+        )
 
-        let oldArchiveDirectory = testRoot
-            .appendingPathComponent("old-library/meetings/audio/Failed_Customer_Call_audio", isDirectory: true)
+        let oldRoot = testRoot.appendingPathComponent("old-library", isDirectory: true)
+        let oldPaths = makePaths(root: oldRoot)
+        let oldArchiveDirectory = oldPaths.transcripts
+            .appendingPathComponent("audio/Failed_Customer_Call_audio", isDirectory: true)
         try FileManager.default.createDirectory(at: oldArchiveDirectory, withIntermediateDirectories: true)
+        let oldPlaceholderURL = oldArchiveDirectory.appendingPathComponent("microphone_placeholder.wav")
         let oldSystemURL = oldArchiveDirectory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: oldPlaceholderURL.path, contents: Data("silence".utf8))
         FileManager.default.createFile(atPath: oldSystemURL.path, contents: Data("system".utf8))
         let entry = FailedTranscription(
             id: UUID(),
             timestamp: Date(timeIntervalSince1970: 1_000),
-            micAudioURL: oldArchiveDirectory.appendingPathComponent("microphone_placeholder.wav"),
+            micAudioURL: oldPlaceholderURL,
             systemAudioURL: oldSystemURL,
             errorMessage: "Temporary transcription failure"
         )
@@ -723,17 +733,43 @@ final class FailedTranscriptionManagerTests: XCTestCase {
 
         let manager = FailedTranscriptionManager(paths: paths)
 
-        // The row's only real audio lives outside the active library, so it
-        // is hidden from the active list rather than shown as a dead row,
-        // but the persisted queue keeps the system reference intact.
-        XCTAssertTrue(manager.failedTranscriptions.isEmpty, "a row whose real audio is outside the active library is hidden, not shown")
+        XCTAssertTrue(manager.failedTranscriptions.isEmpty, "with the new library active the row is hidden, not shown as a dead row")
         let persisted = try JSONDecoder.iso8601.decode(
             [FailedTranscription].self,
             from: Data(contentsOf: paths.failedQueue)
         )
-        let kept = try XCTUnwrap(persisted.first { $0.id == entry.id })
-        XCTAssertEqual(kept.micAudioURL, currentPlaceholderURL)
-        XCTAssertEqual(kept.systemAudioURL, oldSystemURL, "the uncopied system track must keep its reference")
+        XCTAssertEqual(persisted, [entry], "the queue keeps the whole row in the old library, untouched")
+
+        // Switch the old library back on: the same row is active and retryable.
+        try writeQueue([entry], to: oldPaths)
+        let oldManager = FailedTranscriptionManager(paths: oldPaths)
+        let active = try XCTUnwrap(oldManager.failedTranscriptions.first)
+        XCTAssertEqual(active.id, entry.id)
+        XCTAssertEqual(active.systemAudioURL, oldSystemURL)
+        XCTAssertTrue(active.audioFilesExist(), "the real system track makes the row retryable again")
+    }
+
+    func testMicrophonePlaceholderPredicateMatchesOnlyGeneratedNames() {
+        let base = URL(fileURLWithPath: "/tmp/Failed_Call_audio")
+        let id = UUID().uuidString
+        for name in [
+            "microphone_placeholder.wav",
+            "microphone_placeholder.m4a",
+            "microphone_placeholder_\(id).wav",
+            "microphone_placeholder-2.wav",
+            "microphone_placeholder_\(id)-3.m4a",
+        ] {
+            XCTAssertTrue(FailedTranscription.isMicrophonePlaceholder(base.appendingPathComponent(name)), name)
+        }
+        for name in [
+            "microphone.wav",
+            "microphone_placeholder_interview.wav",
+            "microphone_placeholders.wav",
+            "my_microphone_placeholder.wav",
+            "microphone_placeholder_\(id)_take2.wav",
+        ] {
+            XCTAssertFalse(FailedTranscription.isMicrophonePlaceholder(base.appendingPathComponent(name)), name)
+        }
     }
 
     func testLoadKeepsRowWhenPlaceholderMicIsMissingButSystemAudioExists() throws {

--- a/Tests/TranscriptedCoreTests/StorageTests/RecordingAudioArchiverTests.swift
+++ b/Tests/TranscriptedCoreTests/StorageTests/RecordingAudioArchiverTests.swift
@@ -87,6 +87,29 @@ final class RecordingAudioArchiverTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: retained.micURL!), Data("mic".utf8))
     }
 
+    func testArchiveKeepsThePlaceholderIdentityOfASilentMic() throws {
+        let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
+        let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let placeholderURL = scratch.appendingPathComponent("microphone_placeholder_\(UUID().uuidString).wav")
+        let systemURL = scratch.appendingPathComponent("system.wav")
+        let transcriptURL = tempRoot.appendingPathComponent("Failed_2026-04-20_10-30-00.md")
+        try Data("silence".utf8).write(to: placeholderURL)
+        try Data("system".utf8).write(to: systemURL)
+
+        let retained = try RecordingAudioArchiver.archive(
+            micURL: placeholderURL,
+            systemURL: systemURL,
+            transcriptURL: transcriptURL,
+            archiveRoot: archiveRoot
+        )
+
+        XCTAssertEqual(retained.micURL?.lastPathComponent, "microphone_placeholder.wav")
+        XCTAssertTrue(FailedTranscription.isMicrophonePlaceholder(try XCTUnwrap(retained.micURL)))
+        XCTAssertEqual(retained.systemURL?.lastPathComponent, "system_audio.wav")
+    }
+
     func testArchiveStillRetainsSystemAudioWhenMicCopyFails() throws {
         let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
         let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)


### PR DESCRIPTION
## Summary

Follow-up from the adversarial review of #1711.

`FailedTranscription.audioFilesExist()` answers true when either audio file survives, so a row whose system track is gone but whose silent microphone placeholder remains passes both retry gates in `TranscriptionTaskManager.retryFailedTranscription`. The retry transcribes 2.5 s of silence, fails with "no speech detected", and the row returns to the queue with "the audio was kept, try again" copy: a dead row the user can retry forever.

- The placeholder now counts only alongside a surviving system track. `FailedTranscription.isMicrophonePlaceholder` matches by the `microphone_placeholder` prefix, so task-suffixed and compressed (`.m4a`) placeholders are covered.
- Rows with a real mic recording, and placeholder rows whose system track is still on disk, are unchanged; the existing tests for both stay green.
- A placeholder-only row now takes the existing "audio files no longer exist" path: one heal attempt, then removal from the queue.

## Tests

`testAudioFilesExistIsFalseWhenOnlyThePlaceholderMicSurvives` (plain, task-suffixed, and compressed placeholders; retryable again once the system track exists) and `testAudioFilesExistIsTrueWhenOnlyARealMicFileSurvives`.

## Verification

`bash build-deps.sh --force` → `bash build.sh --no-open` → `bash run-tests.sh` → `bash run-integration-smoke.sh` → `swift test`, green locally. Codex review (built-in and adversarial pass) attached in the comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
