### PR TITLE
Validate current release artifacts without replacing the signed app

### DIFF
--- a/Tests/NightlySecurityContractTests.swift
+++ b/Tests/NightlySecurityContractTests.swift
@@ -1,12 +1,21 @@
-// Repo-structure / contract suite, not behavioral coverage.
+// Security contracts: manifest checks, offline built-app behavior, and source checks.
 // The suites parsing config/security/nightly-security-manifest.json are real data
 // contracts (they decode and validate manifest values). The remaining doc and
-// checker-script suites are structural greps that confirm files exist and stay in
-// sync; none of them exercise runtime security logic.
+// checker-script suites mostly pin source structure. The offline built-app
+// suite invokes Python behavioral tests with synthetic plists and signed-payload
+// stubs; it does not require real signing, keychain access, or hardware.
 
 import Foundation
 
 func testNightlySecurityContract() {
+    runSuite("Nightly built-app security enforces the exact contract for each build channel") {
+        let result = runNightlySecurityChecker(
+            arguments: [],
+            script: "scripts/ops/test-nightly-security-check.py"
+        )
+        assertEqual(result.status, 0, "offline signed-app entitlement fixtures should pass: \(result.output)")
+    }
+
     runSuite("Nightly security manifest is parseable and weights sum to 100") {
         let manifest = loadJSONFixture("config/security/nightly-security-manifest.json", as: [String: AnyDecodable].self)
         let weights = manifest["scoring"]?.dictionaryValue?["weights"]?.dictionaryValue ?? [:]
@@ -219,7 +228,10 @@ private struct ShellResult {
     let output: String
 }
 
-private func runNightlySecurityChecker(arguments: [String]) -> ShellResult {
+private func runNightlySecurityChecker(
+    arguments: [String],
+    script: String = "scripts/ops/nightly-security-check.py"
+) -> ShellResult {
     let process = Process()
     let outputURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         .appendingPathComponent("nightly-security-check-\(UUID().uuidString).log")
@@ -232,7 +244,7 @@ private func runNightlySecurityChecker(arguments: [String]) -> ShellResult {
     }
 
     process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["python3", "scripts/ops/nightly-security-check.py"] + arguments
+    process.arguments = ["python3", script] + arguments
     process.currentDirectoryURL = repoFixtureURL(".")
     process.standardOutput = outputHandle
     process.standardError = outputHandle

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -118,8 +118,12 @@ smoke, and local log privacy. For a stricter release-candidate report after
 packaging, compose it with:
 
 ```bash
-python3 scripts/ops/release-gate-report.py --qa-mode deep --strict-artifacts --include-packaged-app-smoke --require-release-debug-files
+python3 scripts/ops/release-gate-report.py --qa-mode deep --skip-qa-build --strict-artifacts --include-packaged-app-smoke --require-release-debug-files
 ```
+
+After packaging, `--skip-qa-build` keeps QA from replacing the signed release
+app with a development build. Tests still run, and packaged-app smoke verifies
+the existing app, DMG, and matching dSYM.
 
 Yellow is expected when notarization is intentionally skipped or the appcast has
 not yet been updated for a new version. Red means the package itself is broken.

--- a/scripts/ops/fixtures/packaged-app-launch-current.json
+++ b/scripts/ops/fixtures/packaged-app-launch-current.json
@@ -1,0 +1,82 @@
+{
+  "appLaunched": true,
+  "content": {
+    "header": {
+      "detailText": "",
+      "isReady": true,
+      "statusText": "Ready",
+      "warningText": ""
+    },
+    "primaryActions": {
+      "pasteLastDictation": {
+        "automationIdentifier": "transcripted.menubar.primary.paste-last-dictation",
+        "detail": "No saved dictation yet.",
+        "isEnabled": false,
+        "isVisible": true,
+        "title": "Paste Last Dictation",
+        "trailingText": ""
+      },
+      "startDictation": {
+        "automationIdentifier": "transcripted.menubar.primary.start-dictation",
+        "detail": "Starts local voice setup on first use",
+        "isEnabled": true,
+        "isVisible": true,
+        "title": "Start Dictation",
+        "trailingText": "Fn / Right ⌥"
+      },
+      "startMeeting": {
+        "automationIdentifier": "transcripted.menubar.primary.start-meeting",
+        "detail": "Starts local meeting setup on first use",
+        "isEnabled": true,
+        "isVisible": true,
+        "title": "Record Meeting",
+        "trailingText": "⌥M"
+      }
+    },
+    "updateCallout": {
+      "automationIdentifier": "",
+      "detail": "",
+      "isEnabled": true,
+      "isVisible": false,
+      "title": "",
+      "trailingText": ""
+    },
+    "utilityActions": {
+      "checkUpdates": {
+        "automationIdentifier": "transcripted.menubar.utility.check-updates",
+        "detail": "",
+        "isEnabled": false,
+        "isVisible": true,
+        "title": "Check for Updates",
+        "trailingText": ""
+      },
+      "openTranscripted": {
+        "automationIdentifier": "transcripted.menubar.utility.open-transcripted",
+        "detail": "",
+        "isEnabled": true,
+        "isVisible": true,
+        "title": "Open Transcripted",
+        "trailingText": ""
+      },
+      "quit": {
+        "automationIdentifier": "transcripted.menubar.utility.quit",
+        "detail": "",
+        "isEnabled": true,
+        "isVisible": true,
+        "title": "Quit",
+        "trailingText": "⌘Q"
+      },
+      "settings": {
+        "automationIdentifier": "transcripted.menubar.utility.settings",
+        "detail": "",
+        "isEnabled": true,
+        "isVisible": true,
+        "title": "Settings…",
+        "trailingText": ""
+      }
+    }
+  },
+  "onboardingCompleted": true,
+  "popoverConfigured": true,
+  "statusItemExists": true
+}

--- a/scripts/ops/nightly-security-check.py
+++ b/scripts/ops/nightly-security-check.py
@@ -1495,18 +1495,35 @@ def check_built_app(root: Path, manifest: dict, app_bundle_argument: str | None)
         )
         return findings
 
-    expected_local = manifest["expected_entitlements"]["local"]
-    if entitlements != expected_local:
+    # These are the exact channels stamped by build.sh and build-beta.sh.
+    # Never accept either entitlement set interchangeably: release permissions
+    # on a local build (or missing permissions on a release) are still drift.
+    build_channel = built_info.get("TranscriptedBuildChannel")
+    contract = {"local": "local", "release": "beta"}.get(build_channel) if isinstance(build_channel, str) else None
+    if contract is None:
         findings.append(
             make_finding(
                 "entitlements_and_signing",
                 "high",
-                "built-entitlements-drift",
-                "Built app entitlements drifted from the expected local contract.",
-                f"Expected {expected_local!r}, got {entitlements!r}.",
+                "built-channel-unknown",
+                "Built app has a missing or unsupported build channel.",
+                f"Expected TranscriptedBuildChannel 'local' or 'release', got {build_channel!r}.",
                 app_bundle_argument,
             )
         )
+    else:
+        expected = manifest["expected_entitlements"][contract]
+        if entitlements != expected:
+            findings.append(
+                make_finding(
+                    "entitlements_and_signing",
+                    "high",
+                    "built-entitlements-drift",
+                    f"Built app entitlements drifted from the expected {contract} contract.",
+                    f"Channel {build_channel!r}: expected {expected!r}, got {entitlements!r}.",
+                    app_bundle_argument,
+                )
+            )
 
     forbidden_entitlements = set(manifest.get("forbidden_entitlements", []))
     forbidden_present = sorted(forbidden_entitlements.intersection(entitlements.keys()))

--- a/scripts/ops/packaged-app-smoke.py
+++ b/scripts/ops/packaged-app-smoke.py
@@ -190,17 +190,14 @@ def validate_launch_report(report: dict[str, Any]) -> list[str]:
     primary = report.get("content", {}).get("primaryActions", {})
     utility = report.get("content", {}).get("utilityActions", {})
     required_primary = {
-        "home": ("Home", "transcripted.menubar.primary.home"),
         "startDictation": ("Start Dictation", "transcripted.menubar.primary.start-dictation"),
-        "startMeeting": ("Start Meeting", "transcripted.menubar.primary.start-meeting"),
+        "startMeeting": ("Record Meeting", "transcripted.menubar.primary.start-meeting"),
         "pasteLastDictation": ("Paste Last Dictation", "transcripted.menubar.primary.paste-last-dictation"),
-        "recentMeetings": ("Recent Meetings", "transcripted.menubar.primary.recent-meetings"),
     }
     required_utility = {
-        "connectAgent": ("Connect Agent", "transcripted.menubar.utility.connect-agent"),
-        "submitFeedback": ("Submit Feedback", "transcripted.menubar.utility.submit-feedback"),
+        "openTranscripted": ("Open Transcripted", "transcripted.menubar.utility.open-transcripted"),
         "checkUpdates": ("Check for Updates", "transcripted.menubar.utility.check-updates"),
-        "settings": ("Settings", "transcripted.menubar.utility.settings"),
+        "settings": ("Settings…", "transcripted.menubar.utility.settings"),
         "quit": ("Quit", "transcripted.menubar.utility.quit"),
     }
 
@@ -213,7 +210,7 @@ def validate_launch_report(report: dict[str, Any]) -> list[str]:
             errors.append(f"{key} automation identifier mismatch")
         if not row.get("isVisible"):
             errors.append(f"{key} row hidden")
-    for key in ("home", "startDictation", "startMeeting"):
+    for key in ("startDictation", "startMeeting"):
         if not (primary.get(key) or {}).get("isEnabled"):
             errors.append(f"{key} row disabled")
 
@@ -226,7 +223,7 @@ def validate_launch_report(report: dict[str, Any]) -> list[str]:
             errors.append(f"{key} automation identifier mismatch")
         if not row.get("isVisible"):
             errors.append(f"{key} row hidden")
-    for key in ("connectAgent", "submitFeedback", "settings", "quit"):
+    for key in ("openTranscripted", "settings", "quit"):
         if not (utility.get(key) or {}).get("isEnabled"):
             errors.append(f"{key} row disabled")
 
@@ -642,6 +639,38 @@ def self_test() -> int:
     if payload["status"] != "FAIL" or EXIT_CODES[payload["status"]] != 1:
         print("packaged-app-smoke self-test failed", file=sys.stderr)
         return 1
+    launch = json.loads((Path(__file__).parent / "fixtures" / "packaged-app-launch-current.json").read_text())
+    if errors := validate_launch_report(launch):
+        print(f"current menu fixture rejected: {errors}", file=sys.stderr)
+        return 1
+    # This fixture intentionally omits old Home/Recent Meetings/Connect Agent/
+    # Submit Feedback rows. Their replacement and every remaining row are required.
+    for group in ("primaryActions", "utilityActions"):
+        for key in launch["content"][group]:
+            for mutation in ("missing", "hidden", "identifier", "title"):
+                broken = json.loads(json.dumps(launch))
+                row = broken["content"][group][key]
+                if mutation == "missing":
+                    del broken["content"][group][key]
+                elif mutation == "hidden":
+                    row["isVisible"] = False
+                elif mutation == "identifier":
+                    row["automationIdentifier"] = "incorrect"
+                else:
+                    row["title"] = "incorrect"
+                if not validate_launch_report(broken):
+                    print(f"menu fixture accepted {mutation} required row {key}", file=sys.stderr)
+                    return 1
+    for group, keys in (
+        ("primaryActions", ("startDictation", "startMeeting")),
+        ("utilityActions", ("openTranscripted", "settings", "quit")),
+    ):
+        for key in keys:
+            broken = json.loads(json.dumps(launch))
+            broken["content"][group][key]["isEnabled"] = False
+            if not validate_launch_report(broken):
+                print(f"menu fixture accepted disabled required action {key}", file=sys.stderr)
+                return 1
     print("packaged-app-smoke self-test passed")
     return 0
 
@@ -659,7 +688,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--out-dir", default=f"/tmp/transcripted-packaged-app-smoke/smoke-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}", help="Directory for local smoke evidence.")
     parser.add_argument("--write-report", help="Write JSON report. Default: <out-dir>/packaged-app-smoke.json")
     parser.add_argument("--markdown-out", help="Write Markdown report. Default: <out-dir>/packaged-app-smoke.md")
-    parser.add_argument("--self-test", action="store_true", help="Run a small renderer/status self-test.")
+    parser.add_argument("--self-test", action="store_true", help="Run renderer, status, and current menu contract regressions.")
     return parser.parse_args()
 
 

--- a/scripts/ops/release-gate-report.py
+++ b/scripts/ops/release-gate-report.py
@@ -281,6 +281,8 @@ def run_qa_bench(args: argparse.Namespace, root: Path, out_dir: Path, commands: 
     ]
     if args.strict_artifacts:
         command.append("--strict-artifacts")
+    if args.skip_qa_build:
+        command.append("--skip-build")
 
     env = os.environ.copy()
     env["TRANSCRIPTED_DISABLE_FILE_LOGGER"] = "1"
@@ -977,6 +979,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--qa-mode", default="quick", choices=["quick", "deep", "full", "live"], help="QA bench mode to run. Default: quick.")
     parser.add_argument("--strict-artifacts", action="store_true", help="Forward --strict-artifacts to the QA bench.")
     parser.add_argument("--skip-qa", action="store_true", help="Skip the build/test QA bench and mark it unknown.")
+    parser.add_argument("--skip-qa-build", action="store_true", help="Run QA tests without replacing an already packaged app with a development build. Use with packaged-app smoke to verify the existing artifact.")
     parser.add_argument("--include-packaged-app-smoke", action="store_true", help="Run packaged app smoke against build/Transcripted.app and the versioned DMG.")
     parser.add_argument("--require-packaged-app-dmg", action="store_true", help="When packaged smoke is enabled, fail if build/Transcripted-<version>.dmg is missing.")
     parser.add_argument("--skip-live-release-surfaces", action="store_true", help="Skip live appcast/download/crawler checks.")

--- a/scripts/ops/test-nightly-security-check.py
+++ b/scripts/ops/test-nightly-security-check.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Offline built-app contract tests; no signing, keychain, or hardware access."""
+
+import copy
+import importlib.util
+import json
+import plistlib
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("nightly_security", ROOT / "scripts/ops/nightly-security-check.py")
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class BuiltAppEntitlementTests(unittest.TestCase):
+    def setUp(self):
+        self.manifest = json.loads((ROOT / "config/security/nightly-security-manifest.json").read_text())
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.app = self.root / "Transcripted.app"
+        (self.app / "Contents").mkdir(parents=True)
+
+    def check(self, channel, entitlements, info_overrides=None):
+        info = dict(self.manifest["expected_info_plist"])
+        if channel is not None:
+            info["TranscriptedBuildChannel"] = channel
+        info.update(info_overrides or {})
+        (self.app / "Contents/Info.plist").write_bytes(plistlib.dumps(info))
+        with patch.object(CHECKER, "parse_codesign_entitlements", return_value=entitlements):
+            return {item["check_id"] for item in CHECKER.check_built_app(self.root, self.manifest, str(self.app))}
+
+    def test_each_channel_accepts_only_its_exact_contract(self):
+        for channel, contract in [("local", "local"), ("release", "beta")]:
+            with self.subTest(channel=channel):
+                self.assertEqual(self.check(channel, self.manifest["expected_entitlements"][contract]), set())
+
+    def test_swapped_contracts_fail(self):
+        for channel, contract in [("local", "beta"), ("release", "local")]:
+            with self.subTest(channel=channel):
+                self.assertIn("built-entitlements-drift", self.check(channel, self.manifest["expected_entitlements"][contract]))
+
+    def test_unknown_missing_and_malformed_channels_fail(self):
+        for channel in [None, "", "beta", "production", "Release", ["release"]]:
+            with self.subTest(channel=channel):
+                self.assertIn("built-channel-unknown", self.check(channel, self.manifest["expected_entitlements"]["beta"]))
+
+    def test_added_removed_or_changed_entitlements_fail(self):
+        for channel, contract in [("local", "local"), ("release", "beta")]:
+            expected = self.manifest["expected_entitlements"][contract]
+            altered = [copy.deepcopy(expected) for _ in range(3)]
+            altered[0]["com.example.unreviewed"] = True
+            altered[1].pop("com.apple.security.device.audio-input")
+            altered[2]["com.apple.security.device.audio-input"] = False
+            for index, entitlements in enumerate(altered):
+                with self.subTest(channel=channel, alteration=index):
+                    self.assertIn("built-entitlements-drift", self.check(channel, entitlements))
+
+    def test_forbidden_permissions_fail_even_with_unknown_channel(self):
+        for channel in ["local", "release", None]:
+            entitlements = dict(self.manifest["expected_entitlements"]["beta"])
+            entitlements[self.manifest["forbidden_entitlements"][0]] = True
+            with self.subTest(channel=channel):
+                self.assertIn("built-forbidden-entitlements", self.check(channel, entitlements))
+
+    def test_unreadable_signature_and_info_drift_still_fail(self):
+        self.assertIn("built-entitlements-unreadable", self.check("release", None))
+        self.assertIn("built-info-SUFeedURL", self.check("release", self.manifest["expected_entitlements"]["beta"], {"SUFeedURL": "https://invalid.example/feed"}))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Release checks were rejecting the current packaged app: menu expectations described an older layout, and the security checker compared distribution entitlements against the local-build contract. Match the current menu and enforce the exact entitlement contract for each explicit build channel; unknown channels and permission drift still fail.

Add `--skip-qa-build` so post-packaging QA runs tests without overwriting the signed app with a development build. Skipping the build still leaves that QA stage unverified; signature, DMG, dSYM, and other packaged-artifact checks remain separate and unchanged. This branch changes tools, fixtures, tests, and documentation only; app version remains 1.1.57.

Validation:
- Independent Codex review approved this exact seven-file patch; no blocking findings.
- Full QA passed 15/15 checks, including a fresh app build, 12,622 fast assertions, integration/core tests, synthetic audio, pasteback, and release-health fixtures.
- Strict security check passed against the freshly built local app.
- Packaged-app and release-gate self-tests passed; six offline security tests passed.
- All active GitHub CI checks passed. Hardware jobs were skipped; synthetic tests do not prove real Bluetooth or target-app behavior.
- Dependency artifacts were reused only after their recorded source-content digest exactly matched this checkout. No path-specific Swift build cache was copied.

This prepares the release tools before the separate version-only release candidate. No release is published by this PR.
